### PR TITLE
Support shared_ptr<T> class types in serialization and typemeta modules

### DIFF
--- a/doc/doxygen-pages/lib_mrpt_serialization.h
+++ b/doc/doxygen-pages/lib_mrpt_serialization.h
@@ -40,6 +40,11 @@ Serialization happens via `archive << object` operators in all cases but, undern
 Support for STL containers is provided via this "direct mechanism" for the container structure itself, but contained
 elements can use any of the serialization mechanisms.
 
+Serializing `shared_ptr<T>` is supported for any arbitrary type `T`. It is legal to serialize an empty (`nullptr`)
+smart pointer; an empty pointer will be read back. Polymorphic classes can be also writen and read, although reading
+a smart pointer to a polymorphic base class is only supported for classes derived from MRPT's CSerializable, since
+that operation requires registering types in a class factory (see \a mrpt_rtti_grp and mrpt::serialization::CSerializable).
+
 ## Example #1: serialize STL container via MRPT `CStream`s
 
 See: \ref serialization_stl/test.cpp

--- a/doc/doxygen-pages/lib_mrpt_typemeta.h
+++ b/doc/doxygen-pages/lib_mrpt_typemeta.h
@@ -9,7 +9,7 @@
 
 /** \defgroup mrpt_typemeta_grp [mrpt-typemeta]
 
-Metaprogramming header-only library to obtain `constexpr` textual string representations of enum types and type names, including complex STL compound types.
+Metaprogramming header-only library to obtain `constexpr` textual string representations of enum types and type names, including smart pointers and complex STL compound types.
 
 <small> <a href="index.html#libs">Back to list of all libraries</a> | <a href="modules.html" >See all modules</a> </small>
 <br>

--- a/libs/serialization/include/mrpt/serialization/CArchive.h
+++ b/libs/serialization/include/mrpt/serialization/CArchive.h
@@ -344,9 +344,14 @@ class CArchive
 	 */
 	bool receiveMessage(CMessage& msg);
 
-	/** Write an object to a stream in the binary MRPT format. */
+	/** Write a CSerializable object to a stream in the binary MRPT format */
 	CArchive& operator<<(const CSerializable& obj);
+	/** \overload */
+	CArchive& operator<<(const CSerializable::Ptr& pObj);
+	/** Reads a CSerializable object from the stream */
 	CArchive& operator>>(CSerializable& obj);
+	/** \overload */
+	CArchive& operator>>(CSerializable::Ptr& pObj);
 
 	/** @} */
 

--- a/libs/serialization/include/mrpt/serialization/CArchive.h
+++ b/libs/serialization/include/mrpt/serialization/CArchive.h
@@ -344,8 +344,9 @@ class CArchive
 	bool receiveMessage(CMessage& msg);
 
 	/** Write a shared_ptr to a non-CSerializable object */
-	template <class T, std::enable_if_t<!std::is_base_of<
-		mrpt::serialization::CSerializable, T>::value>* = nullptr>
+	template <class T,
+			  std::enable_if_t<!std::is_base_of<
+				  mrpt::serialization::CSerializable, T>::value>* = nullptr>
 	CArchive& operator<<(const std::shared_ptr<T>& pObj)
 	{
 		if (pObj)
@@ -361,8 +362,9 @@ class CArchive
 	}
 
 	/** Read a smart pointer to a non-CSerializable (POD,...) data type*/
-	template <class T, std::enable_if_t<!std::is_base_of<
-		mrpt::serialization::CSerializable, T>::value>* = nullptr>
+	template <class T,
+			  std::enable_if_t<!std::is_base_of<
+				  mrpt::serialization::CSerializable, T>::value>* = nullptr>
 	CArchive& operator>>(std::shared_ptr<T>& pObj)
 	{
 		std::string stored_name;
@@ -380,7 +382,6 @@ class CArchive
 		}
 		return *this;
 	}
-
 
 	/** Write an object to a stream in the binary MRPT format. */
 	CArchive& operator<<(const CSerializable& obj);
@@ -494,9 +495,9 @@ CArchive& operator>>(CArchive& s, std::vector<size_t>& a);
 #endif
 //
 
-template <
-	typename T, std::enable_if_t<std::is_base_of<
-					mrpt::serialization::CSerializable, T>::value>* = nullptr>
+template <typename T,
+		  std::enable_if_t<std::is_base_of<mrpt::serialization::CSerializable,
+										   T>::value>* = nullptr>
 CArchive& operator>>(CArchive& in, typename std::shared_ptr<T>& pObj)
 {
 	pObj = in.ReadObject<T>();
@@ -527,7 +528,6 @@ class CArchiveStreamBase : public CArchive
 
    public:
 	CArchiveStreamBase(STREAM& s) : m_s(s) {}
-
    protected:
 	size_t write(const void* d, size_t n) override { return m_s.Write(d, n); }
 	size_t read(void* d, size_t n) override { return m_s.Read(d, n); }

--- a/libs/serialization/include/mrpt/serialization/CSerializable.h
+++ b/libs/serialization/include/mrpt/serialization/CSerializable.h
@@ -132,7 +132,7 @@ void OctetVectorToObject(
 	/*! @name Virtual methods for MRPT-MEX conversion */ \
 	/*! @{ */                                            \
    public:                                               \
-	mxArray* writeToMatlab() const override;              \
+	mxArray* writeToMatlab() const override;             \
 /*! @} */
 
 /** This must be inserted if a custom conversion method for MEX API is

--- a/libs/serialization/src/CArchive.cpp
+++ b/libs/serialization/src/CArchive.cpp
@@ -177,10 +177,22 @@ void CArchive::WriteObject(const CSerializable* o)
 	MRPT_END;
 }
 
+CArchive& CArchive::operator<<(const CSerializable::Ptr& pObj)
+{
+	WriteObject(pObj.get());
+	return *this;
+}
+
 /** Write an object to a stream in the binary MRPT format. */
 CArchive& CArchive::operator<<(const CSerializable& obj)
 {
 	WriteObject(&obj);
+	return *this;
+}
+
+CArchive& CArchive::operator>>(CSerializable::Ptr& pObj)
+{
+	pObj = ReadObject();
 	return *this;
 }
 
@@ -215,9 +227,9 @@ inline CArchive& readStdVectorToStream(CArchive& s, VEC& v)
 	if (n) s.ReadBufferFixEndianness(&v[0], n);
 	return s;
 }
-}
-}
-}
+}  // namespace detail
+}  // namespace serialization
+}  // namespace mrpt
 
 // Write:
 CArchive& mrpt::serialization::operator<<(
@@ -532,11 +544,10 @@ void CArchive::ReadObject(CSerializable* existingObj)
 			"Stored object has class '%s' which is not registered!",
 			strClassName.c_str());
 	if (id != id2)
-		THROW_EXCEPTION(
-			format(
-				"Stored class does not match with existing object!!:\n Stored: "
-				"%s\n Expected: %s",
-				id2->className, id->className));
+		THROW_EXCEPTION(format(
+			"Stored class does not match with existing object!!:\n Stored: "
+			"%s\n Expected: %s",
+			id2->className, id->className));
 
 	internal_ReadObject(existingObj, strClassName, isOldFormat, version);
 }

--- a/libs/serialization/src/CArchive.cpp
+++ b/libs/serialization/src/CArchive.cpp
@@ -177,22 +177,10 @@ void CArchive::WriteObject(const CSerializable* o)
 	MRPT_END;
 }
 
-CArchive& CArchive::operator<<(const CSerializable::Ptr& pObj)
-{
-	WriteObject(pObj.get());
-	return *this;
-}
-
 /** Write an object to a stream in the binary MRPT format. */
 CArchive& CArchive::operator<<(const CSerializable& obj)
 {
 	WriteObject(&obj);
-	return *this;
-}
-
-CArchive& CArchive::operator>>(CSerializable::Ptr& pObj)
-{
-	pObj = ReadObject();
 	return *this;
 }
 

--- a/libs/serialization/src/CArchive.cpp
+++ b/libs/serialization/src/CArchive.cpp
@@ -276,7 +276,8 @@ CArchive& mrpt::serialization::operator>>(CArchive& s, std::vector<float>& a)
 {
 	return detail::readStdVectorToStream(s, a);
 }
-CArchive& mrpt::serialization::operator>>(CArchive& s, mrpt::aligned_std_vector<float>& a)
+CArchive& mrpt::serialization::operator>>(
+	CArchive& s, mrpt::aligned_std_vector<float>& a)
 {
 	return detail::readStdVectorToStream(s, a);
 }

--- a/libs/serialization/src/stl_serialize_unittest.cpp
+++ b/libs/serialization/src/stl_serialize_unittest.cpp
@@ -108,7 +108,7 @@ TEST(Serialization, vector_shared_ptr)
 	f.Seek(0);
 	arch >> m2;
 	EXPECT_EQ(m1.size(), m2.size());
-	for (auto i = 0; i < m1.size(); i++)
+	for (auto i = 0U; i < m1.size(); i++)
 	{
 		if (!m1[i])
 		{

--- a/libs/serialization/src/stl_serialize_unittest.cpp
+++ b/libs/serialization/src/stl_serialize_unittest.cpp
@@ -12,7 +12,7 @@
 #include <mrpt/serialization/stl_serialization.h>
 #include <mrpt/io/CMemoryStream.h>
 #include <gtest/gtest.h>
-#include <memory> // shared_ptr
+#include <memory>  // shared_ptr
 
 using namespace mrpt::serialization;
 
@@ -63,30 +63,26 @@ TEST(Serialization, STL_complex_error_type)
 
 struct Foo
 {
-	Foo(int i=0) : m_i(i) {}
+	Foo(int i = 0) : m_i(i) {}
 	int m_i;
 
 	DECLARE_TTYPENAME_CLASSNAME(Foo)
-	bool operator==(const Foo &b) const
-	{
-		return m_i == b.m_i;
-	}
+	bool operator==(const Foo& b) const { return m_i == b.m_i; }
 };
-CArchive & operator <<(CArchive &a, const Foo& f)
+CArchive& operator<<(CArchive& a, const Foo& f)
 {
 	a << f.m_i;
 	return a;
 }
-CArchive & operator >>(CArchive &a, Foo &f)
+CArchive& operator>>(CArchive& a, Foo& f)
 {
 	a >> f.m_i;
 	return a;
 }
 
-
 TEST(Serialization, vector_custom_type)
 {
-	std::vector<Foo> m2, m1{1,2,3};
+	std::vector<Foo> m2, m1{1, 2, 3};
 
 	mrpt::io::CMemoryStream f;
 	auto arch = mrpt::serialization::archiveFrom(f);
@@ -102,7 +98,7 @@ TEST(Serialization, vector_shared_ptr)
 	std::vector<std::shared_ptr<Foo>> m2, m1;
 	m1.push_back(std::make_shared<Foo>(1));
 	m1.push_back(std::make_shared<Foo>(2));
-	m1.push_back(std::shared_ptr<Foo>()); // nullptr 
+	m1.push_back(std::shared_ptr<Foo>());  // nullptr
 	m1.push_back(std::make_shared<Foo>(3));
 
 	mrpt::io::CMemoryStream f;
@@ -118,7 +114,7 @@ TEST(Serialization, vector_shared_ptr)
 		{
 			EXPECT_EQ(m1[i], m2[i]);
 		}
-		else 
+		else
 		{
 			EXPECT_EQ(*m1[i], *m2[i]);
 		}

--- a/libs/serialization/src/stl_serialize_unittest.cpp
+++ b/libs/serialization/src/stl_serialize_unittest.cpp
@@ -12,6 +12,7 @@
 #include <mrpt/serialization/stl_serialization.h>
 #include <mrpt/io/CMemoryStream.h>
 #include <gtest/gtest.h>
+#include <memory> // shared_ptr
 
 using namespace mrpt::serialization;
 
@@ -58,4 +59,68 @@ TEST(Serialization, STL_complex_error_type)
 	// Trying to read to a different variable raises an exception:
 	f.Seek(0);
 	EXPECT_THROW(arch >> v2, std::exception);
+}
+
+struct Foo
+{
+	Foo(int i=0) : m_i(i) {}
+	int m_i;
+
+	DECLARE_TTYPENAME_CLASSNAME(Foo)
+	bool operator==(const Foo &b) const
+	{
+		return m_i == b.m_i;
+	}
+};
+CArchive & operator <<(CArchive &a, const Foo& f)
+{
+	a << f.m_i;
+	return a;
+}
+CArchive & operator >>(CArchive &a, Foo &f)
+{
+	a >> f.m_i;
+	return a;
+}
+
+
+TEST(Serialization, vector_custom_type)
+{
+	std::vector<Foo> m2, m1{1,2,3};
+
+	mrpt::io::CMemoryStream f;
+	auto arch = mrpt::serialization::archiveFrom(f);
+	arch << m1;
+
+	f.Seek(0);
+	arch >> m2;
+	EXPECT_EQ(m1, m2);
+}
+
+TEST(Serialization, vector_shared_ptr)
+{
+	std::vector<std::shared_ptr<Foo>> m2, m1;
+	m1.push_back(std::make_shared<Foo>(1));
+	m1.push_back(std::make_shared<Foo>(2));
+	m1.push_back(std::shared_ptr<Foo>()); // nullptr 
+	m1.push_back(std::make_shared<Foo>(3));
+
+	mrpt::io::CMemoryStream f;
+	auto arch = mrpt::serialization::archiveFrom(f);
+	arch << m1;
+
+	f.Seek(0);
+	arch >> m2;
+	EXPECT_EQ(m1.size(), m2.size());
+	for (auto i = 0; i < m1.size(); i++)
+	{
+		if (!m1[i])
+		{
+			EXPECT_EQ(m1[i], m2[i]);
+		}
+		else 
+		{
+			EXPECT_EQ(*m1[i], *m2[i]);
+		}
+	}
 }

--- a/libs/typemeta/include/mrpt/typemeta/TTypeName.h
+++ b/libs/typemeta/include/mrpt/typemeta/TTypeName.h
@@ -11,6 +11,12 @@
 #include <cstdint>
 #include <mrpt/typemeta/static_string.h>
 
+// frwd decl for TTypeName specialization:
+namespace std {
+template<class T>
+class shared_ptr;
+}
+
 namespace mrpt
 {
 namespace typemeta
@@ -58,6 +64,16 @@ template <typename T>
 struct TTypeName
 {
 	constexpr static auto get() { return T::getClassName(); }
+};
+
+/** Specialization for shared_ptr<T> */
+template <typename T>
+struct TTypeName<std::shared_ptr<T>>
+{
+	constexpr static auto get()
+	{
+		return literal("std::shared_ptr<") + TTypeName<T>::get() + literal(">");
+	}
 };
 
 /** Identical to MRPT_DECLARE_TTYPENAME but intended for user code.

--- a/libs/typemeta/include/mrpt/typemeta/TTypeName.h
+++ b/libs/typemeta/include/mrpt/typemeta/TTypeName.h
@@ -12,8 +12,9 @@
 #include <mrpt/typemeta/static_string.h>
 
 // frwd decl for TTypeName specialization:
-namespace std {
-template<class T>
+namespace std
+{
+template <class T>
 class shared_ptr;
 }
 

--- a/libs/typemeta/src/enumtype_unittest.cpp
+++ b/libs/typemeta/src/enumtype_unittest.cpp
@@ -63,6 +63,7 @@ TEST(TEnumType, value2str)
 
 	EXPECT_EQ(TEnumType<Directions>::value2name(East), "East");
 
-
-	EXPECT_THROW(TEnumType<TestColors>::value2name(static_cast<TestColors>(5)), std::exception);
+	EXPECT_THROW(
+		TEnumType<TestColors>::value2name(static_cast<TestColors>(5)),
+		std::exception);
 }

--- a/libs/typemeta/src/typename_unittest.cpp
+++ b/libs/typemeta/src/typename_unittest.cpp
@@ -11,7 +11,7 @@
 #include <mrpt/typemeta/TTypeName_stl.h>
 #include <gtest/gtest.h>
 #include <iostream>
-#include <memory> // shared_ptr
+#include <memory>  // shared_ptr
 
 struct MyFooClass
 {
@@ -81,7 +81,9 @@ TEST(TTypeName, types2str_shared_ptr)
 
 	TST_FOR_TYPE(std::shared_ptr<MyFooClass>);
 	TST_FOR_TYPE(std::vector<std::shared_ptr<MyFooClass>>);
-	EXPECT_STREQ("std::shared_ptr<MyFooClass>", TTypeName<MyFooClass::Ptr>::get().c_str());
+	EXPECT_STREQ(
+		"std::shared_ptr<MyFooClass>",
+		TTypeName<MyFooClass::Ptr>::get().c_str());
 }
 
 TEST(TTypeName, types2stdstring)

--- a/libs/typemeta/src/typename_unittest.cpp
+++ b/libs/typemeta/src/typename_unittest.cpp
@@ -11,9 +11,11 @@
 #include <mrpt/typemeta/TTypeName_stl.h>
 #include <gtest/gtest.h>
 #include <iostream>
+#include <memory> // shared_ptr
 
 struct MyFooClass
 {
+	using Ptr = std::shared_ptr<MyFooClass>;
 };
 namespace MyNS
 {
@@ -29,13 +31,22 @@ struct MyBarClass2
 DECLARE_CUSTOM_TTYPENAME(MyFooClass);
 DECLARE_CUSTOM_TTYPENAME(MyNS::MyBarClass);
 
+#define TST_FOR_TYPE(__TSTTYPE) \
+	EXPECT_STREQ(#__TSTTYPE, TTypeName<__TSTTYPE>::get().c_str())
+
+// templates with a "," in its name break all our and gtest macros:
+#define TST_FOR_TYPE2(__TSTTYPE, __TSTTYPE2ndpart)                            \
+	if (std::string(#__TSTTYPE "," #__TSTTYPE2ndpart) !=                      \
+		TTypeName<__TSTTYPE, __TSTTYPE2ndpart>::get().c_str())                \
+		GTEST_FAIL() << "Failed: " << #__TSTTYPE "," #__TSTTYPE2ndpart        \
+					 << "\n Computed type is: "                               \
+					 << TTypeName<__TSTTYPE, __TSTTYPE2ndpart>::get().c_str() \
+					 << endl;
+
 TEST(TTypeName, types2str)
 {
 	using namespace mrpt::typemeta;
 	using namespace std;
-
-#define TST_FOR_TYPE(__TSTTYPE) \
-	EXPECT_STREQ(#__TSTTYPE, TTypeName<__TSTTYPE>::get().c_str())
 
 	// Basic types:
 	TST_FOR_TYPE(int32_t);
@@ -50,15 +61,6 @@ TEST(TTypeName, types2str)
 	TST_FOR_TYPE(std::set<double>);
 	TST_FOR_TYPE(std::set<std::vector<double>>);
 
-// templates with a "," in its name break all our and gtest macros:
-#define TST_FOR_TYPE2(__TSTTYPE, __TSTTYPE2ndpart)                            \
-	if (std::string(#__TSTTYPE "," #__TSTTYPE2ndpart) !=                      \
-		TTypeName<__TSTTYPE, __TSTTYPE2ndpart>::get().c_str())                \
-		GTEST_FAIL() << "Failed: " << #__TSTTYPE "," #__TSTTYPE2ndpart        \
-					 << "\n Computed type is: "                               \
-					 << TTypeName<__TSTTYPE, __TSTTYPE2ndpart>::get().c_str() \
-					 << endl;
-
 	TST_FOR_TYPE2(std::pair<int32_t, int32_t>);
 	TST_FOR_TYPE2(std::map<double, std::set<int32_t>>);
 	TST_FOR_TYPE2(std::array<double, 3>);
@@ -71,6 +73,15 @@ TEST(TTypeName, types2str)
 	TST_FOR_TYPE(std::set<MyNS::MyBarClass>);
 	TST_FOR_TYPE(std::set<MyNS::MyBarClass2>);
 	TST_FOR_TYPE2(std::vector<std::array<MyNS::MyBarClass, 10>>);
+}
+
+TEST(TTypeName, types2str_shared_ptr)
+{
+	using namespace mrpt::typemeta;
+
+	TST_FOR_TYPE(std::shared_ptr<MyFooClass>);
+	TST_FOR_TYPE(std::vector<std::shared_ptr<MyFooClass>>);
+	EXPECT_STREQ("std::shared_ptr<MyFooClass>", TTypeName<MyFooClass::Ptr>::get().c_str());
 }
 
 TEST(TTypeName, types2stdstring)

--- a/samples/typemeta_TTypeName/console.out
+++ b/samples/typemeta_TTypeName/console.out
@@ -1,6 +1,7 @@
 int32_t
 std::set<std::vector<double>>
 MyFooClass
+std::shared_ptr<MyFooClass>
 MyNS::MyBarClass
 MyNS::MyBarClass2
 double

--- a/samples/typemeta_TTypeName/test.cpp
+++ b/samples/typemeta_TTypeName/test.cpp
@@ -12,10 +12,12 @@
 #include <mrpt/typemeta/TTypeName.h>
 #include <mrpt/typemeta/TTypeName_stl.h>
 #include <iostream>
+#include <memory> // shared_ptr
 
 // Declare custom user types:
 struct MyFooClass
 {
+	using Ptr = std::shared_ptr<MyFooClass>;
 };
 namespace MyNS
 {
@@ -43,6 +45,7 @@ void Test_TypeName()
 
 	// Evaluation of user-defined types:
 	cout << TTypeName<MyFooClass>::get() << endl;
+	cout << TTypeName<MyFooClass::Ptr>::get() << endl;
 	cout << TTypeName<MyNS::MyBarClass>::get() << endl;
 	cout << TTypeName<MyNS::MyBarClass2>::get() << endl;
 

--- a/samples/typemeta_TTypeName/test.cpp
+++ b/samples/typemeta_TTypeName/test.cpp
@@ -12,7 +12,7 @@
 #include <mrpt/typemeta/TTypeName.h>
 #include <mrpt/typemeta/TTypeName_stl.h>
 #include <iostream>
-#include <memory> // shared_ptr
+#include <memory>  // shared_ptr
 
 // Declare custom user types:
 struct MyFooClass


### PR DESCRIPTION
That's it. Refer to the modified examples and docs.

`shared_ptr`'s can now be safely (de)serialized, not only for CSerializable classes, but for POD or custom user's classes.