### PR TITLE
use std::visit()

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,7 @@ Minimum compiler requisites:
     * gcc-7 or newer.
       * Ubuntu 18.04LTS Bionic: Its default gcc version is ok.
       * Ubuntu 16.04LTS Xenial: [Instructions](https://gist.github.com/jlblancoc/99521194aba975286c80f93e47966dc5) for installing gcc-7 in this version of Ubuntu.
+    * clang-4 or newer.
     * Windows: Visual Studio 2017 version 15.3 or newer.
     * cmake >= 3.3 required (>=3.4 for Windows).
   * mrpt 1.5.* and maintenance `mrpt-1.5` branch:

--- a/libs/serialization/include/mrpt/serialization/CArchive.h
+++ b/libs/serialization/include/mrpt/serialization/CArchive.h
@@ -277,7 +277,7 @@ class CArchive
 	template <typename T>
 	void WriteVariant(T t)
 	{
-		t.match([&](auto& o) { this->WriteObject(o); });
+		std::visit([&](auto& o) { this->WriteObject(o); }, t);
 	}
 
 	/** Reads a simple POD type and returns by value. Useful when `stream >>
@@ -478,8 +478,7 @@ CArchive& operator>>(CArchive& in, typename std::variant<T...>& pObj)
 }
 
 template <typename... T>
-CArchive& operator<<(
-	CArchive& out, const typename std::variant<T...>& pObj)
+CArchive& operator<<(CArchive& out, const typename std::variant<T...>& pObj)
 {
 	pObj.match([&](auto& t) { out << t; });
 	return out;

--- a/libs/serialization/include/mrpt/serialization/CArchive.h
+++ b/libs/serialization/include/mrpt/serialization/CArchive.h
@@ -18,8 +18,13 @@
 #include <type_traits>  // remove_reference_t, is_polymorphic
 #include <stdexcept>
 #include <mrpt/typemeta/TTypeName.h>
-
 #include <variant>
+
+// See: https://gcc.gnu.org/viewcvs/gcc?view=revision&revision=258854
+#if defined(__clang__) && (__GLIBCXX__ <= 20180419)
+#define HAS_BROKEN_CLANG_STD_VISIT
+#endif
+
 namespace mrpt
 {
 namespace serialization
@@ -272,6 +277,7 @@ class CArchive
 		}
 	}
 
+#ifndef HAS_BROKEN_CLANG_STD_VISIT
 	/** Writes a Variant to the stream.
 	 */
 	template <typename T>
@@ -279,6 +285,7 @@ class CArchive
 	{
 		std::visit([&](auto& o) { this->WriteObject(o); }, t);
 	}
+#endif
 
 	/** Reads a simple POD type and returns by value. Useful when `stream >>
 	 * var;`

--- a/libs/vision/include/mrpt/vision/CFeatureLines.h
+++ b/libs/vision/include/mrpt/vision/CFeatureLines.h
@@ -9,6 +9,9 @@
 #ifndef CFeatureLines_H
 #define CFeatureLines_H
 
+#include <mrpt/config.h>
+
+#ifdef MRPT_HAS_OPENCV
 #include <mrpt/vision/utils.h>
 //#include <mrpt/utils/CImage.h>
 #include <opencv2/core/core.hpp>
@@ -40,4 +43,5 @@ namespace mrpt
     } // end of namespace
 } // end of namespace
 
+#endif
 #endif

--- a/libs/vision/include/mrpt/vision/CFeatureLines.h
+++ b/libs/vision/include/mrpt/vision/CFeatureLines.h
@@ -24,7 +24,7 @@ namespace mrpt
           *
           *  \ingroup mrpt_vision_grp
           */
-        class VISION_IMPEXP CFeatureLines
+        class CFeatureLines
         {
           public:
             void extractLines (const cv::Mat & image,

--- a/libs/vision/include/mrpt/vision/CFeatureLines.h
+++ b/libs/vision/include/mrpt/vision/CFeatureLines.h
@@ -11,7 +11,7 @@
 
 #include <mrpt/config.h>
 
-#ifdef MRPT_HAS_OPENCV
+#if MRPT_HAS_OPENCV
 #include <mrpt/vision/utils.h>
 //#include <mrpt/utils/CImage.h>
 #include <opencv2/core/core.hpp>

--- a/samples/serialization_variant_example/test.cpp
+++ b/samples/serialization_variant_example/test.cpp
@@ -40,11 +40,12 @@ void thread_reader(CPipeReadEndPoint& read_pipe)
 		// *Note*: If the object class is known in advance, one can avoid smart
 		// pointers with ReadObject(&existingObj)
 		auto arch = archiveFrom(read_pipe);
+		auto doprint = [](auto& pose) { cout << "RX pose: " << pose << endl; };
 		auto var =
 			arch.ReadVariant<mrpt::poses::CPose2D, mrpt::poses::CPose3D>();
-		var.match([](auto& pose) { cout << "RX pose: " << pose << endl; });
+		std::visit(doprint, var);
 		var = arch.ReadVariant<mrpt::poses::CPose2D, mrpt::poses::CPose3D>();
-		var.match([](auto& pose) { cout << "RX pose: " << pose << endl; });
+		std::visit(doprint, var);
 
 		printf("[thread_reader] Finished.\n");
 	}

--- a/samples/serialization_variant_example/test.cpp
+++ b/samples/serialization_variant_example/test.cpp
@@ -40,12 +40,14 @@ void thread_reader(CPipeReadEndPoint& read_pipe)
 		// *Note*: If the object class is known in advance, one can avoid smart
 		// pointers with ReadObject(&existingObj)
 		auto arch = archiveFrom(read_pipe);
+#ifndef HAS_BROKEN_CLANG_STD_VISIT
 		auto doprint = [](auto& pose) { cout << "RX pose: " << pose << endl; };
 		auto var =
 			arch.ReadVariant<mrpt::poses::CPose2D, mrpt::poses::CPose3D>();
 		std::visit(doprint, var);
 		var = arch.ReadVariant<mrpt::poses::CPose2D, mrpt::poses::CPose3D>();
 		std::visit(doprint, var);
+#endif
 
 		printf("[thread_reader] Finished.\n");
 	}
@@ -76,9 +78,10 @@ void thread_writer(CPipeWriteEndPoint& write_pipe)
 		std::variant<mrpt::poses::CPose3D, mrpt::poses::CPose2D> var2(
 			std::move(pose2));
 		auto arch = archiveFrom(write_pipe);
+#ifndef HAS_BROKEN_CLANG_STD_VISIT
 		arch.WriteVariant(var1);
 		arch.WriteVariant(var2);
-
+#endif
 		printf("[thread_writer] Finished.\n");
 	}
 	catch (std::exception& e)


### PR DESCRIPTION
Fixes mapbox's `t.match()` ==> `std::visit()`.

PS: First test after setting mrpt/master as a Github "protected branch". Travis CI (and only Travis) being green is now a pre-requisite for merging. 