### PR TITLE
Don't compile CGlCanvaseBase if Gl is disabled

### DIFF
--- a/libs/gui/CMakeLists.txt
+++ b/libs/gui/CMakeLists.txt
@@ -67,6 +67,9 @@ IF(BUILD_mrpt-gui)
 		target_link_libraries(mrpt-gui ${OpenCV_LIBRARIES})
 	ENDIF()
 
-	# Link against gl:
-	TARGET_LINK_LIBRARIES(mrpt-gui ${MRPT_OPENGL_LIBS})
+	IF(CMAKE_MRPT_HAS_OPENGL_GLUT)
+		# Link against gl:
+		TARGET_LINK_LIBRARIES(mrpt-gui ${MRPT_OPENGL_LIBS})
+	ENDIF()
+
 ENDIF()

--- a/libs/gui/src/CGlCanvasBase.cpp
+++ b/libs/gui/src/CGlCanvasBase.cpp
@@ -38,7 +38,6 @@ float CGlCanvasBase::SENSIBILITY_DEG_PER_PIXEL = 0.1f;
 #endif
 #endif
 
-#endif
 
 void CGlCanvasBase::setMinimumZoom(float zoom) { m_minZoom = zoom; }
 void CGlCanvasBase::setMaximumZoom(float zoom) { m_maxZoom = zoom; }
@@ -338,3 +337,4 @@ void CGlCanvasBase::CamaraParams::setElevationDeg(float deg)
 	else if (cameraElevationDeg > 90.0f)
 		cameraElevationDeg = 90.0f;
 }
+#endif


### PR DESCRIPTION
Partial fix for #599

I acknowledge to have:
* Read the [`CONTRIBUTING`](https://github.com/MRPT/mrpt/blob/master/.github/CONTRIBUTING.md) page
* Updated [`doc/doxygen-pages/changeLog_doc.h`](https://github.com/MRPT/mrpt/blob/master/doc/doxygen-pages/changeLog_doc.h) to describe these changes (if applicable)
* Updated [`AUTHORS`](https://github.com/MRPT/mrpt/blob/master/AUTHORS) (if applicable)

(Notify: @MRPT/owners )
