### PR TITLE
mrpt-graphslam: Use stream versions to suppress gcc warning

### DIFF
--- a/libs/graphslam/include/mrpt/graphslam/CGraphSlamEngine_impl.h
+++ b/libs/graphslam/include/mrpt/graphslam/CGraphSlamEngine_impl.h
@@ -53,37 +53,35 @@ CGraphSlamEngine<GRAPH_t>::~CGraphSlamEngine() {
 	using namespace mrpt;
 	using namespace std;
 
-	this->logFmt(LVL_INFO, "In Destructor: Deleting CGraphSlamEngine instance...");
+	MRPT_LOG_DEBUG_STREAM << "In Destructor: Deleting CGraphSlamEngine instance...";
 
 	// close all open files
 	for (fstreams_out_it it  = m_out_streams.begin(); it != m_out_streams.end();
 			++it) {
 		if ((it->second)->fileOpenCorrectly()) {
-			this->logFmt(LVL_INFO, "Closing file: %s", (it->first).c_str());
+			MRPT_LOG_INFO_STREAM << "Closing file: " << (it->first);
 			(it->second)->close();
 		}
 	}
 
 	// delete m_odometry_poses
 	if (m_odometry_poses.size()) {
-		this->logFmt(LVL_DEBUG,
-				"Releasing m_odometry_poses vector; size: %lu",
-				m_odometry_poses.size());
+		MRPT_LOG_DEBUG_STREAM << "Releasing m_odometry_poses vector; size: " << m_odometry_poses.size();
 		for (size_t i = 0; i != m_odometry_poses.size(); ++i) {
 			delete m_odometry_poses[i];
 		}
-		this->logFmt(LVL_DEBUG, "Released m_odometry_poses vector");
+		MRPT_LOG_DEBUG_STREAM << "Released m_odometry_poses vector";
 	}
 
 	// change back the CImage path
 	if (mrpt::system::strCmpI(m_GT_file_format, "rgbd_tum")) {
-		this->logFmt(LVL_DEBUG, "Changing back the CImage PATH");
+		MRPT_LOG_DEBUG_STREAM << "Changing back the CImage PATH";
 		CImage::IMAGES_PATH_BASE = m_img_prev_path_base;
 	}
 
 	// delete the CDisplayWindowPlots object
 	if (m_win_plot) {
-		this->logFmt(LVL_DEBUG, "Releasing CDisplayWindowPlots... ");
+		MRPT_LOG_DEBUG_STREAM << "Releasing CDisplayWindowPlots...";
 		delete m_win_plot;
 	}
 }
@@ -139,7 +137,7 @@ void CGraphSlamEngine<GRAPH_t>::initCGraphSlamEngine() {
 		m_win = NULL;
 		m_win_observer = NULL;
 
-		this->logFmt(LVL_WARN, "Visualization is off. Running on headless mode");
+		MRPT_LOG_WARN_STREAM << "Visualization is off. Running on headless mode";
 	}
 
 	// set the CDisplayWindowPlots pointer to null for starters, we don't know if
@@ -181,7 +179,7 @@ void CGraphSlamEngine<GRAPH_t>::initCGraphSlamEngine() {
 	this->loadParams(m_config_fname);
 
 	if (!m_enable_visuals) {
-		this->logFmt(LVL_WARN, "Switching all visualization parameters off...");
+		MRPT_LOG_WARN_STREAM << "Switching all visualization parameters off...";
 		m_visualize_odometry_poses       = 0;
 		m_visualize_GT                   = 0;
 		m_visualize_map                  = 0;
@@ -205,8 +203,7 @@ void CGraphSlamEngine<GRAPH_t>::initCGraphSlamEngine() {
 
 	// plot the GT related visuals only if ground-truth file is given
 	if (!m_use_GT) {
-		this->logFmt(LVL_WARN,
-				"Ground truth file was not provided. Switching the related visualization parameters off...");
+		MRPT_LOG_WARN_STREAM << "Ground truth file was not provided. Switching the related visualization parameters off...";
 		m_visualize_GT          = 0;
 		m_visualize_SLAM_metric = 0;
 	}
@@ -365,13 +362,13 @@ void CGraphSlamEngine<GRAPH_t>::initCGraphSlamEngine() {
 				m_info_params.fields["Overall number of objects"].c_str());
 		m_GT_poses_step = m_GT_poses.size() / num_of_objects;
 
-		this->logFmt(LVL_INFO,
-				"Overall number of objects in rawlog: %d", num_of_objects);
-		this->logFmt(LVL_INFO,
-				"Setting the Ground truth read step to: %lu", m_GT_poses_step);
+		MRPT_LOG_INFO_STREAM <<	"Overall number of objects in rawlog: "
+			<< num_of_objects;
+		MRPT_LOG_INFO_STREAM << "Setting the Ground truth read step to: "
+			<< m_GT_poses_step;
 	}
 	catch (std::exception& e) {
-		this->logFmt(LVL_INFO, "Error loading rawlog file: %s",e.what());
+		MRPT_LOG_INFO_STREAM << "RGBD_TUM info file was not found: " << e.what();
 	}
 
 	// SLAM evaluation metric
@@ -728,7 +725,7 @@ void CGraphSlamEngine<GRAPH_t>::computeOccupancyGridMap2D() const {
 	using namespace mrpt::utils;
 	using namespace mrpt::poses;
 
-	this->logFmt(LVL_DEBUG, "Computing the occupancy gridmap...");
+	MRPT_LOG_DEBUG_STREAM << "Computing the occupancy gridmap...";
 	mrpt::synch::CCriticalSectionLocker m_graph_lock(&m_graph_section);
 
 	// set the map parameters
@@ -738,8 +735,13 @@ void CGraphSlamEngine<GRAPH_t>::computeOccupancyGridMap2D() const {
 			/* float min_y = */ -20.0f,
 			/* float max_y = */ 20.0f,
 			/* float resolution = */ 0.05f);
+
+
+	// observation insertion options
   gridmap.insertionOptions.maxOccupancyUpdateCertainty = 0.8;
   gridmap.insertionOptions.maxDistanceInsertion = 15;
+  gridmap.insertionOptions.wideningBeamsWithDistance = true;
+  gridmap.insertionOptions.decimation = 2;
 
 	// traverse all the nodes - add their laser scans at their corresponding poses
 	for (std::map<mrpt::utils::TNodeID,
@@ -773,7 +775,7 @@ void CGraphSlamEngine<GRAPH_t>::computeOccupancyGridMap2D() const {
 	m_gridmap_is_cached = true;
 	m_gridmap_acq_time = mrpt::system::now();
 
-	this->logFmt(LVL_INFO, "Computed the occupancy gridmap successfully.");
+	MRPT_LOG_DEBUG_STREAM << "Computed the occupancy gridmap successfully.";
 	MRPT_END;
 }
 
@@ -788,7 +790,7 @@ void CGraphSlamEngine<GRAPH_t>::loadParams(
 	ASSERTMSG_(mrpt::system::fileExists(fname),
 			mrpt::format("\nConfiguration file not found: \n%s\n", fname.c_str()));
 
-	this->logFmt(LVL_INFO, "Reading the .ini file... ");
+	MRPT_LOG_INFO_STREAM << "Reading the .ini file... ";
 
 	CConfigFile cfg_file(fname);
 
@@ -939,8 +941,7 @@ void CGraphSlamEngine<GRAPH_t>::initOutputDir(
 	using namespace mrpt::utils;
 	using namespace mrpt::system;
 
-	this->logFmt(LVL_INFO,
-			"Setting up Output directory: %s", output_dir_fname.c_str());
+	MRPT_LOG_INFO_STREAM << "Setting up output directory: " << output_dir_fname;
 
 	// current time vars - handy in the rest of the function.
 	mrpt::system::TTimeStamp cur_date(getCurrentTime());
@@ -981,7 +982,7 @@ void CGraphSlamEngine<GRAPH_t>::initOutputDir(
 		{
 			case 2:
 				{
-					this->logFmt(LVL_INFO, "Deleting existing files...");
+					MRPT_LOG_INFO_STREAM << "Deleting existing files...";
 					// purge directory
 					deleteFilesInDirectory(output_dir_fname,
 							/*deleteDirectoryAsWell = */ false);
@@ -997,7 +998,7 @@ void CGraphSlamEngine<GRAPH_t>::initOutputDir(
 				{
 					// rename the whole directory to DATE_TIME_${OUTPUT_DIR_NAME}
 					string dst_fname = output_dir_fname + cur_date_validstr;
-					this->logFmt(LVL_INFO, "Renaming directory to: %s", dst_fname.c_str());
+					MRPT_LOG_INFO_STREAM << "Renaming directory to: " << dst_fname;
 					string* error_msg = NULL;
 					bool did_rename = renameFile(output_dir_fname,
 							dst_fname,
@@ -1011,12 +1012,12 @@ void CGraphSlamEngine<GRAPH_t>::initOutputDir(
 	} // IF DIRECTORY EXISTS..
 
 	// Now rebuild the directory from scratch
-	this->logFmt(LVL_INFO, "Creating the new directory structure...");
+	MRPT_LOG_INFO_STREAM << "Creating the new directory structure...";
 	string cur_fname;
 
 	// debug_fname
 	createDirectory(output_dir_fname);
-	this->logFmt(LVL_INFO, "Finished initializing output directory.");
+	MRPT_LOG_INFO_STREAM << "Finished initializing output directory.";
 
 	MRPT_END;
 } // end of initOutputDir
@@ -1029,7 +1030,7 @@ void CGraphSlamEngine<GRAPH_t>::initResultsFile(
 	using namespace std;
 	using namespace mrpt::system;
 
-	this->logFmt(LVL_INFO, "Setting up file: %s", fname.c_str());
+	MRPT_LOG_INFO_STREAM << "Setting up file: " << fname;
 
 	// current time vars - handy in the rest of the function.
 	mrpt::system::TTimeStamp cur_date(getCurrentTime());
@@ -1190,7 +1191,7 @@ inline void CGraphSlamEngine<GRAPH_t>::updateCurrPosViewport() {
 
 	m_win->unlockAccess3DScene();
 	m_win->forceRepaint();
-	this->logFmt(LVL_DEBUG, "Updated the \"current_pos\" viewport");
+	MRPT_LOG_DEBUG_STREAM << "Updated the \"current_pos\" viewport";
 
 	MRPT_END;
 }
@@ -1410,7 +1411,7 @@ void CGraphSlamEngine<GRAPH_t>::alignOpticalWithMRPTFrame() {
 	ss_out << "rotx: " << endl << rotx << endl;
 	ss_out << "Full rotation matrix: " << endl << m_rot_TUM_to_MRPT << endl;
 
-	this->logFmt(LVL_DEBUG, "%s", ss_out.str().c_str());
+	MRPT_LOG_DEBUG_STREAM << ss_out;
 
 	MRPT_END;
 }
@@ -1449,10 +1450,11 @@ void CGraphSlamEngine<GRAPH_t>::queryObserverForEvents() {
 
 		// message to the user
 		if (m_program_paused) {
-			this->logFmt(LVL_INFO, "Program was paused. Press \"p\" or \"P\" in the dipslay window to resume");
+			MRPT_LOG_INFO_STREAM << "Program is paused. "
+				<< "Press \"p\" or \"P\" in the dipslay window to resume";
 		}
 		else {
-			this->logFmt(LVL_INFO, "Program resumed.");
+			MRPT_LOG_INFO_STREAM << "Program resumed.";
 		}
 
 		while (m_program_paused) {
@@ -1476,7 +1478,7 @@ void CGraphSlamEngine<GRAPH_t>::toggleOdometryVisualization() {
 	ASSERT_(m_enable_visuals);
 	using namespace mrpt::utils;
 	using namespace mrpt::opengl;
-	this->logFmt(LVL_INFO, "Toggling Odometry visualization...");
+	MRPT_LOG_INFO_STREAM << "Toggling Odometry visualization...";
 
 	COpenGLScenePtr scene = m_win->get3DSceneAndLock();
 
@@ -1502,7 +1504,7 @@ void CGraphSlamEngine<GRAPH_t>::toggleGTVisualization() {
 	ASSERT_(m_enable_visuals);
 	using namespace mrpt::opengl;
 	using namespace mrpt::utils;
-	this->logFmt(LVL_INFO, "Toggling Ground Truth visualization");
+	MRPT_LOG_INFO_STREAM << "Toggling Ground Truth visualization";
 
 	COpenGLScenePtr scene = m_win->get3DSceneAndLock();
 
@@ -1530,7 +1532,7 @@ void CGraphSlamEngine<GRAPH_t>::toggleMapVisualization() {
 	using namespace std;
 	using namespace mrpt::opengl;
 	using namespace mrpt::utils;
-	this->logFmt(LVL_INFO, "Toggling Map visualization... ");
+	MRPT_LOG_INFO_STREAM << "Toggling Map visualization... ";
 
 	COpenGLScenePtr scene = m_win->get3DSceneAndLock();
 
@@ -1567,7 +1569,7 @@ void CGraphSlamEngine<GRAPH_t>::toggleEstimatedTrajectoryVisualization() {
 	ASSERT_(m_enable_visuals);
 	using namespace mrpt::opengl;
 	using namespace mrpt::utils;
-	this->logFmt(LVL_INFO, "Toggling Estimated Trajectory visualization... ");
+	MRPT_LOG_INFO_STREAM << "Toggling Estimated Trajectory visualization... ";
 
 	COpenGLScenePtr scene = m_win->get3DSceneAndLock();
 
@@ -1594,11 +1596,10 @@ void CGraphSlamEngine<GRAPH_t>::dumpVisibilityErrorMsg(
 	MRPT_START;
 	using namespace mrpt::utils;
 
-	this->logFmt(LVL_ERROR,
-			"Cannot toggle visibility of specified object.\n "
-			"Make sure that the corresponding visualization flag ( %s "
-			") is set to true in the .ini file.\n",
-			viz_flag.c_str());
+	MRPT_LOG_ERROR_STREAM << "Cannot toggle visibility of specified object.\n"
+			<< "Make sure that the corresponding visualization flag ("
+			<< viz_flag
+			<< ") is set to true in the .ini file.";
 	mrpt::system::sleep(sleep_time);
 
 	MRPT_END;
@@ -1628,7 +1629,7 @@ void CGraphSlamEngine<GRAPH_t>::updateMapVisualization(
 			// for all the nodes get the node position and the corresponding laser scan
 			// if they were recorded and visualize them
 			m_graph.getAllNodes(nodes_set);
-			this->logFmt(LVL_INFO, "Executing full update of the map");
+			MRPT_LOG_INFO_STREAM << "Executing full update of the map";
 
 		} // IF FULL UPDATE
 		else { // add only current CSimplePointMap
@@ -1669,9 +1670,8 @@ void CGraphSlamEngine<GRAPH_t>::updateMapVisualization(
 
 			CSetOfObjectsPtr scan_obj;
 			if (obj.null()) {
-				this->logFmt(LVL_DEBUG,
-						"CSetOfObjects for nodeID %lu doesn't exist. Creating it...",
-						*node_it);
+				MRPT_LOG_DEBUG_STREAM << "CSetOfObjects for nodeID " << *node_it <<
+					"doesn't exist. Creating it...";
 
 				scan_obj = CSetOfObjects::Create();
 
@@ -1708,15 +1708,15 @@ void CGraphSlamEngine<GRAPH_t>::updateMapVisualization(
 			m_win->forceRepaint();
 		}
 		else {
-			this->logFmt(LVL_DEBUG,
-					"Laser scans of NodeID %lu are empty/invalid",
-					*node_it);
+			MRPT_LOG_DEBUG_STREAM << "Laser scans of NodeID " << *node_it <<
+				"are  empty/invalid";
 		}
 	}
 
 
 	double elapsed_time = map_update_timer.Tac();
-	this->logFmt(LVL_DEBUG, "updateMapVisualization took: %fs", elapsed_time);
+	MRPT_LOG_DEBUG_STREAM << "updateMapVisualization took: "
+		<< elapsed_time << "s";
 	MRPT_END;
 }
 
@@ -2116,9 +2116,7 @@ void CGraphSlamEngine<GRAPH_t>::saveGraph(
 		fname = "output_graph.graph";
 	}
 
-	this->logFmt(LVL_INFO,
-				"Saving generated graph in VERTEX/EDGE format: %s",
-				fname.c_str());
+	MRPT_LOG_INFO_STREAM << "Saving generated graph in VERTEX/EDGE format: " << fname;
 	m_graph.saveToTextFile(fname);
 
 	MRPT_END;
@@ -2140,11 +2138,9 @@ void CGraphSlamEngine<GRAPH_t>::save3DScene(
 	{
 		CPlanarLaserScanPtr laser_scan;
 		for (; (laser_scan = scene->getByClass<CPlanarLaserScan>()) ;) {
-			this->logFmt(LVL_DEBUG,
-					"Removing CPlanarlaserScan from generated 3DScene...");
+			MRPT_LOG_DEBUG_STREAM << "Removing CPlanarLaserScan from generated 3DScene...";
 			scene->removeObject(laser_scan);
 		}
-
 	}
 
 	// what's the name of the file to be saved?
@@ -2156,7 +2152,7 @@ void CGraphSlamEngine<GRAPH_t>::save3DScene(
 		fname = "output_scene.3DScene";
 	}
 
-	this->logFmt(LVL_INFO, "Saving generated scene to %s", fname.c_str());
+	MRPT_LOG_INFO_STREAM << "Saving generated scene to " << fname;
 	scene->saveToFile(fname);
 
 	m_win->unlockAccess3DScene();
@@ -2178,9 +2174,6 @@ void CGraphSlamEngine<GRAPH_t>::computeSlamMetric(mrpt::utils::TNodeID nodeID, s
 
 	// add to the map - keep track of which gt index corresponds to which nodeID
 	m_nodeID_to_gt_indices[nodeID] = gt_index;
-	this->logFmt(LVL_DEBUG, "Current nodeID-gt pair: %lu - %lu",
-			static_cast<unsigned long>(nodeID),
-			static_cast<unsigned long>(gt_index));
 
 	// initialize the loop variables only once
 	pose_t curr_node_pos;
@@ -2191,9 +2184,6 @@ void CGraphSlamEngine<GRAPH_t>::computeSlamMetric(mrpt::utils::TNodeID nodeID, s
 	double rot_diff;
 
 	size_t indices_size = m_nodeID_to_gt_indices.size();
-	this->logFmt(LVL_DEBUG,
-			"Total size of nodeID - gt_index map: %lu",
-			indices_size);
 
 	// recompute the metric from scratch
 	m_curr_deformation_energy = 0;
@@ -2236,9 +2226,8 @@ void CGraphSlamEngine<GRAPH_t>::computeSlamMetric(mrpt::utils::TNodeID nodeID, s
 		prev_gt_pos = curr_gt_pos;
 	}
 
-	this->logFmt(LVL_DEBUG,
-			"Total deformation energy: %f",
-			m_curr_deformation_energy);
+	MRPT_LOG_DEBUG_STREAM << "Total deformation energy: "
+		<< m_curr_deformation_energy;
 
 	MRPT_END;
 }
@@ -2250,8 +2239,8 @@ void CGraphSlamEngine<GRAPH_t>::initSlamMetricVisualization() {
 	using namespace mrpt::utils;
 	using namespace mrpt::gui;
 
-	this->logFmt(LVL_DEBUG, "In initializeSlamMetricVisualization...");
 	MRPT_START;
+	MRPT_LOG_DEBUG_STREAM << "In initializeSlamMetricVisualization...";
 	ASSERT_(m_visualize_SLAM_metric);
 
 	// initialize the m_win_plot on the stack
@@ -2354,7 +2343,7 @@ void CGraphSlamEngine<GRAPH_t>::generateReportFiles(
 	// first initialize the directory where the files are to be placed
 	this->initOutputDir(output_dir_fname);
 
-	this->logFmt(LVL_INFO, "Generating detailed class report...");
+	MRPT_LOG_INFO_STREAM << "Generating detailed class report...";
 	mrpt::synch::CCriticalSectionLocker m_graph_lock(&m_graph_section);
 
 	std::string report_str;


### PR DESCRIPTION
**Changed apps/libraries:** 
mrpt-graphslam

Deal with conversion warnings on 32bit systems

I acknowledge to have: 
* Read the [`CONTRIBUTING`](https://github.com/MRPT/mrpt/blob/master/.github/CONTRIBUTING.md) page
* Updated [`docs/doxygen-pages/changelog.h`](https://github.com/MRPT/mrpt/blob/master/doc/doxygen-pages/changeLog_doc.h) to describe these changes (if applicable)
* Updated [`AUTHORS`](https://github.com/MRPT/mrpt/blob/master/AUTHORS) (if applicable)

(Notify: @MRPT/owners )

Use COutputLogger stream versions instead of logFmt to suppress
warning for conversion from %lu to %u on 32bit systems.