### PR TITLE
Fix python build

### DIFF
--- a/libs/slam/include/mrpt/slam/CMetricMapBuilderICP.h
+++ b/libs/slam/include/mrpt/slam/CMetricMapBuilderICP.h
@@ -41,10 +41,11 @@ namespace slam
 		 struct SLAM_IMPEXP TConfigParams : public mrpt::utils::CLoadableOptions
 		 {
 			 /** Initializer */
-			 TConfigParams (mrpt::utils::VerbosityLevel &parent_verbosity_level);
-			 void loadFromConfigFile(const mrpt::utils::CConfigFileBase &source,const std::string &section) MRPT_OVERRIDE; // See base docs
-			 void dumpToTextStream(mrpt::utils::CStream &out) const MRPT_OVERRIDE; // See base docs
+			TConfigParams (mrpt::utils::VerbosityLevel &parent_verbosity_level);
+			TConfigParams &operator=(const TConfigParams &other);  //Copy assignment
 
+			void loadFromConfigFile(const mrpt::utils::CConfigFileBase &source,const std::string &section) MRPT_OVERRIDE; // See base docs
+			void dumpToTextStream(mrpt::utils::CStream &out) const MRPT_OVERRIDE; // See base docs
 			/** (default:false) Match against the occupancy grid or the points map? The former is quicker but less precise. */
 			bool	matchAgainstTheGrid;
 

--- a/libs/slam/src/slam/CMetricMapBuilderICP.cpp
+++ b/libs/slam/src/slam/CMetricMapBuilderICP.cpp
@@ -65,6 +65,19 @@ CMetricMapBuilderICP::TConfigParams::TConfigParams(mrpt::utils::VerbosityLevel &
 {
 }
 
+CMetricMapBuilderICP::TConfigParams &CMetricMapBuilderICP::TConfigParams::operator=(const CMetricMapBuilderICP::TConfigParams &other){
+	matchAgainstTheGrid     = other.matchAgainstTheGrid;
+	insertionLinDistance    = other.insertionLinDistance;
+	insertionAngDistance    = other.insertionAngDistance;
+	localizationLinDistance = other.localizationLinDistance;
+	localizationAngDistance = other.localizationAngDistance;
+	minICPgoodnessToAccept  = other.minICPgoodnessToAccept;
+//	We can't copy a reference type
+//	verbosity_level         = other.verbosity_level;
+	mapInitializers         = other.mapInitializers;
+	return *this;
+}
+
 void  CMetricMapBuilderICP::TConfigParams::loadFromConfigFile(
 	const mrpt::utils::CConfigFileBase	&source,
 	const std::string		&section)

--- a/python/src/slam_bindings.cpp
+++ b/python/src/slam_bindings.cpp
@@ -413,7 +413,7 @@ void export_slam()
         ;
 
         // TConfigParams
-        class_<CMetricMapBuilderICP::TConfigParams, bases<CLoadableOptions> >("TConfigParams", init<>())
+        class_<CMetricMapBuilderICP::TConfigParams, bases<CLoadableOptions> >("TConfigParams", init<mrpt::utils::VerbosityLevel&>())
             .def_readwrite("matchAgainstTheGrid", &CMetricMapBuilderICP::TConfigParams::matchAgainstTheGrid)
             .def_readwrite("insertionLinDistance", &CMetricMapBuilderICP::TConfigParams::insertionLinDistance)
             .def_readwrite("insertionAngDistance", &CMetricMapBuilderICP::TConfigParams::insertionAngDistance)


### PR DESCRIPTION
@jlblancoc This isn't the most ideal fix because verbosity_level is a reference in TConfigParams. Perhaps verbosity_level could be a shared_pointer when we move to c++11, so that the copy assignment can do the intuitive thing.

I acknowledge to have: 
* Read the [`CONTRIBUTING`](https://github.com/MRPT/mrpt/blob/master/.github/CONTRIBUTING.md) page
* Updated [`docs/doxygen-pages/changelog.h`](https://github.com/MRPT/mrpt/blob/master/doc/doxygen-pages/changeLog_doc.h) to describe these changes (if applicable)
* Updated [`AUTHORS`](https://github.com/MRPT/mrpt/blob/master/AUTHORS) (if applicable)

(Notify: @MRPT/owners )
