### PR TITLE
Add *_IMPEXP for Windows support

### DIFF
--- a/libs/base/include/mrpt/utils/COutputLogger.h
+++ b/libs/base/include/mrpt/utils/COutputLogger.h
@@ -62,7 +62,7 @@ enum VerbosityLevel { LVL_DEBUG=0, LVL_INFO, LVL_WARN, LVL_ERROR };
  * \sa TMsg
  * \ingroup mrpt_base_grp
  */
-class COutputLogger {
+class BASE_IMPEXP COutputLogger {
   public:
   	/**
   	 * \brief Construct a COutputLogger instance with the given name as the
@@ -251,7 +251,7 @@ class COutputLogger {
 		 *
 		 * <center><em> [name | level | timestamp:] body </em></center>
 		 */
-    struct TMsg {
+    struct BASE_IMPEXP TMsg {
     	/** \brief Class constructor that passes a message in std::string
     	 * form as well as a reference to the COutputLogger that provided the
     	 * current message


### PR DESCRIPTION
**Changed apps/libraries:** 
mrpt-base
Add Windows support for COutputLogger class

I acknowledge to have: 
* Read the [`CONTRIBUTING`](https://github.com/MRPT/mrpt/blob/master/.github/CONTRIBUTING.md) page
* Updated [`docs/doxygen-pages/changelog.h`](https://github.com/MRPT/mrpt/blob/master/doc/doxygen-pages/changeLog_doc.h) to describe these changes (if applicable)
* Updated [`AUTHORS`](https://github.com/MRPT/mrpt/blob/master/AUTHORS) (if applicable)

(Notify: @MRPT/owners )

