### PR TITLE
Add libopenni2-dev to debian build dependencies

### DIFF
--- a/packaging/debian/control.in
+++ b/packaging/debian/control.in
@@ -31,7 +31,8 @@ Build-Depends: debhelper (>= 9),
 	libjs-jquery,
 	libassimp-dev,
 	libfreenect-dev (>= 0.2) | perl,
-	libpcap-dev
+	libpcap-dev,
+	libopenni2-dev
 Standards-Version: 3.9.6
 Homepage: http://www.mrpt.org/
 


### PR DESCRIPTION
Changed: Debian Packaging
OpenNI2 is available from Ubuntu repos.
This breaks the trusty build, but works with wily and xenial.

A simple solution for trusty is to copy the openni2 package from Jochen's PCL PPA.

I acknowledge to have: 
* Read the [`CONTRIBUTING`](https://github.com/MRPT/mrpt/blob/master/.github/CONTRIBUTING.md) page
* Updated [`docs/doxygen-pages/changelog.h`](https://github.com/MRPT/mrpt/blob/master/doc/doxygen-pages/changeLog_doc.h) to describe these changes (if applicable)
* Updated [`AUTHORS`](https://github.com/MRPT/mrpt/blob/master/AUTHORS) (if applicable)

(Notify: @MRPT/owners )
