### PR TITLE
[CReactiveNavigationSystem] Make loggingGetWSObstaclesAndShape protected

### DIFF
--- a/libs/nav/include/mrpt/nav/reactive/CReactiveNavigationSystem.h
+++ b/libs/nav/include/mrpt/nav/reactive/CReactiveNavigationSystem.h
@@ -81,11 +81,11 @@ namespace mrpt
 
 			// See docs in parent class
 			bool implementSenseObstacles(mrpt::system::TTimeStamp &obs_timestamp) MRPT_OVERRIDE;
-
+		protected:
 			/** Generates a pointcloud of obstacles, and the robot shape, to be saved in the logging record for the current timestep */
 			virtual void loggingGetWSObstaclesAndShape(CLogFileRecord &out_log) MRPT_OVERRIDE;
 
-		protected:
+		
 			void internal_loadConfigFile(const mrpt::utils::CConfigFileBase &ini, const std::string &section_prefix="") MRPT_OVERRIDE;
 			mrpt::maps::CSimplePointsMap m_WS_Obstacles;  //!< The obstacle points, as seen from the local robot frame.
 			// See docs in parent class


### PR DESCRIPTION
Allow CReactiveNavigationSystem::loggingGetWSObstaclesAndShape to be called from a derived class

I acknowledge to have: 
* Read the [`CONTRIBUTING`](https://github.com/MRPT/mrpt/blob/master/.github/CONTRIBUTING.md) page
* Updated [`docs/doxygen-pages/changelog.h`](https://github.com/MRPT/mrpt/blob/master/doc/doxygen-pages/changeLog_doc.h) to describe these changes (if applicable)
* Updated [`AUTHORS`](https://github.com/MRPT/mrpt/blob/master/AUTHORS) (if applicable)

(Notify: @MRPT/owners )

