### PR TITLE
Changed PYTHON_VERSION_STRING for MRPT python lib

### DIFF
--- a/python/CMakeLists.txt
+++ b/python/CMakeLists.txt
@@ -2,8 +2,10 @@ cmake_minimum_required(VERSION 2.8.3)
 
 project(pymrpt)
 
+find_package(PythonInterp)
+
 # Note: relative paths are relative to ${CMAKE_INSTALL_PREFIX} (defaults to /usr/local on Ubuntu)
-set( PYMRPT_INSTALL_DIR "lib/python${PYTHON_MAJOR_VERSION}.${PYTHON_MINOR_VERSION}/dist-packages" )
+set( PYMRPT_INSTALL_DIR "lib/python${PYTHON_VERSION_MAJOR}.${PYTHON_VERSION_MINOR}/dist-packages" )
 
 include_directories(include)
 include_directories(

--- a/python/samples/pnp_perf_comp.py
+++ b/python/samples/pnp_perf_comp.py
@@ -1,6 +1,5 @@
 #!/usr/bin/env python
 import sys
-sys.path.append("../../build/lib")
 import numpy as np
 import matplotlib as mpl
 import matplotlib.pyplot as plt


### PR DESCRIPTION
**mrpt->python->CMakeLists.txt** 
*   *${PYTHON_VERSION_MAJOR} and ${PYTHON_VERSION_MINOR} are not being found without find_package{PythonInterp}* ...

I acknowledge to have: 
* Read the [`CONTRIBUTING`](https://github.com/MRPT/mrpt/blob/master/.github/CONTRIBUTING.md) page
* Updated [`docs/doxygen-pages/changelog.h`](https://github.com/MRPT/mrpt/blob/master/doc/doxygen-pages/changeLog_doc.h) to describe these changes (if applicable)
* Updated [`AUTHORS`](https://github.com/MRPT/mrpt/blob/master/AUTHORS) (if applicable)

(Notify: @MRPT/owners )

