### PR TITLE
Fix compilation of CInterfaceFTDI if MRPT_HAD_FTDI is false

### DIFF
--- a/libs/hwdrivers/src/CInterfaceFTDI_LIN.cpp
+++ b/libs/hwdrivers/src/CInterfaceFTDI_LIN.cpp
@@ -159,8 +159,8 @@ void  CInterfaceFTDI::OpenBySerialNumber( const std::string &serialNumber )
 -------------------------------------------------------------*/
 void CInterfaceFTDI::ListAllDevices( TFTDIDeviceList &outList )
 {
-#if MRPT_HAS_FTDI
 	MRPT_TRY_START
+#if MRPT_HAS_FTDI
 
 	outList.clear();
 


### PR DESCRIPTION
As MRPT_TRY_END is outside the MRPT_HAS_FTDI block, the
MRPT_TRY_START macro should be outside as well.