### PR TITLE
MRPTConfig.cmake enforces C++17 in CMake<3.8

### DIFF
--- a/parse-files/MRPTConfig.cmake.in
+++ b/parse-files/MRPTConfig.cmake.in
@@ -47,6 +47,7 @@ if (MSVC)
 else()
 	if(${CMAKE_VERSION} VERSION_LESS "3.8.0")
 		set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++17")
+		unset(CMAKE_CXX_STANDARD) # Required not to override the flag above to c++14 or lower
 	else()
 		if ("${CMAKE_CXX_STANDARD}" STREQUAL "" OR "${CMAKE_CXX_STANDARD}" LESS 17)
 			set(CMAKE_CXX_STANDARD 17)


### PR DESCRIPTION
If an app sets CMAKE_CXX_STANDARD to 14 or 11 in CMake<3.8, our MRPTConfig.cmake script flag `-std=c++17` is overriden by a lower version since apparently the CMAKE_CXX_STANDARD var has priority; but setting it to 17 is an error in CMake<3.8, so we must UNSET() it.

