### PR TITLE
Add custom timing output

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -24,6 +24,16 @@ else()
 	CMAKE_MINIMUM_REQUIRED(VERSION 3.3)
 endif()
 
+# Display timing information for each compiler instance on screen
+option(CMAKE_TIMING_VERBOSE "Enable the display of timing information for each compiler instance." OFF)
+mark_as_advanced(CMAKE_TIMING_VERBOSE)
+
+# Enable verbose timing display?
+if(CMAKE_TIMING_VERBOSE AND UNIX)
+  set_property(GLOBAL PROPERTY RULE_MESSAGES OFF)
+  set_property(GLOBAL PROPERTY RULE_LAUNCH_COMPILE "${CMAKE_SOURCE_DIR}/cmakemodules/custom_output.sh")
+endif(CMAKE_TIMING_VERBOSE AND UNIX)
+
 set (CMAKE_CXX_STANDARD 14)  # Require C++14
 if(COMMAND cmake_policy)
 	cmake_policy(SET CMP0003 NEW) # We don't want to mix relative and absolute paths in linker lib lists.

--- a/cmakemodules/custom_output.sh
+++ b/cmakemodules/custom_output.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+SOURCE_FILE="${@: -1:1}"
+SOURCE_FILE_NAME=`basename \"$SOURCE_FILE\" | tr -d '"'`
+
+TIME_OUTPUT=`/usr/bin/time --format=" %E real, %U user, %S sys" $@ 2>&1 |tr '\n' ' '`
+echo "-BUILD TIME: $TIME_OUTPUT $SOURCE_FILE_NAME"


### PR DESCRIPTION
Set CMAKE_TIMING_VERBOSE=ON
This is similar to the PCL version, but it uses time instead of date.

The standard cmake output is replaced with this:
```
-BUILD TIME:  0:01.14 real, 1.02 user, 0.07 sys  CObservationCANBusJ1939.cpp
-BUILD TIME:  0:00.89 real, 0.79 user, 0.06 sys  CObservationComment.cpp
-BUILD TIME:  0:04.68 real, 4.48 user, 0.18 sys  CObservation2DRangeScan.cpp
-BUILD TIME:  0:05.50 real, 5.13 user, 0.25 sys  error_box.cpp
-BUILD TIME:  0:02.95 real, 2.75 user, 0.17 sys  CObservationBeaconRanges.cp
```
---

I acknowledge to have:
* Read the [`CONTRIBUTING`](https://github.com/MRPT/mrpt/blob/master/.github/CONTRIBUTING.md) page
* Updated [`doc/doxygen-pages/changeLog_doc.h`](https://github.com/MRPT/mrpt/blob/master/doc/doxygen-pages/changeLog_doc.h) to describe these changes (if applicable)
* Updated [`AUTHORS`](https://github.com/MRPT/mrpt/blob/master/AUTHORS) (if applicable)

(Notify: @MRPT/owners )
