### PR TITLE
Add package.xml for easier building in ROS workspace.

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0"?>
+<package format="2">
+  <name>mrpt</name>
+  <version>1.4.0</version>
+  <description>
+    Mobile Robot Programming Toolkit (MRPT) provides C++ libraries aimed at researchers
+    in mobile robotics and computer vision. Libraries include 3D(6D) geometry, SE(2)/SE(3) Lie groups,
+    probability density functions (pdfs) over points, landmarks, poses and maps,
+    Bayesian inference (Kalman filters, particle filters), image processing, obstacle
+    avoidance, etc.
+    MRPT also provides GUI apps for Stereo camera calibration, dataset inspection,
+    and much more.
+  </description>
+
+  <author     email="joseluisblancoc@gmail.com">Jose-Luis Blanco-Claraco</author>
+  <maintainer email="joseluisblancoc@gmail.com">Jose-Luis Blanco-Claraco</maintainer>
+
+  <url type="website">http://www.mrpt.org/</url>
+  <url type="bugtracker">https://github.com/jlblancoc/mrpt/issues</url>
+
+  <license>BSD</license>
+
+  <buildtool_depend>cmake</buildtool_depend>
+
+  <export>
+    <build_type>cmake</build_type>
+  </export>
+</package>


### PR DESCRIPTION
With this you can just checkout the repository in any catkin workspace and build
it alongside your ROS packages with `catkin build` or `catkin_make_isolated`.

We need to CATKIN_IGNORE the `otherlibs` directory, since for example octomap
has a `package.xml`, that we don't want catkin to pick up.


I acknowledge to have: 
* [ ] Read the [`CONTRIBUTING`](https://github.com/MRPT/mrpt/blob/master/.github/CONTRIBUTING.md) page
* [ ] Updated [`docs/doxygen-pages/changelog.h`](https://github.com/MRPT/mrpt/blob/master/doc/doxygen-pages/changeLog_doc.h) to describe these changes (if applicable)
* [ ] Updated [`AUTHORS`](https://github.com/MRPT/mrpt/blob/master/AUTHORS) (if applicable)

(Notify: @MRPT/owners )

