### PR TITLE
delayed-template-parsing breaks clang PCH

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -492,9 +492,6 @@ if (${CMAKE_CXX_COMPILER_ID} STREQUAL "Clang")
 		SET(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} -stdlib=libstdc++")
 	ENDIF()
 
-	# This is to fix the compilation of C++ templates
-	SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fdelayed-template-parsing")
-
 endif()
 
 # Shared options between GCC and CLANG:


### PR DESCRIPTION
I acknowledge to have: 
* Read the [`CONTRIBUTING`](https://github.com/MRPT/mrpt/blob/master/.github/CONTRIBUTING.md) page
* Updated [`docs/doxygen-pages/changelog.h`](https://github.com/MRPT/mrpt/blob/master/doc/doxygen-pages/changeLog_doc.h) to describe these changes (if applicable)
* Updated [`AUTHORS`](https://github.com/MRPT/mrpt/blob/master/AUTHORS) (if applicable)

(Notify: @MRPT/owners )
