### PR TITLE
use portable sleep in benchmarking-image-features

### DIFF
--- a/apps/benchmarking-image-features/src/mainwindow.cpp
+++ b/apps/benchmarking-image-features/src/mainwindow.cpp
@@ -23,6 +23,9 @@
 #include <mrpt/obs/CObservationStereoImages.h>
 #include <mrpt/obs/CRawlog.h>
 
+#include <chrono>
+#include <thread>
+
 /// using namespaces
 using namespace mrpt::obs;
 using namespace mrpt::system;
@@ -2577,7 +2580,8 @@ void MainWindow::on_generateVisualOdometry_clicked()
 	this->progressBar->show();
 	vo_message_running->show();
 	vo_message_dialog->show();
-	sleep(4);
+	using namespace std::chrono_literals;
+	std::this_thread::sleep_for(4s);
 	QFuture<Mat> future = QtConcurrent::run(
 		&this->visual_odom, &VisualOdometry::generateVO, fext, numFeats,
 		file_paths, feat_type);


### PR DESCRIPTION
This is in response to the fix proposed in PR #601
---

I acknowledge to have:
* Read the [`CONTRIBUTING`](https://github.com/MRPT/mrpt/blob/master/.github/CONTRIBUTING.md) page
* Updated [`doc/doxygen-pages/changeLog_doc.h`](https://github.com/MRPT/mrpt/blob/master/doc/doxygen-pages/changeLog_doc.h) to describe these changes (if applicable)
* Updated [`AUTHORS`](https://github.com/MRPT/mrpt/blob/master/AUTHORS) (if applicable)

(Notify: @MRPT/owners )
