### PR TITLE
removed backslash at the end of MRPT_UNSCOPED_LOGGER_START

### DIFF
--- a/libs/system/include/mrpt/system/COutputLogger.h
+++ b/libs/system/include/mrpt/system/COutputLogger.h
@@ -536,7 +536,7 @@ struct COutputLoggerStreamWrapper
 			{                                                           \
 				do                                                      \
 				{                                                       \
-			} while (0)                                                 \
+			} while (0)                                                 
 // Here comes the user code, which is run in the ctor, and will call the object
 // log methods.
 


### PR DESCRIPTION
## Changed apps/libraries

* modified-libs/system/include/mrpt/system/COutputLogger.h

## PR Description

* this PR fixes the issue #592 

---

I acknowledge to have:
* Read the [`CONTRIBUTING`](https://github.com/MRPT/mrpt/blob/master/.github/CONTRIBUTING.md) page
* Updated [`doc/doxygen-pages/changeLog_doc.h`](https://github.com/MRPT/mrpt/blob/master/doc/doxygen-pages/changeLog_doc.h) to describe these changes (if applicable)
* Updated [`AUTHORS`](https://github.com/MRPT/mrpt/blob/master/AUTHORS) (if applicable)

(Notify: @MRPT/owners )
