### PR TITLE
Revert cur_vel back to cur_vel_local

### DIFF
--- a/apps/navlog-viewer/navlog_viewer_GUI_designMain.cpp
+++ b/apps/navlog-viewer/navlog_viewer_GUI_designMain.cpp
@@ -745,7 +745,7 @@ void navlog_viewer_GUI_designDialog::OnslidLogCmdScroll(wxScrollEvent& event)
 								gl_shape = mrpt::opengl::CSetOfLinesPtr(gl_shape_r);
 							}
 							gl_shape->clear();
-							const mrpt::math::TTwist2D &velLocal = log.cur_vel;
+							const mrpt::math::TTwist2D &velLocal = log.cur_vel_local;
 							gl_shape->appendLine(0,0,0, velLocal.vx, velLocal.vy, 0);
 						}
 					}
@@ -792,7 +792,6 @@ void navlog_viewer_GUI_designDialog::OnslidLogCmdScroll(wxScrollEvent& event)
 		ADD_WIN_TEXTMSG(mrpt::format("cmd_vel=%s", log.cmd_vel ? log.cmd_vel->asString().c_str() : "NOP (Continue last PTG)"));
 
 		ADD_WIN_TEXTMSG(mrpt::format("cur_vel=[%.02f m/s, %0.2f m/s, %.02f dps] cur_vel_local=[%.02f m/s, %0.2f m/s, %.02f dps]",
-			log.cur_vel.vx, log.cur_vel.vy, mrpt::utils::RAD2DEG(log.cur_vel.omega),
 			log.cur_vel_local.vx, log.cur_vel_local.vy, mrpt::utils::RAD2DEG(log.cur_vel_local.omega))
 			);
 


### PR DESCRIPTION
**Changed apps/libraries:** 
*   *Describe the pull request here* ...
* (*REMOVE THIS LINE IF NOT NEEDED*) This PR Closes issue #XXX
* (*REMOVE THIS LINE IF NOT NEEDED*) 

I acknowledge to have: 
* Read the [`CONTRIBUTING`](https://github.com/MRPT/mrpt/blob/master/.github/CONTRIBUTING.md) page
* Updated [`docs/doxygen-pages/changelog.h`](https://github.com/MRPT/mrpt/blob/master/doc/doxygen-pages/changeLog_doc.h) to describe these changes (if applicable)
* Updated [`AUTHORS`](https://github.com/MRPT/mrpt/blob/master/AUTHORS) (if applicable)

(Notify: @MRPT/owners )

The rendering origin is the robot Pose
I thought it was the odometry space.
cur_vel_local should work.

I tricked myself with a bug on my side.