### PR TITLE
PIMPL refactor

### DIFF
--- a/libs/base/include/mrpt/utils/CReferencedMemBlock.h
+++ b/libs/base/include/mrpt/utils/CReferencedMemBlock.h
@@ -40,13 +40,13 @@ namespace mrpt
 			{
 				if (!m_data.present()) throw std::runtime_error("Trying to access to an uninitialized memory block");
 				if (m_data->empty()) throw std::runtime_error("Trying to access to a memory block of size 0");
-				return reinterpret_cast<T*>(&m_data.pointer()->operator [](0));
+				return reinterpret_cast<T*>(&((*m_data)[0]));
 			}
 			template <class T> const T* getAsPtr() const
 			{
 				if (!m_data.present()) throw std::runtime_error("Trying to access to an uninitialized memory block");
 				if (m_data->empty()) throw std::runtime_error("Trying to access to a memory block of size 0");
-				return reinterpret_cast<const T*>(&m_data.pointer()->operator [](0));
+				return reinterpret_cast<const T*>(&((*m_data)[0]));
 			}
 
 			template <class T> T&       getAs()       { return *getAsPtr<T>(); }

--- a/libs/base/include/mrpt/utils/pimpl.h
+++ b/libs/base/include/mrpt/utils/pimpl.h
@@ -9,21 +9,70 @@
 
 #pragma once
 
+#include <mrpt/config.h>
+#include <memory>
+
 /** \file Macros to help implementing the PIMPL idiom and make all 
  * declarations easier to read and less error-prone. 
  */
+namespace mrpt {
+	namespace utils {
+		/** Pointer to IMPLementation auxiliary structure to make raw pointers movable, copiable and automatically deleted.
+		 *\ingroup mrpt_base_grp
+		 */
+		template <typename T>
+		struct pimpl
+		{
+			// This should be only parsed by MRPT sources (which since 1.5.0 require C++11). 
+			// It does not matter if user code, using C++98, does not see this declaration, since PIMPL 
+			// are always "private" or "protected".
+#if MRPT_HAS_CXX11
+			std::unique_ptr<T> ptr;
 
-#define PIMPL_DECLARE_TYPE(_TYPE, _VAR_NAME)  void *_VAR_NAME
+			// All these must be defined in a .cpp file with PIMPL_DEFINE(_TYPE), after including the 
+			// real definition of T, which is only forward-declared in the headers:
+			pimpl();
+			~pimpl();
+			pimpl(pimpl && op) noexcept;              // movable
+			pimpl& operator=(pimpl&& op) noexcept;   //
+			pimpl(const pimpl& op);                   // and copyable
+			pimpl& operator=(const pimpl& op);        //
+#endif
+		};
+	}
+}
 
-#define PIMPL_CTOR_INIT(_TYPE, _VAR_NAME)  _VAR_NAME(NULL)
+// ========== Header file ==============
+#define PIMPL_FORWARD_DECLARATION(_TYPE)  _TYPE
 
-#define PIMPL_DESTROY(_TYPE,_VAR_NAME)  \
-	if (_VAR_NAME) { delete reinterpret_cast<_TYPE*>(_VAR_NAME); _VAR_NAME=NULL; }
+#define PIMPL_DECLARE_TYPE(_TYPE, _VAR_NAME)  mrpt::utils::pimpl<_TYPE> _VAR_NAME
 
-#define PIMPL_CONSTRUCT(_TYPE,_VAR_NAME)  \
-	PIMPL_DESTROY(_TYPE,_VAR_NAME) \
-	_VAR_NAME = new _TYPE();
+// ========== Implementation file ==============
+#define PIMPL_IMPLEMENT(_TYPE)  \
+	namespace mrpt { namespace utils { \
+	template <> pimpl<_TYPE>::pimpl() : ptr() {} \
+	template <> pimpl<_TYPE>::~pimpl() {} \
+	/* Movable */ \
+	pimpl<_TYPE>::pimpl(pimpl<_TYPE> && op) noexcept : ptr(std::move(op.ptr)) {} \
+	pimpl<_TYPE>& pimpl<_TYPE>::operator=(pimpl<_TYPE>&& op) noexcept { ptr = std::move(op.ptr); return *this; } \
+	/* Copyable: */ \
+	template <> pimpl<_TYPE>::pimpl(const pimpl<_TYPE> & op) { \
+		if (op.ptr.get() == ptr.get()) return; \
+		ptr.reset(new  _TYPE()); \
+		*ptr = *op.ptr; \
+	} \
+	template <> pimpl<_TYPE>& pimpl<_TYPE>::operator=(const pimpl<_TYPE>& op) { \
+		if (op.ptr.get() == ptr.get()) return *this; \
+		ptr.reset(new  _TYPE()); \
+		*ptr = *op.ptr; \
+		return *this; \
+	}  \
+} } 
 
-#define PIMPL_GET_REF(_TYPE, _VAR_NAME)  (*reinterpret_cast<_TYPE*>(_VAR_NAME))
-#define PIMPL_GET_CONSTREF(_TYPE, _VAR_NAME)  (*reinterpret_cast<const _TYPE*>(_VAR_NAME))
+// Put in the constructor, initializer, etc.
+#define PIMPL_CONSTRUCT(_TYPE,_VAR_NAME)  _VAR_NAME.ptr.reset( new _TYPE())
+
+#define PIMPL_GET_PTR(_TYPE, _VAR_NAME)   _VAR_NAME.ptr.get()
+#define PIMPL_GET_REF(_TYPE, _VAR_NAME)  (*_VAR_NAME.ptr.get())
+#define PIMPL_GET_CONSTREF(_TYPE, _VAR_NAME)  (*_VAR_NAME.ptr.get())
 

--- a/libs/base/src/synch/CCriticalSection_LIN.cpp
+++ b/libs/base/src/synch/CCriticalSection_LIN.cpp
@@ -43,7 +43,7 @@ CCriticalSection::CCriticalSection( const char *name )
 	m_data.resize( sizeof( CRIT_SECT_LIN ) + 10 );
 
 	pthread_mutex_t cs = PTHREAD_MUTEX_INITIALIZER;
-	m_data.getAs<CRIT_SECT_LIN*>()->cs = cs;
+	m_data.getAsPtr<CRIT_SECT_LIN>()->cs = cs;
 
 	if (name!=NULL)
             m_name = name;
@@ -58,8 +58,8 @@ CCriticalSection::~CCriticalSection()
 	if (m_data.alias_count()==1)
 	{
 		// JL (mar/2011): Disabled to avoid weird errors when suddenly closing a pogram with running mrpt::gui windows.
-//		if ( m_data.getAs<CRIT_SECT_LIN*>()->currentThreadOwner != 0 )
-//			THROW_EXCEPTION(format("Destroying a critical section ('%s') currently locked by thread 0x%08lX", m_name.c_str(), m_data.getAs<CRIT_SECT_LIN*>()->currentThreadOwner ) );
+//		if ( m_data.getAsPtr<CRIT_SECT_LIN>()->currentThreadOwner != 0 )
+//			THROW_EXCEPTION(format("Destroying a critical section ('%s') currently locked by thread 0x%08lX", m_name.c_str(), m_data.getAsPtr<CRIT_SECT_LIN>()->currentThreadOwner ) );
 	}
 }
 
@@ -72,7 +72,7 @@ void  CCriticalSection::enter() const
 
 	if (m_debugOut)	m_debugOut->printf("[CCriticalSection:%s] Entering Thread ID:0x%08lX\n",m_name.c_str(),threadid );
 
-	CRIT_SECT_LIN *myCS = const_cast<CRIT_SECT_LIN *>( m_data.getAs<const CRIT_SECT_LIN*>() );
+	CRIT_SECT_LIN *myCS = const_cast<CRIT_SECT_LIN *>( m_data.getAsPtr<CRIT_SECT_LIN>() );
 
 	if( myCS->currentThreadOwner == threadid )
 		THROW_EXCEPTION(format("Detected recursive lock on critical section ('%s') by the same thread: 0x%08lX",m_name.c_str(),threadid))
@@ -95,7 +95,7 @@ void  CCriticalSection::leave() const
 
 	if (m_debugOut)	m_debugOut->printf("[CCriticalSection:%s] Leaving Thread ID:0x%08lX\n",m_name.c_str(),threadid );
 
-	CRIT_SECT_LIN *myCS = const_cast<CRIT_SECT_LIN *>( m_data.getAs<const CRIT_SECT_LIN*>() );
+	CRIT_SECT_LIN *myCS = const_cast<CRIT_SECT_LIN *>( m_data.getAsPtr<CRIT_SECT_LIN>() );
 
 	if ( myCS->currentThreadOwner!=threadid )
 		THROW_EXCEPTION(format("Trying to release a critical section  ('%s') locked by a different thread.",m_name.c_str()));

--- a/libs/base/src/synch/CCriticalSection_WIN.cpp
+++ b/libs/base/src/synch/CCriticalSection_WIN.cpp
@@ -37,7 +37,7 @@ CCriticalSection::CCriticalSection( const char *name )
 
 	m_data.resize( sizeof(CRIT_SECT_WIN) + 30 );
 
-	InitializeCriticalSection( & m_data.getAs<CRIT_SECT_WIN*>()->cs );
+	InitializeCriticalSection( & m_data.getAsPtr<CRIT_SECT_WIN>()->cs );
 
 	if (name!=NULL)
 		m_name = name;
@@ -53,12 +53,12 @@ CCriticalSection::~CCriticalSection()
 {
 	if (m_data.alias_count()==1)
 	{
-		//unsigned long	cur_own = m_data.getAs<CRIT_SECT_WIN*>()->currentThreadOwner;
+		//unsigned long	cur_own = m_data.getAsPtr<CRIT_SECT_WIN>()->currentThreadOwner;
 		// JL (mar/2011): Disabled to avoid weird errors when suddenly closing a pogram with running mrpt::gui windows.
 //		if ( cur_own != 0 )
 //			THROW_EXCEPTION(format("Destroying a critical section ('%s') currently locked by thread %lu", m_name.c_str(), cur_own ) )
 
-		DeleteCriticalSection( & m_data.getAs<CRIT_SECT_WIN*>()->cs );
+		DeleteCriticalSection( & m_data.getAsPtr<CRIT_SECT_WIN>()->cs );
 
 		m_data.clear();
 	}
@@ -73,7 +73,7 @@ void  CCriticalSection::enter() const
 
 	if (m_debugOut) m_debugOut->printf("[CCriticalSection:%s] Entering Thread ID:%lu\n", m_name.c_str(), threadid  );
 
-	CRIT_SECT_WIN *myCS = const_cast<CRIT_SECT_WIN  *>(  m_data.getAs<const CRIT_SECT_WIN*>() );
+	CRIT_SECT_WIN *myCS = const_cast<CRIT_SECT_WIN  *>(  m_data.getAsPtr<CRIT_SECT_WIN>() );
 
 	if( myCS->currentThreadOwner == threadid )
 		THROW_EXCEPTION(format("Detected recursive lock on critical section ('%s') by the same thread: %lu",m_name.c_str(),threadid ) )
@@ -95,7 +95,7 @@ void  CCriticalSection::leave() const
 
 	if (m_debugOut) m_debugOut->printf("[CCriticalSection:%s] Leaving Thread ID:%lu\n",m_name.c_str(),threadid );
 
-	CRIT_SECT_WIN *myCS = const_cast<CRIT_SECT_WIN  *>(  m_data.getAs<const CRIT_SECT_WIN*>() );
+	CRIT_SECT_WIN *myCS = const_cast<CRIT_SECT_WIN  *>(  m_data.getAsPtr<CRIT_SECT_WIN>() );
 
 	if ( myCS->currentThreadOwner!=threadid )
 		THROW_EXCEPTION(format("Trying to release a critical section  ('%s') locked by a different thread.",m_name.c_str()));

--- a/libs/base/src/synch/CSemaphore_APP.cpp
+++ b/libs/base/src/synch/CSemaphore_APP.cpp
@@ -45,7 +45,7 @@ CSemaphore::CSemaphore(
   MRPT_START
 
 	m_data.resize(sizeof(semaphore_t));
-	semaphore_t * sem = m_data.getAs<semaphore_t *>();
+	semaphore_t * sem = m_data.getAsPtr<semaphore_t>();
 
 	kern_return_t error = semaphore_create(mach_task_self(), sem, SYNC_POLICY_FIFO, initialCount);
 	if(error != KERN_SUCCESS)
@@ -61,7 +61,7 @@ CSemaphore::~CSemaphore()
 
   if (m_data.alias_count()==1)
   {
-	semaphore_t * sem = m_data.getAs<semaphore_t *>();
+	semaphore_t * sem = m_data.getAsPtr<semaphore_t>();
 	semaphore_destroy(mach_task_self(), *sem);
   }
 
@@ -73,7 +73,7 @@ bool CSemaphore::waitForSignal( unsigned int timelimit )
 {
   MRPT_START
 
-	semaphore_t * sem = m_data.getAs<semaphore_t *>();
+	semaphore_t * sem = m_data.getAsPtr<semaphore_t>();
 
 	if(timelimit == 0)
 	{
@@ -100,7 +100,7 @@ void CSemaphore::release(unsigned int increaseCount )
 {
   MRPT_START
 
-	semaphore_t * sem = m_data.getAs<semaphore_t *>();
+	semaphore_t * sem = m_data.getAsPtr<semaphore_t>();
 	for(unsigned int i=0; i<increaseCount; ++i)
 	{
 		kern_return_t result = semaphore_signal(*sem);

--- a/libs/base/src/synch/CSemaphore_LIN.cpp
+++ b/libs/base/src/synch/CSemaphore_LIN.cpp
@@ -50,8 +50,8 @@ CSemaphore::CSemaphore(
 	MRPT_START
 
 	// Reserve memory for my data:
-    m_data.resize( sizeof(sem_private_struct) );
-    sem_private token = m_data.getAs<sem_private>();
+	m_data.resize( sizeof(sem_private_struct) );
+	sem_private token = m_data.getAsPtr<sem_private_struct>();
 
 	// Unnamed semaphore:
 	token->has_to_free_mem = true;  // sem_init() requires an already allocated "sem_t"
@@ -76,7 +76,7 @@ CSemaphore::~CSemaphore()
 {
 	if (m_data.alias_count()==1)
 	{
-		sem_private token = m_data.getAs<sem_private>();
+		sem_private token = m_data.getAsPtr<sem_private_struct>();
 		
 		// Unnamed sems: sem_destroy()
 		sem_destroy((sem_t *)token->semid);
@@ -95,7 +95,7 @@ bool CSemaphore::waitForSignal( unsigned int timelimit )
 {
 	MRPT_START
 
-    sem_private token = m_data.getAs<sem_private>();
+    sem_private token = m_data.getAsPtr<sem_private_struct>();
 
 
 	int rc;
@@ -147,7 +147,7 @@ void CSemaphore::release(unsigned int increaseCount )
 {
 	MRPT_START
 
-    sem_private token = m_data.getAs<sem_private>();
+    sem_private token = m_data.getAsPtr<sem_private_struct>();
 
     for (unsigned int i=0;i<increaseCount;i++)
     	if (sem_post(token->semid))

--- a/libs/base/src/synch/CSemaphore_WIN.cpp
+++ b/libs/base/src/synch/CSemaphore_WIN.cpp
@@ -42,7 +42,7 @@ CSemaphore::CSemaphore(
 
 	m_data.resize( sizeof(HANDLE) );
 
-	* m_data.getAs<HANDLE*>() = hSem;
+	* m_data.getAsPtr<HANDLE>() = hSem;
 
 	MRPT_END
 }
@@ -54,7 +54,7 @@ CSemaphore::~CSemaphore()
 {
 	if (m_data.alias_count()==1)
 	{
-		CloseHandle( * m_data.getAs<HANDLE*>() );
+		CloseHandle( * m_data.getAsPtr<HANDLE>() );
 	}
 }
 
@@ -68,7 +68,7 @@ bool CSemaphore::waitForSignal( unsigned int timeout_ms )
 	MRPT_START
 
 	DWORD tim = (timeout_ms==0) ? INFINITE : timeout_ms;
-	DWORD ret = WaitForSingleObject( * m_data.getAs<HANDLE*>(), tim );
+	DWORD ret = WaitForSingleObject( * m_data.getAsPtr<HANDLE>(), tim );
 
 	return (ret==WAIT_OBJECT_0);
 
@@ -83,7 +83,7 @@ void CSemaphore::release(unsigned int increaseCount )
 	MRPT_START
 
 	if (!ReleaseSemaphore(
-		*m_data.getAs<HANDLE*>(),		// handle of the semaphore object
+		*m_data.getAsPtr<HANDLE>(),		// handle of the semaphore object
 		increaseCount,		// amount to add to current count
 		NULL ))				// address of previous count
 			THROW_EXCEPTION("Error increasing semaphore count!");

--- a/libs/base/src/utils/CReferencedMemBlock.cpp
+++ b/libs/base/src/utils/CReferencedMemBlock.cpp
@@ -13,11 +13,8 @@
 
 using namespace mrpt::utils;
 
-/*---------------------------------------------------------------
-						constructor
----------------------------------------------------------------*/
 CReferencedMemBlock::CReferencedMemBlock(size_t mem_block_size) :
-	base_t( new std::vector<char>(mem_block_size) )
+	m_data( new std::vector<char>(mem_block_size) )
 {
 }
 
@@ -25,11 +22,17 @@ CReferencedMemBlock::~CReferencedMemBlock()
 {
 }
 
-/*---------------------------------------------------------------
-						resize
----------------------------------------------------------------*/
 void CReferencedMemBlock::resize(size_t mem_block_size)
 {
-	this->operator ->()->resize(mem_block_size);
+	m_data->resize(mem_block_size);
 }
 
+unsigned int CReferencedMemBlock::alias_count() const 
+{
+	return m_data.alias_count(); 
+}
+
+void CReferencedMemBlock::clear() 
+{
+	m_data.clear(); 
+}

--- a/libs/gui/include/mrpt/gui/CMyRedirector.h
+++ b/libs/gui/include/mrpt/gui/CMyRedirector.h
@@ -52,14 +52,14 @@ public:
 		bool also_cerr = false,
 		bool threadSafe = false,
 		bool also_to_cout_cerr = false ) : m_txt(obj), m_yieldApplication(yieldApplication), m_also_cerr(also_cerr),m_threadSafe(threadSafe), m_also_to_cout_cerr(also_to_cout_cerr)
-    {
-        if (bufferSize)
-        {
-            char *ptr = new char[bufferSize];
-            setp(ptr, ptr + bufferSize);
-        }
-        else
-            setp(0, 0);
+	{
+		if (bufferSize)
+		{
+			char *ptr = new char[bufferSize];
+			setp(ptr, ptr + bufferSize);
+		}
+		else
+			setp(0, 0);
 
 		// Redirect:
 		sbOld = std::cout.rdbuf();
@@ -70,19 +70,19 @@ public:
 			sbOldErr = std::cerr.rdbuf();
 			std::cerr.rdbuf( this );
 		}
-    }
-    virtual ~CMyRedirector()
-    {
-        sync();
+	}
+	virtual ~CMyRedirector()
+	{
+		sync();
 
 		// Restore normal output:
-        std::cout.rdbuf(sbOld);
+		std::cout.rdbuf(sbOld);
 
-        if (m_also_cerr)
+		if (m_also_cerr)
 			std::cerr.rdbuf(sbOldErr);
 
-        delete[] pbase();
-    }
+		delete[] pbase();
+	}
 
 	void flush()
 	{
@@ -115,8 +115,8 @@ public:
 	}
 
 	/** Writes all the stored strings to the text control (only for threadSafe mode).
-	    CALL THIS METHOD FROM THE MAIN THREAD!
-	    */
+		CALL THIS METHOD FROM THE MAIN THREAD!
+		*/
 	void dumpNow()
 	{
 		wxCriticalSectionLocker  lock(m_cs);
@@ -134,39 +134,39 @@ public:
 	}
 
 private:
-    int	overflow(int c)
-    {
-        sync();
+	int	overflow(int c)
+	{
+		sync();
 
-        if (c != EOF)
-        {
+		if (c != EOF)
+		{
 			wxCriticalSectionLocker  lock(m_cs);
-            if (pbase() == epptr())
-            {
-                std::string temp;
-                temp += char(c);
-                writeString(temp);
-            }
-            else
-                sputc(c);
-        }
+			if (pbase() == epptr())
+			{
+				std::string temp;
+				temp += char(c);
+				writeString(temp);
+			}
+			else
+				sputc(c);
+		}
 
-        return 0;
-    }
+		return 0;
+	}
 
-    int	sync()
-    {
+	int	sync()
+	{
 		wxCriticalSectionLocker  lock(m_cs);
 
-        if (pbase() != pptr())
-        {
-            int len = int(pptr() - pbase());
-            std::string temp(pbase(), len);
-            writeString(temp);
-            setp(pbase(), epptr());
-        }
-        return 0;
-    }
+		if (pbase() != pptr())
+		{
+			int len = int(pptr() - pbase());
+			std::string temp(pbase(), len);
+			writeString(temp);
+			setp(pbase(), epptr());
+		}
+		return 0;
+	}
 };
 
 #endif

--- a/libs/nav/include/mrpt/nav/tpspace/CPTG_Holo_Blend.h
+++ b/libs/nav/include/mrpt/nav/tpspace/CPTG_Holo_Blend.h
@@ -11,6 +11,8 @@
 #include <mrpt/nav/tpspace/CParameterizedTrajectoryGenerator.h>
 #include <mrpt/utils/pimpl.h>
 
+PIMPL_FORWARD_DECLARATION(namespace exprtk { template <typename T> class expression; })
+
 namespace mrpt
 {
   namespace nav

--- a/libs/nav/src/tpspace/CPTG_Holo_Blend.cpp
+++ b/libs/nav/src/tpspace/CPTG_Holo_Blend.cpp
@@ -23,6 +23,7 @@ using namespace mrpt::system;
 
 IMPLEMENTS_SERIALIZABLE(CPTG_Holo_Blend,CParameterizedTrajectoryGenerator,mrpt::nav)
 
+
 /*
 Closed-form PTG. Parameters:
 - Initial velocity vector (xip, yip)

--- a/libs/nav/src/tpspace/CPTG_Holo_Blend_expr.cpp
+++ b/libs/nav/src/tpspace/CPTG_Holo_Blend_expr.cpp
@@ -14,6 +14,8 @@
 #include <mrpt/nav/tpspace/CPTG_Holo_Blend.h>
 #include <mrpt/otherlibs/exprtk.hpp>
 
+PIMPL_IMPLEMENT(exprtk::expression<double>);
+
 using namespace mrpt::nav;
 
 CPTG_Holo_Blend::CPTG_Holo_Blend() :
@@ -21,20 +23,14 @@ CPTG_Holo_Blend::CPTG_Holo_Blend() :
 	V_MAX(-1.0),
 	W_MAX(-1.0),
 	turningRadiusReference(0.30),
-	curVelLocal(0,0,0),
-	PIMPL_CTOR_INIT(exprtk::expression<double>, m_expr_v),
-	PIMPL_CTOR_INIT(exprtk::expression<double>, m_expr_w),
-	PIMPL_CTOR_INIT(exprtk::expression<double>, m_expr_T_ramp)
+	curVelLocal(0,0,0)
 {
 	internal_init_exprtks();
 }
 
 CPTG_Holo_Blend::CPTG_Holo_Blend(const mrpt::utils::CConfigFileBase &cfg,const std::string &sSection) :
 	turningRadiusReference(0.30),
-	curVelLocal(0,0,0),
-	PIMPL_CTOR_INIT(exprtk::expression<double>, m_expr_v),
-	PIMPL_CTOR_INIT(exprtk::expression<double>, m_expr_w),
-	PIMPL_CTOR_INIT(exprtk::expression<double>, m_expr_T_ramp)
+	curVelLocal(0,0,0)
 {
 	internal_init_exprtks();
 	this->loadFromConfigFile(cfg,sSection);
@@ -42,9 +38,6 @@ CPTG_Holo_Blend::CPTG_Holo_Blend(const mrpt::utils::CConfigFileBase &cfg,const s
 
 CPTG_Holo_Blend::~CPTG_Holo_Blend()
 {
-	PIMPL_DESTROY(exprtk::expression<double>, m_expr_v);
-	PIMPL_DESTROY(exprtk::expression<double>, m_expr_w);
-	PIMPL_DESTROY(exprtk::expression<double>, m_expr_T_ramp);
 }
 
 void CPTG_Holo_Blend::internal_init_exprtks()


### PR DESCRIPTION
Refactoring of PIMPL macros via an auxiliary structure that holds a C++11 `std::unique_ptr<>`. 
Old C++98 user code will see no declaration inside the structure, but that's no problem since all PIMPL must be non-`public` members, by definition.