### PR TITLE
cmath contains std::abs for float types

### DIFF
--- a/libs/vision/src/pnp/rpnp.cpp
+++ b/libs/vision/src/pnp/rpnp.cpp
@@ -10,7 +10,7 @@
 #include "vision-precomp.h"   // Precompiled headers
 #include <iostream>
 #include <vector>
-#include <stdlib.h>
+#include <cmath>
 
 #include <mrpt/utils/types_math.h> // Eigen must be included first via MRPT to enable the plugin system
 #include <Eigen/Dense>


### PR DESCRIPTION
I acknowledge to have: 
* Read the [`CONTRIBUTING`](https://github.com/MRPT/mrpt/blob/master/.github/CONTRIBUTING.md) page
* Updated [`docs/doxygen-pages/changelog.h`](https://github.com/MRPT/mrpt/blob/master/doc/doxygen-pages/changeLog_doc.h) to describe these changes (if applicable)
* Updated [`AUTHORS`](https://github.com/MRPT/mrpt/blob/master/AUTHORS) (if applicable)

(Notify: @MRPT/owners )

This will be added to c++17, but we aren't there yet.