### PR TITLE
Fixed named semaphore in OS X

### DIFF
--- a/libs/base/src/synch/CSemaphore_APP.cpp
+++ b/libs/base/src/synch/CSemaphore_APP.cpp
@@ -81,7 +81,7 @@ CSemaphore::~CSemaphore()
     if(isNamed())
     {
       sem_private token = m_data.getAs<sem_private>();
-      sem_destroy(token->semid);
+      sem_close(token->semid);
     }
     else
     {


### PR DESCRIPTION
Fixed timeout conditions and destructor in named semaphores
- Adding no-timeout case
- Fixed timeout conditions:
  - The nowtime was not updated.
  - Named semaphores always retried sem_trywait() if rc!=0 is true.
- Fixed destructor:
  sem_destroy() is not implemented in OS X.
