### PR TITLE
Initialize CMetricMapBuilderRBPF properly if map is empty

### DIFF
--- a/libs/slam/src/slam/CMetricMapBuilderRBPF.cpp
+++ b/libs/slam/src/slam/CMetricMapBuilderRBPF.cpp
@@ -255,8 +255,7 @@ void  CMetricMapBuilderRBPF::initialize(
 		const CSimpleMap &initialMap,
 		const CPosePDF  *x0 )
 {
-	// Enter critical section (updating map)
-	enterCriticalSection();
+	mrpt::synch::CCriticalSectionLocker csl(&critZoneChangingMap); // Enter critical section (updating map)
 
 	MRPT_LOG_INFO_STREAM( "[initialize] Called with " << initialMap.size() << " nodes in fixed map"); 
 
@@ -276,8 +275,6 @@ void  CMetricMapBuilderRBPF::initialize(
 	// Clear maps for each particle & set pose:
 	mapPDF.clear(initialMap,curPose);
 
-	// Leaving critical section (updating map)
-	leaveCriticalSection();
 }
 
 

--- a/libs/slam/src/slam/CMultiMetricMapPDF.cpp
+++ b/libs/slam/src/slam/CMultiMetricMapPDF.cpp
@@ -105,6 +105,12 @@ void  CMultiMetricMapPDF::clear( const CPose3D &initialPose )
 void CMultiMetricMapPDF::clear(const mrpt::maps::CSimpleMap &prevMap, const mrpt::poses::CPose3D &currentPose)
 {
 	const size_t nParts = m_particles.size(), nOldKeyframes = prevMap.size();
+	if(nOldKeyFrames == 0)
+	{
+		//prevMap is empty, so reset the map
+		clear(currentPose);
+		return;
+	}
 	for (size_t idxPart = 0; idxPart<nParts; idxPart++)
 	{
 		auto &p = m_particles[idxPart];


### PR DESCRIPTION
If you try to initialize CMetricMapBuilderRBPF with an empty map
it won't work because it wasn't give it a starting location.

If you try just reinitialize the pose using by calling the other
method.

Also this uses the critical section locker for RTTI.
If an exception is thrown that lock should be unlocked.

---

I acknowledge to have:
* Read the [`CONTRIBUTING`](https://github.com/MRPT/mrpt/blob/master/.github/CONTRIBUTING.md) page
* Updated [`doc/doxygen-pages/changeLog_doc.h`](https://github.com/MRPT/mrpt/blob/master/doc/doxygen-pages/changeLog_doc.h) to describe these changes (if applicable)
* Updated [`AUTHORS`](https://github.com/MRPT/mrpt/blob/master/AUTHORS) (if applicable)

(Notify: @MRPT/owners )
