### PR TITLE
Fix undefined reference to symbol on tests linking

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -43,7 +43,7 @@ ENDIF ()
 
 # Fix issue #367: undefined reference to symbol on tests linking
 IF(NOT MSVC)
-    SET(CMAKE_THREAD_LIBS_INIT ${CMAKE_THREAD_LIBS_INIT} " -lpthread")
+    SET(CMAKE_THREAD_LIBS_INIT ${CMAKE_THREAD_LIBS_INIT} "-lpthread")
 ENDIF()
 
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -56,10 +56,10 @@ FOREACH(_TSTLIB ${LST_LIB_TESTS})
 	# Add the required libraries for linking:
 IF (CMAKE_MRPT_HAS_GTEST_SYSTEM)
 	# System vesion:
-	TARGET_LINK_LIBRARIES(test_${_TSTLIB} ${MRPT_LINKER_LIBS_RELorDEB} gtest)
+	TARGET_LINK_LIBRARIES(test_${_TSTLIB} ${MRPT_LINKER_LIBS_RELorDEB} gtest -lpthread)
 ELSE ()
 	# Own version:
-	TARGET_LINK_LIBRARIES(test_${_TSTLIB} ${MRPT_LINKER_LIBS_RELorDEB} mrptgtest)
+	TARGET_LINK_LIBRARIES(test_${_TSTLIB} ${MRPT_LINKER_LIBS_RELorDEB} mrptgtest -lpthread)
 	ADD_DEPENDENCIES(test_${_TSTLIB} mrptgtest)  # Assure the MRPT library is updated:
 ENDIF ()
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -41,6 +41,11 @@ IF (NOT "${CMAKE_GTEST_CFLAGS}" STREQUAL "")
 	ADD_DEFINITIONS(${CMAKE_GTEST_CFLAGS})
 ENDIF ()
 
+# Fix issue #367: undefined reference to symbol on tests linking
+IF(NOT MSVC)
+    SET(CMAKE_THREAD_LIBS_INIT ${CMAKE_THREAD_LIBS_INIT} " -lpthread")
+ENDIF()
+
 
 get_property(LST_LIB_TESTS GLOBAL PROPERTY "MRPT_TEST_LIBS")
 FOREACH(_TSTLIB ${LST_LIB_TESTS})
@@ -56,10 +61,10 @@ FOREACH(_TSTLIB ${LST_LIB_TESTS})
 	# Add the required libraries for linking:
 IF (CMAKE_MRPT_HAS_GTEST_SYSTEM)
 	# System vesion:
-	TARGET_LINK_LIBRARIES(test_${_TSTLIB} ${MRPT_LINKER_LIBS_RELorDEB} gtest -lpthread)
+	TARGET_LINK_LIBRARIES(test_${_TSTLIB} ${MRPT_LINKER_LIBS_RELorDEB} gtest ${CMAKE_THREAD_LIBS_INIT})
 ELSE ()
 	# Own version:
-	TARGET_LINK_LIBRARIES(test_${_TSTLIB} ${MRPT_LINKER_LIBS_RELorDEB} mrptgtest -lpthread)
+	TARGET_LINK_LIBRARIES(test_${_TSTLIB} ${MRPT_LINKER_LIBS_RELorDEB} mrptgtest ${CMAKE_THREAD_LIBS_INIT})
 	ADD_DEPENDENCIES(test_${_TSTLIB} mrptgtest)  # Assure the MRPT library is updated:
 ENDIF ()
 


### PR DESCRIPTION
**Changed apps/libraries:**   tests

More precisely: undefined reference to symbol 'pthread_key_delete@@GLIBC_2.2.5

The solution is described [here](http://stackoverflow.com/questions/25617839/undefined-reference-to-symbol-pthread-key-deleteglibc-2-2-5), but seems like nobody bothered to contribute it. Probably someone with more knowledge on CMake can do more elegant

I acknowledge to have: 
* Read the [`CONTRIBUTING`](https://github.com/MRPT/mrpt/blob/master/.github/CONTRIBUTING.md) page
* Updated [`docs/doxygen-pages/changelog.h`](https://github.com/MRPT/mrpt/blob/master/doc/doxygen-pages/changeLog_doc.h) to describe these changes (if applicable)
* Updated [`AUTHORS`](https://github.com/MRPT/mrpt/blob/master/AUTHORS) (if applicable)

(Notify: @MRPT/owners )
