### PR TITLE
Python binding poses

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -30,6 +30,9 @@ The following list is roughly sorted in reverse cronological order.
   - Driver for Rovio mobile robot with webcam.
   - New algorithms in gas maps.
 
+* Nikolaus Demmel, Robert Bosch Start-up GmbH (2016)
+  - Additions to python bindings.
+
 * Robert Schattschneider, University of Canterbury (2012)
   - Patches for bug fixes, serialization of templates.
 

--- a/libs/base/include/mrpt/poses/CPose3DPDFGaussian.h
+++ b/libs/base/include/mrpt/poses/CPose3DPDFGaussian.h
@@ -94,6 +94,9 @@ namespace poses
 			mean_point = this->mean;
 		}
 
+        void asString(std::string &s) const;
+        inline std::string asString() const { std::string s; asString(s); return s; }
+
 		/** Copy operator, translating if necesary (for example, between particles and gaussian representations)
 		  */
 		void  copyFrom(const CPose3DPDF &o) MRPT_OVERRIDE;

--- a/libs/base/src/poses/CPose3DPDFGaussian.cpp
+++ b/libs/base/src/poses/CPose3DPDFGaussian.cpp
@@ -18,6 +18,8 @@
 #include <mrpt/system/os.h>
 #include <mrpt/utils/CStream.h>
 
+#include <sstream>
+
 using namespace mrpt;
 using namespace mrpt::poses;
 using namespace mrpt::math;
@@ -111,6 +113,16 @@ CPose3DPDFGaussian::CPose3DPDFGaussian( const CPose3DQuatPDFGaussian &o)  :
 	mean(UNINITIALIZED_POSE), cov(UNINITIALIZED_MATRIX)
 {
 	this->copyFrom(o);
+}
+
+/*---------------------------------------------------------------
+                    asString
+ ---------------------------------------------------------------*/
+void CPose3DPDFGaussian::asString(std::string &s) const
+{
+    ostringstream ss;
+    ss << *this;
+    s = ss.str();
 }
 
 /*---------------------------------------------------------------

--- a/python/CMakeLists.txt
+++ b/python/CMakeLists.txt
@@ -2,7 +2,8 @@ cmake_minimum_required(VERSION 2.8.3)
 
 project(pymrpt)
 
-set( PYMRPT_INSTALL_DIR "/usr/local/lib/python2.7/dist-packages" CACHE STRING "Set install directory for pymrpt. Ensure directory is in PYTHONPATH!")
+# Note: relative paths are relative to ${CMAKE_INSTALL_PREFIX} (defaults to /usr/local on Ubuntu)
+set( PYMRPT_INSTALL_DIR "lib/python${PYTHON_MAJOR_VERSION}.${PYTHON_MINOR_VERSION}/dist-packages" )
 
 include_directories(include)
 include_directories(

--- a/python/src/math_bindings.cpp
+++ b/python/src/math_bindings.cpp
@@ -95,6 +95,9 @@ MAKE_SETITEM(TPose3DQuat, double)
 // CMatrix
 MAKE_FIXED_DOUBLE_MATRIX_GETSET(3, 3)
 MAKE_FIXED_DOUBLE_MATRIX_GETSET(6, 6)
+
+// TODO: add conversion from/to list for convenience
+
 // end of CMatrix
 
 // re-implement inline functions, otherwise they are not included inside pymrpt.so


### PR DESCRIPTION
These are the changes I mentioned over at https://github.com/MRPT/mrpt/pull/198#issuecomment-194752629.

I used the Python bindings with these additions to do math with `PoseWithCovariance` ROS messages from python (actually, it would be nice to add some more glue code to offer something like https://github.com/mrpt-ros-pkg/pose_cov_ops for python).

The Python bindings worked nicely (thanks @sem23). I have not much experience with using Boost.Python though, so @sem23, could you maybe check if I'm doing things the right way?

I don't think this is ready to merge as is, but I wanted to get some input first before polishing it up.

~~I acknowledge to have~~ (I will do the following if the PR is deemed acceptable):
* Read the [`CONTRIBUTING`](https://github.com/MRPT/mrpt/blob/master/.github/CONTRIBUTING.md) page
* Updated [`docs/doxygen-pages/changelog.h`](https://github.com/MRPT/mrpt/blob/master/doc/doxygen-pages/changeLog_doc.h) to describe these changes (if applicable)
* Updated [`AUTHORS`](https://github.com/MRPT/mrpt/blob/master/AUTHORS) (if applicable)

(Notify: @MRPT/owners )
