### PR TITLE
Allow robot poses from external algorithms to be integrated into mrpt particles filter

### DIFF
--- a/libs/obs/include/mrpt/obs.h
+++ b/libs/obs/include/mrpt/obs.h
@@ -29,6 +29,7 @@ MRPT_WARNING("Including <mrpt/obs.h> makes compilation much slower, consider inc
 #include <mrpt/obs/CObservationStereoImagesFeatures.h>
 #include <mrpt/obs/CObservationBeaconRanges.h>
 #include <mrpt/obs/CObservation6DFeatures.h>
+#include <mrpt/obs/CObservationRobotPose.h>
 #include <mrpt/obs/CObservationGasSensors.h>
 #include <mrpt/obs/CObservationGPS.h>
 #include <mrpt/obs/CObservationBatteryState.h>

--- a/libs/obs/include/mrpt/obs/CObservationRobotPose.h
+++ b/libs/obs/include/mrpt/obs/CObservationRobotPose.h
@@ -1,0 +1,47 @@
+/* +---------------------------------------------------------------------------+
+   |                     Mobile Robot Programming Toolkit (MRPT)               |
+   |                          http://www.mrpt.org/                             |
+   |                                                                           |
+   | Copyright (c) 2005-2016, Individual contributors, see AUTHORS file        |
+   | See: http://www.mrpt.org/Authors - All rights reserved.                   |
+   | Released under BSD License. See details in http://www.mrpt.org/License    |
+   +---------------------------------------------------------------------------+ */
+#ifndef CObservationRobotPose_H
+#define CObservationRobotPose_H
+
+#include <mrpt/utils/CSerializable.h>
+#include <mrpt/obs/CObservation.h>
+#include <mrpt/poses/CPose3DPDFGaussian.h>
+
+namespace mrpt
+{
+namespace obs
+{
+	DEFINE_SERIALIZABLE_PRE_CUSTOM_BASE_LINKAGE( CObservationRobotPose, CObservation, OBS_IMPEXP  )
+
+	/** An observation providing an alternative robot pose from an external source.
+	 * \sa CObservation
+	 * \ingroup mrpt_obs_grp
+	 */
+	class OBS_IMPEXP CObservationRobotPose : public CObservation
+	{
+		// This must be added to any CSerializable derived class:
+		DEFINE_SERIALIZABLE( CObservationRobotPose )
+	 public:
+		CObservationRobotPose( );  //!< Default ctor
+
+		mrpt::poses::CPose3DPDFGaussian pose; //!< The observed robot pose
+
+		mrpt::poses::CPose3D sensorPose; //!< The pose of the sensor on the robot/vehicle
+
+		void getSensorPose( mrpt::poses::CPose3D &out_sensorPose ) const MRPT_OVERRIDE;// See base class docs.
+		void setSensorPose( const mrpt::poses::CPose3D &newSensorPose ) MRPT_OVERRIDE;// See base class docs.
+		void getDescriptionAsText(std::ostream &o) const MRPT_OVERRIDE;// See base class docs
+
+	}; // End of class def.
+	DEFINE_SERIALIZABLE_POST_CUSTOM_BASE_LINKAGE( CObservationRobotPose, CObservation, OBS_IMPEXP  )
+
+	} // End of namespace
+} // End of namespace
+
+#endif

--- a/libs/obs/src/CObservationRobotPose.cpp
+++ b/libs/obs/src/CObservationRobotPose.cpp
@@ -1,0 +1,83 @@
+/* +---------------------------------------------------------------------------+
+   |                     Mobile Robot Programming Toolkit (MRPT)               |
+   |                          http://www.mrpt.org/                             |
+   |                                                                           |
+   | Copyright (c) 2005-2016, Individual contributors, see AUTHORS file        |
+   | See: http://www.mrpt.org/Authors - All rights reserved.                   |
+   | Released under BSD License. See details in http://www.mrpt.org/License    |
+   +---------------------------------------------------------------------------+ */
+
+#include "obs-precomp.h"   // Precompiled headers
+
+
+#include <mrpt/utils/CStream.h>
+#include <mrpt/obs/CObservationRobotPose.h>
+#include <mrpt/system/os.h>
+#include <mrpt/math/matrix_serialization.h>
+
+using namespace mrpt::obs;
+using namespace mrpt::utils;
+using namespace mrpt::poses;
+
+
+// This must be added to any CSerializable class implementation file.
+IMPLEMENTS_SERIALIZABLE(CObservationRobotPose, CObservation,mrpt::obs)
+
+/** Default constructor */
+CObservationRobotPose::CObservationRobotPose( )
+{
+}
+
+
+/*---------------------------------------------------------------
+  Implements the writing to a CStream capability of CSerializable objects
+ ---------------------------------------------------------------*/
+void  CObservationRobotPose::writeToStream(mrpt::utils::CStream &out, int *version) const
+{
+	if (version)
+		*version = 0;
+	else
+	{
+		out << pose;
+		out << sensorLabel
+			<< timestamp;
+	}
+}
+
+/*---------------------------------------------------------------
+  Implements the reading from a CStream capability of CSerializable objects
+ ---------------------------------------------------------------*/
+void  CObservationRobotPose::readFromStream(mrpt::utils::CStream &in, int version)
+{
+	switch(version)
+	{
+	case 0:
+		{
+			in >> pose;
+			in >> sensorLabel
+			   >> timestamp;
+		} break;
+	default:
+		MRPT_THROW_UNKNOWN_SERIALIZATION_VERSION(version)
+	};
+
+}
+
+void CObservationRobotPose::getSensorPose( CPose3D &out_sensorPose ) const
+{ 
+	out_sensorPose = sensorPose; 
+}
+
+void CObservationRobotPose::setSensorPose( const CPose3D &newSensorPose )
+{ 
+	sensorPose = newSensorPose; 
+}
+
+void CObservationRobotPose::getDescriptionAsText(std::ostream &o) const
+{
+	using namespace std;
+	CObservation::getDescriptionAsText(o);
+
+	o << "Sensor pose: " << sensorPose << endl;
+	o << "Pose: " << pose.asString() << endl;
+}

--- a/libs/obs/src/registerAllClasses.cpp
+++ b/libs/obs/src/registerAllClasses.cpp
@@ -49,6 +49,7 @@ MRPT_INITIALIZER(registerAllClasses_mrpt_obs)
 	registerClass( CLASS_ID( CObservationStereoImagesFeatures ) );
 	//registerClass( CLASS_ID( CObservationVisualLandmarks ) );
 	registerClass( CLASS_ID( CObservation6DFeatures) );
+	registerClass( CLASS_ID( CObservationRobotPose) );
 	registerClass( CLASS_ID( CObservationCANBusJ1939 ) );
 	registerClass( CLASS_ID( CObservationRawDAQ ) );
 


### PR DESCRIPTION
**Changed apps/libraries:** 
*   *CLandmarksMap* 
This is a tentative PR following the discussion on https://github.com/mrpt-ros-pkg/mrpt_navigation/issues/43. It's just an addition, so it should not affect current code. The only additions are a likelihood calculation for the robot poses and a new observation class, The idea is to allow the MRPT particle filter to integrate poses estimated by other localization sources, typically not active all the time, for example [ar_track_alvar](http://wiki.ros.org/ar_track_alvar). 
