### PR TITLE
MRPT_INITIALIZER obsoletes do_nothing()

### DIFF
--- a/libs/detectors/src/CObjectDetection.cpp
+++ b/libs/detectors/src/CObjectDetection.cpp
@@ -23,9 +23,6 @@ using namespace mrpt::utils;
 
 void CObjectDetection::detectObjects(const CImage *img, vector_detectable_object &detected)
 {
-	//static const int dumm2 =
-	mrpt_detectors_class_reg.do_nothing(); // Avoid compiler removing this class in static linking
-
 	mrpt::obs::CObservationImage o;
 	o.timestamp = mrpt::system::now();
 	o.image.setFromImageReadOnly(*img);


### PR DESCRIPTION
I acknowledge to have: 
* Read the [`CONTRIBUTING`](https://github.com/MRPT/mrpt/blob/master/.github/CONTRIBUTING.md) page
* Updated [`docs/doxygen-pages/changelog.h`](https://github.com/MRPT/mrpt/blob/master/doc/doxygen-pages/changeLog_doc.h) to describe these changes (if applicable)
* Updated [`AUTHORS`](https://github.com/MRPT/mrpt/blob/master/AUTHORS) (if applicable)

(Notify: @MRPT/owners )

MRPT_INITIALIZER now prevents the compiler from removing unused global variables