### PR TITLE
Qt/Wx compat fixes, "proper" numpy CMake

### DIFF
--- a/apps/benchmarking-image-features/src/mainwindow.cpp
+++ b/apps/benchmarking-image-features/src/mainwindow.cpp
@@ -23,6 +23,11 @@
 #include <mrpt/obs/CObservationStereoImages.h>
 #include <mrpt/obs/CRawlog.h>
 
+// provides `sleep` on unix systems
+#if !defined(_WIN32)
+    #include <unistd.h>
+#endif
+
 /// using namespaces
 using namespace mrpt::obs;
 using namespace mrpt::system;

--- a/libs/gui/include/mrpt/gui/CMyRedirector.h
+++ b/libs/gui/include/mrpt/gui/CMyRedirector.h
@@ -101,7 +101,8 @@ class CMyRedirector : public std::streambuf
 #endif
 
 #if wxCHECK_VERSION(3, 0, 0)
-			m_txt->GetEventHandler()->CallAfter(&wxTextCtrl::WriteText, s);
+			// m_txt->GetEventHandler()->CallAfter(&wxTextCtrl::WriteText, s);
+            m_txt->WriteText(s);
 #else
 			m_txt->WriteText(s);  // bad solution, but at least compiles (and
 // may work, unsafely) for old wx2.8 in Ubuntu

--- a/libs/gui/src/about_box_qt.cpp
+++ b/libs/gui/src/about_box_qt.cpp
@@ -1,0 +1,28 @@
+/* +------------------------------------------------------------------------+
+   |                     Mobile Robot Programming Toolkit (MRPT)            |
+   |                          http://www.mrpt.org/                          |
+   |                                                                        |
+   | Copyright (c) 2005-2017, Individual contributors, see AUTHORS file     |
+   | See: http://www.mrpt.org/Authors - All rights reserved.                |
+   | Released under BSD License. See details in http://www.mrpt.org/License |
+   +------------------------------------------------------------------------+ */
+
+#include "gui-precomp.h"  // Precompiled headers
+
+#include <mrpt/gui/about_box.h>
+
+#if MRPT_HAS_Qt5
+#include "CAboutBoxQt.h"
+#endif
+
+void GUI_IMPEXP mrpt::gui::show_mrpt_about_box_Qt(
+	const std::string& appName, const std::string& additionalInfo,
+	const bool showStandardInfo)
+{
+#if MRPT_HAS_Qt5
+	CAboutBoxQt dlg(appName, additionalInfo, showStandardInfo);
+	dlg.exec();
+#else
+	THROW_EXCEPTION("MRPT compiled without Qt support");
+#endif
+}

--- a/libs/gui/src/about_box_wx.cpp
+++ b/libs/gui/src/about_box_wx.cpp
@@ -15,10 +15,6 @@
 #include "CAboutBox_wx.h"
 #endif
 
-#if MRPT_HAS_Qt5
-#include "CAboutBoxQt.h"
-#endif
-
 void GUI_IMPEXP mrpt::gui::show_mrpt_about_box_wxWidgets(
 	void* parent_wx_window, const std::string& appName,
 	const std::string& additionalInfo, const bool showStandardInfo)
@@ -29,17 +25,5 @@ void GUI_IMPEXP mrpt::gui::show_mrpt_about_box_wxWidgets(
 	dlg.ShowModal();
 #else
 	THROW_EXCEPTION("MRPT compiled without wxWidgets support");
-#endif
-}
-
-void GUI_IMPEXP mrpt::gui::show_mrpt_about_box_Qt(
-	const std::string& appName, const std::string& additionalInfo,
-	const bool showStandardInfo)
-{
-#if MRPT_HAS_Qt5
-	CAboutBoxQt dlg(appName, additionalInfo, showStandardInfo);
-	dlg.exec();
-#else
-	THROW_EXCEPTION("MRPT compiled without Qt support");
 #endif
 }

--- a/libs/hwdrivers/src/CKinect.cpp
+++ b/libs/hwdrivers/src/CKinect.cpp
@@ -30,7 +30,7 @@ IMPLEMENTS_GENERIC_SENSOR(CKinect, mrpt::hwdrivers)
 //#define KINECT_PROFILE_MEM_ALLOC
 
 #if MRPT_HAS_KINECT_FREENECT
-#include <libfreenect.h>
+#include <libfreenect/libfreenect.h>
 #else
 #define KINECT_W 640
 #define KINECT_H 480

--- a/python/CMakeLists.txt
+++ b/python/CMakeLists.txt
@@ -12,6 +12,23 @@ include_directories(
   ${Boost_INCLUDE_DIRS}
   ${PYTHON_INCLUDE_DIRS}
 )
+# Find Numpy include directory
+execute_process(
+    COMMAND
+    "${PYTHON_EXECUTABLE}" -c
+# multiline string; indentation would break this
+"try:
+    import sys
+    import numpy
+    sys.stdout.write(numpy.get_include())
+except:
+    pass
+"
+    OUTPUT_VARIABLE MRPT_NUMPY_INCLUDE_DIRECTORY
+)
+if(MRPT_NUMPY_INCLUDE_DIRECTORY)
+  include_directories(${MRPT_NUMPY_INCLUDE_DIRECTORY})
+endif()
 
 add_library(pymrpt
   SHARED # Python lib must be shared


### PR DESCRIPTION
## Changed apps/libraries

--------------------------

> These changes are dubious things that I did locally just to get it to compile, but they may not be universal and could easily either be OSXisms or nonstandard local configs.

--------------------------

### [`libs/gui/include/mrpt/gui/CMyRedirector.h`](https://github.com/MRPT/mrpt/compare/master...svenevs:osx-fixes?expand=1#diff-007e4002997b3f741feaa1a4e3889ef2)

@jlblancoc the blame shows you wrote this part, indicating you may know what this stuff actually does.  Possibly 3.1 has changed or something?  I get the following error:

```
/opt/wxWidgets/include/wx-3.1/wx/event.h:3415:17: error: static_cast from 'wxEvtHandler *' to 'wxTextEntry *', which are not related by inheritance, is not allowed
                static_cast<T*>(this), method, x1)
                ^~~~~~~~~~~~~~~~~~~~~
/opt/mrpt_build/libs/gui/include/mrpt/gui/CMyRedirector.h:104:30: note: in instantiation of function template specialization 'wxEvtHandler::CallAfter<wxTextEntry, const wxString
      &, wxString>' requested here
                        m_txt->GetEventHandler()->CallAfter(&wxTextCtrl::WriteText, s);
```

I can easily revert this if you think it is a local problem.

--------------------------

> These changes should be valid

--------------------------

### [`apps/benchmarking-image-features/src/mainwindow.cpp`](https://github.com/MRPT/mrpt/compare/master...svenevs:osx-fixes?expand=1#diff-add91a34afd7eae0794927ae32277fa7)

This was the first compiler error on this file.  This one seems reasonable, but I'm not sure how this has been compiling previously.  Note I could compile this on Linux just fine...

As for the rest of the file, I can't figure out what the other problem is (and have run out of energy to keep investigating).  Possible OSX thing, more likely Qt 5.9 thing.  It seems it may be getting confused because the first parameter to the bound function is also a function?  **This is not being fixed, I can redact this and create a separate issue if you like, but I'm not interested in solving it**...

```
/usr/local/opt/qt5/include/QtConcurrent/qtconcurrentstoredfunctioncall.h:1633:59: error: array initializer must be an initializer list
    : fn(_fn), object(_object), arg1(_arg1), arg2(_arg2), arg3(_arg3), arg4(_arg4){ }
                                                          ^
/usr/local/opt/qt5/include/QtConcurrent/qtconcurrentrun.h:299:17: note: in instantiation of member function 'QtConcurrent::StoredMemberFunctionPointerCall4<cv::Mat,
      VisualOdometry, mrpt::vision::CFeatureExtraction, mrpt::vision::CFeatureExtraction, int, int, std::__1::basic_string<char> *, std::__1::basic_string<char> [3], int,
      int>::StoredMemberFunctionPointerCall4' requested here
    return (new typename SelectStoredMemberFunctionPointerCall4<T, Class, Param1, Arg1, Param2, Arg2, Param3, Arg3, Param4, Arg4>::type(fn, object, arg1, arg2, arg3, arg4...
                ^
/opt/mrpt_build/apps/benchmarking-image-features/src/mainwindow.cpp:2586:38: note: in instantiation of function template specialization 'QtConcurrent::run<cv::Mat,
      VisualOdometry, mrpt::vision::CFeatureExtraction, mrpt::vision::CFeatureExtraction, int, int, std::__1::basic_string<char> *, std::__1::basic_string<char> [3], int, int>'
      requested here
        QFuture<Mat> future = QtConcurrent::run(
```

### `about_box` -> [`about_box_wx`](https://github.com/MRPT/mrpt/pull/601/files#diff-b0ff4a863de93d0abb980e358b2cbf96), [`about_box_qt`](https://github.com/MRPT/mrpt/pull/601/files#diff-89015dfaff936ac5f518826845dbda5a)

Separate out `wx` and `qt` code into their own source files for the gui.  Without this, I get the following compilation error that I had absolutely **no idea** how to fix, so just decided to avoid including Qt and Wx in the same file :smirk:

    ```
    [ 35%] Building CXX object libs/gui/CMakeFiles/mrpt-gui.dir/src/about_box.cpp.o
    In file included from /opt/mrpt_build/libs/gui/src/about_box.cpp:19:
    In file included from /opt/mrpt_build/libs/gui/src/CAboutBoxQt.h:12:
    In file included from /usr/local/opt/qt5/lib/QtWidgets.framework/Headers/QDialog:1:
    In file included from /usr/local/opt/qt5/lib/QtWidgets.framework/Headers/qdialog.h:44:
    In file included from /usr/local/opt/qt5/include/QtWidgets/qwidget.h:45:
    In file included from /usr/local/opt/qt5/include/QtCore/qobject.h:47:
    /usr/local/opt/qt5/include/QtCore/qstring.h:73:30: error: typedef redefinition with different types ('struct objc_object' vs 'NSString')
    Q_FORWARD_DECLARE_OBJC_CLASS(NSString);
                                 ^
    /opt/wxWidgets/include/wx-3.1/wx/defs.h:3149:28: note: previous definition is here
    DECLARE_WXCOCOA_OBJC_CLASS(NSString);
                               ^
    ```

    Woah...

### [`libs/hwdrivers/src/CKinect.cpp`](https://github.com/MRPT/mrpt/compare/master...svenevs:osx-fixes?expand=1#diff-c75415d880b0a425c40caf2df6ebc22b)

Maybe this should be in an `#if defined(__APPLE__)`?  I'm not sure why this wouldn't have been caught before.  It's pretty reasonable to assume OSX users had a `brew install` of this.  This is the proper include for that scenario (how I installed it).

### [`python/CMakeLists.txt`](https://github.com/MRPT/mrpt/compare/master...svenevs:osx-fixes?expand=1#diff-79b695dff65b8b0a69bfed14e824cb18)

You can't assume the python interp package will get you the **right** numpy include directory, if it even does give you one.  OSX is a notorious example of this, since they vendor obscenely outdated versions internally.  However, this fix applies to linux as well.  If I have a system python with numpy, and a custom python with numpy, I want my custom numpy :wink:


## PR Description

This came about from trying to compile on OSX with all GUI bells / whistles turned on.  I had just installed `wxWidgets` 3.1, and had Qt 5.9 via `brew`.  There seem to be some incompatibilities between them?  Basically, I was just hacking away and some of the fixes I think are worth sharing back.  Some of them I am not sure about...

## BEFORE MERGE!

- [x] Decision on `m_txt->GetEventHandler()->CallAfter(&wxTextCtrl::WriteText, s);` (keep new, or revert to old).
- [ ] Coding style convention for guarded include ([this part](https://github.com/MRPT/mrpt/blob/128715817362be8808998c2f405426e05c2a9952/apps/benchmarking-image-features/src/mainwindow.cpp#L26-L29))?
- [ ] (@svenevs) verify what's going on with `#include <libfreenect.h>` and why `pkg-config` isn't finding it for OSX.

I will fix the spaces to be tabs in a commit resolving the dangling stuff if these changes seem like things you actually want!

---

I acknowledge to have:
* Read the [`CONTRIBUTING`](https://github.com/MRPT/mrpt/blob/master/.github/CONTRIBUTING.md) page
* Updated [`doc/doxygen-pages/changeLog_doc.h`](https://github.com/MRPT/mrpt/blob/master/doc/doxygen-pages/changeLog_doc.h) to describe these changes (if applicable)
* Updated [`AUTHORS`](https://github.com/MRPT/mrpt/blob/master/AUTHORS) (if applicable)

(Notify: @MRPT/owners )
