### PR TITLE
initialize m_use_odo_error to false

### DIFF
--- a/libs/kinematics/src/CVehicleSimulVirtualBase.cpp
+++ b/libs/kinematics/src/CVehicleSimulVirtualBase.cpp
@@ -14,7 +14,7 @@
 using namespace mrpt::kinematics;
 
 CVehicleSimulVirtualBase::CVehicleSimulVirtualBase() :
-m_firmware_control_period(500e-6)
+m_firmware_control_period(500e-6), m_use_odo_error(false)
 {
 }
 


### PR DESCRIPTION
I acknowledge to have: 
* Read the [`CONTRIBUTING`](https://github.com/MRPT/mrpt/blob/master/.github/CONTRIBUTING.md) page
* Updated [`docs/doxygen-pages/changelog.h`](https://github.com/MRPT/mrpt/blob/master/doc/doxygen-pages/changeLog_doc.h) to describe these changes (if applicable)
* Updated [`AUTHORS`](https://github.com/MRPT/mrpt/blob/master/AUTHORS) (if applicable)

(Notify: @MRPT/owners )

Right now vehicle simulators can be in the inconsistent state where m_use_odo_error is initialized to true and the error parameters aren't set.