### PR TITLE
Added a new insertionOptions: 'noInvalidPoints'

### DIFF
--- a/libs/maps/include/mrpt/slam/CPointsMap.h
+++ b/libs/maps/include/mrpt/slam/CPointsMap.h
@@ -181,7 +181,7 @@ namespace slam
 			bool    isPlanarMap;                 //!< If set to true, only HORIZONTAL (in the XY plane) measurements will be inserted in the map (Default value is false, thus 3D maps are generated). \sa	horizontalTolerance
 			float   horizontalTolerance;	     //!< The tolerance in rads in pitch & roll for a laser scan to be considered horizontal, considered only when isPlanarMap=true (default=0).
 			float   maxDistForInterpolatePoints; //!< The maximum distance between two points to interpolate between them (ONLY when also_interpolate=true)
-			bool    noInvalidPoints;             //!< Points with x,y,z coordinates set to zero will also be inserted
+			bool    insertInvalidPoints;             //!< Points with x,y,z coordinates set to zero will also be inserted
 
 		 };
 

--- a/libs/maps/src/maps/CColouredPointsMap.cpp
+++ b/libs/maps/src/maps/CColouredPointsMap.cpp
@@ -158,7 +158,7 @@ void  CColouredPointsMap::writeToStream(CStream &out, int *version) const
 		likelihoodOptions.writeToStream(out);
 
 		// Added in version 8:
-		out << insertionOptions.noInvalidPoints;
+		out << insertionOptions.insertInvalidPoints;
 	}
 }
 
@@ -273,8 +273,8 @@ void  CColouredPointsMap::readFromStream(CStream &in, int version)
 			if (version>=5) // version 5: added likelihoodOptions
 				likelihoodOptions.readFromStream(in);
 
-			if (version>=8) // version 8: added noInvalidPoints
-				in >> insertionOptions.noInvalidPoints;
+			if (version>=8) // version 8: added insertInvalidPoints
+				in >> insertionOptions.insertInvalidPoints;
 
 		} break;
 	default:

--- a/libs/maps/src/maps/CPointsMap.cpp
+++ b/libs/maps/src/maps/CPointsMap.cpp
@@ -613,7 +613,7 @@ CPointsMap::TInsertionOptions::TInsertionOptions() :
 	isPlanarMap					( false),
 	horizontalTolerance			( DEG2RAD(0.05) ),
 	maxDistForInterpolatePoints	( 2.0f ),
-	noInvalidPoints				( false)
+	insertInvalidPoints				( false)
 {
 }
 
@@ -665,7 +665,7 @@ void  CPointsMap::TInsertionOptions::dumpToTextStream(CStream	&out) const
 	LOADABLEOPTS_DUMP_VAR(fuseWithExisting,bool);
 	LOADABLEOPTS_DUMP_VAR(isPlanarMap,bool);
 
-	LOADABLEOPTS_DUMP_VAR(noInvalidPoints,bool);
+	LOADABLEOPTS_DUMP_VAR(insertInvalidPoints,bool);
 
 	out.printf("\n");
 }
@@ -697,7 +697,7 @@ void  CPointsMap::TInsertionOptions::loadFromConfigFile(
 
 	MRPT_LOAD_CONFIG_VAR(maxDistForInterpolatePoints,	float, iniFile,section);
 
-	MRPT_LOAD_CONFIG_VAR(noInvalidPoints,bool, iniFile,section);
+	MRPT_LOAD_CONFIG_VAR(insertInvalidPoints,bool, iniFile,section);
 }
 
 void  CPointsMap::TLikelihoodOptions::loadFromConfigFile(

--- a/libs/maps/src/maps/CPointsMap_crtp_common.h
+++ b/libs/maps/src/maps/CPointsMap_crtp_common.h
@@ -352,7 +352,7 @@ namespace detail
 			for (size_t i=0;i<sizeRangeScan;i++)
 			{
 				// Valid point?
-				if ( rangeScan.points3D_x[i]!=0 || rangeScan.points3D_y[i]!=0 || rangeScan.points3D_z[i]!=0 || obj.insertionOptions.noInvalidPoints)
+				if ( rangeScan.points3D_x[i]!=0 || rangeScan.points3D_y[i]!=0 || rangeScan.points3D_z[i]!=0 || obj.insertionOptions.insertInvalidPoints)
 				{
 					lric.scan_x = rangeScan.points3D_x[i];
 					lric.scan_y = rangeScan.points3D_y[i];

--- a/libs/maps/src/maps/CSimplePointsMap.cpp
+++ b/libs/maps/src/maps/CSimplePointsMap.cpp
@@ -121,7 +121,7 @@ void  CSimplePointsMap::writeToStream(CStream &out, int *version) const
 		likelihoodOptions.writeToStream(out);
 
 		// Added in version 8:
-		out << insertionOptions.noInvalidPoints;
+		out << insertionOptions.insertInvalidPoints;
 	}
 }
 
@@ -214,8 +214,8 @@ void  CSimplePointsMap::readFromStream(CStream &in, int version)
 			if (version>=5) // version 5: added likelihoodOptions
 				likelihoodOptions.readFromStream(in);
 
-			if (version>=8) // version 8: added noInvalidPoints
-				in >> insertionOptions.noInvalidPoints;
+			if (version>=8) // version 8: added insertInvalidPoints
+				in >> insertionOptions.insertInvalidPoints;
 
 		} break;
 	default:


### PR DESCRIPTION
Added a new  insertionOptions 'noInvalidPoints' so that every point is kept when inserting a point map from a CObservation into a CColouredPointsMap or into a CSimplePointsMap.

I implemented this so that the cloud was still ordered after insertion from the CObservation.

I'm not sure of what to do about implementing this also into CWeightedPointsMap (or if it makes sense to do so), since it's readFromStream method doesn't have any version check like CSimplePointsMap & CColouredPointsMap.
