### PR TITLE
Add interface for pfAuxiliaryPFStandard.

### DIFF
--- a/doc/doxygen-pages/changeLog_doc.h
+++ b/doc/doxygen-pages/changeLog_doc.h
@@ -34,6 +34,8 @@
 			- [ABI change] mrpt::hwdrivers::COpenNI2Generic:
 				- refactored to expose more methods and allow changing parameters via its constructor.
 				- Now supports reading from an IR, RGB and Depth channels independenty.
+		- \ref mrpt_maps_grp
+			- mrpt::maps::CMultiMetricMapPDF added method CMultiMetricMapPDF::prediction_and_update_pfAuxiliaryPFStandard().
 	- Changes in build system:
 		- [Windows only] `DLL`s/`LIB`s now have the signature `lib-${name}${2-digits-version}${compiler-name}_{x32|x64}.{dll/lib}`, allowing several MRPT versions to coexist in the system PATH.
 		- [Visual Studio only] There are no longer `pragma comment(lib...)` in any MRPT header, so it is the user responsibility to correctly tell user projects to link against MRPT libraries.

--- a/libs/slam/include/mrpt/maps/CMultiMetricMapPDF.h
+++ b/libs/slam/include/mrpt/maps/CMultiMetricMapPDF.h
@@ -92,6 +92,13 @@ namespace maps
 			const mrpt::obs::CSensoryFrame		* observation,
 			const bayes::CParticleFilter::TParticleFilterOptions &PF_options );
 
+		/** The PF algorithm implementation.
+		  */
+		void  prediction_and_update_pfAuxiliaryPFStandard(
+			const mrpt::obs::CActionCollection	* action,
+			const mrpt::obs::CSensoryFrame		* observation,
+			const bayes::CParticleFilter::TParticleFilterOptions &PF_options );
+
 
 	private:
 		/** Internal buffer for the averaged map. */

--- a/libs/slam/src/slam/CMultiMetricMapPDF_RBPF.cpp
+++ b/libs/slam/src/slam/CMultiMetricMapPDF_RBPF.cpp
@@ -148,6 +148,20 @@ void  CMultiMetricMapPDF::prediction_and_update_pfAuxiliaryPFOptimal(
 	MRPT_END
 }
 
+/*----------------------------------------------------------------------------------
+			PF_SLAM_implementation_pfAuxiliaryPFStandard
+ ----------------------------------------------------------------------------------*/
+void  CMultiMetricMapPDF::prediction_and_update_pfAuxiliaryPFStandard(
+	const mrpt::obs::CActionCollection	* actions,
+	const mrpt::obs::CSensoryFrame		* sf,
+	const bayes::CParticleFilter::TParticleFilterOptions &PF_options )
+{
+	MRPT_START
+
+	PF_SLAM_implementation_pfAuxiliaryPFStandard<mrpt::slam::detail::TPoseBin2D>( actions, sf, PF_options,options.KLD_params);
+
+	MRPT_END
+}
 
 
 /*----------------------------------------------------------------------------------


### PR DESCRIPTION
**Changed apps/libraries:** 
*  Added a method CMultiMetricMapPDF::prediction_and_update_pfAuxiliaryPFStandard() which exposes pfAuxilaryPFStandard option in RBPF SLAM.

I acknowledge to have: 
* Read the [`CONTRIBUTING`](https://github.com/MRPT/mrpt/blob/master/.github/CONTRIBUTING.md) page
* Updated [`docs/doxygen-pages/changelog.h`](https://github.com/MRPT/mrpt/blob/master/doc/doxygen-pages/changeLog_doc.h) to describe these changes (if applicable)

(Notify: @MRPT/owners )

