### PR TITLE
Add MAKE_ORGANIZED parameter

### DIFF
--- a/doc/doxygen-pages/changeLog_doc.h
+++ b/doc/doxygen-pages/changeLog_doc.h
@@ -83,6 +83,8 @@ CObservationReflectivity to support different colors of light.
 				- New parameter `scan_interval` to decimate scans.
 		- \ref mrpt_opengl_grp
 			- Update Assimp lib version 4.0.1 -> 4.1.0 (when built as ExternalProject)
+		- \ref mrpt_obs_grp
+			- mrpt::obs::T3DPointsProjectionParams and mrpt::obs::CObservation3DRangeScan::project3DPointsFromDepthImageInto now together support organized PCL point clouds.
 	- BUG FIXES:
 		- Fix reactive navigator inconsistent state if navigation API is called
 from within rnav callbacks.

--- a/libs/maps/include/mrpt/maps/CColouredPointsMap.h
+++ b/libs/maps/include/mrpt/maps/CColouredPointsMap.h
@@ -382,6 +382,10 @@ class PointCloudAdapter<mrpt::maps::CColouredPointsMap>
 	inline size_t size() const { return m_obj.size(); }
 	/** Set number of points (to uninitialized values) */
 	inline void resize(const size_t N) { m_obj.resize(N); }
+	/** Does nothing as of now */
+	inline void setDimensions(const size_t &height, const size_t &width)
+	{
+	}
 	/** Get XYZ coordinates of i'th point */
 	template <typename T>
 	inline void getPointXYZ(const size_t idx, T& x, T& y, T& z) const

--- a/libs/maps/include/mrpt/maps/CPointsMap.h
+++ b/libs/maps/include/mrpt/maps/CPointsMap.h
@@ -1200,6 +1200,10 @@ class PointCloudAdapter<mrpt::maps::CPointsMap>
 	inline size_t size() const { return m_obj.size(); }
 	/** Set number of points (to uninitialized values) */
 	inline void resize(const size_t N) { m_obj.resize(N); }
+	/** Does nothing as of now */
+	inline void setDimensions(const size_t& height, const size_t& width)
+	{
+	}
 	/** Get XYZ coordinates of i'th point */
 	template <typename T>
 	inline void getPointXYZ(const size_t idx, T& x, T& y, T& z) const

--- a/libs/maps/include/mrpt/maps/CSimplePointsMap.h
+++ b/libs/maps/include/mrpt/maps/CSimplePointsMap.h
@@ -177,6 +177,10 @@ class PointCloudAdapter<mrpt::maps::CSimplePointsMap>
 	inline size_t size() const { return m_obj.size(); }
 	/** Set number of points (to uninitialized values) */
 	inline void resize(const size_t N) { m_obj.resize(N); }
+	/** Does nothing as of now */
+	inline void setDimensions(const size_t& height, const size_t& width)
+	{
+	}
 	/** Get XYZ coordinates of i'th point */
 	template <typename T>
 	inline void getPointXYZ(const size_t idx, T& x, T& y, T& z) const

--- a/libs/maps/include/mrpt/maps/CWeightedPointsMap.h
+++ b/libs/maps/include/mrpt/maps/CWeightedPointsMap.h
@@ -185,6 +185,10 @@ class PointCloudAdapter<mrpt::maps::CWeightedPointsMap>
 	inline size_t size() const { return m_obj.size(); }
 	/** Set number of points (to uninitialized values) */
 	inline void resize(const size_t N) { m_obj.resize(N); }
+	/** Does nothing as of now */
+	inline void setDimensions(const size_t &height, const size_t &width)
+	{
+	}
 	/** Get XYZ coordinates of i'th point */
 	template <typename T>
 	inline void getPointXYZ(const size_t idx, T& x, T& y, T& z) const

--- a/libs/maps/include/mrpt/maps/PCL_adapters.h
+++ b/libs/maps/include/mrpt/maps/PCL_adapters.h
@@ -51,6 +51,12 @@ class PointCloudAdapter<pcl::PointCloud<pcl::PointXYZ>>
 	inline size_t size() const { return m_obj.points.size(); }
 	/** Set number of points (to uninitialized values) */
 	inline void resize(const size_t N) { m_obj.points.resize(N); }
+	/** Set height and width (for organized) */
+	inline void setDimensions(const size_t& height, const size_t& width)
+	{
+		m_obj.height = height;
+		m_obj.width = width;
+	}
 	/** Get XYZ coordinates of i'th point */
 	template <typename T>
 	inline void getPointXYZ(const size_t idx, T& x, T& y, T& z) const
@@ -106,6 +112,13 @@ class PointCloudAdapter<pcl::PointCloud<pcl::PointXYZRGB>>
 	inline size_t size() const { return m_obj.points.size(); }
 	/** Set number of points (to uninitialized values) */
 	inline void resize(const size_t N) { m_obj.points.resize(N); }
+	/** Set height and width (for organized) */
+	inline void setDimensions(const size_t& height, const size_t& width)
+	{
+		m_obj.height = height;
+		m_obj.width = width;
+	}
+
 	/** Get XYZ coordinates of i'th point */
 	template <typename T>
 	inline void getPointXYZ(const size_t idx, T& x, T& y, T& z) const
@@ -250,6 +263,13 @@ class PointCloudAdapter<pcl::PointCloud<pcl::PointXYZRGBA>>
 	inline size_t size() const { return m_obj.points.size(); }
 	/** Set number of points (to uninitialized values) */
 	inline void resize(const size_t N) { m_obj.points.resize(N); }
+	/** Set height and width (for organized) */
+	inline void setDimensions(const size_t& height, const size_t& width)
+	{
+		m_obj.height = height;
+		m_obj.width = width;
+	}
+
 	/** Get XYZ coordinates of i'th point */
 	template <typename T>
 	inline void getPointXYZ(const size_t idx, T& x, T& y, T& z) const

--- a/libs/obs/include/mrpt/obs/CObservation3DRangeScan.h
+++ b/libs/obs/include/mrpt/obs/CObservation3DRangeScan.h
@@ -44,15 +44,18 @@ struct T3DPointsProjectionParams
 	bool PROJ3D_USE_LUT;
 	/** (Default:true) If possible, use SSE2 optimized code. */
 	bool USE_SSE2;
-	/** (Default:true) set to false if you want to preserve the organization of
-	 * the point cloud */
+	/** (Default:true) set to false if your point cloud can contain undefined values */
 	bool MAKE_DENSE;
+	/** (Default:false) set to true if you want an organized point cloud */
+	bool MAKE_ORGANIZED;
+
 	T3DPointsProjectionParams()
 		: takeIntoAccountSensorPoseOnRobot(false),
 		  robotPoseInTheWorld(nullptr),
 		  PROJ3D_USE_LUT(true),
 		  USE_SSE2(true),
-		  MAKE_DENSE(true)
+		  MAKE_DENSE(true),
+		  MAKE_ORGANIZED(false)
 	{
 	}
 };
@@ -828,6 +831,11 @@ class PointCloudAdapter<mrpt::obs::CObservation3DRangeScan>
 		if (N) m_obj.hasPoints3D = true;
 		m_obj.resizePoints3DVectors(N);
 	}
+	/** Does nothing as of now */
+	inline void setDimensions(const size_t& height, const size_t& width)
+	{
+	}
+
 
 	/** Get XYZ coordinates of i'th point */
 	template <typename T>

--- a/libs/obs/include/mrpt/obs/CObservation3DRangeScan_project3D_impl.h
+++ b/libs/obs/include/mrpt/obs/CObservation3DRangeScan_project3D_impl.h
@@ -56,6 +56,9 @@ void project3DPointsFromDepthImageInto(
 	pca.resize(WH);  // Reserve memory for 3D points. It will be later resized
 	// again to the actual number of valid points
 
+	if(projectParams.MAKE_ORGANIZED)
+		pca.setDimensions(H,W);
+
 	if (src_obs.range_is_depth)
 	{
 		// range_is_depth = true

--- a/libs/opengl/include/mrpt/opengl/CPointCloud.h
+++ b/libs/opengl/include/mrpt/opengl/CPointCloud.h
@@ -334,6 +334,10 @@ class PointCloudAdapter<mrpt::opengl::CPointCloud>
 	inline size_t size() const { return m_obj.size(); }
 	/** Set number of points (to uninitialized values) */
 	inline void resize(const size_t N) { m_obj.resize(N); }
+	/** Does nothing as of now */
+	inline void setDimensions(const size_t& height, const size_t& width)
+	{
+	}
 	/** Get XYZ coordinates of i'th point */
 	template <typename T>
 	inline void getPointXYZ(const size_t idx, T& x, T& y, T& z) const

--- a/libs/opengl/include/mrpt/opengl/CPointCloudColoured.h
+++ b/libs/opengl/include/mrpt/opengl/CPointCloudColoured.h
@@ -299,6 +299,10 @@ class PointCloudAdapter<mrpt::opengl::CPointCloudColoured>
 	inline size_t size() const { return m_obj.size(); }
 	/** Set number of points (to uninitialized values) */
 	inline void resize(const size_t N) { m_obj.resize(N); }
+	/** Does nothing as of now */
+	inline void setDimensions(const size_t& height, const size_t& width)
+	{
+	}
 	/** Get XYZ coordinates of i'th point */
 	template <typename T>
 	inline void getPointXYZ(const size_t idx, T& x, T& y, T& z) const


### PR DESCRIPTION
## PR Description
* Added MAKE_ORGANIZED parameter to T3DPointsProjectionParams to be able to generate an organized pcl point cloud from a 2D range image
* Appropriately set pcl cloud dimensions
* More of an "ad-hoc" solution, just to get pcl::IntegralNormalEstimation to work for my gsoc project. Please let me know if I need to make more changes.
---

I acknowledge to have:
* Read the [`CONTRIBUTING`](https://github.com/MRPT/mrpt/blob/master/.github/CONTRIBUTING.md) page

(Notify: @MRPT/owners )
