### PR TITLE
add libsuitesparse-dev as libmrpt-dev dependency

### DIFF
--- a/packaging/debian/control.in
+++ b/packaging/debian/control.in
@@ -349,7 +349,8 @@ Depends: ${shlibs:Depends}, ${misc:Depends}, libeigen3-dev,
          libmrpt-tfest@MRPT_VER_MM@ (= ${binary:Version}),
          libmrpt-slam@MRPT_VER_MM@ (= ${binary:Version}),
          libmrpt-topography@MRPT_VER_MM@ (= ${binary:Version}),
-         libmrpt-vision@MRPT_VER_MM@ (= ${binary:Version})
+         libmrpt-vision@MRPT_VER_MM@ (= ${binary:Version}),
+         libsuitesparse-dev
 Description: Mobile Robot Programming Toolkit - Development headers
  The Mobile Robot Programming Toolkit (MRPT) is an extensive, cross-platform,
  and open source C++ library aimed to help robotics researchers to design and


### PR DESCRIPTION
I acknowledge to have: 
* Read the [`CONTRIBUTING`](https://github.com/MRPT/mrpt/blob/master/.github/CONTRIBUTING.md) page
* Updated [`docs/doxygen-pages/changelog.h`](https://github.com/MRPT/mrpt/blob/master/doc/doxygen-pages/changeLog_doc.h) to describe these changes (if applicable)
* Updated [`AUTHORS`](https://github.com/MRPT/mrpt/blob/master/AUTHORS) (if applicable)

(Notify: @MRPT/owners )

CSparseMatrix.h needs "cs.h" when not using otherlibs version of CSparse.