### PR TITLE
Fix PNP OpenCV exceptions when running unit tests in debug mode

### DIFF
--- a/libs/vision/src/pnp/dls.cpp
+++ b/libs/vision/src/pnp/dls.cpp
@@ -42,14 +42,14 @@ mrpt::vision::pnp::dls::dls(const cv::Mat& opoints, const cv::Mat& ipoints)
 	if (opoints.depth() == ipoints.depth())
 	{
 		if (opoints.depth() == CV_32F)
-			init_points<cv::Point3f, cv::Point2f>(opoints, ipoints);
+			init_points<float, float>(opoints, ipoints);
 		else
-			init_points<cv::Point3d, cv::Point2d>(opoints, ipoints);
+			init_points<double, double>(opoints, ipoints);
 	}
 	else if (opoints.depth() == CV_32F)
-		init_points<cv::Point3f, cv::Point2d>(opoints, ipoints);
+		init_points<float, double>(opoints, ipoints);
 	else
-		init_points<cv::Point3d, cv::Point2f>(opoints, ipoints);
+		init_points<double, float>(opoints, ipoints);
 }
 
 mrpt::vision::pnp::dls::~dls()

--- a/libs/vision/src/pnp/dls.h
+++ b/libs/vision/src/pnp/dls.h
@@ -53,9 +53,9 @@ class dls
 	{
 		for (int i = 0; i < N; i++)
 		{
-			p.at<double>(0, i) = opoints.at<OpointType>(i).x;
-			p.at<double>(1, i) = opoints.at<OpointType>(i).y;
-			p.at<double>(2, i) = opoints.at<OpointType>(i).z;
+			p.at<double>(0, i) = opoints.at<OpointType>(i,0);
+			p.at<double>(1, i) = opoints.at<OpointType>(i,1);
+			p.at<double>(2, i) = opoints.at<OpointType>(i,2);
 
 			// compute mean of object points
 			mn.at<double>(0) += p.at<double>(0, i);
@@ -63,12 +63,12 @@ class dls
 			mn.at<double>(2) += p.at<double>(2, i);
 
 			// make z into unit vectors from normalized pixel coords
-			double sr = std::pow(ipoints.at<IpointType>(i).x, 2) +
-						std::pow(ipoints.at<IpointType>(i).y, 2) + (double)1;
+			double sr = std::pow(ipoints.at<IpointType>(i,0), 2) +
+						std::pow(ipoints.at<IpointType>(i,1), 2) + (double)1;
 			sr = std::sqrt(sr);
 
-			z.at<double>(0, i) = ipoints.at<IpointType>(i).x / sr;
-			z.at<double>(1, i) = ipoints.at<IpointType>(i).y / sr;
+			z.at<double>(0, i) = ipoints.at<IpointType>(i,0) / sr;
+			z.at<double>(1, i) = ipoints.at<IpointType>(i,1) / sr;
 			z.at<double>(2, i) = (double)1 / sr;
 		}
 

--- a/libs/vision/src/pnp/epnp.cpp
+++ b/libs/vision/src/pnp/epnp.cpp
@@ -42,14 +42,14 @@ mrpt::vision::pnp::epnp::epnp(
 	if (opoints.depth() == ipoints.depth())
 	{
 		if (opoints.depth() == CV_32F)
-			init_points<cv::Point3f, cv::Point2f>(opoints, ipoints);
+			init_points<float, float>(opoints, ipoints);
 		else
-			init_points<cv::Point3d, cv::Point2d>(opoints, ipoints);
+			init_points<double, double>(opoints, ipoints);
 	}
 	else if (opoints.depth() == CV_32F)
-		init_points<cv::Point3f, cv::Point2d>(opoints, ipoints);
+		init_points<float, double>(opoints, ipoints);
 	else
-		init_points<cv::Point3d, cv::Point2f>(opoints, ipoints);
+		init_points<double, float>(opoints, ipoints);
 
 	alphas.resize(4 * number_of_correspondences);
 	pcs.resize(3 * number_of_correspondences);

--- a/libs/vision/src/pnp/epnp.h
+++ b/libs/vision/src/pnp/epnp.h
@@ -86,12 +86,12 @@ class epnp
 	{
 		for (int i = 0; i < number_of_correspondences; i++)
 		{
-			pws[3 * i] = opoints.at<OpointType>(0, i).x;
-			pws[3 * i + 1] = opoints.at<OpointType>(0, i).y;
-			pws[3 * i + 2] = opoints.at<OpointType>(0, i).z;
+			pws[3 * i] = opoints.at<OpointType>(i, 0);
+			pws[3 * i + 1] = opoints.at<OpointType>(i, 1);
+			pws[3 * i + 2] = opoints.at<OpointType>(i, 2);
 
-			us[2 * i] = ipoints.at<IpointType>(0, i).x * fu + uc;
-			us[2 * i + 1] = ipoints.at<IpointType>(0, i).y * fv + vc;
+			us[2 * i] = ipoints.at<IpointType>(i, 0) * fu + uc;
+			us[2 * i + 1] = ipoints.at<IpointType>(i, 1) * fv + vc;
 		}
 	}
 


### PR DESCRIPTION
cv::eigen2cv does not produce cv::Point[2,3][d,f] from a MatrixXd. It produces a cv::Mat where the pixel type is a double.

---

I acknowledge to have:
* Read the [`CONTRIBUTING`](https://github.com/MRPT/mrpt/blob/master/.github/CONTRIBUTING.md) page
* Updated [`doc/doxygen-pages/changeLog_doc.h`](https://github.com/MRPT/mrpt/blob/master/doc/doxygen-pages/changeLog_doc.h) to describe these changes (if applicable)
* Updated [`AUTHORS`](https://github.com/MRPT/mrpt/blob/master/AUTHORS) (if applicable)

(Notify: @MRPT/owners )
