### PR TITLE
Add shippable (backup for travis)

### DIFF
--- a/shippable.yml
+++ b/shippable.yml
@@ -1,0 +1,43 @@
+language: c
+
+compiler:
+  - gcc
+  - clang
+
+cache: true
+
+env:
+  - TASK="build" CCACHE_SLOPPINESS="pch_defines,time_macros"
+
+build:
+  pre_ci_boot:
+    image_name: drydock/u16cppall
+  ci:
+    - sudo add-apt-repository -y ppa:jolting/backport
+    - sudo apt-get update
+    - sudo apt-get install -y build-essential
+    - sudo apt-get install -y pkg-config
+    - sudo apt-get install -y cmake
+    - sudo apt-get install -y libwxgtk3.0-dev
+    - sudo apt-get install -y libftdi-dev
+    - sudo apt-get install -y freeglut3-dev
+    - sudo apt-get install -y zlib1g-dev
+    - sudo apt-get install -y libusb-1.0-0-dev
+    - sudo apt-get install -y libdc1394-22-dev
+    - sudo apt-get install -y libavformat-dev
+    - sudo apt-get install -y libswscale-dev
+    - sudo apt-get install -y libassimp-dev
+    - sudo apt-get install -y libjpeg-dev
+    - sudo apt-get install -y libopencv-dev
+    - sudo apt-get install -y libgtest-dev
+    - sudo apt-get install -y libeigen3-dev
+    - sudo apt-get install -y libsuitesparse-dev
+    - sudo apt-get install -y libpcl-dev
+    - sudo apt-get install -y libopenni2-dev
+    - sudo apt-get install -y libudev-dev
+    - sudo apt-get install -y libproj-dev
+    - sudo apt-get install -y gdb
+    - sudo apt-get install -y libboost-python-dev
+    - sudo apt-get install -y libpython-dev python-numpy 
+    - sudo apt-get install -y lcov
+    - bash .travis.sh


### PR DESCRIPTION
Shippable has a 60 minute deadline.
It's possible to use Dockerhub images, further reducing the build startup time.

Sign up the repository here: https://app.shippable.com/

This uses a 16.04 container. Travis is stuck on 14.04.

This uses my backport PPA to pull down updated versions of PCL and VTK. The 16.04 version is broken.

I acknowledge to have: 
* Read the [`CONTRIBUTING`](https://github.com/MRPT/mrpt/blob/master/.github/CONTRIBUTING.md) page
* Updated [`docs/doxygen-pages/changelog.h`](https://github.com/MRPT/mrpt/blob/master/doc/doxygen-pages/changeLog_doc.h) to describe these changes (if applicable)
* Updated [`AUTHORS`](https://github.com/MRPT/mrpt/blob/master/AUTHORS) (if applicable)

(Notify: @MRPT/owners )
