### PR TITLE
Graphslam devel

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -33,14 +33,14 @@ The following list is roughly sorted in reverse cronological order.
 * Hunter (2016-) https://github.com/jolting
   - Add-ons to 2D range scan observations.
   - Port towards C++11 for MRPT 2.0
-  - Code clean ups. 
+  - Code clean ups.
   - Multiple bug fixes.
-  
+
 * Nikos Koukis, National Technical University of Athens, Greece (2016) - https://github.com/bergercookie
   - Support for executing graphSLAM in graphslam lib/ + Corresponding
   	graphslam-engine application
   - Initial version of MRPT logging module - COutputLogger
-  
+
 * Chandra Mangipudi, University of Minnesota (2016) - https://github.com/mangi020
   - The PnP module in mrpt::vision
 

--- a/apps/graphslam-engine/graphslam-engine_app.cpp
+++ b/apps/graphslam-engine/graphslam-engine_app.cpp
@@ -278,7 +278,7 @@ int main(int argc, char **argv)
 							rawlog_fname,
 							ground_truth_fname,
 							!disable_visuals.getValue());
-				graph_engine.parseRawlogFile();
+				graph_engine.execGraphSlam();
 			}
 			else if (system::strCmpI(edge_reg, "CLoopCloserERD")) { // CFixedIntervalsNRD - CICPCriteriaERD
 				// Initialize the CGraphSlamEngine class
@@ -294,7 +294,7 @@ int main(int argc, char **argv)
 							rawlog_fname,
 							ground_truth_fname,
 							!disable_visuals.getValue());
-				graph_engine.parseRawlogFile();
+				graph_engine.execGraphSlam();
 			}
 			else if (system::strCmpI(edge_reg, "CEmptyERD")) { // CFixedIntervalsNRD - CEmptyERD
 				// Initialize the CGraphSlamEngine class
@@ -310,7 +310,7 @@ int main(int argc, char **argv)
 							rawlog_fname,
 							ground_truth_fname,
 							!disable_visuals.getValue());
-				graph_engine.parseRawlogFile();
+				graph_engine.execGraphSlam();
 			}
 
 		}
@@ -329,7 +329,7 @@ int main(int argc, char **argv)
 							rawlog_fname,
 							ground_truth_fname,
 							!disable_visuals.getValue());
-				graph_engine.parseRawlogFile();
+				graph_engine.execGraphSlam();
 			}
 			else if (system::strCmpI(edge_reg, "CLoopCloserERD")) { // CFixedIntervalsNRD - CICPCriteriaERD
 				// Initialize the CGraphSlamEngine class
@@ -345,7 +345,7 @@ int main(int argc, char **argv)
 							rawlog_fname,
 							ground_truth_fname,
 							!disable_visuals.getValue());
-				graph_engine.parseRawlogFile();
+				graph_engine.execGraphSlam();
 			}
 			else if (system::strCmpI(edge_reg, "CEmptyERD")) { // CEmtpyNRD - CEmptyERD
 				// Initialize the CGraphSlamEngine class
@@ -361,7 +361,7 @@ int main(int argc, char **argv)
 							rawlog_fname,
 							ground_truth_fname,
 							!disable_visuals.getValue());
-				graph_engine.parseRawlogFile();
+				graph_engine.execGraphSlam();
 			}
 
 		}
@@ -380,7 +380,7 @@ int main(int argc, char **argv)
 							rawlog_fname,
 							ground_truth_fname,
 							!disable_visuals.getValue());
-				graph_engine.parseRawlogFile();
+				graph_engine.execGraphSlam();
 			}
 			else if (system::strCmpI(edge_reg, "CLoopCloserERD")) { // CFixedIntervalsNRD - CICPCriteriaERD
 				// Initialize the CGraphSlamEngine class
@@ -396,7 +396,7 @@ int main(int argc, char **argv)
 							rawlog_fname,
 							ground_truth_fname,
 							!disable_visuals.getValue());
-				graph_engine.parseRawlogFile();
+				graph_engine.execGraphSlam();
 			}
 			else if (system::strCmpI(edge_reg, "CEmptyERD")) { // CICPGooodnessNRD - CEmptyERD
 
@@ -413,7 +413,7 @@ int main(int argc, char **argv)
 							rawlog_fname,
 							ground_truth_fname,
 							!disable_visuals.getValue());
-				graph_engine.parseRawlogFile();
+				graph_engine.execGraphSlam();
 			}
 
 		}

--- a/libs/graphslam/include/mrpt/graphslam.h
+++ b/libs/graphslam/include/mrpt/graphslam.h
@@ -36,6 +36,11 @@
 // GraphSlamOptimizers
 #include "graphslam/CLevMarqGSO.h"
 
+// MeasurementProviders
+#include "graphslam/CMeasurementProvider.h"
+#include "graphslam/CRawlogMP.h"
+#include "graphslam/CRosTopicMP.h"
+
 // Graph SLAM Engine - Relevant headers
 #include "graphslam/CEdgeCounter.h"
 #include "graphslam/CWindowManager.h"

--- a/libs/graphslam/include/mrpt/graphslam/CEdgeCounter.h
+++ b/libs/graphslam/include/mrpt/graphslam/CEdgeCounter.h
@@ -20,7 +20,6 @@
 #include <string>
 #include <map>
 
-
 namespace mrpt { namespace graphslam {
 
 /**\brief Generic class for tracking the total number of edges for different

--- a/libs/graphslam/include/mrpt/graphslam/CFixedIntervalsNRD.h
+++ b/libs/graphslam/include/mrpt/graphslam/CFixedIntervalsNRD.h
@@ -119,8 +119,7 @@ class CFixedIntervalsNRD:
 						const mrpt::utils::CConfigFileBase &source,
 						const std::string &section);
 				void 	dumpToTextStream(mrpt::utils::CStream &out) const;
-				/**
-				 * Return a string with the configuration parameters
+				/**\brief Return a string with the configuration parameters
 				 */
 				void getAsString(std::string* params_out) const;
 				std::string getAsString() const;

--- a/libs/graphslam/include/mrpt/graphslam/CGraphSlamEngine.h
+++ b/libs/graphslam/include/mrpt/graphslam/CGraphSlamEngine.h
@@ -61,7 +61,6 @@
 #include "CRawlogMP.h"
 #include "CRosTopicMP.h"
 
-
 #include <cstdlib>
 #include <string>
 #include <sstream>
@@ -303,7 +302,7 @@ class CGraphSlamEngine : public mrpt::utils::COutputLogger {
 		 * Reads the dataset file and builds the graph. Method returns false if
 		 * user terminates execution (<em>Ctrl+c</em> is pressed) otherwise true.
 		 **/
-		bool parseRawlogFile();
+		bool execGraphSlam();
 		/**\brief Return a reference to the underlying GRAPH_t instance. */
 		const GRAPH_t& getGraph() const { return m_graph; }
 		/**\brief Return the filename of the used rawlog file.*/
@@ -428,7 +427,7 @@ class CGraphSlamEngine : public mrpt::utils::COutputLogger {
 		/** \name Update of Visuals
 		 * Methods used for updating various visualization features relevant to
 		 * the application at hand. If relevant to the application at hand update
-		 * is periodically scheduled inside the parseRawlogFile method
+		 * is periodically scheduled inside the execGraphSlam method
 		 */
 		/**\{*/
 		/**\brief In RGB-D TUM Datasets update the Range image displayed in a

--- a/libs/graphslam/include/mrpt/graphslam/CGraphSlamEngine.h
+++ b/libs/graphslam/include/mrpt/graphslam/CGraphSlamEngine.h
@@ -53,7 +53,14 @@
 #include <mrpt/utils/types_simple.h>
 #include <mrpt/utils/TColor.h>
 #include <mrpt/utils/CImage.h>
-//#include <mrpt/graphslam.h>
+#include <mrpt/utils/COutputLogger.h>
+
+#include "CEdgeCounter.h"
+
+#include "CMeasurementProvider.h"
+#include "CRawlogMP.h"
+#include "CRosTopicMP.h"
+
 
 #include <cstdlib>
 #include <string>
@@ -291,7 +298,7 @@ class CGraphSlamEngine : public mrpt::utils::COutputLogger {
 		 * \sa getParamsAsString
 		 */
 		void printParams() const;
-		/**\brief Main Class method responsible for reading the .rawlog file.
+		/**\brief Main class method responsible for reading the .rawlog file.
 		 *
 		 * Reads the dataset file and builds the graph. Method returns false if
 		 * user terminates execution (<em>Ctrl+c</em> is pressed) otherwise true.
@@ -537,6 +544,8 @@ class CGraphSlamEngine : public mrpt::utils::COutputLogger {
 		EDGE_REGISTRAR m_edge_registrar;
 		OPTIMIZER m_optimizer;
 		/**\}*/
+
+		mrpt::graphslam::measurement_providers::CMeasurementProvider* m_provider;
 
 		std::string	m_config_fname;
 		std::string	m_rawlog_fname;

--- a/libs/graphslam/include/mrpt/graphslam/CGraphSlamEngine_impl.h
+++ b/libs/graphslam/include/mrpt/graphslam/CGraphSlamEngine_impl.h
@@ -153,11 +153,13 @@ void CGraphSlamEngine<GRAPH_t, NODE_REGISTRAR, EDGE_REGISTRAR, OPTIMIZER>::initC
 	m_optimizer.setCriticalSectionPtr(&m_graph_section);
 
 	// Decide where to read the measurements from
-	if (!m_rawlog_fname.empty()) {
-			m_provider = new CRawlogMP();
-	}
-	else { // run in online mode
+	if (m_rawlog_fname.empty()) { // run in online mode
+		MRPT_LOG_INFO_STREAM << "Executing online graphSLAM";
 		m_provider = new CRosTopicMP();
+	}
+	else {
+		MRPT_LOG_INFO_STREAM << "Executing graphSLAM using rawlog files";
+		m_provider = new CRawlogMP();
 	}
 
 	// Calling of initialization-relevant functions
@@ -178,7 +180,7 @@ void CGraphSlamEngine<GRAPH_t, NODE_REGISTRAR, EDGE_REGISTRAR, OPTIMIZER>::initC
 	m_edge_registrar.setRawlogFname(m_rawlog_fname);
 	m_optimizer.setRawlogFname(m_rawlog_fname);
 
-	if (!(m_provider->run_online)) {
+	if (!(m_provider->providerRunsOnline())) {
 		dynamic_cast<CRawlogMP*>(m_provider)->setRawlogFname(m_rawlog_fname);
 	}
 

--- a/libs/graphslam/include/mrpt/graphslam/CGraphSlamEngine_impl.h
+++ b/libs/graphslam/include/mrpt/graphslam/CGraphSlamEngine_impl.h
@@ -627,22 +627,24 @@ bool CGraphSlamEngine<GRAPH_t, NODE_REGISTRAR, EDGE_REGISTRAR, OPTIMIZER>::execG
 
 		// ensure that the GT is visualized at the same rate as the SLAM procedure
 		// handle RGBD-TUM datasets manually. Advance the GT index accordingly
-		if (mrpt::system::strCmpI(m_GT_file_format, "rgbd_tum")) { // 1/loop
+		if (m_use_GT) {
+			if (mrpt::system::strCmpI(m_GT_file_format, "rgbd_tum")) { // 1/loop
 				this->updateGTVisualization(); // I have already taken care of the step
 				m_GT_poses_index += m_GT_poses_step;
-		}
-		else if (mrpt::system::strCmpI(m_GT_file_format, "navsimul")) {
-			if (m_observation_only_rawlog) { // 1/2loops
-				if (curr_rawlog_entry % 2 == 0) {
-					this->updateGTVisualization();
-					m_GT_poses_index += m_GT_poses_step;
-					MRPT_LOG_ERROR_STREAM << "observation_only_rawlog..." << std::endl;
-				}
 			}
-			else { // 1/loop
-				// get both action and observation at a single step - same rate as GT
-				this->updateGTVisualization(); 
-				m_GT_poses_index += m_GT_poses_step;
+			else if (mrpt::system::strCmpI(m_GT_file_format, "navsimul")) {
+				if (m_observation_only_rawlog) { // 1/2loops
+					if (curr_rawlog_entry % 2 == 0) {
+						this->updateGTVisualization();
+						m_GT_poses_index += m_GT_poses_step;
+						MRPT_LOG_ERROR_STREAM << "observation_only_rawlog..." << std::endl;
+					}
+				}
+				else { // 1/loop
+					// get both action and observation at a single step - same rate as GT
+					this->updateGTVisualization(); 
+					m_GT_poses_index += m_GT_poses_step;
+				}
 			}
 		}
 
@@ -836,7 +838,7 @@ void CGraphSlamEngine<GRAPH_t, NODE_REGISTRAR, EDGE_REGISTRAR, OPTIMIZER>::getPa
 
 	stringstream ss_out;
 
-	ss_out << "\n------------[ Graphslamm_engine Problem Parameters ]------------"
+	ss_out << "\n------------[ Graphslam_engine Problem Parameters ]------------"
 		<< std::endl;
 	ss_out << "Config filename                 = "
 		<< m_config_fname << std::endl;

--- a/libs/graphslam/include/mrpt/graphslam/CGraphSlamEngine_impl.h
+++ b/libs/graphslam/include/mrpt/graphslam/CGraphSlamEngine_impl.h
@@ -2155,12 +2155,16 @@ void CGraphSlamEngine<GRAPH_t, NODE_REGISTRAR, EDGE_REGISTRAR, OPTIMIZER>::compu
 	m_curr_deformation_energy = 0;
 
 	// first element of map
-	std::map<mrpt::utils::TNodeID, size_t>::const_iterator start_it =
-		std::next(m_nodeID_to_gt_indices.begin(), 1);
+	//std::map<mrpt::utils::TNodeID, size_t>::const_iterator start_it =
+		//std::next(m_nodeID_to_gt_indices.begin(), 1);
+	std::map<mrpt::utils::TNodeID, size_t>::const_iterator start_it = m_nodeID_to_gt_indices.begin();
+	start_it++;
 
 
 	// fetch the first node, gt positions separately
-	std::map<mrpt::utils::TNodeID, size_t>::const_iterator prev_it = std::prev(start_it, 1);
+	//std::map<mrpt::utils::TNodeID, size_t>::const_iterator prev_it = std::prev(start_it, 1);
+	std::map<mrpt::utils::TNodeID, size_t>::const_iterator prev_it = start_it;
+	prev_it--;
 	pose_t prev_node_pos = m_graph.nodes[prev_it->first];
 	pose_t prev_gt_pos = m_GT_poses[prev_it->second];
 

--- a/libs/graphslam/include/mrpt/graphslam/CICPCriteriaNRD.h
+++ b/libs/graphslam/include/mrpt/graphslam/CICPCriteriaNRD.h
@@ -251,8 +251,8 @@ class CICPCriteriaNRD:
 		mrpt::utils::CTimeLogger m_time_logger; /**<Time logger instance */
 
 		// criteria for adding new a new node
-		bool m_use_angle_difference_node_reg = true;
-		bool m_use_distance_node_reg = true;
+		bool m_use_angle_difference_node_reg;
+		bool m_use_distance_node_reg;
 
 		size_t m_times_used_ICP; /**<How many times we used the ICP Edge */
 		size_t m_times_used_odom; /**<How many times we used the Odometry Edge instead of the ICP edge */

--- a/libs/graphslam/include/mrpt/graphslam/CICPCriteriaNRD_impl.h
+++ b/libs/graphslam/include/mrpt/graphslam/CICPCriteriaNRD_impl.h
@@ -31,6 +31,10 @@ void CICPCriteriaNRD<GRAPH_t>::initCICPCriteriaNRD() {
 	m_first_time_call3D = true;
 	m_is_using_3DScan = false;
 
+	m_use_angle_difference_node_reg = true;
+	m_use_distance_node_reg = true;
+
+
 	m_graph = NULL;
 
 	// Current node registration decider *decides* how many nodes are there

--- a/libs/graphslam/include/mrpt/graphslam/CLoopCloserERD_impl.h
+++ b/libs/graphslam/include/mrpt/graphslam/CLoopCloserERD_impl.h
@@ -759,7 +759,7 @@ void CLoopCloserERD<GRAPH_t>::execDijkstraProjection(
 	m_node_optimal_paths.clear();
 
 	// get the neighbors of each node
-	std::map<TNodeID, std::set<TNodeID>>  neighbors_of;
+	std::map<TNodeID, std::set<TNodeID> >  neighbors_of;
 	m_graph->getAdjacencyMatrix(neighbors_of);
 
 	// initialize a pool of TPaths - draw the minimum-uncertainty path during
@@ -790,15 +790,22 @@ void CLoopCloserERD<GRAPH_t>::execDijkstraProjection(
 	//int iters = 0;
 	//// TODO Remove these - <<<<<<<<<<<<<<<<<<<<< vvvUNCOMMENT BELOW AS WELLvvv
 
-	// for all unvisited nodes
-	while ( std::any_of(visited_nodes.begin(), visited_nodes.end(),
-			[](bool b) {return !b;} ) ) { // if there is at least one false..
+	while (true) {
+
+		// if there is at least one false, exit loop
+		for (std::vector<bool>::const_iterator it = visited_nodes.begin();
+				it != visited_nodes.end(); ++it) {
+			if (! *it) {
+				break;
+			}
+		}
 
 		// if an ending nodeID has been specified, end the method when the path to
 		// it is found.
 		if (ending_node != INVALID_NODEID) {
 			if (visited_nodes.at(ending_node)) {
-				this->logFmt(mrpt::utils::LVL_DEBUG, "----------- Done with Dijkstra Projection... ----------");
+				this->logFmt(mrpt::utils::LVL_DEBUG,
+						"----------- Done with Dijkstra Projection... ----------");
 				m_time_logger.leave("Dijkstra Projection");
 				return;
 			}

--- a/libs/graphslam/include/mrpt/graphslam/CMeasurementProvider.h
+++ b/libs/graphslam/include/mrpt/graphslam/CMeasurementProvider.h
@@ -1,0 +1,102 @@
+/* +---------------------------------------------------------------------------+
+	 |                     Mobile Robot Programming Toolkit (MRPT)               |
+	 |                          http://www.mrpt.org/                             |
+	 |                                                                           |
+	 | Copyright (c) 2005-2016, Individual contributors, see AUTHORS file        |
+	 | See: http://www.mrpt.org/Authors - All rights reserved.                   |
+	 | Released under BSD License. See details in http://www.mrpt.org/License    |
+	 +---------------------------------------------------------------------------+ */
+
+#ifndef CMEASUREMENTPROVIDER_H
+#define CMEASUREMENTPROVIDER_H
+
+#include <mrpt/obs/CActionCollection.h>
+#include <mrpt/obs/CObservationComment.h>
+#include <mrpt/obs/CSensoryFrame.h>
+#include <mrpt/utils/COutputLogger.h>
+
+#include <string>
+
+namespace mrpt { namespace graphslam { namespace measurement_providers {
+
+/**
+ * \brief Formats that can be used by the specific implementations of the CMeasurementProvider
+ * interface
+ */
+enum RawlogFormat { 
+	ACTION_OBSERVATIONS=1,
+	OBSERVATIONS_ONLY,
+	UNDEFINED
+};
+
+/**\brief Inteface for implementing measurement provider classes that are to
+ * be used when running graph-slam. For an example of inheriting from
+ * this class see CRawlogMP.
+ *
+ * \note As a naming convention, all the implemented measurement providers
+ * are suffixed with the MP acronym.
+ *
+ * \ingroup mrpt_graphslam_grp
+ */
+class CMeasurementProvider : public mrpt::utils::COutputLogger {
+public:
+	// 
+	// public function definitions
+	//
+
+	CMeasurementProvider() {
+
+		// just some default values - to be changed in the interface
+		// implementations
+
+		this->init();
+	}
+	virtual ~CMeasurementProvider() { };
+
+	virtual void init() {
+		m_class_name = "CMeasurementProvider";
+		this->setLoggerName(m_class_name);
+
+		run_online = false;
+		provider_ready = false;
+		rawlog_format = UNDEFINED;
+
+
+	};
+
+	/**\brief Main method that can be used to query the provider for the next
+	 * measurement(s).
+	 *
+	 * \return False if there is no other measurement to be read, otherwise True
+	 */
+	virtual bool getActionObservationPairOrObservation(
+			mrpt::obs::CActionCollectionPtr& action,
+			mrpt::obs::CSensoryFramePtr& observations,
+			mrpt::obs::CObservationPtr& observation,
+			size_t& rawlog_entry )=0;
+
+	//
+	// public variables
+	//
+	/**\brief Indicates whether the provider is ready to be querried for
+	 * measurements
+	 */
+	bool provider_ready;
+	/**\brief Variable indicating whether the current provider class is used in
+	 * an online fashion.
+	 */
+	bool run_online;
+
+	/**\brief Format that is used by the current provider class.
+	 */
+	RawlogFormat rawlog_format;
+
+private:
+
+	std::string m_class_name;
+
+};
+
+} } } // end of namespaces
+
+#endif /* end of include guard: CMEASUREMENTPROVIDER_H */

--- a/libs/graphslam/include/mrpt/graphslam/CMeasurementProvider.h
+++ b/libs/graphslam/include/mrpt/graphslam/CMeasurementProvider.h
@@ -23,6 +23,7 @@ namespace mrpt { namespace graphslam { namespace measurement_providers {
  * \brief Formats that can be used by the specific implementations of the CMeasurementProvider
  * interface
  */
+	// TODO - do I use it?
 enum RawlogFormat { 
 	ACTION_OBSERVATIONS=1,
 	OBSERVATIONS_ONLY,
@@ -57,11 +58,6 @@ public:
 		m_class_name = "CMeasurementProvider";
 		this->setLoggerName(m_class_name);
 
-		run_online = false;
-		provider_ready = false;
-		rawlog_format = UNDEFINED;
-
-
 	};
 
 	/**\brief Main method that can be used to query the provider for the next
@@ -90,15 +86,14 @@ public:
 	/**\brief Indicates whether the provider is ready to be querried for
 	 * measurements
 	 */
-	bool provider_ready;
+	virtual bool providerIsReady()=0;
 	/**\brief Variable indicating whether the current provider class is used in
 	 * an online fashion.
 	 */
-	bool run_online;
+	virtual bool providerRunsOnline()=0;
 
 	/**\brief Format that is used by the current provider class.
 	 */
-	RawlogFormat rawlog_format;
 
 private:
 

--- a/libs/graphslam/include/mrpt/graphslam/CMeasurementProvider.h
+++ b/libs/graphslam/include/mrpt/graphslam/CMeasurementProvider.h
@@ -51,7 +51,7 @@ public:
 
 		this->init();
 	}
-	virtual ~CMeasurementProvider() { };
+	virtual ~CMeasurementProvider() { }
 
 	virtual void init() {
 		m_class_name = "CMeasurementProvider";
@@ -75,9 +75,18 @@ public:
 			mrpt::obs::CObservationPtr& observation,
 			size_t& rawlog_entry )=0;
 
+	/**\brief Load the parameters related to the current class from an external
+	 * .ini file.
+	 */
+	virtual void loadParams(const std::string& source_fname) {}
+	/**\brief Print the class parameters to the console - handy for debugging
+	 */
+	virtual void printParams() const { }
+
 	//
 	// public variables
 	//
+
 	/**\brief Indicates whether the provider is ready to be querried for
 	 * measurements
 	 */

--- a/libs/graphslam/include/mrpt/graphslam/CRawlogMP.h
+++ b/libs/graphslam/include/mrpt/graphslam/CRawlogMP.h
@@ -39,7 +39,14 @@ public:
 			size_t& rawlog_entry);
 	void setRawlogFname(std::string rawlog_fname);
 
+	/** Getter method in sake of polymorphic behavior. */
+	bool providerIsReady();
+	/** Getter method in sake of polymorphic behavior. */
+	bool providerRunsOnline();
+
 private:
+	bool run_online;
+	bool provider_ready;
 
 	std::string m_class_name;
 	std::string m_rawlog_fname;

--- a/libs/graphslam/include/mrpt/graphslam/CRawlogMP.h
+++ b/libs/graphslam/include/mrpt/graphslam/CRawlogMP.h
@@ -1,0 +1,53 @@
+/* +---------------------------------------------------------------------------+
+	 |                     Mobile Robot Programming Toolkit (MRPT)               |
+	 |                          http://www.mrpt.org/                             |
+	 |                                                                           |
+	 | Copyright (c) 2005-2016, Individual contributors, see AUTHORS file        |
+	 | See: http://www.mrpt.org/Authors - All rights reserved.                   |
+	 | Released under BSD License. See details in http://www.mrpt.org/License    |
+	 +---------------------------------------------------------------------------+ */
+
+#ifndef CRAWLOGMP_H
+#define CRAWLOGMP_H
+
+#include "link_pragmas.h"
+#include "CMeasurementProvider.h"
+
+#include <mrpt/obs/CRawlog.h>
+#include <mrpt/system/filesystem.h>
+#include <mrpt/system/datetime.h>
+#include <mrpt/system/os.h>
+#include <mrpt/utils/mrpt_macros.h>
+#include <mrpt/utils/CFileGZInputStream.h>
+
+namespace mrpt { namespace graphslam { namespace measurement_providers {
+
+class GRAPHSLAM_IMPEXP CRawlogMP : public CMeasurementProvider
+{
+public:
+
+	typedef CMeasurementProvider super;
+
+	CRawlogMP();
+	~CRawlogMP();
+	void init();
+
+	bool getActionObservationPairOrObservation(
+			mrpt::obs::CActionCollectionPtr& action,
+			mrpt::obs::CSensoryFramePtr& observations,
+			mrpt::obs::CObservationPtr& observation,
+			size_t& rawlog_entry);
+	void setRawlogFname(std::string rawlog_fname);
+
+private:
+
+	std::string m_class_name;
+	std::string m_rawlog_fname;
+	mrpt::utils::CFileGZInputStream m_rawlog_file;
+};
+ 
+
+} } } // end of namespaces
+
+
+#endif /* end of include guard: CRAWLOGMP_H */

--- a/libs/graphslam/include/mrpt/graphslam/CRosTopicMP.h
+++ b/libs/graphslam/include/mrpt/graphslam/CRosTopicMP.h
@@ -1,0 +1,112 @@
+/* +---------------------------------------------------------------------------+
+	 |                     Mobile Robot Programming Toolkit (MRPT)               |
+	 |                          http://www.mrpt.org/                             |
+	 |                                                                           |
+	 | Copyright (c) 2005-2016, Individual contributors, see AUTHORS file        |
+	 | See: http://www.mrpt.org/Authors - All rights reserved.                   |
+	 | Released under BSD License. See details in http://www.mrpt.org/License    |
+	 +---------------------------------------------------------------------------+ */
+
+#ifndef CROSTOPICMP_H
+#define CROSTOPICMP_H
+
+#include "link_pragmas.h"
+#include "CMeasurementProvider.h"
+
+
+#include <mrpt/system/filesystem.h>
+#include <mrpt/system/datetime.h>
+#include <mrpt/system/os.h>
+#include <mrpt/utils/CLoadableOptions.h>
+#include <mrpt/utils/CConfigFile.h>
+#include <mrpt/utils/mrpt_macros.h>
+#include <mrpt/utils/CStream.h>
+#include <mrpt/utils/CMessage.h>
+#include <mrpt/utils/CServerTCPSocket.h>
+#include <mrpt/utils/CClientTCPSocket.h>
+
+#include <string>
+#include <sstream>
+#include <map>
+
+namespace mrpt { namespace graphslam { namespace measurement_providers {
+
+class GRAPHSLAM_IMPEXP CRosTopicMP : public CMeasurementProvider
+{
+public:
+
+	typedef CMeasurementProvider super;
+	typedef CRosTopicMP provider_t;
+
+	CRosTopicMP();
+	~CRosTopicMP();
+	void init();
+
+	bool getActionObservationPairOrObservation(
+			mrpt::obs::CActionCollectionPtr& action,
+			mrpt::obs::CSensoryFramePtr& observations,
+			mrpt::obs::CObservationPtr& observation,
+			size_t& rawlog_entry);
+
+	void loadParams(const std::string& source_fname);
+	void printParams() const;
+	
+	bool run_online;
+	bool provider_ready;
+
+private:
+	std::string m_class_name;
+	std::string m_ini_section_name;
+
+	mrpt::utils::CClientTCPSocket* client;
+
+	/** Given a client object, initialize a connection to the remote part
+	 * based on the parameters of the TClientParams.
+	 */
+	void initClient(mrpt::utils::CClientTCPSocket* cl);
+
+	/**\brief Parameters structure for managing the relevant to the decider
+	 * variables in a compact manner
+	 */
+	struct TClientParams: public mrpt::utils::CLoadableOptions {
+		public:
+			TClientParams(provider_t& p);
+			~TClientParams();
+
+			void loadFromConfigFile(
+					const mrpt::utils::CConfigFileBase &source,
+					const std::string &section);
+			void dumpToTextStream(mrpt::utils::CStream &out) const;
+			/**\brief Return a string with the configuration parameters
+			 */
+			void getAsString(std::string* params_out) const;
+			std::string getAsString() const;
+			
+
+			/**\brief Reference to the outer provider class.
+			 *
+			 * Handy for using its logging functions
+			 */
+			provider_t& provider;
+
+			// TCP communication parameters
+			int port_no;
+			std::string server_addr;
+			int client_timeout_ms;
+
+
+			/**\brief Types indicating the content of the MRPT class instance that
+			 * is contained in the message
+			 */
+			std::map<std::string, unsigned int> msg_types;
+			
+
+	} client_params;
+
+
+};
+
+
+} } } // end of namespaces
+
+#endif /* end of include guard: CROSTOPICMP_H */

--- a/libs/graphslam/include/mrpt/graphslam/CRosTopicMP.h
+++ b/libs/graphslam/include/mrpt/graphslam/CRosTopicMP.h
@@ -15,6 +15,7 @@
 
 
 #include <mrpt/system/filesystem.h>
+#include <mrpt/system/threads.h>
 #include <mrpt/system/datetime.h>
 #include <mrpt/system/os.h>
 #include <mrpt/utils/CLoadableOptions.h>
@@ -24,6 +25,8 @@
 #include <mrpt/utils/CMessage.h>
 #include <mrpt/utils/CServerTCPSocket.h>
 #include <mrpt/utils/CClientTCPSocket.h>
+#include <mrpt/obs/CObservation.h>
+#include <mrpt/obs/CObservation2DRangeScan.h>
 
 #include <string>
 #include <sstream>
@@ -62,17 +65,17 @@ private:
 	bool run_online;
 	bool provider_ready;
 
-	mrpt::utils::CClientTCPSocket* client;
+	mrpt::utils::CClientTCPSocket* m_client;
 
 	/** Given a client object, initialize a connection to the remote part
 	 * based on the parameters of the TClientParams.
 	 */
 	void initClient(mrpt::utils::CClientTCPSocket* cl);
 
-	/**\brief Parameters structure for managing the relevant to the decider
+	/**\brief Parameters structure for managing the relevant to the client
 	 * variables in a compact manner
 	 */
-	struct TClientParams: public mrpt::utils::CLoadableOptions {
+	struct GRAPHSLAM_IMPEXP TClientParams: public mrpt::utils::CLoadableOptions {
 		public:
 			TClientParams(provider_t& p);
 			~TClientParams();
@@ -102,7 +105,13 @@ private:
 			/**\brief Types indicating the content of the MRPT class instance that
 			 * is contained in the message
 			 */
+			// TODO - have the exit codes defined in the .ini file
 			std::map<std::string, unsigned int> msg_types;
+
+			/**\brief Indicates whether client and server have communicated any valid
+			 * data until now.
+			 */
+			bool has_transmitted_valid_data;
 			
 
 	} client_params;

--- a/libs/graphslam/include/mrpt/graphslam/CRosTopicMP.h
+++ b/libs/graphslam/include/mrpt/graphslam/CRosTopicMP.h
@@ -50,13 +50,17 @@ public:
 
 	void loadParams(const std::string& source_fname);
 	void printParams() const;
-	
-	bool run_online;
-	bool provider_ready;
 
+	/** Getter method in sake of polymorphic behavior. */
+	bool providerIsReady();
+	/** Getter method in sake of polymorphic behavior. */
+	bool providerRunsOnline();
+	
 private:
 	std::string m_class_name;
 	std::string m_ini_section_name;
+	bool run_online;
+	bool provider_ready;
 
 	mrpt::utils::CClientTCPSocket* client;
 
@@ -90,7 +94,7 @@ private:
 			provider_t& provider;
 
 			// TCP communication parameters
-			int port_no;
+			int server_port_no;
 			std::string server_addr;
 			int client_timeout_ms;
 

--- a/libs/graphslam/src/CEdgeCounter.cpp
+++ b/libs/graphslam/src/CEdgeCounter.cpp
@@ -8,7 +8,6 @@
    +---------------------------------------------------------------------------+ */
 
 #include "graphslam-precomp.h"  // Precompiled headers
-
 #include <mrpt/graphslam/CEdgeCounter.h>
 
 namespace mrpt { namespace graphslam {

--- a/libs/graphslam/src/CRawlogMP.cpp
+++ b/libs/graphslam/src/CRawlogMP.cpp
@@ -1,0 +1,66 @@
+#include "graphslam-precomp.h"  // Precompiled headers
+#include <mrpt/graphslam/CRawlogMP.h>
+
+namespace mrpt { namespace graphslam { namespace measurement_providers {
+
+CRawlogMP::CRawlogMP() {
+	this->init();
+}
+
+CRawlogMP::~CRawlogMP() { 
+	MRPT_LOG_DEBUG_STREAM << "In class Destructor";
+
+	if (m_rawlog_file.fileOpenCorrectly()) {
+		MRPT_LOG_DEBUG_STREAM << "Closing rawlog file: " << m_rawlog_fname;
+		m_rawlog_file.close();
+	}
+
+}
+
+void CRawlogMP::init() {
+	// configure the current provider
+	m_class_name = "CRawlogMP";
+	this->setLoggerName(m_class_name);
+	rawlog_format = UNDEFINED; // It depends on the format of the rawlog file to be used
+
+	run_online = false;
+	provider_ready = false;
+}
+
+bool CRawlogMP::getActionObservationPairOrObservation(
+		mrpt::obs::CActionCollectionPtr& action,
+		mrpt::obs::CSensoryFramePtr& observations,
+		mrpt::obs::CObservationPtr& observation,
+		size_t& rawlog_entry ) {
+	using namespace mrpt::obs;
+
+	ASSERTMSG_(provider_ready,"getActionObservationPairOrObservation was called even though provider is not ready yet.");
+
+	// just use the corresponding CRawlog method
+	bool success = CRawlog::getActionObservationPairOrObservation(
+			m_rawlog_file,
+			action,
+			observations,
+			observation,
+			rawlog_entry );
+
+	return success;
+}
+
+void CRawlogMP::setRawlogFname(std::string rawlog_fname) {
+	m_rawlog_fname = rawlog_fname;
+	ASSERTMSG_(mrpt::system::fileExists(m_rawlog_fname),
+			format("\nRawlog file: %s was not found\n", m_rawlog_fname.c_str() ));
+
+	bool did_open = m_rawlog_file.open(rawlog_fname);
+	ASSERTMSG_(did_open,
+			format("Rawlog file %s could not be opened", m_rawlog_fname.c_str() ));
+
+	// initial setup is now complete...
+	MRPT_LOG_DEBUG_STREAM << "Successfully read the rawlog file: " << m_rawlog_fname;
+	provider_ready = true;
+}
+
+
+} } } // end of namespaces
+

--- a/libs/graphslam/src/CRawlogMP.cpp
+++ b/libs/graphslam/src/CRawlogMP.cpp
@@ -21,7 +21,6 @@ void CRawlogMP::init() {
 	// configure the current provider
 	m_class_name = "CRawlogMP";
 	this->setLoggerName(m_class_name);
-	rawlog_format = UNDEFINED; // It depends on the format of the rawlog file to be used
 
 	run_online = false;
 	provider_ready = false;
@@ -61,6 +60,12 @@ void CRawlogMP::setRawlogFname(std::string rawlog_fname) {
 	provider_ready = true;
 }
 
+bool CRawlogMP::providerIsReady() {
+	return provider_ready;
+}
+bool CRawlogMP::providerRunsOnline() {
+	return run_online;
+}
 
 } } } // end of namespaces
 

--- a/libs/graphslam/src/CRosTopicMP.cpp
+++ b/libs/graphslam/src/CRosTopicMP.cpp
@@ -1,0 +1,207 @@
+/* +---------------------------------------------------------------------------+
+	 |                     Mobile Robot Programming Toolkit (MRPT)               |
+	 |                          http://www.mrpt.org/                             |
+	 |                                                                           |
+	 | Copyright (c) 2005-2016, Individual contributors, see AUTHORS file        |
+	 | See: http://www.mrpt.org/Authors - All rights reserved.                   |
+	 | Released under BSD License. See details in http://www.mrpt.org/License    |
+	 +---------------------------------------------------------------------------+ */
+
+#include "graphslam-precomp.h"  // Precompiled headers
+#include <mrpt/graphslam/CRosTopicMP.h>
+
+namespace mrpt { namespace graphslam { namespace measurement_providers {
+
+CRosTopicMP::CRosTopicMP():
+	client_params(*this) {
+	this->init();
+}
+
+CRosTopicMP::~CRosTopicMP() { 
+	MRPT_LOG_DEBUG_STREAM << "In class Destructor";
+
+	MRPT_LOG_DEBUG_STREAM << "Deleting client socket instance.";
+	delete client;
+
+}
+
+void CRosTopicMP::init() {
+	// configure the current provider
+	m_class_name = "CRosTopicMP";
+	m_ini_section_name = "CMeraurementProviderParameters";
+	this->setLoggerName(m_class_name);
+	rawlog_format = ACTION_OBSERVATIONS;
+	run_online = true;
+	provider_ready = false;
+
+	client = NULL;
+}
+
+bool CRosTopicMP::getActionObservationPairOrObservation(
+		mrpt::obs::CActionCollectionPtr& action,
+		mrpt::obs::CSensoryFramePtr& observations,
+		mrpt::obs::CObservationPtr& observation,
+		size_t& rawlog_entry ) {
+	using namespace std;
+	using namespace mrpt::obs;
+	using namespace mrpt::utils;
+
+	ASSERTMSG_(provider_ready, "getActionObservationPairOrObservation was called even though provider is not ready yet.");
+
+	//is there any data available - if so return it, otherwise block and wait
+	// TODO - maybe inform of the user if it takes too long to return from this
+	// --> requires multithreading
+
+	// Ask the server of data
+	CMessage msg;
+	bool did_receive = client->receiveMessage(msg,
+			/*timeoutStart_ms =*/ 2000,
+			/*timeoutBetween_ms =*/ 2000 );
+	ASSERTMSG_(did_receive, "\nCould not successfully receive message from server! Exiting\n");
+
+	stringstream ss("");
+	ss <<  "Received message: Type: " << msg.type
+		<< " | Length: " << msg.content.size();
+	MRPT_LOG_DEBUG_STREAM << ss.str();
+
+	// discard anything that might be in the rawlog
+	action.clear_unique();
+	observations.clear_unique();
+	observation.clear_unique();
+
+	bool success;
+	if (msg.type == client_params.msg_types["FORMAT 1"]) {
+		// in case of format #1 I need two objects:
+		// - CActionCollection
+		// - CSensoryFrame
+
+		// TODO
+		THROW_EXCEPTION("FORMAT 1 (action-observations) is not implemented yet.");
+
+		//msg.deserializeIntoExistingObject(action.pointer());
+	}
+	else if (msg.type == client_params.msg_types["FORMAT 2"]) {
+		msg.deserializeIntoExistingObject(observation.pointer());
+		success=true;
+	}
+	else if (msg.type == client_params.msg_types["EXIT"]) {
+		success = false;
+	}
+	else {
+		THROW_EXCEPTION(mrpt::format("%s: Received measurement was not understood.", m_class_name.c_str()));
+	}
+
+	return success;
+}
+
+void CRosTopicMP::printParams() const {
+	MRPT_START;
+
+	// TODO - implement this.
+
+	client_params.dumpToConsole();
+
+	MRPT_END;
+}
+void CRosTopicMP::loadParams(const std::string& source_fname) {
+	MRPT_START;
+	using namespace mrpt::utils;
+
+	client_params.loadFromConfigFileName(source_fname, m_ini_section_name);
+
+	// set the logging level if given by the user
+	CConfigFile source(source_fname);
+	// Minimum verbosity level of the logger
+	int min_verbosity_level = source.read_int(
+			m_ini_section_name,
+			"class_verbosity",
+			1, false);
+	this->setMinLoggingLevel(VerbosityLevel(min_verbosity_level));
+	this->logStr(LVL_DEBUG, "Successfully loaded parameters.");
+
+	// initialize the client - connect to remote part...
+	this->initClient(client);
+
+	provider_ready = true;
+	MRPT_END;
+}
+
+void CRosTopicMP::initClient(mrpt::utils::CClientTCPSocket* cl) {
+	using namespace std;
+
+	stringstream msg_ss;
+
+	msg_ss << "Connecting to server side...\n";
+	msg_ss << client_params.getAsString();
+	MRPT_LOG_INFO_STREAM << msg_ss;
+
+	client = new mrpt::utils::CClientTCPSocket();
+	client->connect(
+			client_params.server_addr,
+			client_params.port_no,
+			client_params.client_timeout_ms);
+
+	MRPT_LOG_INFO_STREAM << "TCP Socket was successfully established." << endl;
+}
+
+// TClientParams
+////////////////////////////////////////////////////////////////////////////////
+
+CRosTopicMP::TClientParams::TClientParams(provider_t& p):
+	provider(p)
+{
+	MRPT_START;
+
+	msg_types["FORMAT 1"] = 1; /**< Transmit data in the 1st rawlog MRPT format */
+	msg_types["FORMAT 2"] = 2; /**< Transmit data in the 2nd rawlog MRPT format */
+	msg_types["EXIT"] = 99; /**< Code is returned when no more data is to be transmitted */
+
+
+	MRPT_END;
+}
+
+CRosTopicMP::TClientParams::~TClientParams() { }
+
+void CRosTopicMP::TClientParams::dumpToTextStream(
+		mrpt::utils::CStream &out) const {
+	MRPT_START;
+
+	out.printf("%s", this->getAsString().c_str());
+
+	MRPT_END;
+}
+void CRosTopicMP::TClientParams::loadFromConfigFile(
+		const mrpt::utils::CConfigFileBase &source,
+		const std::string &section) {
+	MRPT_START;
+	using namespace mrpt::utils;
+
+	port_no = source.read_int(section           , "tcp_port_no"           , 68000       , false);
+	server_addr = source.read_string(section    , "tcp_server_addr"       , "127.0.0.1" , false);
+	client_timeout_ms = source.read_int(section , "tcp_client_timeout_ms" , 10000       , false);
+
+	MRPT_END;
+}
+
+void CRosTopicMP::TClientParams::getAsString(std::string* params_out) const {
+	using namespace std;
+
+	stringstream ss("");
+	ss << "------------------[ CRosTopicMP ]------------------\n";
+	ss << "Port No.                           : " << port_no << endl;
+	ss << "Server IP Address                  : " << server_addr.c_str() << endl;
+	ss << "Client Time to wait for connection : " << client_timeout_ms << endl;
+
+	*params_out = ss.str();
+}
+
+std::string CRosTopicMP::TClientParams::getAsString() const {
+	std::string str;
+	this->getAsString(&str);
+	return str;
+}
+
+} } } // end of namespaces
+
+
+

--- a/libs/graphslam/src/CRosTopicMP.cpp
+++ b/libs/graphslam/src/CRosTopicMP.cpp
@@ -26,15 +26,18 @@ CRosTopicMP::~CRosTopicMP() {
 }
 
 void CRosTopicMP::init() {
+	MRPT_START;
+
 	// configure the current provider
 	m_class_name = "CRosTopicMP";
-	m_ini_section_name = "CMeraurementProviderParameters";
+	m_ini_section_name = "CMeasurementProviderParameters";
 	this->setLoggerName(m_class_name);
-	rawlog_format = ACTION_OBSERVATIONS;
 	run_online = true;
 	provider_ready = false;
 
 	client = NULL;
+
+	MRPT_END;
 }
 
 bool CRosTopicMP::getActionObservationPairOrObservation(
@@ -42,6 +45,8 @@ bool CRosTopicMP::getActionObservationPairOrObservation(
 		mrpt::obs::CSensoryFramePtr& observations,
 		mrpt::obs::CObservationPtr& observation,
 		size_t& rawlog_entry ) {
+	MRPT_START;
+
 	using namespace std;
 	using namespace mrpt::obs;
 	using namespace mrpt::utils;
@@ -92,6 +97,15 @@ bool CRosTopicMP::getActionObservationPairOrObservation(
 	}
 
 	return success;
+
+	MRPT_END;
+}
+
+bool CRosTopicMP::providerIsReady() {
+	return provider_ready;
+}
+bool CRosTopicMP::providerRunsOnline() {
+	return run_online;
 }
 
 void CRosTopicMP::printParams() const {
@@ -127,6 +141,7 @@ void CRosTopicMP::loadParams(const std::string& source_fname) {
 }
 
 void CRosTopicMP::initClient(mrpt::utils::CClientTCPSocket* cl) {
+	MRPT_START;
 	using namespace std;
 
 	stringstream msg_ss;
@@ -138,10 +153,12 @@ void CRosTopicMP::initClient(mrpt::utils::CClientTCPSocket* cl) {
 	client = new mrpt::utils::CClientTCPSocket();
 	client->connect(
 			client_params.server_addr,
-			client_params.port_no,
+			client_params.server_port_no,
 			client_params.client_timeout_ms);
 
 	MRPT_LOG_INFO_STREAM << "TCP Socket was successfully established." << endl;
+
+	MRPT_END;
 }
 
 // TClientParams
@@ -176,29 +193,37 @@ void CRosTopicMP::TClientParams::loadFromConfigFile(
 	MRPT_START;
 	using namespace mrpt::utils;
 
-	port_no = source.read_int(section           , "tcp_port_no"           , 68000       , false);
 	server_addr = source.read_string(section    , "tcp_server_addr"       , "127.0.0.1" , false);
+	server_port_no = source.read_int(section    , "tcp_server_port_no"    , 6800        , false);
 	client_timeout_ms = source.read_int(section , "tcp_client_timeout_ms" , 10000       , false);
 
 	MRPT_END;
 }
 
 void CRosTopicMP::TClientParams::getAsString(std::string* params_out) const {
+	MRPT_START;
+
 	using namespace std;
 
 	stringstream ss("");
 	ss << "------------------[ CRosTopicMP ]------------------\n";
-	ss << "Port No.                           : " << port_no << endl;
+	ss << "Port No.                           : " << server_port_no << endl;
 	ss << "Server IP Address                  : " << server_addr.c_str() << endl;
 	ss << "Client Time to wait for connection : " << client_timeout_ms << endl;
 
 	*params_out = ss.str();
+
+	MRPT_END;
 }
 
 std::string CRosTopicMP::TClientParams::getAsString() const {
+	MRPT_START;
+
 	std::string str;
 	this->getAsString(&str);
 	return str;
+
+	MRPT_END;
 }
 
 } } } // end of namespaces

--- a/share/mrpt/config_files/graphslam-engine/odometry_2DRangeScans.ini
+++ b/share/mrpt/config_files/graphslam-engine/odometry_2DRangeScans.ini
@@ -36,7 +36,7 @@ ground_truth_file_format = NavSimul // variable for determining how to parse the
 ; LVL_INFO  => 1,
 ; LVL_WARN  => 2,
 ; LVL_ERROR => 3
-class_verbosity = 0
+class_verbosity = 1
 
 
 ; min node difference for an edge to be considered as a loop closure

--- a/share/mrpt/config_files/graphslam-engine/ros_laser_odometry.ini
+++ b/share/mrpt/config_files/graphslam-engine/ros_laser_odometry.ini
@@ -7,14 +7,15 @@
 ###############################################################
 # Sat Jun 25 16:43:35 EEST 2016, Nikos Koukis, nickkouk@gmail.com
 # Used, tested for the following specifications
-# observations handled                          : CObservation2DRangeScan
-# Produced map                                  : 2D
-# Graph type                                    : mrpt::graphs::CNetworkOfPoses2DInf
-# NodeRegistrationDecider tested                : CICPGoodnessNRD
-# EdgeRegistrationDecider                       : CICPGoodnessERD
-# GraphSlamSolver                               : CLevMarqGSO
-# Datasets used                                 : MRPT_DIR/share/mrpt/datasets/graphslam-engine-demos/observation_only_map2/
-# Notes                                         : Combination of NRD, ERD is slow due to the large number of edges
+# observations handled            : CObservation2DRangeScan
+# Produced map                    : 2D
+# Graph type                      : mrpt::graphs::CNetworkOfPoses2DInf
+# NodeRegistrationDecider tested  : CICPGoodnessNRD
+# EdgeRegistrationDecider         : CICPGoodnessERD
+# GraphSlamSolver                 : CLevMarqGSO
+# Datasets used                   : MRPT_DIR/share/mrpt/datasets/graphslam-engine-demos/observation_only_map2/
+# Notes                           : Combination of NRD, ERD is slow due to the large number of edges
+# Description                     : ini file can be sued in an online using information from ROS topics
 ###############################################################
 
 [GeneralConfiguration]
@@ -39,7 +40,7 @@ class_verbosity = 1
 ########################################################
 [NodeRegistrationDeciderParameters]
 
-registration_max_distance = 0.3 // meters
+registration_max_distance = 0.1 // meters
 registration_max_angle = 8 // degrees
 
 ; number of ICP goodness values to consider for estimating the current ICP threshold
@@ -77,6 +78,11 @@ class_verbosity = 1
 server_addr = 127.0.0.1
 server_port_no = 6800
 client_timeout_ms = 60000
+
+# message headers for the communication between server and client
+MSG_TYPE_FORMAT_1 = 1
+MSG_TYPE_FORMAT_2 = 2
+MSG_TYPE_EXIT = 99
 
 ########################################################
 # seems that it doesn't read hex, using cfg_file.read_int


### PR DESCRIPTION
**Changed apps/libraries:** 
- mrpt-graphlam
- graphslam-engine

Current PR provides support for running graphslam-engine application in an online fashion. More specifically, a new abstract class ([CMeasurementProvider](https://github.com/bergercookie/mrpt/blob/7ed106e66c529a16775ba6e4afebed3be7a7b31c/libs/graphslam/include/mrpt/graphslam/CMeasurementProvider.h)) is added that sets the rules for classes that can potentially provide measurements to the CGraphSlamEngine instance. Given this, we have [CRawlogMP](https://github.com/bergercookie/mrpt/blob/7ed106e66c529a16775ba6e4afebed3be7a7b31c/libs/graphslam/include/mrpt/graphslam/CRawlogMP.h) and [CRosTopicMP](https://github.com/bergercookie/mrpt/blob/7ed106e66c529a16775ba6e4afebed3be7a7b31c/libs/graphslam/include/mrpt/graphslam/CRosTopicMP.h) classes that read measurements from rawlog files and ROS topics respectively. 

_note:_ Class CRosTopicMP should be built both on Windows and Linux (despite the fact that ROS practically runs only on the latter) since its not necessary for the MRPT and ROS nodes to coexist on the same machine (e.g. we could have the ROS node - that could run on Ubuntu - listen on a non-localhost address and the MRPT node connects to and receives the required measurements).

_note2:_ Proposed implementation has been successfully tested with LaserScan measurements from a hokuyo laser scanner.

This PR closes issue https://github.com/MRPT/mrpt/issues/312

I acknowledge to have: 
* Read the [`CONTRIBUTING`](https://github.com/MRPT/mrpt/blob/master/.github/CONTRIBUTING.md) page
* Updated [`docs/doxygen-pages/changelog.h`](https://github.com/MRPT/mrpt/blob/master/doc/doxygen-pages/changeLog_doc.h) to describe these changes (if applicable)
* Updated [`AUTHORS`](https://github.com/MRPT/mrpt/blob/master/AUTHORS) (if applicable)

(Notify: @MRPT/owners )
