### PR TITLE
Allow setting MRPT_DEB_DIR from env variable

### DIFF
--- a/scripts/prepare_debian.sh
+++ b/scripts/prepare_debian.sh
@@ -97,7 +97,7 @@ mkdir -p ${MRPT_DEBSRC_DIR}
 if [ -d "$MRPTSRC/.git" ];
 then
 	echo "Exporting git source tree to ${MRPT_DEBSRC_DIR}"
-	git archive  --format=tar master | tar -x -C ${MRPT_DEBSRC_DIR}
+	git archive  --format=tar HEAD | tar -x -C ${MRPT_DEBSRC_DIR}
 
 	# Generate ./SOURCE_DATE_EPOCH with UNIX time_t
 	SOURCE_DATE_EPOCH=$(git log -1 --pretty=%ct)

--- a/scripts/prepare_debian.sh
+++ b/scripts/prepare_debian.sh
@@ -56,7 +56,9 @@ else
 fi
 
 MRPTSRC=`pwd`
-MRPT_DEB_DIR="$HOME/mrpt_debian"
+if [ -z "$MRPT_DEB_DIR" ]; then
+        MRPT_DEB_DIR="$HOME/mrpt_debian"
+fi
 MRPT_EXTERN_DEBIAN_DIR="$MRPTSRC/packaging/debian/"
 
 if [ -f ${MRPT_EXTERN_DEBIAN_DIR}/control.in ];

--- a/scripts/prepare_ubuntu_pkgs_for_ppa.sh
+++ b/scripts/prepare_ubuntu_pkgs_for_ppa.sh
@@ -28,9 +28,13 @@ else
 	exit 1
 fi
 
-MRPT_UBUNTU_OUT_DIR="$HOME/mrpt_ubuntu"
+if [ -z "${MRPT_UBUNTU_OUT_DIR}" ]; then
+       export MRPT_UBUNTU_OUT_DIR="$HOME/mrpt_ubuntu"
+fi
 MRPTSRC=`pwd`
-MRPT_DEB_DIR="$HOME/mrpt_debian"
+if [ -z "${MRPT_DEB_DIR}" ]; then
+       export MRPT_DEB_DIR="$HOME/mrpt_debian"
+fi
 MRPT_EXTERN_DEBIAN_DIR="$MRPTSRC/packaging/debian/"
 EMAIL4DEB="Jose Luis Blanco (University of Malaga) <joseluisblancoc@gmail.com>"
 


### PR DESCRIPTION
This is useful if you want builds confined to a workspace (e.g. Jenkins).

I acknowledge to have:
* Read the [`CONTRIBUTING`](https://github.com/MRPT/mrpt/blob/master/.github/CONTRIBUTING.md) page
* Updated [`doc/doxygen-pages/changeLog_doc.h`](https://github.com/MRPT/mrpt/blob/master/doc/doxygen-pages/changeLog_doc.h) to describe these changes (if applicable)
* Updated [`AUTHORS`](https://github.com/MRPT/mrpt/blob/master/AUTHORS) (if applicable)

(Notify: @MRPT/owners )
