### PR TITLE
Refl map channel

### DIFF
--- a/doc/doxygen-pages/changeLog_doc.h
+++ b/doc/doxygen-pages/changeLog_doc.h
@@ -39,6 +39,8 @@
 			- Added methods to load/save mrpt::nav::TWaypointSequence to configuration files.
 		- \ref mrpt_comms_grp [NEW IN MRPT 2.0.0]
 			- This new module has been created to hold all serial devices & networking classes, with minimal dependencies.
+		- \ref mrpt_maps_grp
+			- Added optional "channel" attribute to CReflectivityGrdMap2D and CObservationReflectivity to support different colors of light.
 	- BUG FIXES:
 		- Fix reactive navigator inconsistent state if navigation API is called from within rnav callbacks.
 		- Fix incorrect evaluation of "ASSERT" formulas in mrpt::nav::CMultiObjectiveMotionOptimizerBase

--- a/libs/maps/include/mrpt/maps/CReflectivityGridMap2D.h
+++ b/libs/maps/include/mrpt/maps/CReflectivityGridMap2D.h
@@ -81,6 +81,8 @@ class MAPS_IMPEXP CReflectivityGridMap2D : public CMetricMap,
 			const std::string& section) override;  // See base docs
 		void dumpToTextStream(
 			mrpt::utils::CStream& out) const override;  // See base docs
+
+		int16_t channel; //!< The reflectivity channel for this map. If channel=-1, then any channel will be accepted. Otherwise, the map will ignore CObservationReflectivity instances with a differing channel. (Default=-1)
 	} insertionOptions;
 
 	/** See docs in base class: in this class this always returns 0 */

--- a/libs/maps/src/maps/CReflectivityGridMap2D.cpp
+++ b/libs/maps/src/maps/CReflectivityGridMap2D.cpp
@@ -274,7 +274,7 @@ void CReflectivityGridMap2D::readFromStream(
 			if (n) in.ReadBuffer(&m_map[0], n);
 
 			// Load the insertion options:
-			if (version>=3) in >> insertionOptions.channel;
+			if (version >= 3) in >> insertionOptions.channel;
 
 			if (version >= 1) in >> genericMapParams;
 		}

--- a/libs/obs/include/mrpt/maps/TMetricMapInitializer.h
+++ b/libs/obs/include/mrpt/maps/TMetricMapInitializer.h
@@ -270,7 +270,7 @@ class OBS_IMPEXP TSetOfMetricMapInitializers
 	  *
 	  * // ====================================================
 	  * // Creation Options for ReflectivityGridMap ##:
-	  * [<sectionName>+"_reflectivityGrid_##_creationOpts"]
+	  * [<sectionName>+"_reflectivityMap_##_creationOpts"]
 	  *  min_x=<value>  // See CReflectivityGridMap2D::CReflectivityGridMap2D
 	  *  max_x=<value>
 	  *  min_y=<value>
@@ -278,7 +278,7 @@ class OBS_IMPEXP TSetOfMetricMapInitializers
 	  *  resolution=<value>
 	  *
 	  * // Insertion Options for HeightGridMap ##:
-	  * [<sectionName>+"_reflectivityGrid_##_insertOpts"]
+	  * [<sectionName>+"_reflectivityMap_##_insertOpts"]
 	  *  <See CReflectivityGridMap2D::TInsertionOptions>
 	  *
 	  *

--- a/libs/obs/include/mrpt/obs/CObservationReflectivity.h
+++ b/libs/obs/include/mrpt/obs/CObservationReflectivity.h
@@ -37,6 +37,10 @@ class OBS_IMPEXP CObservationReflectivity : public CObservation
 	  */
 	float reflectivityLevel;
 
+	/** The channel for this observation. If channel=-1, it can be inserted into any CReflectivityGridMap2D. Otherwise, it can only be inserted into reflectivity maps with the same channel. (Default=-1)
+		 */
+	int16_t channel;
+
 	/** The pose of this sensor in robot's local coordinates.
 	  */
 	mrpt::poses::CPose3D sensorPose;

--- a/libs/obs/src/CObservationReflectivity.cpp
+++ b/libs/obs/src/CObservationReflectivity.cpp
@@ -22,7 +22,7 @@ IMPLEMENTS_SERIALIZABLE(CObservationReflectivity, CObservation, mrpt::obs)
 /** Default constructor.
  */
 CObservationReflectivity::CObservationReflectivity()
-	: reflectivityLevel(0.5f), sensorPose(), sensorStdNoise(0.2f)
+	: reflectivityLevel(0.5f), channel(-1), sensorPose(), sensorStdNoise(0.2f)
 {
 }
 
@@ -34,10 +34,10 @@ void CObservationReflectivity::writeToStream(
 	mrpt::utils::CStream& out, int* version) const
 {
 	if (version)
-		*version = 0;
+		*version = 1;
 	else
 	{
-		out << reflectivityLevel << sensorPose;
+		out << reflectivityLevel << channel << sensorPose;
 		out << sensorLabel << timestamp;
 	}
 }
@@ -52,7 +52,9 @@ void CObservationReflectivity::readFromStream(
 	{
 		case 0:
 		{
-			in >> reflectivityLevel >> sensorPose;
+			in >> reflectivityLevel;
+			if (version >= 1) in >> channel;
+			in >> sensorPose;
 			in >> sensorLabel >> timestamp;
 		}
 		break;


### PR DESCRIPTION
## Changed apps/libraries

* modified-libmpt-maps
* modified libmrpt-obs

## PR Description
Adds an attribute named "channel" to CReflectivityGridMap2D and CObservationReflectivity that allows restricting which observations can be inserted into which maps. Defaults to -1, which allows all reflectivity observations to be inserted into all reflectivity maps (matches previous behavior). Useful for differentiating colors (e.g RGB channels).

---

I acknowledge to have:
* Read the [`CONTRIBUTING`](https://github.com/MRPT/mrpt/blob/master/.github/CONTRIBUTING.md) page
* Updated [`doc/doxygen-pages/changeLog_doc.h`](https://github.com/MRPT/mrpt/blob/master/doc/doxygen-pages/changeLog_doc.h) to describe these changes (if applicable)
* Updated [`AUTHORS`](https://github.com/MRPT/mrpt/blob/master/AUTHORS) (if applicable)

(Notify: @MRPT/owners )
