### PR TITLE
Fix the rest of the examples

### DIFF
--- a/samples/hwdrivers_capture_video_dc1394/test.cpp
+++ b/samples/hwdrivers_capture_video_dc1394/test.cpp
@@ -15,6 +15,7 @@
 using namespace mrpt::hwdrivers;
 using namespace mrpt::gui;
 using namespace mrpt::obs;
+using namespace mrpt::system;
 using namespace std;
 
 //#define DO_CAPTURE		1

--- a/samples/hwdrivers_capture_video_flycapture2/test.cpp
+++ b/samples/hwdrivers_capture_video_flycapture2/test.cpp
@@ -11,12 +11,17 @@
 #include <mrpt/io/CFileGZOutputStream.h>
 #include <mrpt/system/CTicTac.h>
 #include <mrpt/gui/CDisplayWindow.h>
+#include <mrpt/serialization/CArchive.h>
 #include <mrpt/system/os.h>
+#include <mrpt/system/CTicTac.h>
 #include <iostream>
 
 using namespace mrpt::hwdrivers;
 using namespace mrpt::obs;
 using namespace mrpt::gui;
+using namespace mrpt::io;
+using namespace mrpt::serialization;
+using namespace mrpt::system;
 using namespace std;
 
 // ------------------------------------------------------
@@ -77,7 +82,7 @@ void TestCapture_FlyCapture2()
 		cout.flush();
 		if (win.isOpen()) win.showImage(obs->image);
 
-		fil << obs;
+		archiveFrom(fil) << obs;
 	}
 }
 

--- a/samples/hwdrivers_capture_video_flycapture2_stereo/test.cpp
+++ b/samples/hwdrivers_capture_video_flycapture2_stereo/test.cpp
@@ -13,11 +13,15 @@
 #include <mrpt/obs/CObservationImage.h>
 #include <mrpt/gui/CDisplayWindow.h>
 #include <mrpt/system/os.h>
+#include <mrpt/serialization/CArchive.h>
 #include <iostream>
 
 using namespace mrpt::hwdrivers;
 using namespace mrpt::gui;
 using namespace mrpt::obs;
+using namespace mrpt::io;
+using namespace mrpt::system;
+using namespace mrpt::serialization;
 using namespace std;
 
 // ------------------------------------------------------
@@ -127,7 +131,7 @@ void TestCapture_FlyCapture2_stereo()
 		if (winL.isOpen()) winL.showImage(obsL->image);
 		if (winR.isOpen()) winR.showImage(obsR->image);
 
-		fil << obsL << obsR;
+		archiveFrom(fil) << obsL << obsR;
 	}
 }
 

--- a/samples/hwdrivers_capture_video_opencv/test.cpp
+++ b/samples/hwdrivers_capture_video_opencv/test.cpp
@@ -11,11 +11,15 @@
 #include <mrpt/io/CFileGZOutputStream.h>
 #include <mrpt/system/CTicTac.h>
 #include <mrpt/gui/CDisplayWindow.h>
+#include <mrpt/serialization/CArchive.h>
 #include <iostream>
 
 using namespace mrpt::hwdrivers;
 using namespace mrpt::gui;
 using namespace mrpt::obs;
+using namespace mrpt::system;
+using namespace mrpt::io;
+using namespace mrpt::serialization;
 using namespace std;
 
 // ------------------------------------------------------
@@ -79,7 +83,7 @@ void TestCapture_OpenCV()
 			break;
 		}
 
-		fil << obs;
+		archiveFrom(fil) << obs;
 
 		cout << ".";
 		cout.flush();

--- a/samples/hwdrivers_joystick_example/test.cpp
+++ b/samples/hwdrivers_joystick_example/test.cpp
@@ -17,6 +17,7 @@
 
 using namespace std;
 using namespace mrpt;
+using namespace mrpt::system;
 using namespace mrpt::hwdrivers;
 
 // ------------------------------------------------------

--- a/samples/maps_gridmap_benchmark/test.cpp
+++ b/samples/maps_gridmap_benchmark/test.cpp
@@ -12,6 +12,7 @@
 #include <mrpt/obs/CObservation2DRangeScan.h>
 #include <mrpt/obs/CRawlog.h>
 #include <mrpt/config/CConfigFile.h>
+#include <mrpt/system/CTicTac.h>
 #include <iostream>
 
 using namespace mrpt;
@@ -19,6 +20,7 @@ using namespace mrpt::maps;
 using namespace mrpt::obs;
 using namespace mrpt::random;
 using namespace mrpt::poses;
+using namespace mrpt::system;
 using namespace std;
 
 #include <mrpt/examples_config.h>

--- a/samples/obs_mox_model_rawlog/test.cpp
+++ b/samples/obs_mox_model_rawlog/test.cpp
@@ -90,7 +90,7 @@ int main(int argc, char** argv)
 	{
 		try
 		{
-			CObservation::Ptr o;
+			CSerializable::Ptr o;
 			archiveFrom(file_input) >> o;
 
 			if (o)  // ASSERT_(o);

--- a/samples/opengl_video_viewport_demo/test.cpp
+++ b/samples/opengl_video_viewport_demo/test.cpp
@@ -44,7 +44,7 @@ void TestOpenGLVideo()
 	{
 		COpenGLScene::Ptr& theScene = win.get3DSceneAndLock();
 		gl_view_main = theScene->getViewport("main");
-		ASSERT_(gl_view_main)
+		ASSERT_(gl_view_main);
 		// IMPORTANT!!! IF NOT UNLOCKED, THE WINDOW WILL NOT BE UPDATED!
 		win.unlockAccess3DScene();
 	}

--- a/samples/slam_icp3d_simple_example/test.cpp
+++ b/samples/slam_icp3d_simple_example/test.cpp
@@ -141,11 +141,7 @@ void test_icp3D()
 	CSetOfObjects::Ptr PTNS1 = mrpt::make_aligned_shared<CSetOfObjects>();
 	CSetOfObjects::Ptr PTNS2 = mrpt::make_aligned_shared<CSetOfObjects>();
 
-<<<<<<< HEAD
 	CPointsMap::COLOR_3DSCENE(mrpt::img::TColorf(1, 0, 0));
-=======
-	CPointsMap::COLOR_3DSCENE(mrpt::utils::TColorf(1, 0, 0));
->>>>>>> master
 	M1.getAs3DObject(PTNS1);
 
 	CPointsMap::COLOR_3DSCENE(mrpt::img::TColorf(0, 0, 1));

--- a/samples/slam_range_only_localization_rej_sampling_example/test.cpp
+++ b/samples/slam_range_only_localization_rej_sampling_example/test.cpp
@@ -21,6 +21,7 @@ using namespace mrpt::maps;
 using namespace mrpt::system;
 using namespace mrpt::random;
 using namespace mrpt::poses;
+using namespace mrpt::config;
 using namespace std;
 
 float SIGMA = 0.03f;


### PR DESCRIPTION
There is still a linker error related to OpenNI, but this looks like a problem with mrpt-hwdrivers not linking against the library.

I acknowledge to have:
* Read the [`CONTRIBUTING`](https://github.com/MRPT/mrpt/blob/master/.github/CONTRIBUTING.md) page
* Updated [`doc/doxygen-pages/changeLog_doc.h`](https://github.com/MRPT/mrpt/blob/master/doc/doxygen-pages/changeLog_doc.h) to describe these changes (if applicable)
* Updated [`AUTHORS`](https://github.com/MRPT/mrpt/blob/master/AUTHORS) (if applicable)

(Notify: @MRPT/owners )
