### PR TITLE
Use PF_options.BETA parameter also with adaptive sample size

### DIFF
--- a/libs/slam/include/mrpt/slam/PF_implementations.h
+++ b/libs/slam/include/mrpt/slam/PF_implementations.h
@@ -673,7 +673,7 @@ namespace mrpt
 				// ------------------------------------------------------------------------------
 				double		delta_1 = 1.0 - KLD_options.KLD_delta;
 				double		epsilon_1 = 0.5 / KLD_options.KLD_epsilon;
-				bool		doResample = me->ESS() < 0.5;
+				bool		doResample = me->ESS() < PF_options.BETA;
 				//double	maxLik = math::maximum(m_pfAuxiliaryPFOptimal_maxLikelihood); // For normalization purposes only
 
 				// The desired dynamic number of m_particles (to be modified dynamically below):


### PR DESCRIPTION
**Changed apps/libraries:** 
* SLAM

Now it's only used on fixed sample size, while on adaptive sample size  is hardcoded as 0.5

(Notify: @MRPT/owners )

