### PR TITLE
Fixed bug in CVelodyneScanner's close function

### DIFF
--- a/libs/hwdrivers/src/CVelodyneScanner.cpp
+++ b/libs/hwdrivers/src/CVelodyneScanner.cpp
@@ -472,9 +472,9 @@ void CVelodyneScanner::close()
 	{
 		shutdown(m_hPositionSock, 2 ); //SD_BOTH  );
 #ifdef MRPT_OS_WINDOWS
-		closesocket( m_hDataSock );
+		closesocket( m_hPositionSock );
 #else
-		::close( m_hDataSock );
+		::close( m_hPositionSock );
 #endif
 		m_hPositionSock=INVALID_SOCKET;
 	}


### PR DESCRIPTION
Changed apps/libraries: hwdrivers
This PR fixes a bug where you cannot connect and disconnect to a Velodyne sensor multiple times. The cause of the bug was because the CVelodyneScanner's position socket was not being properly closed, resulting in a runtime exception after calling initialize() more than once.

I acknowledge to have: 
* Read the [`CONTRIBUTING`](https://github.com/MRPT/mrpt/blob/master/.github/CONTRIBUTING.md) page
* Updated [`docs/doxygen-pages/changelog.h`](https://github.com/MRPT/mrpt/blob/master/doc/doxygen-pages/changeLog_doc.h) to describe these changes (if applicable)
* Updated [`AUTHORS`](https://github.com/MRPT/mrpt/blob/master/AUTHORS) (if applicable)

(Notify: @MRPT/owners )
