### PR TITLE
CQuaternion.h needs to include bits.h for square

### DIFF
--- a/libs/base/include/mrpt/math/CQuaternion.h
+++ b/libs/base/include/mrpt/math/CQuaternion.h
@@ -12,6 +12,7 @@
 
 #include <mrpt/math/CMatrixTemplateNumeric.h>
 #include <mrpt/math/CArrayNumeric.h>
+#include <mrpt/utils/bits.h>
 
 namespace mrpt
 {


### PR DESCRIPTION
I acknowledge to have: 
* Read the [`CONTRIBUTING`](https://github.com/MRPT/mrpt/blob/master/.github/CONTRIBUTING.md) page
* Updated [`docs/doxygen-pages/changelog.h`](https://github.com/MRPT/mrpt/blob/master/doc/doxygen-pages/changeLog_doc.h) to describe these changes (if applicable)
* Updated [`AUTHORS`](https://github.com/MRPT/mrpt/blob/master/AUTHORS) (if applicable)

(Notify: @MRPT/owners )
