### PR TITLE
bug(icp-slam): can not run correctly under windows

### DIFF
--- a/libs/slam/src/slam/CMetricMapBuilderICP.cpp
+++ b/libs/slam/src/slam/CMetricMapBuilderICP.cpp
@@ -178,7 +178,7 @@ void CMetricMapBuilderICP::processObservation(const CObservation::Ptr& obs)
 		// Current robot pose given the timestamp of the observation (this can
 		// include a small extrapolation
 		//  using the latest known robot velocities):
-		TPose2D initialEstimatedRobotPose;
+		TPose2D initialEstimatedRobotPose(0,0,0);
 		{
 			mrpt::math::TTwist2D robotVelLocal, robotVelGlobal;
 			if (obs->timestamp != INVALID_TIMESTAMP)


### PR DESCRIPTION
The initial pose should be [x = 0, y = 0, phi = 0], but under windows the x, y and phi are all -9.25596e+61, so we need to give them initial value.

## Changed apps/libraries

* modified-libX
* modified-appY
* ...

## PR Description

* (*REMOVE THIS LINE IF NOT NEEDED*) This PR Closes issue #XXX
* (*REMOVE THIS LINE IF NOT NEEDED*)

---

I acknowledge to have:
* Read the [`CONTRIBUTING`](https://github.com/MRPT/mrpt/blob/master/.github/CONTRIBUTING.md) page
* Updated [`doc/doxygen-pages/changeLog_doc.h`](https://github.com/MRPT/mrpt/blob/master/doc/doxygen-pages/changeLog_doc.h) to describe these changes (if applicable)
* Updated [`AUTHORS`](https://github.com/MRPT/mrpt/blob/master/AUTHORS) (if applicable)

(Notify: @MRPT/owners )
