### PR TITLE
Adding some mrpt::system implementation on OS X

### DIFF
--- a/libs/base/src/system/memory.cpp
+++ b/libs/base/src/system/memory.cpp
@@ -11,6 +11,10 @@
 
 #include <mrpt/system/memory.h>
 
+#ifdef MRPT_OS_APPLE
+#include <mach/mach_init.h>
+#include <mach/task.h>
+#endif
 
 using namespace mrpt;
 using namespace mrpt::utils;
@@ -208,8 +212,12 @@ unsigned long  mrpt::system::getMemoryUsage()
 #endif
 
 #ifdef MRPT_OS_APPLE
-	//TODO: Not implemented for Apple.
-	MEM = 0;
+	mach_task_basic_info info;
+	mach_msg_type_number_t count = MACH_TASK_BASIC_INFO_COUNT;
+	if(task_info(mach_task_self(), MACH_TASK_BASIC_INFO, (task_info_t)&info, &count)==0)
+	{
+		MEM=info.virtual_size;
+	}
 #endif
 
 	return MEM;

--- a/libs/base/src/system/threads.cpp
+++ b/libs/base/src/system/threads.cpp
@@ -38,6 +38,11 @@
 
 #include <sys/types.h>
 #include <sys/stat.h>
+#ifdef MRPT_OS_APPLE
+	#include <sys/sysctl.h>
+	#include <mach/mach_init.h>
+	#include <mach/thread_act.h>
+#endif
 
 using namespace mrpt;
 using namespace mrpt::utils;
@@ -409,10 +414,14 @@ void mrpt::system::getCurrentThreadTimes(
 #endif
 
 #ifdef MRPT_OS_APPLE
-	//TODO: Not implemented for Apple.
-	creationTime = 0;
-	exitTime = 0;
-	cpuTime = 0;
+	thread_basic_info info;
+	mach_msg_type_number_t count = THREAD_BASIC_INFO_COUNT;
+	if(thread_info(mach_thread_self(), THREAD_BASIC_INFO, (thread_info_t)&info, &count)==0)
+	{
+		double utime = info.user_time.seconds + info.user_time.microseconds * 1e-6;
+		double stime = info.system_time.seconds + info.system_time.microseconds * 1e-6;
+		cpuTime = utime + stime;
+	}
 #endif
 
 	MRPT_END
@@ -464,6 +473,10 @@ unsigned int mrpt::system::getNumberOfProcessors()
         GetSystemInfo(&si);
         ret=si.dwNumberOfProcessors;
         if (ret<1) ret=1;
+#elif defined(MRPT_OS_APPLE)
+        size_t len=sizeof(int);
+        if(sysctlbyname("hw.logicalcpu", &ret, &len, NULL, 0) != 0)
+            ret = 1; // failed
 #else
         // This assumes a Linux kernel 2.6
         ifstream f;


### PR DESCRIPTION
I implemented some mrpt::system functions for OS X.
These had not been implemented.
- getNumberOfProcessors()
  /proc/cpuinfo does not exist in OS X. sysctlbyname() is used.
- getCurrentThreadTimes(), getMemoryUsage()
  Mach functions are used: task_info(), thread_info().
