### PR TITLE
Add a velocity visualization to navlog-viewer

### DIFF
--- a/apps/navlog-viewer/navlog_viewer_GUI_designMain.cpp
+++ b/apps/navlog-viewer/navlog_viewer_GUI_designMain.cpp
@@ -745,7 +745,7 @@ void navlog_viewer_GUI_designDialog::OnslidLogCmdScroll(wxScrollEvent& event)
 								gl_shape = mrpt::opengl::CSetOfLinesPtr(gl_shape_r);
 							}
 							gl_shape->clear();
-							const mrpt::math::TTwist2D &velLocal = log.cur_vel_local;
+							const mrpt::math::TTwist2D &velLocal = log.cur_vel;
 							gl_shape->appendLine(0,0,0, velLocal.vx, velLocal.vy, 0);
 						}
 					}

--- a/apps/navlog-viewer/navlog_viewer_GUI_designMain.cpp
+++ b/apps/navlog-viewer/navlog_viewer_GUI_designMain.cpp
@@ -732,6 +732,22 @@ void navlog_viewer_GUI_designDialog::OnslidLogCmdScroll(wxScrollEvent& event)
 							gl_shape->clear();
 							ptg->add_robotShape_to_setOfLines(*gl_shape);
 						}
+						{
+							mrpt::opengl::CSetOfLinesPtr   gl_shape;
+							mrpt::opengl::CRenderizablePtr gl_shape_r = gl_robot_frame->getByName("velocity");  // Get or create if new
+							if (!gl_shape_r) {
+								gl_shape = mrpt::opengl::CSetOfLines::Create();
+								gl_shape->setName("velocity");
+								gl_shape->setLineWidth(4.0);
+								gl_shape->setColor_u8( mrpt::utils::TColor(0x00,0xff,0xff) );
+								gl_robot_frame->insert(gl_shape);
+							} else {
+								gl_shape = mrpt::opengl::CSetOfLinesPtr(gl_shape_r);
+							}
+							gl_shape->clear();
+							const mrpt::math::TTwist2D &velLocal = log.cur_vel_local;
+							gl_shape->appendLine(0,0,0, velLocal.vx, velLocal.vy, 0);
+						}
 					}
 				}
 			}


### PR DESCRIPTION
I acknowledge to have: 
* Read the [`CONTRIBUTING`](https://github.com/MRPT/mrpt/blob/master/.github/CONTRIBUTING.md) page
* Updated [`docs/doxygen-pages/changelog.h`](https://github.com/MRPT/mrpt/blob/master/doc/doxygen-pages/changeLog_doc.h) to describe these changes (if applicable)
* Updated [`AUTHORS`](https://github.com/MRPT/mrpt/blob/master/AUTHORS) (if applicable)

(Notify: @MRPT/owners )

The cur_vel_local is now a teal line.