### PR TITLE
[ransac] break when stuck on degenerate cases

### DIFF
--- a/libs/base/src/math/ransac.cpp
+++ b/libs/base/src/math/ransac.cpp
@@ -101,6 +101,7 @@ bool RANSAC_Template<NUMTYPE>::execute(
 			if (++count > maxDataTrials)
 			{
 				MRPT_LOG_WARN("Unable to select a nondegenerate data set");
+				break;
 			}
 		}
 


### PR DESCRIPTION
I acknowledge to have: 
* Read the [`CONTRIBUTING`](https://github.com/MRPT/mrpt/blob/master/.github/CONTRIBUTING.md) page
* Updated [`docs/doxygen-pages/changelog.h`](https://github.com/MRPT/mrpt/blob/master/doc/doxygen-pages/changeLog_doc.h) to describe these changes (if applicable)
* Updated [`AUTHORS`](https://github.com/MRPT/mrpt/blob/master/AUTHORS) (if applicable)

(Notify: @MRPT/owners )

This replaces the break that was removed when switching over to the new logging system.
This is a regression introduced in the previous commit SHA: bd8177da7dd914ee8ba3587bb7918d64c2407fdd