### PR TITLE
Minor update to 'm_exprstr_score2_formula' expression

### DIFF
--- a/libs/nav/src/reactive/CAbstractPTGBasedReactive.cpp
+++ b/libs/nav/src/reactive/CAbstractPTGBasedReactive.cpp
@@ -83,7 +83,7 @@ CAbstractPTGBasedReactive::CAbstractPTGBasedReactive(CRobot2NavInterface &react_
 	BEST_ETA_MARGIN_TOLERANCE_WRT_BEST(1.05),
 	ENABLE_OBSTACLE_FILTERING(false),
 	m_navlogfiles_dir(sLogDir),
-	m_exprstr_score2_formula("var dif:=abs(k_target-k); if (dif>(num_paths/2)) { dif:=num_paths-dif; } var result := exp(-abs(dif / (num_paths/10.0)));")
+	m_exprstr_score2_formula("var dif:=abs(k_target-k); if (dif>(num_paths/2)) { dif:=num_paths-dif; }; exp(-abs(dif / (num_paths/10.0)));")
 {
 	internal_construct_exprs();
 	this->enableLogFile( enableLogFile );

--- a/share/mrpt/config_files/navigation-ptgs/reactivenav-app-config.ini
+++ b/share/mrpt/config_files/navigation-ptgs/reactivenav-app-config.ini
@@ -136,7 +136,7 @@ weights=  0.5  1.0  0.05  2.0  0.3  0.1
 
 # Formula for score #2: distance in "path indices". 
 # Available variables: `k`,`k_target`, `num_paths`
-#score2_formula = var dif:=abs(k_target-k); if (dif>(num_paths/2)) { dif:=num_paths-dif; } var result := exp(-abs(dif / (num_paths/10.0)));
+#score2_formula = var dif:=abs(k_target-k); if (dif>(num_paths/2)) { dif:=num_paths-dif; }; exp(-abs(dif / (num_paths/10.0)));
 
 
 DIST_TO_TARGET_FOR_SENDING_EVENT=0.6	# Minimum. distance to target for sending the end event. Set to 0 to send it just on navigation end


### PR DESCRIPTION
This is a very minor change. Initially please note that everything in ExprTk is a value returning entity. As an example the for-loop below will return the value 10 assigning it to x:

`var x := for (var y := 0; y < 10; y +=1 ) { y + 1 }`


Furthermore the _last sub-expression_ is deemed to be the return value of the whole expression.

-------

In the expression **m_exprstr_score2_formula** by adding a _semi-colon ';'_ to the end of the if-statement that creates an end to that particular sub-expression, and implicitly makes the next part the last sub-expression.

I'm thinking the "var result" was added because the expression was resulting in weird values - The reason for that is because there is an implicit multiplication inserted between the if-statement and the final expression. This is what the compiler generates when there isn't the ';' or the `'var result := ...'` :

`if (dif > (num_paths / 2)) { dif := num_paths - dif; } * exp(-abs(dif / (num_paths / 10.0)));`


When the if-statement isn't true and due to there not being an else section (aka alternative) the if-statement returns a **NaN** value.

That NaN is then used in a multiplication operation with the last part of the expression - which then results in "weird" return values - sometimes **NaN**.

Instead by simply adding a _semi-colon_ between the two sub-expressions, the calculation will be as expected and the expression wont incur the run-time cost of evaluating a variable initialization and assignment.

-------

The reason for having implicit multiplication is for scenarios like the following:
- 2x^2
- 2.5abs(3x)
- sin(x)(1/cos(x))
- [Other examples](https://github.com/ArashPartow/exprtk/blob/master/readme.txt#L1066)

