### PR TITLE
[CPointCloudFilterByDistance_unittest] use size_t for iterator

### DIFF
--- a/libs/maps/src/maps/CPointCloudFilterByDistance_unittest.cpp
+++ b/libs/maps/src/maps/CPointCloudFilterByDistance_unittest.cpp
@@ -36,8 +36,8 @@ void run_pc_filter_test(
 	const mrpt::system::TTimeStamp pts2_tim = mrpt::system::timestampAdd(pts1_tim, 0.2+ map2_tim_off);
 
 	mrpt::maps::CSimplePointsMap map1, map2;
-	for (int i = 0; i< sizeof(pts1) / sizeof(pts1[0]); i++) map1.insertPoint(pts1[i][0], pts1[i][1], pts1[i][2]);
-	for (int i = 0; i < sizeof(pts1) / sizeof(pts1[0]); i++) 
+	for (size_t i = 0; i< sizeof(pts1) / sizeof(pts1[0]); i++) map1.insertPoint(pts1[i][0], pts1[i][1], pts1[i][2]);
+	for (size_t i = 0; i < sizeof(pts1) / sizeof(pts1[0]); i++) 
 	{
 		double x, y, z;
 		pts2_pose.inverseComposePoint(pts1[i][0], pts1[i][1], pts1[i][2], x, y, z);


### PR DESCRIPTION
I acknowledge to have: 
* Read the [`CONTRIBUTING`](https://github.com/MRPT/mrpt/blob/master/.github/CONTRIBUTING.md) page
* Updated [`docs/doxygen-pages/changelog.h`](https://github.com/MRPT/mrpt/blob/master/doc/doxygen-pages/changeLog_doc.h) to describe these changes (if applicable)
* Updated [`AUTHORS`](https://github.com/MRPT/mrpt/blob/master/AUTHORS) (if applicable)

(Notify: @MRPT/owners )
