### PR TITLE
PnP: Python bindings require python-numpy

### DIFF
--- a/packaging/debian/control.in
+++ b/packaging/debian/control.in
@@ -34,7 +34,8 @@ Build-Depends: debhelper (>= 9),
 	libopenni2-dev | perl,
 	gdb,
 	lib3ds-dev,
-	libsuitesparse-dev
+	libsuitesparse-dev,
+	python-numpy
 Standards-Version: 3.9.8
 Homepage: http://www.mrpt.org/
 


### PR DESCRIPTION
I acknowledge to have: 
* Read the [`CONTRIBUTING`](https://github.com/MRPT/mrpt/blob/master/.github/CONTRIBUTING.md) page
* Updated [`docs/doxygen-pages/changelog.h`](https://github.com/MRPT/mrpt/blob/master/doc/doxygen-pages/changeLog_doc.h) to describe these changes (if applicable)
* Updated [`AUTHORS`](https://github.com/MRPT/mrpt/blob/master/AUTHORS) (if applicable)

(Notify: @MRPT/owners )


https://launchpadlibrarian.net/281616406/buildlog_ubuntu-xenial-amd64.mrpt_1%3A1.5.0~snapshot201608271628-git-93617af-201608291811~ubuntu16.04.1_BUILDING.txt.gz