### PR TITLE
Add a extRobotPoseStd parameter to external robot poses likelihood

### DIFF
--- a/libs/vision/include/mrpt/maps/CLandmarksMap.h
+++ b/libs/vision/include/mrpt/maps/CLandmarksMap.h
@@ -270,7 +270,7 @@ namespace maps
 			void loadFromConfigFile(const mrpt::utils::CConfigFileBase &source,const std::string &section) MRPT_OVERRIDE; // See base docs
 			void dumpToTextStream(mrpt::utils::CStream &out) const MRPT_OVERRIDE; // See base docs
 
-			/** @name Parameters for: 2D LIDAR scans 
+			/** @name Parameters for: 2D LIDAR scans
 			  * @{ */
 			unsigned int rangeScan2D_decimation; //!< The number of rays from a 2D range scan will be decimated by this factor (default = 1, no decimation)
 			/** @} */
@@ -293,7 +293,12 @@ namespace maps
 			float  beaconRangesStd; //!< The standard deviation used for Beacon ranges likelihood (default=0.08) [meters] \sa beaconRangesUseObservationStd
 			bool   beaconRangesUseObservationStd; //!< (Default: false) If true, `beaconRangesStd` is ignored and each individual `CObservationBeaconRanges::stdError` field is used instead.
 			/** @} */
-			
+
+            /** @name Parameters for: External robot poses observation
+              * @{ */
+            float  extRobotPoseStd; //!< The standard deviation used for external robot poses likelihood (default=0.05) [meters]
+            /** @} */
+
 			/** @name Parameters for: GPS readings
 			  * @{ */
 
@@ -306,7 +311,7 @@ namespace maps
 				double	longitude;   //!< degrees
 				double	latitude;    //!< degrees
 				double	altitude;    //!< meters
-				/** These 3 params allow rotating and shifting GPS coordinates with other 2D maps (e.g. gridmaps). 
+				/** These 3 params allow rotating and shifting GPS coordinates with other 2D maps (e.g. gridmaps).
 				  * - ang : Map rotation [deg]
 				  * - x_shift, y_shift: (x,y) offset [m] */
 				double	ang, x_shift, y_shift;
@@ -393,10 +398,10 @@ namespace maps
 		/** Loads into this landmarks map the SIFT features extracted from an image observation (Previous contents of map will be erased)
 		  *  The robot is assumed to be at the origin of the map.
 		  *  Some options may be applicable from "insertionOptions" (insertionOptions.SIFTsLoadDistanceOfTheMean)
-		  * 
+		  *
 		  *  \param feat_options Optionally, you can pass here parameters for changing the default SIFT detector settings.
 		  */
-		void  loadSiftFeaturesFromImageObservation( 
+		void  loadSiftFeaturesFromImageObservation(
 			const mrpt::obs::CObservationImage	&obs,
 			const mrpt::vision::CFeatureExtraction::TOptions & feat_options = mrpt::vision::CFeatureExtraction::TOptions(mrpt::vision::featSIFT)
 			);
@@ -407,8 +412,8 @@ namespace maps
 		  *
 		  *  \param feat_options Optionally, you can pass here parameters for changing the default SIFT detector settings.
 		  */
-		void  loadSiftFeaturesFromStereoImageObservation( 
-			const mrpt::obs::CObservationStereoImages	&obs, 
+		void  loadSiftFeaturesFromStereoImageObservation(
+			const mrpt::obs::CObservationStereoImages	&obs,
 			mrpt::maps::CLandmark::TLandmarkID fID,
 			const mrpt::vision::CFeatureExtraction::TOptions & feat_options = mrpt::vision::CFeatureExtraction::TOptions(mrpt::vision::featSIFT)
 			);

--- a/libs/vision/src/maps/CLandmarksMap.cpp
+++ b/libs/vision/src/maps/CLandmarksMap.cpp
@@ -75,7 +75,7 @@ void CLandmarksMap::TMapDefinition::loadFromConfigFile_map_specific(const mrpt::
 
 void CLandmarksMap::TMapDefinition::dumpToTextStream_map_specific(mrpt::utils::CStream &out) const
 {
-	out.printf("number of initial beacons               = %u\n",(int)initialBeacons.size());
+	out.printf("number of initial beacons                = %u\n",(int)initialBeacons.size());
 
 	out.printf("      ID         (X,Y,Z)\n");
 	out.printf("--------------------------------------------------------\n");
@@ -371,16 +371,16 @@ double	 CLandmarksMap::internal_computeObservationLikelihood(
 		dij(0,0) =          o->pose.mean.x()     - sensorPose3D.x();
 		dij(0,1) =          o->pose.mean.y()     - sensorPose3D.y();
 		dij(0,2) =          o->pose.mean.z()     - sensorPose3D.z();
-		dij(0,3) = wrapToPi(o->pose.mean.roll()  - sensorPose3D.roll());
+        dij(0,3) = wrapToPi(o->pose.mean.yaw()   - sensorPose3D.yaw());
 		dij(0,4) = wrapToPi(o->pose.mean.pitch() - sensorPose3D.pitch());
-		dij(0,5) = wrapToPi(o->pose.mean.yaw()   - sensorPose3D.yaw());
+        dij(0,5) = wrapToPi(o->pose.mean.roll()  - sensorPose3D.roll());
 
 		// Equivalent covariance from "i" to "j":
 		Cij = CMatrixDouble(o->pose.cov);
 		Cij_1 = Cij.inv();
 
-		double distMahaFlik2 =  dij.multiply_HCHt_scalar(Cij_1); //( dij * Cij_1 * (~dij) )(0,0);
-		double ret = -0.5f * distMahaFlik2;
+		double distMahaFlik2 =  dij.multiply_HCHt_scalar(Cij_1);
+		double ret = - 0.5  * (distMahaFlik2 / square(likelihoodOptions.extRobotPoseStd));
 
 		MRPT_CHECK_NORMAL_NUMBER(ret);
 		return ret;
@@ -2106,20 +2106,20 @@ void  CLandmarksMap::TInsertionOptions::dumpToTextStream(mrpt::utils::CStream	&o
 	out.printf("\n");
 	out.printf("SiftCorrRatioThreshold                  = %f\n", SiftCorrRatioThreshold);
 	out.printf("SiftLikelihoodThreshold                 = %f\n", SiftLikelihoodThreshold);
-	out.printf("SiftEDDThreshold						= %f\n", SiftEDDThreshold);
-	out.printf("SIFTMatching3DMethod					= %d\n", SIFTMatching3DMethod);
-	out.printf("SIFTLikelihoodMethod					= %d\n", SIFTLikelihoodMethod);
+	out.printf("SiftEDDThreshold                        = %f\n", SiftEDDThreshold);
+	out.printf("SIFTMatching3DMethod                    = %d\n", SIFTMatching3DMethod);
+    out.printf("SIFTLikelihoodMethod                    = %d\n", SIFTLikelihoodMethod);
 
-	out.printf("SIFTsLoadDistanceOfTheMean              = %f\n", SIFTsLoadDistanceOfTheMean);
-	out.printf("SIFTsLoadEllipsoidWidth                 = %f\n", SIFTsLoadEllipsoidWidth);
-	out.printf("\n");
-	out.printf("SIFTs_stdXY                             = %f\n", SIFTs_stdXY);
-	out.printf("SIFTs_stdDisparity                      = %f\n", SIFTs_stdDisparity);
-	out.printf("\n");
-	out.printf("SIFTs_numberOfKLTKeypoints              = %i\n", SIFTs_numberOfKLTKeypoints);
-	out.printf("SIFTs_stereo_maxDepth                   = %f\n", SIFTs_stereo_maxDepth);
-	out.printf("SIFTs_epipolar_TH						= %f\n", SIFTs_epipolar_TH);
-	out.printf("PLOT_IMAGES								= %c\n", PLOT_IMAGES ? 'Y':'N');
+    out.printf("SIFTsLoadDistanceOfTheMean              = %f\n", SIFTsLoadDistanceOfTheMean);
+    out.printf("SIFTsLoadEllipsoidWidth                 = %f\n", SIFTsLoadEllipsoidWidth);
+    out.printf("\n");
+    out.printf("SIFTs_stdXY                             = %f\n", SIFTs_stdXY);
+    out.printf("SIFTs_stdDisparity                      = %f\n", SIFTs_stdDisparity);
+    out.printf("\n");
+    out.printf("SIFTs_numberOfKLTKeypoints              = %i\n", SIFTs_numberOfKLTKeypoints);
+    out.printf("SIFTs_stereo_maxDepth                   = %f\n", SIFTs_stereo_maxDepth);
+    out.printf("SIFTs_epipolar_TH                       = %f\n", SIFTs_epipolar_TH);
+    out.printf("PLOT_IMAGES                             = %c\n", PLOT_IMAGES ? 'Y':'N');
 
 	SIFT_feat_options.dumpToTextStream(out);
 
@@ -2167,6 +2167,7 @@ CLandmarksMap::TLikelihoodOptions::TLikelihoodOptions() :
 	SIFT_feat_options				( vision::featSIFT ),
 	beaconRangesStd					( 0.08f ),
 	beaconRangesUseObservationStd	(false),
+	extRobotPoseStd                 ( 0.05f ),
 	GPSOrigin						(),
 	GPS_sigma						( 1.0f )
 {
@@ -2198,7 +2199,7 @@ void  CLandmarksMap::TLikelihoodOptions::dumpToTextStream(mrpt::utils::CStream	&
 	out.printf("SIFTnullCorrespondenceDistance          = %f\n",SIFTnullCorrespondenceDistance);
 	out.printf("beaconRangesStd                         = %f\n",beaconRangesStd);
 	out.printf("beaconRangesUseObservationStd           = %c\n",beaconRangesUseObservationStd ? 'Y':'N');
-
+    out.printf("extRobotPoseStd                         = %f\n",extRobotPoseStd);
 
 	out.printf("GPSOrigin:LATITUDE                      = %f\n",GPSOrigin.latitude);
 	out.printf("GPSOrigin:LONGITUDE                     = %f\n",GPSOrigin.longitude);
@@ -2241,6 +2242,8 @@ void  CLandmarksMap::TLikelihoodOptions::loadFromConfigFile(
 
 	beaconRangesStd					= iniFile.read_float(section.c_str(),"beaconRangesStd",beaconRangesStd);
 	beaconRangesUseObservationStd	= iniFile.read_bool(section.c_str(),"beaconRangesUseObservationStd",beaconRangesUseObservationStd);
+
+    extRobotPoseStd                 = iniFile.read_float(section.c_str(),"extRobotPoseStd",extRobotPoseStd);
 
 	SIFT_feat_options.loadFromConfigFile(iniFile,section);
 }


### PR DESCRIPTION
**Changed apps/libraries:** 
* SLAM

Add a extRobotPoseStd parameter to external robot poses likelihood calculation, so we can configure their influence in the filter.

**Advice needed:** Actually, I'm not fully sure if this is the right way to calculate the likelihood; I copied the way it's done with beacons, but for example on SIFT is done differently, with an exponential. Suggestions welcomed; thanks!

Also align filter parameters std output.

I acknowledge to have: 
* Read the [`CONTRIBUTING`](https://github.com/MRPT/mrpt/blob/master/.github/CONTRIBUTING.md) page
* Updated [`docs/doxygen-pages/changelog.h`](https://github.com/MRPT/mrpt/blob/master/doc/doxygen-pages/changeLog_doc.h) to describe these changes (if applicable)
* Updated [`AUTHORS`](https://github.com/MRPT/mrpt/blob/master/AUTHORS) (if applicable)

(Notify: @MRPT/owners )
