### PR TITLE
Fix CObservationSkeleton to write its sensorPose into a rawlog.

### DIFF
--- a/libs/obs/src/CObservationSkeleton.cpp
+++ b/libs/obs/src/CObservationSkeleton.cpp
@@ -52,7 +52,8 @@ void  CObservationSkeleton::writeToStream(CStream &out, int *version) const
 		WRITE_JOINT(right_foot)
 
 		out << sensorLabel
-		    << timestamp;
+		    << timestamp
+		    << sensorPose;
 	}
 }
 
@@ -86,7 +87,7 @@ void  CObservationSkeleton::readFromStream(CStream &in, int version)
 
 			in >> sensorLabel;
 			in >> timestamp;
-
+			in >> sensorPose;
 		} break;
 	default:
 		MRPT_THROW_UNKNOWN_SERIALIZATION_VERSION(version)

--- a/libs/obs/src/CObservationSkeleton.cpp
+++ b/libs/obs/src/CObservationSkeleton.cpp
@@ -30,7 +30,7 @@ IMPLEMENTS_SERIALIZABLE(CObservationSkeleton, CObservation, mrpt::obs)
 void  CObservationSkeleton::writeToStream(CStream &out, int *version) const
 {
 	if (version)
-		*version = 1;
+		*version = 2;
 	else
 	{
 		WRITE_JOINT(head)
@@ -66,6 +66,7 @@ void  CObservationSkeleton::readFromStream(CStream &in, int version)
 	{
 	case 0:
 	case 1:
+	case 2:
 		{
 			READ_JOINT(head)
 			READ_JOINT(neck)
@@ -87,7 +88,9 @@ void  CObservationSkeleton::readFromStream(CStream &in, int version)
 
 			in >> sensorLabel;
 			in >> timestamp;
-			in >> sensorPose;
+			if (version >= 2){
+				in >> sensorPose;
+			}
 		} break;
 	default:
 		MRPT_THROW_UNKNOWN_SERIALIZATION_VERSION(version)


### PR DESCRIPTION
**Changed apps/libraries: mrpt::obs::CObservationSkeleton** 
*   CObservationSkeleton can't write its sensorPose into a rawlog. writeToStream and readFromStream methods should be modified.

I acknowledge to have: 
* Read the [`CONTRIBUTING`](https://github.com/MRPT/mrpt/blob/master/.github/CONTRIBUTING.md) page
* Updated [`docs/doxygen-pages/changelog.h`](https://github.com/MRPT/mrpt/blob/master/doc/doxygen-pages/changeLog_doc.h) to describe these changes (if applicable)
* Updated [`AUTHORS`](https://github.com/MRPT/mrpt/blob/master/AUTHORS) (if applicable)

(Notify: @MRPT/owners )
