### PR TITLE
Add lib3ds-dev libsuitesparse-dev to build-deps

### DIFF
--- a/packaging/debian/control.in
+++ b/packaging/debian/control.in
@@ -32,7 +32,9 @@ Build-Depends: debhelper (>= 9),
 	libfreenect-dev (>= 0.2) | perl,
 	libpcap-dev,
 	libopenni2-dev | perl,
-	gdb
+	gdb,
+	lib3ds-dev,
+	libsuitesparse-dev
 Standards-Version: 3.9.8
 Homepage: http://www.mrpt.org/
 


### PR DESCRIPTION
I acknowledge to have: 
* Read the [`CONTRIBUTING`](https://github.com/MRPT/mrpt/blob/master/.github/CONTRIBUTING.md) page
* Updated [`docs/doxygen-pages/changelog.h`](https://github.com/MRPT/mrpt/blob/master/doc/doxygen-pages/changeLog_doc.h) to describe these changes (if applicable)
* Updated [`AUTHORS`](https://github.com/MRPT/mrpt/blob/master/AUTHORS) (if applicable)

(Notify: @MRPT/owners )

lib3ds is used to render the CSkeletonTracker visualizations.
libsuitesparse replaces CSparse and is primarily used for Cholesky decomposition.