### PR TITLE
fixed deadlock in CMetricMapBuilderRBPF::clear()

### DIFF
--- a/libs/slam/src/slam/CMetricMapBuilderRBPF.cpp
+++ b/libs/slam/src/slam/CMetricMapBuilderRBPF.cpp
@@ -288,14 +288,15 @@ MRPT_TODO(
 void CMetricMapBuilderRBPF::initialize(
 	const CSimpleMap& initialMap, const CPosePDF* x0)
 {
-	std::lock_guard<std::mutex> csl(
-		critZoneChangingMap);  // Enter critical section (updating map)
-
 	MRPT_LOG_INFO_STREAM(
 		"[initialize] Called with " << initialMap.size()
 									<< " nodes in fixed map");
 
 	this->clear();
+
+	std::lock_guard<std::mutex> csl(
+		critZoneChangingMap);  // Enter critical section (updating map)
+
 	mrpt::poses::CPose3D curPose;
 	if (x0)
 	{


### PR DESCRIPTION
## Changed apps/libraries

* modified lib mrpt::slam::CMetricMapBuilderRBPF

## PR Description
when calling  **CMetricMapBuilderRBPF::initialize( [...] )** the _critZoneChangingMap_ lock is taken, then the function call **this->clear()** and the same lock is taken twice.
This PR simply take the lock after calling the clear function. 

---

I acknowledge to have:
* Read the [`CONTRIBUTING`](https://github.com/MRPT/mrpt/blob/master/.github/CONTRIBUTING.md) page
* Updated [`doc/doxygen-pages/changeLog_doc.h`](https://github.com/MRPT/mrpt/blob/master/doc/doxygen-pages/changeLog_doc.h) to describe these changes (if applicable)
* Updated [`AUTHORS`](https://github.com/MRPT/mrpt/blob/master/AUTHORS) (if applicable)

(Notify: @MRPT/owners )
