### PR TITLE
Revert resolution change

### DIFF
--- a/libs/hwdrivers/src/COpenNI2Generic.cpp
+++ b/libs/hwdrivers/src/COpenNI2Generic.cpp
@@ -240,12 +240,6 @@ void COpenNI2Generic::open(unsigned sensor_id)
 		return;
 	}
 	if (m_verbose) printf("[COpenNI2Generic] DBG: [%s] about to call vDevices[%d]->open()\n",__FUNCTION__,sensor_id);
-	if(sensor_id == openni::SENSOR_IR)
-		//Don't mess with IR stream
-		vDevices[openni::SENSOR_IR]->open(640, 480, m_fps);
-	else
-		vDevices[sensor_id]->open(m_width, m_height, m_fps);
-
 	vDevices[sensor_id]->open(m_width, m_height, m_fps);
 	showLog(vDevices[sensor_id]->getLog() + "\n");
 	showLog(mrpt::format(" Device [%d] ", sensor_id));
@@ -283,8 +277,8 @@ unsigned int COpenNI2Generic::openDevicesBySerialNum(const std::set<unsigned>& s
       num_open_dev++;
       continue;
     }
-    int width  = sensor_id == openni::SENSOR_IR ? 640 : m_width;
-    int height = sensor_id == openni::SENSOR_IR ? 480 : m_height;
+    int width  = m_width;
+    int height = m_height;
     if (m_verbose) printf("[COpenNI2Generic] DBG: [%s] about to call vDevices[%d]->open(%d,%d,%d)\n",
     __FUNCTION__,sensor_id,width,height,(int)m_fps);
     if(vDevices[sensor_id]->open(width, height, m_fps) == false){


### PR DESCRIPTION
Woops... this is definitely wrong. I was looking at the wrong open.

It seems like the order the streams are opened might have something to do with it, but depth decimation doesn't seem to work automatically in firmware. For now we may be stuck setting all the resolutions the same. Judging by this[1] the firmware is a bit finicky, so it might be worth capturing at a higher resolution and decimating in software to get better range performance.

1. https://github.com/OpenNI/OpenNI2/blob/115cf06c6efea32304182d293eca16ca883c9150/Source/Drivers/PS1080/Sensor/XnSensorIRStream.cpp#L222

I acknowledge to have: 
* Read the [`CONTRIBUTING`](https://github.com/MRPT/mrpt/blob/master/.github/CONTRIBUTING.md) page
* Updated [`docs/doxygen-pages/changelog.h`](https://github.com/MRPT/mrpt/blob/master/doc/doxygen-pages/changeLog_doc.h) to describe these changes (if applicable)
* Updated [`AUTHORS`](https://github.com/MRPT/mrpt/blob/master/AUTHORS) (if applicable)

(Notify: @MRPT/owners )
