### PR TITLE
use wxSpinCtrl SetRange method

### DIFF
--- a/apps/ptg-configurator/ptgConfiguratorMain.cpp
+++ b/apps/ptg-configurator/ptgConfiguratorMain.cpp
@@ -431,9 +431,8 @@ void ptgConfiguratorframe::OnbtnReloadParamsClick(wxCommandEvent& event)
 	ptg->initialize();
 
 	// one-time GUI init for each PTG settings:
-	edIndexHighlightPath->SetMin(0);
+	edIndexHighlightPath->SetRange(0, ptg->getPathCount()-1);
 	slidPathHighlight->SetMin(0);
-	edIndexHighlightPath->SetMax( ptg->getPathCount()-1 );
 	slidPathHighlight->SetMax(ptg->getPathCount() - 1);
 
 	// first time full GUI refresh:


### PR DESCRIPTION
I acknowledge to have: 
* Read the [`CONTRIBUTING`](https://github.com/MRPT/mrpt/blob/master/.github/CONTRIBUTING.md) page
* Updated [`docs/doxygen-pages/changelog.h`](https://github.com/MRPT/mrpt/blob/master/doc/doxygen-pages/changeLog_doc.h) to describe these changes (if applicable)
* Updated [`AUTHORS`](https://github.com/MRPT/mrpt/blob/master/AUTHORS) (if applicable)

(Notify: @MRPT/owners )


wxSpinCtrl does not have a method SetMin or SetMax.
use SetRange instead.
http://docs.wxwidgets.org/trunk/classwx_spin_ctrl.html