### PR TITLE
[CVehicleVelCmd_Holo::cmdVel_limits] Remove unnecessary cast and assertion

### DIFF
--- a/libs/kinematics/src/CVehicleVelCmd_Holo.cpp
+++ b/libs/kinematics/src/CVehicleVelCmd_Holo.cpp
@@ -113,8 +113,6 @@ void CVehicleVelCmd_Holo::cmdVel_scale(double vel_scale)
 void CVehicleVelCmd_Holo::cmdVel_limits(const mrpt::kinematics::CVehicleVelCmd &prev_vel_cmd, const double beta, const TVelCmdParams &params)
 {
 	ASSERTMSG_(params.robotMax_V_mps >= .0, "[CVehicleVelCmd_Holo] `robotMax_V_mps` must be set to valid values: either assign values programatically or call loadConfigFile()");
-	const mrpt::kinematics::CVehicleVelCmd_Holo *prevcmd = dynamic_cast<const mrpt::kinematics::CVehicleVelCmd_Holo*>(&prev_vel_cmd);
-	ASSERTMSG_(prevcmd, "Expected prevcmd of type `CVehicleVelCmd_Holo`");
 
 	double f = 1.0;
 	if (vel>params.robotMax_V_mps) f = params.robotMax_V_mps / vel;


### PR DESCRIPTION
I acknowledge to have: 
* Read the [`CONTRIBUTING`](https://github.com/MRPT/mrpt/blob/master/.github/CONTRIBUTING.md) page
* Updated [`docs/doxygen-pages/changelog.h`](https://github.com/MRPT/mrpt/blob/master/doc/doxygen-pages/changeLog_doc.h) to describe these changes (if applicable)
* Updated [`AUTHORS`](https://github.com/MRPT/mrpt/blob/master/AUTHORS) (if applicable)

(Notify: @MRPT/owners )