### PR TITLE
Change CLoggerOutput stringstream output to overload

### DIFF
--- a/libs/base/include/mrpt/utils/COutputLogger.h
+++ b/libs/base/include/mrpt/utils/COutputLogger.h
@@ -271,9 +271,8 @@ class BASE_IMPEXP COutputLogger {
 			m_str << val;
 			return m_str;
 		}
-		// Specialization for std::stringstream objects
-		template <>
-		std::stringstream & operator << <std::stringstream>(const std::stringstream &val) {
+		// Overload for std::stringstream objects
+		std::stringstream & operator << (const std::stringstream &val) {
 			m_str << val.str();
 			return m_str;
 		}


### PR DESCRIPTION
I acknowledge to have: 
* Read the [`CONTRIBUTING`](https://github.com/MRPT/mrpt/blob/master/.github/CONTRIBUTING.md) page
* Updated [`docs/doxygen-pages/changelog.h`](https://github.com/MRPT/mrpt/blob/master/doc/doxygen-pages/changeLog_doc.h) to describe these changes (if applicable)
* Updated [`AUTHORS`](https://github.com/MRPT/mrpt/blob/master/AUTHORS) (if applicable)

(Notify: @MRPT/owners )

