### PR TITLE
Patch to build in OS X 10.9

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -402,12 +402,12 @@ if ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang")
 	# Use modern C++11
 # 	SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11")
 
-#	IF(APPLE) # any reason for not using it in all platforms?
+	IF(NOT APPLE) # any reason for not using it in all platforms?
 	# Use the libstdc++ lib vs. libc++, to avoid some build errors in MacOS
-	SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -stdlib=libstdc++")
-	SET(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -stdlib=libstdc++")
-	SET(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} -stdlib=libstdc++")
-#	ENDIF(APPLE)
+		SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -stdlib=libstdc++")
+		SET(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -stdlib=libstdc++")
+		SET(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} -stdlib=libstdc++")
+	ENDIF(NOT APPLE)
 
 	# This is to fix the compilation of C++ templates
 	SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fdelayed-template-parsing")
@@ -600,6 +600,9 @@ IF( BUILD_TESTING)
 	# Try using libgtest (Google testing library) from the system, if available
 	# Note: In gtest 1.6.0 things changed and there's no prebuilt system lib anymore.
 	# TODO: Is it possible to compile here the /usr/src/gtest/ sources??
+	IF("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang" AND APPLE)
+		add_definitions(-DGTEST_USE_OWN_TR1_TUPLE=1)
+	ENDIF("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang" AND APPLE)
 	add_subdirectory(${CMAKE_MRPT_GTEST_SRC_DIR})  # Build gtest from sources
 	add_subdirectory(tests)  # Build my tests
 ENDIF( BUILD_TESTING)

--- a/libs/base/src/synch/atomic_incr.cpp
+++ b/libs/base/src/synch/atomic_incr.cpp
@@ -15,6 +15,8 @@ using namespace mrpt::synch;
 
 #ifdef MRPT_OS_WINDOWS
 	#include <windows.h>
+#elif defined( __clang__ ) && defined( MRPT_OS_APPLE )
+	//no include
 #elif defined( __GNUC__ )
 	#if ( __GNUC__ * 100 + __GNUC_MINOR__ >= 402 )
 	#  include <ext/atomicity.h>

--- a/libs/maps/include/mrpt/otherlibs/octomap/OcTreeKey.h
+++ b/libs/maps/include/mrpt/otherlibs/octomap/OcTreeKey.h
@@ -49,9 +49,10 @@
  */
 
 #include <assert.h>
-#ifdef __GNUC__
+#if defined( __GNUC__ ) && !(defined( __clang__ ) && defined( __APPLE__ ) )
   #include <tr1/unordered_set>
   #include <tr1/unordered_map>
+  #define OCTREE_KEY_USES_TR1
 #else
   #include <unordered_set>
   #include <unordered_map>
@@ -108,14 +109,22 @@ namespace octomap {
    * @note you need to use boost::unordered_set instead if your compiler does not
    * yet support tr1!
    */
+#ifdef OCTREE_KEY_USES_TR1
   typedef std::tr1::unordered_set<OcTreeKey, OcTreeKey::KeyHash> KeySet;
+#else
+  typedef std::unordered_set<OcTreeKey, OcTreeKey::KeyHash> KeySet;
+#endif
 
   /**
    * Data structrure to efficiently track changed nodes as a combination of
    * OcTreeKeys and a bool flag (to denote newly created nodes)
    *
    */
+#ifdef OCTREE_KEY_USES_TR1
   typedef std::tr1::unordered_map<OcTreeKey, bool, OcTreeKey::KeyHash> KeyBoolMap;
+#else
+  typedef std::unordered_map<OcTreeKey, bool, OcTreeKey::KeyHash> KeyBoolMap;
+#endif
 
 
   class KeyRay {

--- a/otherlibs/octomap/src/Pointcloud.cpp
+++ b/otherlibs/octomap/src/Pointcloud.cpp
@@ -39,6 +39,8 @@
 
 #ifdef _MSC_VER
   #include <algorithm>
+#elif defined( __clang__ ) && defined( __APPLE__ )
+  #include <algorithm>
 #else
   #include <ext/algorithm>
 #endif
@@ -205,7 +207,7 @@ namespace octomap {
   void Pointcloud::subSampleRandom(unsigned int num_samples, Pointcloud& sample_cloud) {
     point3d_collection samples;
     // visual studio does not support random_sample_n
-  #ifdef _MSC_VER
+  #if defined( _MSC_VER ) | (defined( __clang__ ) && defined( MRPT_OS_APPLE ))
     samples.reserve(this->size());
     samples.insert(samples.end(), this->begin(), this->end());
     std::random_shuffle(samples.begin(), samples.end());


### PR DESCRIPTION
Tested in OS X 10.9.2 & clang-500.2.79
Not yet 100% in mrpt-hwdrivers

Hi, I successfully built MRPT on my OS X 10.9.2.
Unfortunately, I can't test this patch on OS X 10.8.

-- Yuya
