### PR TITLE
Add a dummy prefetch rule to prevent shippable timeouts

### DIFF
--- a/shippable.yml
+++ b/shippable.yml
@@ -4,10 +4,14 @@ compiler:
   - gcc
   - clang
 
-cache: true
-
 env:
+  - TASK="prefetch"
   - TASK="build" CCACHE_SLOPPINESS="pch_defines,time_macros"
+
+matrix:
+  exclude:
+    - compiler: clang
+      env: TASK="prefetch"
 
 build:
   pre_ci_boot:


### PR DESCRIPTION
This is a bit of a hack, but it appears to work.

I acknowledge to have: 
* Read the [`CONTRIBUTING`](https://github.com/MRPT/mrpt/blob/master/.github/CONTRIBUTING.md) page
* Updated [`docs/doxygen-pages/changelog.h`](https://github.com/MRPT/mrpt/blob/master/doc/doxygen-pages/changeLog_doc.h) to describe these changes (if applicable)
* Updated [`AUTHORS`](https://github.com/MRPT/mrpt/blob/master/AUTHORS) (if applicable)

(Notify: @MRPT/owners )
