### PR TITLE
Include ops_vectors.h in ops_containers.h

### DIFF
--- a/libs/base/include/mrpt/math/ops_containers.h
+++ b/libs/base/include/mrpt/math/ops_containers.h
@@ -41,6 +41,7 @@
 
 #include <mrpt/math/CHistogram.h>  // Used in ::histogram()
 
+#include "ops_vectors.h"
 
 namespace mrpt
 {


### PR DESCRIPTION
Needed for the multiplying a vector by a scalar.
For example, out_mean*=N_inv;

I acknowledge to have: 
* Read the [`CONTRIBUTING`](https://github.com/MRPT/mrpt/blob/master/.github/CONTRIBUTING.md) page
* Updated [`docs/doxygen-pages/changelog.h`](https://github.com/MRPT/mrpt/blob/master/doc/doxygen-pages/changeLog_doc.h) to describe these changes (if applicable)
* Updated [`AUTHORS`](https://github.com/MRPT/mrpt/blob/master/AUTHORS) (if applicable)

(Notify: @MRPT/owners )
