### PR TITLE
Adds missing includes. Fixes Clang build on OSX Mavericks.

### DIFF
--- a/libs/hwdrivers/src/aria/include/ArThread.h
+++ b/libs/hwdrivers/src/aria/include/ArThread.h
@@ -14,6 +14,8 @@
 #include <map>
 #ifndef WIN32
 #include <pthread.h>
+#include <sys/types.h>
+#include <unistd.h>
 #endif
 #include "ariaTypedefs.h"
 #include "ArMutex.h"


### PR DESCRIPTION
`pid_t` is undefined on Clang w/o these includes.
