### PR TITLE
Adding a test with the driver of SICKTim561Eth via rawlog-grabber

### DIFF
--- a/libs/hwdrivers/include/mrpt/hwdrivers.h
+++ b/libs/hwdrivers/include/mrpt/hwdrivers.h
@@ -76,4 +76,6 @@ MRPT_WARNING(
 #include <mrpt/hwdrivers/CSkeletonTracker.h>
 #include <mrpt/hwdrivers/CVelodyneScanner.h>
 
+#include <mrpt/hwdrivers/CSICKTim561Eth_2050101.h>
+
 #endif

--- a/libs/hwdrivers/src/registerAllClasses.cpp
+++ b/libs/hwdrivers/src/registerAllClasses.cpp
@@ -49,5 +49,6 @@ MRPT_INITIALIZER(registerAllClasses_mrpt_hwdrivers)
 	CIMUIntersense::doRegister();
 	CSkeletonTracker::doRegister();
 	CVelodyneScanner::doRegister();
+	CSICKTim561Eth::doRegister();
 #endif
 }

--- a/share/mrpt/config_files/rawlog-grabber/SICK_TIM_56x.ini
+++ b/share/mrpt/config_files/rawlog-grabber/SICK_TIM_56x.ini
@@ -37,6 +37,7 @@ use_sensoryframes 	= 0
 #   
 # =======================================================
 [LASER1]
+process_rate = 50   
 driver			= CSICKTim561Eth 
 
 sensorLabel  	= SICK_TIM_561
@@ -49,4 +50,3 @@ pose_roll		= 0
 
 ip_address = 192.168.0.1  // Default IP address
 TCP_port = 2111       // Default IP Port
-process_rate = 15 // Default Herzt

--- a/share/mrpt/config_files/rawlog-grabber/SICK_TIM_56x.ini
+++ b/share/mrpt/config_files/rawlog-grabber/SICK_TIM_56x.ini
@@ -1,0 +1,53 @@
+# -------------------------------------------------------------------
+#  Config file for the `rawlog-grabber` MRPT application.
+#  Usage: 
+#      rawlog-grabber CONFIG_FILE.ini
+#
+#  Each section `[XXXXX]` but `[global]` defines a dedicated thread where a 
+#  sensor-specific driver runs. Each thread collects observations in parallel 
+#  and the main thread sort them by timestamp and dumps them to a RAWLOG file.
+#  The driver for each thread is set with the field `driver`, which must
+#  match the name of any of the classes in mrpt::hwdrivers implementing 
+#  a CGenericSensor.
+#
+# Read more online: 
+# http://www.mrpt.org/list-of-mrpt-apps/application-rawlog-grabber/
+# -------------------------------------------------------------------
+
+# =======================================================
+#  Section: Global settings to the application   
+# =======================================================
+[global]
+# The prefix can contain a relative or absolute path.
+# The final name will be <PREFIX>_date_time.rawlog
+rawlog_prefix		= ./dataset
+
+# Milliseconds between thread launches
+time_between_launches	= 300
+
+# Maximum time (seconds) between a sequence of observations 
+#  is splitted into sensory frames
+SF_max_time_span	= 0.005
+
+# Whether to use sensory-frames to group close-in-time observations (useful for some SLAM algorithms).
+use_sensoryframes 	= 0
+
+
+# =======================================================
+#  SENSOR: LASER1
+#   
+# =======================================================
+[LASER1]
+driver			= CSICKTim561Eth 
+
+sensorLabel  	= SICK_TIM_561
+pose_x			= 0		// Laser range scaner 3D position in the robot (meters)
+pose_y			= 0
+pose_z			= 0.31
+pose_yaw		= 0		// Angles in degrees
+pose_pitch		= 0
+pose_roll		= 0
+
+m_ip = 192.168.0.1  // Default IP address
+m_port = 2111       // Default IP Port
+m_process_rate = 15 // Default Herzt

--- a/share/mrpt/config_files/rawlog-grabber/SICK_TIM_56x.ini
+++ b/share/mrpt/config_files/rawlog-grabber/SICK_TIM_56x.ini
@@ -25,8 +25,7 @@ rawlog_prefix		= ./dataset
 # Milliseconds between thread launches
 time_between_launches	= 300
 
-# Maximum time (seconds) between a sequence of observations 
-#  is splitted into sensory frames
+# Maximum time (seconds) between a sequence of observations #  is splitted into sensory frames
 SF_max_time_span	= 0.005
 
 # Whether to use sensory-frames to group close-in-time observations (useful for some SLAM algorithms).
@@ -48,6 +47,6 @@ pose_yaw		= 0		// Angles in degrees
 pose_pitch		= 0
 pose_roll		= 0
 
-m_ip = 192.168.0.1  // Default IP address
-m_port = 2111       // Default IP Port
-m_process_rate = 15 // Default Herzt
+ip_address = 192.168.0.1  // Default IP address
+TCP_port = 2111       // Default IP Port
+process_rate = 15 // Default Herzt


### PR DESCRIPTION
## Changed apps/libraries

* modified-libX
* modified-appY
* ...

## PR Description

*  This PR Closes issue #628, registered `SICKTim561Eth` in `registerAllClasses.cpp` and created new `ini` for `SICKTim561Eth`. Developers can test a physical device without building sample problem, just via rawlog-grabber.


---

I acknowledge to have:
* Read the [`CONTRIBUTING`](https://github.com/MRPT/mrpt/blob/master/.github/CONTRIBUTING.md) page
* Updated [`doc/doxygen-pages/changeLog_doc.h`](https://github.com/MRPT/mrpt/blob/master/doc/doxygen-pages/changeLog_doc.h) to describe these changes (if applicable)
* Updated [`AUTHORS`](https://github.com/MRPT/mrpt/blob/master/AUTHORS) (if applicable)

(Notify: @MRPT/owners )
