### PR TITLE
CMetricMapBuilderRBPF copy operator and empty constructor

### DIFF
--- a/libs/slam/include/mrpt/slam/CMetricMapBuilderRBPF.h
+++ b/libs/slam/include/mrpt/slam/CMetricMapBuilderRBPF.h
@@ -92,6 +92,13 @@ namespace slam
 
 		/** Constructor. */
 		CMetricMapBuilderRBPF( const TConstructionOptions &initializationOptions );
+		
+		/** This second constructor is created for the situation where a class member needs to be
+of type CMetricMapBuilderRBPF  */
+		CMetricMapBuilderRBPF();
+		
+		/** Copy Operator. */
+		CMetricMapBuilderRBPF & operator =(const CMetricMapBuilderRBPF &src);
 
 		/** Destructor. */
 		virtual ~CMetricMapBuilderRBPF( );

--- a/libs/slam/src/slam/CMetricMapBuilderRBPF.cpp
+++ b/libs/slam/src/slam/CMetricMapBuilderRBPF.cpp
@@ -50,6 +50,32 @@ CMetricMapBuilderRBPF::CMetricMapBuilderRBPF(  const TConstructionOptions &initi
 	clear();
 }
 
+CMetricMapBuilderRBPF::CMetricMapBuilderRBPF()
+{
+	std::cerr << "WARNING: empty constructor" << std::endl;
+}
+
+/*---------------------------------------------------------------
+				     Copy operator
+  ---------------------------------------------------------------*/
+CMetricMapBuilderRBPF & CMetricMapBuilderRBPF::operator =(const CMetricMapBuilderRBPF &src)
+{
+	if (this==&src) {
+		return *this;
+	}
+	mapPDF = src.mapPDF;
+	m_PF_options = src.m_PF_options;
+	insertionLinDistance = src.insertionLinDistance;
+	insertionAngDistance = src.insertionAngDistance;
+	localizeLinDistance = src.localizeLinDistance;
+	localizeAngDistance = src.localizeAngDistance;
+	odoIncrementSinceLastLocalization = src.odoIncrementSinceLastLocalization;
+	odoIncrementSinceLastMapUpdate = src.odoIncrementSinceLastMapUpdate;
+	currentMetricMapEstimation = NULL;
+	m_statsLastIteration = src.m_statsLastIteration;
+	return *this;
+}
+
 /*---------------------------------------------------------------
 						Destructor
   ---------------------------------------------------------------*/


### PR DESCRIPTION
Need to make the small change of adding a copy operator and empty constructor for CMetricMapBuilderRBPF so that I can use CMetricMapBuilderRBPF in an mrpt_navigation package for range-only slam using RBPF.


I acknowledge to have: 
* Read the [`CONTRIBUTING`](https://github.com/MRPT/mrpt/blob/master/.github/CONTRIBUTING.md) page
* NOT Updated [`docs/doxygen-pages/changelog.h`](https://github.com/MRPT/mrpt/blob/master/doc/doxygen-pages/changeLog_doc.h) to describe these changes since this is tiny.
* NOT Updated [`AUTHORS`](https://github.com/MRPT/mrpt/blob/master/AUTHORS) since this is tiny.

(Notify: @MRPT/owners )
