### PR TITLE
Removed invalid assignment operator with const qualifier

### DIFF
--- a/libs/base/include/mrpt/math/CMatrixD.h
+++ b/libs/base/include/mrpt/math/CMatrixD.h
@@ -70,13 +70,6 @@ namespace mrpt
 			/** Constructor from a TPoint3D, which generates a 3x1 matrix \f$ [x y z]^T \f$ */
 			explicit CMatrixD( const TPoint3D &p);
 
-			/** Assignment from any Eigen matrix/vector */
-			template <typename Derived>
-			inline CMatrixD& operator =(const Eigen::MatrixBase<Derived>& m) const {
-				CMatrixDouble::operator =(m);
-				return *this;
-			}
-
 		}; // end of class definition
 
 	} // End of namespace


### PR DESCRIPTION
In a personal project that depends from MRPT, I detected a problem in the libs/base/include/mrpt/math/CMatrixD.h file when compiling with clang compiler.  It throws the following error:

/usr/local/include/mrpt/base/include/mrpt/math/CMatrixD.h:77:12: error: binding of reference to type 'mrpt::math::CMatrixD' to a value of type 'const mrpt::math::CMatrixD' drops qualifiers [Semantic Issue]
                                return *this;

Actually the block of code removed is the same that the one appearing just some lines above (55-59) but with different typename and without the const qualifier.
