### PR TITLE
Including missing <mutex> header in hmtslam

### DIFF
--- a/libs/hmtslam/include/mrpt/hmtslam/CLocalMetricHypothesis.h
+++ b/libs/hmtslam/include/mrpt/hmtslam/CLocalMetricHypothesis.h
@@ -20,6 +20,7 @@
 #include <mrpt/opengl/opengl_frwds.h>
 
 #include <list>
+#include <mutex>
 
 namespace mrpt
 {


### PR DESCRIPTION
Adding missing #include <mutex> in hmtlslam.
---

I acknowledge to have:
* Read the [`CONTRIBUTING`](https://github.com/MRPT/mrpt/blob/master/.github/CONTRIBUTING.md) page
* Updated [`doc/doxygen-pages/changeLog_doc.h`](https://github.com/MRPT/mrpt/blob/master/doc/doxygen-pages/changeLog_doc.h) to describe these changes (if applicable)
* Updated [`AUTHORS`](https://github.com/MRPT/mrpt/blob/master/AUTHORS) (if applicable)

(Notify: @MRPT/owners )
