### PR TITLE
Add g++-6 and clang-3.8 to travisci

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,18 +4,30 @@ sudo: true
 dist: trusty
 
 before_install:
-  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then  sudo add-apt-repository ppa:v-launchpad-jochen-sprickerhof-de/pcl -y  ; fi
-  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then  sudo apt-get update -d  ; fi
-  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew update          ; fi
+  - if [ "$TRAVIS_OS_NAME" == "linux" ]; then  sudo add-apt-repository ppa:v-launchpad-jochen-sprickerhof-de/pcl -y  ; fi
+  - if [ "$TRAVIS_OS_NAME" == "linux" ]; then
+    sudo add-apt-repository ppa:ubuntu-toolchain-r/test -y ;
+    sudo apt-get update ;
+
+    sudo apt-get install gcc-6 g++-6 clang-3.8 ;
+    sudo rm -rf /usr/local ;
+    sudo update-alternatives --install /usr/bin/clang++ clang++ /usr/bin/clang++-3.8 100 ;
+    sudo update-alternatives --install /usr/bin/clang clang /usr/bin/clang-3.8 100 ;
+    sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-6 20 ;
+    sudo update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-6 20 ;
+    fi
+  - if [ "$TRAVIS_OS_NAME" == "linux" ]; then  sudo apt-get update -d  ; fi
+  - if [ "$TRAVIS_OS_NAME" == "linux" &&  ]; then  sudo apt-get update -d  ; fi
+  - if [ "$TRAVIS_OS_NAME" == "osx" ]; then brew update          ; fi
 
 
 install:
-  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then  sudo apt-get install build-essential pkg-config cmake libwxgtk3.0-dev libftdi-dev freeglut3-dev zlib1g-dev libusb-1.0-0-dev  libdc1394-22-dev libavformat-dev libswscale-dev libassimp-dev libjpeg-dev libopencv-dev libgtest-dev libeigen3-dev libsuitesparse-dev libpcl-all libopenni2-dev libudev-dev gdb libboost-python-dev libpython-dev python-numpy -y ; fi
-  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew tap homebrew/science   ; fi
-  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew install eigen          ; fi
+  - if [ "$TRAVIS_OS_NAME" == "linux" ]; then  sudo apt-get install build-essential pkg-config cmake libwxgtk3.0-dev libftdi-dev freeglut3-dev zlib1g-dev libusb-1.0-0-dev  libdc1394-22-dev libavformat-dev libswscale-dev libassimp-dev libjpeg-dev libopencv-dev libgtest-dev libeigen3-dev libsuitesparse-dev libpcl-all libopenni2-dev libudev-dev gdb libboost-python-dev libpython-dev python-numpy -y ; fi
+  - if [ "$TRAVIS_OS_NAME" == "osx" ]; then brew tap homebrew/science   ; fi
+  - if [ "$TRAVIS_OS_NAME" == "osx" ]; then brew install eigen          ; fi
   - if [ "$TRAVIS_OS_NAME" == "osx" ]; then /usr/bin/yes | pip uninstall numpy; fi
-  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew install opencv         ; fi
-  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew install assimp         ; fi
+  - if [ "$TRAVIS_OS_NAME" == "osx" ]; then brew install opencv         ; fi
+  - if [ "$TRAVIS_OS_NAME" == "osx" ]; then brew install assimp         ; fi
 
 script:
   - bash .travis.sh


### PR DESCRIPTION
Unfortunately, travisci doesn't have a good way to support other versions of compilers.
This doesn't fix the rather verbose warning in Eigen from g++-6. Unfortunately, travis fails the test if the log messages are too big.
Hopefully, the 16.04 version of travis will be available soon and travis will provide better support for switching between C compiler versions.

I acknowledge to have: 
* Read the [`CONTRIBUTING`](https://github.com/MRPT/mrpt/blob/master/.github/CONTRIBUTING.md) page
* Updated [`docs/doxygen-pages/changelog.h`](https://github.com/MRPT/mrpt/blob/master/doc/doxygen-pages/changeLog_doc.h) to describe these changes (if applicable)
* Updated [`AUTHORS`](https://github.com/MRPT/mrpt/blob/master/AUTHORS) (if applicable)

(Notify: @MRPT/owners )
