### PR TITLE
Keep the min of out_scan2d.scan[i_range] and r_wrt_origin

### DIFF
--- a/libs/obs/src/CObservation3DRangeScan.cpp
+++ b/libs/obs/src/CObservation3DRangeScan.cpp
@@ -1036,7 +1036,7 @@ void CObservation3DRangeScan::convertTo2DScan(mrpt::obs::CObservation2DRangeScan
 				continue;
 
 			const float  r_wrt_origin = ::hypotf(xs[i],ys[i]);
-			if (out_scan2d.scan[i_range]< r_wrt_origin) out_scan2d.setScanRange(i_range, r_wrt_origin);
+			if (out_scan2d.scan[i_range]> r_wrt_origin) out_scan2d.setScanRange(i_range, r_wrt_origin);
 			out_scan2d.setScanRangeValidity(i_range, true);
 		}
 


### PR DESCRIPTION

I acknowledge to have: 
* Read the [`CONTRIBUTING`](https://github.com/MRPT/mrpt/blob/master/.github/CONTRIBUTING.md) page
* Updated [`docs/doxygen-pages/changelog.h`](https://github.com/MRPT/mrpt/blob/master/doc/doxygen-pages/changeLog_doc.h) to describe these changes (if applicable)
* Updated [`AUTHORS`](https://github.com/MRPT/mrpt/blob/master/AUTHORS) (if applicable)

(Notify: @MRPT/owners )

