### PR TITLE
Use move semantics with CRawlog

### DIFF
--- a/apps/RawLogViewer/main_convert_ops.cpp
+++ b/apps/RawLogViewer/main_convert_ops.cpp
@@ -885,7 +885,7 @@ void xRawLogViewerFrame::OnMenuResortByTimestamp(wxCommandEvent& event)
 		temp_rawlog.addObservationMemoryReference(rawlog.getAsObservation(idx));
 	}
 
-	rawlog.moveFrom(temp_rawlog);
+	rawlog = std::move(temp_rawlog);
 
 	// Update the views:
 	rebuildTreeView();
@@ -1113,7 +1113,7 @@ void xRawLogViewerFrame::OnMenuConvertSF(wxCommandEvent& event)
 	progDia.Update(nEntries);
 
 	// Update:
-	rawlog.moveFrom(new_rawlog);
+	rawlog = std::move(new_rawlog);
 	rebuildTreeView();
 
 	WX_END_TRY

--- a/apps/RawLogViewer/xRawLogViewerMain.cpp
+++ b/apps/RawLogViewer/xRawLogViewerMain.cpp
@@ -2241,7 +2241,7 @@ void xRawLogViewerFrame::loadRawlogFile(const string& str, int first, int last)
 			else if (newObj->GetRuntimeClass() == CLASS_ID(CRawlog))
 			{
 				CRawlog::Ptr rw = std::dynamic_pointer_cast<CRawlog>(newObj);
-				rawlog.moveFrom(*rw);
+				rawlog = std::move(*rw);
 			}
 			else
 			{

--- a/libs/obs/include/mrpt/obs/CRawlog.h
+++ b/libs/obs/include/mrpt/obs/CRawlog.h
@@ -366,12 +366,6 @@ class CRawlog : public mrpt::serialization::CSerializable
 		TListTimeAndObservations& out_found,
 		size_t guess_start_position = 0) const;
 
-	/** Efficiently copy the contents from other existing object, and remove the
-	 * data from the origin (after calling this, the original object will have
-	 * no actions/observations).
-	  */
-	void moveFrom(CRawlog& obj);
-
 	/** Efficiently swap the contents of two existing objects.
 	  */
 	void swap(CRawlog& obj);

--- a/libs/obs/src/CRawlog.cpp
+++ b/libs/obs/src/CRawlog.cpp
@@ -304,18 +304,6 @@ bool CRawlog::saveToRawLogFile(const std::string& fileName) const
 	}
 }
 
-void CRawlog::moveFrom(CRawlog& obj)
-{
-	MRPT_START
-	if (this == &obj) return;
-	clear();
-	m_commentTexts = obj.m_commentTexts;
-	m_seqOfActObs = obj.m_seqOfActObs;
-	obj.m_seqOfActObs.clear();
-	obj.m_commentTexts.text.clear();
-	MRPT_END
-}
-
 void CRawlog::swap(CRawlog& obj)
 {
 	if (this == &obj) return;

--- a/libs/obs/src/CRawlog_unittest.cpp
+++ b/libs/obs/src/CRawlog_unittest.cpp
@@ -1,0 +1,5 @@
+#include <mrpt/obs/CRawlog.h>
+#include <CTraitsTest.h>
+
+template class mrpt::CTraitsTest<mrpt::obs::CRawlog>;
+


### PR DESCRIPTION
I think we can just use the implicit move here right?

---

I acknowledge to have:
* Read the [`CONTRIBUTING`](https://github.com/MRPT/mrpt/blob/master/.github/CONTRIBUTING.md) page
* Updated [`doc/doxygen-pages/changeLog_doc.h`](https://github.com/MRPT/mrpt/blob/master/doc/doxygen-pages/changeLog_doc.h) to describe these changes (if applicable)
* Updated [`AUTHORS`](https://github.com/MRPT/mrpt/blob/master/AUTHORS) (if applicable)

(Notify: @MRPT/owners )
