### PR TITLE
Patches for New LibLAS Library

### DIFF
--- a/libs/maps/src/maps/CPointsMap_liblas.cpp
+++ b/libs/maps/src/maps/CPointsMap_liblas.cpp
@@ -51,7 +51,8 @@ bool CPointsMap::saveLASFile(const std::string &filename, const LAS_WriteParams 
 	const bool has_color = this->hasColorPoints();
 	const float col_fract = 255.0f;
 
-	liblas::Point pt;
+	//liblas::Point pt;
+	liblas::Point pt(&header);
 	liblas::Color col;
 	for (size_t i=0;i<nPts;i++)
 	{
@@ -114,7 +115,8 @@ bool CPointsMap::loadLASFile(const std::string &filename, LAS_HeaderInfo &out_he
 	out_headerInfo.FileSignature      = header.GetFileSignature();
 	out_headerInfo.SystemIdentifier   = header.GetSystemId();
 	out_headerInfo.SoftwareIdentifier = header.GetSoftwareId();
-	out_headerInfo.project_guid       = header.GetProjectId().to_string();
+	//out_headerInfo.project_guid       = header.GetProjectId().to_string();
+	out_headerInfo.project_guid       = boost::lexical_cast<std::string>(header.GetProjectId());
 	out_headerInfo.spatial_reference_proj4 = header.GetSRS().GetProj4();
 	out_headerInfo.creation_year = header.GetCreationYear();
 	out_headerInfo.creation_DOY  = header.GetCreationDOY();

--- a/libs/maps/src/maps/CPointsMap_liblas.cpp
+++ b/libs/maps/src/maps/CPointsMap_liblas.cpp
@@ -51,7 +51,6 @@ bool CPointsMap::saveLASFile(const std::string &filename, const LAS_WriteParams 
 	const bool has_color = this->hasColorPoints();
 	const float col_fract = 255.0f;
 
-	//liblas::Point pt;
 	liblas::Point pt(&header);
 	liblas::Color col;
 	for (size_t i=0;i<nPts;i++)
@@ -114,8 +113,7 @@ bool CPointsMap::loadLASFile(const std::string &filename, LAS_HeaderInfo &out_he
 
 	out_headerInfo.FileSignature      = header.GetFileSignature();
 	out_headerInfo.SystemIdentifier   = header.GetSystemId();
-	out_headerInfo.SoftwareIdentifier = header.GetSoftwareId();
-	//out_headerInfo.project_guid       = header.GetProjectId().to_string();
+	out_headerInfo.SoftwareIdentifier = header.
 	out_headerInfo.project_guid       = boost::lexical_cast<std::string>(header.GetProjectId());
 	out_headerInfo.spatial_reference_proj4 = header.GetSRS().GetProj4();
 	out_headerInfo.creation_year = header.GetCreationYear();


### PR DESCRIPTION
**Changed apps/libraries:** 
*  lexical_cast is inserted instead of boost::to_string to convert Project Id to string
* This PR Closes issue on make errors with latest liblas library


I acknowledge to have: 
* Read the [`Discussion`](https://github.com/MRPT/mrpt/commit/aacc1c3a0cbf214e468599fbed5c09c49be7e3b2) page


(Notify: @MRPT/owners )
