### PR TITLE
Add missing include to CThreadSafeVariable

### DIFF
--- a/apps/kinect-stereo-calib/kinect_calibrate_guiMain.h
+++ b/apps/kinect-stereo-calib/kinect_calibrate_guiMain.h
@@ -47,6 +47,7 @@
 #include <mrpt/opengl.h>
 #include <mrpt/system/threads.h>
 #include <mrpt/vision/chessboard_stereo_camera_calib.h>
+#include <mrpt/synch/CThreadSafeVariable.h>
 
 // Thread for grabbing: Do this is another thread so we divide rendering and grabbing
 //   and exploit multicore CPUs.


### PR DESCRIPTION
I acknowledge to have: 
* Read the [`CONTRIBUTING`](https://github.com/MRPT/mrpt/blob/master/.github/CONTRIBUTING.md) page
* Updated [`docs/doxygen-pages/changelog.h`](https://github.com/MRPT/mrpt/blob/master/doc/doxygen-pages/changeLog_doc.h) to describe these changes (if applicable)
* Updated [`AUTHORS`](https://github.com/MRPT/mrpt/blob/master/AUTHORS) (if applicable)

(Notify: @MRPT/owners )

