### PR TITLE
Fix wxString unicode error for TravisCI build

### DIFF
--- a/apps/camera-calib/CDlgPoseEst.cpp
+++ b/apps/camera-calib/CDlgPoseEst.cpp
@@ -144,7 +144,7 @@ CDlgPoseEst::CDlgPoseEst(wxWindow* parent,wxWindowID id,const wxPoint& pos,const
 	FlexGridSizer7->Add(StaticTextAlgo, 1, wxALL|wxALIGN_LEFT|wxALIGN_CENTER_VERTICAL, 5);
 	const wxString ch_names[] = { wxT("epnp"), wxT("dls"), wxT("upnp"), wxT("p3p"), wxT("lhm"), wxT("posit"), wxT("ppnp"), wxT("rpnp"), wxT("so3")};
 	wxArrayString ch_wx = wxArrayString(9, ch_names);
-	wxString ch_default("epnp");
+	wxString ch_default(wxT("epnp"));
 	pnpSelect = new wxChoice(this, ID_ALGOCHOICE, wxDefaultPosition, wxDefaultSize, ch_wx, 0, wxDefaultValidator, ch_default );
 	FlexGridSizer7->Add(pnpSelect, 1, wxALL|wxALIGN_LEFT|wxALIGN_CENTER_VERTICAL, 5);
 	pnpSelect->SetSelection(0);


### PR DESCRIPTION
**mrpt->apps->camera_calib** 
*   *Fix TravisCI build error for wxString* ...

I acknowledge to have: 
* Read the [`CONTRIBUTING`](https://github.com/MRPT/mrpt/blob/master/.github/CONTRIBUTING.md) page
* Updated [`docs/doxygen-pages/changelog.h`](https://github.com/MRPT/mrpt/blob/master/doc/doxygen-pages/changeLog_doc.h) to describe these changes (if applicable)
* Updated [`AUTHORS`](https://github.com/MRPT/mrpt/blob/master/AUTHORS) (if applicable)

(Notify: @MRPT/owners )

