### PR TITLE
Add couple of includes to compile on Ubuntu 14.04 LTS

### DIFF
--- a/libs/base/src/system/memory.cpp
+++ b/libs/base/src/system/memory.cpp
@@ -14,6 +14,7 @@
 #include <exception>                 // for exception
 #include <mrpt/config.h>             // for HAVE_POSIX_MEMALIGN, MRPT_OS_LINUX
 #include <mrpt/utils/mrpt_macros.h>  // for MRPT_END, MRPT_START, MRPT_UNUSE...
+#include <mrpt/system/memory.h>
 
 #ifdef MRPT_OS_APPLE
 #include <mach/mach_init.h>

--- a/libs/nav/src/reactive/CRobot2NavInterface.cpp
+++ b/libs/nav/src/reactive/CRobot2NavInterface.cpp
@@ -8,7 +8,7 @@
    +---------------------------------------------------------------------------+ */
 
 #include "nav-precomp.h" // Precomp header
-
+#include <mrpt/utils/COutputLogger.h>
 #include <mrpt/nav/reactive/CRobot2NavInterface.h>
 #include <iostream>
 


### PR DESCRIPTION
The master branch didn't compile with gcc version 4.9.4 (Ubuntu 4.9.4-2ubuntu1~14.04.1) due to couple of missing headers.

In the first case the error was about missing system namespace (``using namespace mrpt::system;``). And in the second case about undefined ``MRPT_UNSCOPED_LOGGER_START``.

I acknowledge to have: 
* Read the [`CONTRIBUTING`](https://github.com/MRPT/mrpt/blob/master/.github/CONTRIBUTING.md) page

(Notify: @MRPT/owners )
