### PR TITLE
merge JSON-capable serialization methods

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -292,6 +292,7 @@ include(cmakemodules/script_pcap.cmake REQUIRED)        # Check for the libpcap 
 include(cmakemodules/script_vtk.cmake REQUIRED)         # Check for VTK
 include(cmakemodules/script_clang_tidy.cmake REQUIRED)  # Clang tidy
 include(cmakemodules/script_cvd.cmake REQUIRED)         # Check for VTK
+include(cmakemodules/script_jsoncpp.cmake REQUIRED)     # Check for jsoncpp
 
 # ---------------------------------------------------------------------------
 #			OPTIONS

--- a/cmakemodules/DefineExamples.cmake
+++ b/cmakemodules/DefineExamples.cmake
@@ -70,6 +70,7 @@ IF(BUILD_EXAMPLES)
 	# === Depending on: serialization, io ===
 	SET(LIST_EXAMPLES_IN_THIS_DIR
 		# ----
+		serialization_json_example
 		serialization_stl
 		serialization_variant_example
 		# ----

--- a/cmakemodules/script_jsoncpp.cmake
+++ b/cmakemodules/script_jsoncpp.cmake
@@ -1,0 +1,15 @@
+
+SET(CMAKE_MRPT_HAS_JSONCPP 0)
+SET(CMAKE_MRPT_HAS_JSONCPP_SYSTEM 0)
+
+OPTION(DISABLE_JSONCPP "Forces NOT using JSONCPP, even if it could be found by CMake" "OFF")
+MARK_AS_ADVANCED(DISABLE_JSONCPP)
+
+IF(NOT DISABLE_JSONCPP)
+	find_package(jsoncpp QUIET)
+	if(jsoncpp_FOUND)
+		# cmake imported target: "jsoncpp_lib"
+		SET(CMAKE_MRPT_HAS_JSONCPP 1)
+		SET(CMAKE_MRPT_HAS_JSONCPP_SYSTEM 1)
+	endif()
+ENDIF()

--- a/cmakemodules/script_show_final_summary.cmake
+++ b/cmakemodules/script_show_final_summary.cmake
@@ -117,6 +117,7 @@ MESSAGE(STATUS " ______________________ OPTIONAL LIBRARIES _____________________
 SHOW_CONFIG_LINE_SYSTEM("Assimp (3D models)                  " CMAKE_MRPT_HAS_ASSIMP "[Version: ${ASSIMP_VERSION}]")
 SHOW_CONFIG_LINE_SYSTEM("ffmpeg libs (Video streaming)       " CMAKE_MRPT_HAS_FFMPEG "[avcodec ${LIBAVCODEC_VERSION}, avutil ${LIBAVUTIL_VERSION}, avformat ${LIBAVFORMAT_VERSION}]")
 SHOW_CONFIG_LINE_SYSTEM("gtest (Google unit testing library) " CMAKE_MRPT_HAS_GTEST )
+SHOW_CONFIG_LINE_SYSTEM("jsoncpp (JSON format serialization) " CMAKE_MRPT_HAS_JSONCPP "[Version: ${jsoncpp_VERSION}]")
 SHOW_CONFIG_LINE_SYSTEM("libjpeg (jpeg)                      " CMAKE_MRPT_HAS_JPEG)
 SHOW_CONFIG_LINE_SYSTEM("liblas (ASPRS LAS LiDAR format)     " CMAKE_MRPT_HAS_LIBLAS)
 SHOW_CONFIG_LINE       ("mexplus                             " CMAKE_MRPT_HAS_MATLAB)

--- a/doc/doxygen-pages/lib_mrpt_rtti.h
+++ b/doc/doxygen-pages/lib_mrpt_rtti.h
@@ -5,29 +5,33 @@
    | Copyright (c) 2005-2018, Individual contributors, see AUTHORS file        |
    | See: http://www.mrpt.org/Authors - All rights reserved.                   |
    | Released under BSD License. See details in http://www.mrpt.org/License    |
-   +---------------------------------------------------------------------------+ */
+   +---------------------------------------------------------------------------+
+ */
 
 /** \defgroup mrpt_rtti_grp [mrpt-rtti]
 
-Runtime Type Information (RTTI) library, providing compiler-independent class registry, class factory, and inheritance information.
+Runtime Type Information (RTTI) library, providing compiler-independent class
+registry, class factory, and inheritance information.
 
-<small> <a href="index.html#libs">Back to list of all libraries</a> | <a href="modules.html" >See all modules</a> </small>
-<br>
+<small> <a href="index.html#libs">Back to list of all libraries</a> | <a
+href="modules.html" >See all modules</a> </small> <br>
 
 # Library `mrpt-rtti`
 <small> [New in MRPT 2.0.0] </small>
 
 This library is part of MRPT and can be installed in Debian-based systems with:
 
-        sudo apt install libmrpt-rtti-dev
+		sudo apt install libmrpt-rtti-dev
+
+[TOC]
 
 Any class with RTTI support has to be derived from mrpt::rtti::CObject, either
 directly or via a hierarchy of inheriting classes.
 Class factory by name enables deserialization of polymorphic classes in the
 library \ref mrpt_serialization_grp.
 
-All classes defined in each MRPT module are automatically registered when loading
-the module (if dynamically linked).
+All classes defined in each MRPT module are automatically registered when
+loading the module (if dynamically linked).
 
 ## Example #1: defining new user classes
 

--- a/doc/doxygen-pages/lib_mrpt_serialization.h
+++ b/doc/doxygen-pages/lib_mrpt_serialization.h
@@ -5,66 +5,110 @@
    | Copyright (c) 2005-2018, Individual contributors, see AUTHORS file        |
    | See: http://www.mrpt.org/Authors - All rights reserved.                   |
    | Released under BSD License. See details in http://www.mrpt.org/License    |
-   +---------------------------------------------------------------------------+ */
+   +---------------------------------------------------------------------------+
+ */
 
 /** \defgroup mrpt_serialization_grp [mrpt-serialization]
 
+\page mrpt_serialization_grp [mrpt-serialization]
+
 Serialization (marshalling) portable library for C++ objects persistence.
 
-<small> <a href="index.html#libs">Back to list of all libraries</a> | <a href="modules.html" >See all modules</a> </small>
-<br>
+<small> <a href="index.html#libs">Back to list of all libraries</a> | <a
+href="modules.html" >See all modules</a> </small> <br>
 
 # Library `mrpt-serialization`
 <small> [New in MRPT 2.0.0] </small>
 
 This library is part of MRPT and can be installed in Debian-based systems with:
 
-        sudo apt install libmrpt-serialization-dev
+		sudo apt install libmrpt-serialization-dev
+
+[TOC]
+
+## Binary serialization (most efficient)
 
 Main classes and concepts associated with this library:
 - mrpt::serialization::CArchive provides:
-	- An abstraction of I/O streams (e.g. std::stream's, MRPT's mrpt::io::CStream's, sockets)
-	- A portable API (endianness aware) for serialization of data structures on those streams.
+	- An abstraction of I/O streams (e.g. std::stream's, MRPT's
+mrpt::io::CStream's, sockets)
+	- A portable API (endianness aware) for serialization of data structures on
+those streams.
 - mrpt::serialization::CSerializable provides:
 	- A generic way to define persistent C++ classes.
-	- Versioning: if class fields are added or removed, you'll still be able to read old data files.
+	- Versioning: if class fields are added or removed, you'll still be able to
+read old data files.
 
-Serialization happens via `archive << object` operators in all cases but, underneath, two mechanisms are provided:
-- **Direct overloading of the `<<`/`>>` operators** for mrpt::serialization::CArchive objects.
+Serialization happens via `archive << object` operators in all cases but,
+underneath, two mechanisms are provided:
+- **Direct overloading of the `<<`/`>>` operators** for
+mrpt::serialization::CArchive objects.
 	- Pros: concise declaration (just the two operator functions).
-	- Cons: Cannot handle versioning. Cannot deserialize unknown types (i.e. no support for class factory).
+	- Cons: Cannot handle versioning. Cannot deserialize unknown types (i.e. no
+support for class factory).
 - **Via mrpt::serialization::CSerializable** and associated macros:
 	- Pros: Allows polymorphic classes to be (de)serialized. Allows versioning.
-	- Cons: Requires adding macros to class definitions. Requires **registering** the class with \ref mrpt_rtti_grp.
+	- Cons: Requires adding macros to class definitions. Requires
+**registering** the class with \ref mrpt_rtti_grp.
 
-Support for STL containers is provided via this "direct mechanism" for the container structure itself, but contained
-elements can use any of the serialization mechanisms.
+Support for STL containers is provided via this "direct mechanism" for the
+container structure itself, but contained elements can use any of the
+serialization mechanisms.
 
-Serializing `shared_ptr<T>` is supported for any arbitrary type `T`. It is legal to serialize an empty (`nullptr`)
-smart pointer; an empty pointer will be read back. Polymorphic classes can be also writen and read, although reading
-a smart pointer to a polymorphic base class is only supported for classes derived from MRPT's CSerializable, since
-that operation requires registering types in a class factory (see \a mrpt_rtti_grp and mrpt::serialization::CSerializable).
+Serializing `shared_ptr<T>` is supported for any arbitrary type `T`. It is legal
+to serialize an empty (`nullptr`) smart pointer; an empty pointer will be read
+back. Polymorphic classes can be also writen and read, although reading a smart
+pointer to a polymorphic base class is only supported for classes derived from
+MRPT's CSerializable, since that operation requires registering types in a class
+factory (see \a mrpt_rtti_grp and mrpt::serialization::CSerializable).
 
-## Example #1: serialize STL container via MRPT `CStream`s
+### Example #1: serialize STL container via MRPT `CStream`s
 
 See: \ref serialization_stl/test.cpp
 \snippet serialization_stl/test.cpp example
 Output:
 \include serialization_stl/console.out
 
-## Example #2: serialize STL container via `std::ostream` and `std::istream`
+### Example #2: serialize STL container via `std::ostream` and `std::istream`
 
 See: \ref serialization_stl/test.cpp
 \snippet serialization_stl/test.cpp example_stdio
 Output:
 \include serialization_stl/console.out
 
-## Example #3: Serialization of existing MRPT classes
+### Example #3: Serialization of existing MRPT classes
 
 Write me!
 
-## Example #4: Polymorphic serialization of user classes
+### Example #4: Polymorphic serialization of user classes
 
 Write me!
+
+
+## Schema (plain-text) serialization (human readable)
+
+An alternative mechanism to serialize objects is based on
+mrpt::serialization::CSchemeArchive and allow objects to be (de)serialized in
+plain text formats like XML, JSON, YAML, etc.
+For now (Aug 2018) only JSON is implemented.
+
+### Example #1: Easy JSON serialization
+
+This method only requires having MRPT built against jsoncpp, but does not
+enforce the user to also depend on that library.
+
+See: \ref serialization_json_example/test.cpp
+\snippet serialization_json_example/test.cpp example
+Output:
+\include serialization_json_example/console.out
+
+### Example #2: JSON serialization with full access to jsoncpp
+
+If you want to have full control on the JSON formatting and other details,
+you may directly depend on jsoncpp and use the following, template-based access
+to MRPT serialization:
+
+See: \ref serialization_json_example/test.cpp
+\snippet serialization_json_example/test.cpp example_raw
 
 */

--- a/doc/doxygen-pages/lib_mrpt_typemeta.h
+++ b/doc/doxygen-pages/lib_mrpt_typemeta.h
@@ -5,14 +5,17 @@
    | Copyright (c) 2005-2018, Individual contributors, see AUTHORS file        |
    | See: http://www.mrpt.org/Authors - All rights reserved.                   |
    | Released under BSD License. See details in http://www.mrpt.org/License    |
-   +---------------------------------------------------------------------------+ */
+   +---------------------------------------------------------------------------+
+ */
 
 /** \defgroup mrpt_typemeta_grp [mrpt-typemeta]
 
-Metaprogramming header-only library to obtain `constexpr` textual string representations of enum types and type names, including smart pointers and complex STL compound types.
+Metaprogramming header-only library to obtain `constexpr` textual string
+representations of enum types and type names, including smart pointers and
+complex STL compound types.
 
-<small> <a href="index.html#libs">Back to list of all libraries</a> | <a href="modules.html" >See all modules</a> </small>
-<br>
+<small> <a href="index.html#libs">Back to list of all libraries</a> | <a
+href="modules.html" >See all modules</a> </small> <br>
 
 # Library `mrpt-typemeta`
 <small> [New in MRPT 2.0.0] </small>
@@ -20,13 +23,15 @@ Metaprogramming header-only library to obtain `constexpr` textual string represe
 This library is part of MRPT but has no dependencies, so it can be installed
 in Debian-based systems with:
 
-        sudo apt install libmrpt-typemeta-dev
+		sudo apt install libmrpt-typemeta-dev
+
+[TOC]
 
 ## Example #1: compile-time type/struct/class names to strings
-Use mrpt::typemeta::TTypeName to extract a `constexpr` string with a compiler-independent
-representation of arbitrarily-complex types and STL containers.
-Note that creating objects from a run-time string representation of its type
-is handled in a different library (\ref mrpt_serialization_grp).
+Use mrpt::typemeta::TTypeName to extract a `constexpr` string with a
+compiler-independent representation of arbitrarily-complex types and STL
+containers. Note that creating objects from a run-time string representation of
+its type is handled in a different library (\ref mrpt_serialization_grp).
 
 See: \ref typemeta_TTypeName/test.cpp
 \snippet typemeta_TTypeName/test.cpp example typename

--- a/doc/doxygen_project.txt.in
+++ b/doc/doxygen_project.txt.in
@@ -301,6 +301,8 @@ MARKDOWN_SUPPORT       = YES
 
 AUTOLINK_SUPPORT       = YES
 
+TOC_INCLUDE_HEADINGS   = 3
+
 # If you use STL classes (i.e. std::string, std::vector, etc.) but do not want
 # to include (a tag file for) the STL sources as input, then you should set this
 # tag to YES in order to let doxygen match functions declarations and
@@ -1137,6 +1139,7 @@ HTML_STYLESHEET        =
 # list). For an example see the documentation.
 # This tag requires that the tag GENERATE_HTML is set to YES.
 
+HTML_EXTRA_STYLESHEET  =
 
 # The HTML_EXTRA_FILES tag can be used to specify one or more extra images or
 # other source files which should be copied to the HTML output directory. Note

--- a/libs/hmtslam/include/mrpt/hmtslam/CLocalMetricHypothesis.h
+++ b/libs/hmtslam/include/mrpt/hmtslam/CLocalMetricHypothesis.h
@@ -20,6 +20,7 @@
 #include <mrpt/opengl/opengl_frwds.h>
 
 #include <list>
+#include <mutex>
 
 namespace mrpt
 {

--- a/libs/math/include/mrpt/math/CMatrix.h
+++ b/libs/math/include/mrpt/math/CMatrix.h
@@ -22,6 +22,7 @@ namespace mrpt::math
 class CMatrix : public mrpt::serialization::CSerializable, public CMatrixFloat
 {
 	DEFINE_SERIALIZABLE(CMatrix)
+	DEFINE_SCHEMA_SERIALIZABLE()
 
    public:
 	/** Constructor  */
@@ -29,10 +30,10 @@ class CMatrix : public mrpt::serialization::CSerializable, public CMatrixFloat
 	/** Constructor  */
 	CMatrix(size_t row, size_t col) : CMatrixFloat(row, col) {}
 	/** Copy constructor
-	  */
+	 */
 	CMatrix(const CMatrixFloat& m) : CMatrixFloat(m) {}
 	/** Copy constructor
-	  */
+	 */
 	CMatrix(const CMatrixTemplateNumeric<double>& m) : CMatrixFloat(0, 0)
 	{
 		*this = m.eval().cast<float>();
@@ -40,7 +41,7 @@ class CMatrix : public mrpt::serialization::CSerializable, public CMatrixFloat
 	MRPT_MATRIX_CONSTRUCTORS_FROM_POSES(CMatrix)
 
 	/** Assignment operator for float matrixes
-	*/
+	 */
 	template <class OTHERMAT>
 	inline CMatrix& operator=(const OTHERMAT& m)
 	{
@@ -66,5 +67,4 @@ class CMatrix : public mrpt::serialization::CSerializable, public CMatrixFloat
 mrpt::serialization::CArchive& operator>>(
 	mrpt::serialization::CArchive& in, CMatrix::Ptr& pObj);
 
-}
-
+}  // namespace mrpt::math

--- a/libs/math/include/mrpt/math/CMatrixD.h
+++ b/libs/math/include/mrpt/math/CMatrixD.h
@@ -23,6 +23,7 @@ class CMatrixD : public mrpt::serialization::CSerializable,
 				 public CMatrixTemplateNumeric<double>
 {
 	DEFINE_SERIALIZABLE(CMatrixD)
+	DEFINE_SCHEMA_SERIALIZABLE()
    public:
 	/** Constructor */
 	CMatrixD() : CMatrixTemplateNumeric<double>(1, 1) {}
@@ -63,5 +64,4 @@ class CMatrixD : public mrpt::serialization::CSerializable,
 mrpt::serialization::CArchive& operator>>(
 	mrpt::serialization::CArchive& in, CMatrixD::Ptr& pObj);
 
-}
-
+}  // namespace mrpt::math

--- a/libs/math/src/CMatrix.cpp
+++ b/libs/math/src/CMatrix.cpp
@@ -12,6 +12,7 @@
 #include <mrpt/math/CMatrix.h>
 #include <mrpt/math/lightweight_geom_data.h>
 #include <mrpt/serialization/CArchive.h>
+#include <mrpt/serialization/CSchemeArchiveBase.h>
 
 using namespace mrpt;
 using namespace mrpt::math;
@@ -52,4 +53,29 @@ void CMatrix::serializeFrom(mrpt::serialization::CArchive& in, uint8_t version)
 		default:
 			MRPT_THROW_UNKNOWN_SERIALIZATION_VERSION(version)
 	};
+}
+
+/** Serialize CSerializable Object to CSchemeArchiveBase derived object*/
+void CMatrix::serializeTo(mrpt::serialization::CSchemeArchiveBase& out) const
+{
+	SCHEMA_SERIALIZE_DATATYPE_VERSION(1);
+	out["nrows"] = this->rows();
+	out["ncols"] = this->cols();
+	out["data"] = this->inMatlabFormat();
+}
+/** Serialize CSchemeArchiveBase derived object to CSerializable Object*/
+void CMatrix::serializeFrom(mrpt::serialization::CSchemeArchiveBase& in)
+{
+	uint8_t version;
+	SCHEMA_DESERIALIZE_DATATYPE_VERSION();
+	switch (version)
+	{
+		case 1:
+		{
+			this->fromMatlabStringFormat(static_cast<std::string>(in["data"]));
+		}
+		break;
+		default:
+			MRPT_THROW_UNKNOWN_SERIALIZATION_VERSION(version)
+	}
 }

--- a/libs/math/src/CMatrixD.cpp
+++ b/libs/math/src/CMatrixD.cpp
@@ -12,6 +12,7 @@
 #include <mrpt/math/CMatrixD.h>
 #include <mrpt/math/lightweight_geom_data.h>
 #include <mrpt/serialization/CArchive.h>
+#include <mrpt/serialization/CSchemeArchiveBase.h>
 
 using namespace mrpt;
 using namespace mrpt::math;
@@ -50,4 +51,29 @@ void CMatrixD::serializeFrom(mrpt::serialization::CArchive& in, uint8_t version)
 		default:
 			MRPT_THROW_UNKNOWN_SERIALIZATION_VERSION(version)
 	};
+}
+
+/** Serialize CSerializable Object to CSchemeArchiveBase derived object*/
+void CMatrixD::serializeTo(mrpt::serialization::CSchemeArchiveBase& out) const
+{
+	SCHEMA_SERIALIZE_DATATYPE_VERSION(1);
+	out["nrows"] = this->rows();
+	out["ncols"] = this->cols();
+	out["data"] = this->inMatlabFormat();
+}
+/** Serialize CSchemeArchiveBase derived object to CSerializable Object*/
+void CMatrixD::serializeFrom(mrpt::serialization::CSchemeArchiveBase& in)
+{
+	uint8_t version;
+	SCHEMA_DESERIALIZE_DATATYPE_VERSION();
+	switch (version)
+	{
+		case 1:
+		{
+			this->fromMatlabStringFormat(static_cast<std::string>(in["data"]));
+		}
+		break;
+		default:
+			MRPT_THROW_UNKNOWN_SERIALIZATION_VERSION(version)
+	}
 }

--- a/libs/opengl/include/mrpt/opengl/CArrow.h
+++ b/libs/opengl/include/mrpt/opengl/CArrow.h
@@ -29,6 +29,7 @@ namespace mrpt::opengl
 class CArrow : public CRenderizableDisplayList
 {
 	DEFINE_SERIALIZABLE(CArrow)
+	DEFINE_SCHEMA_SERIALIZABLE()
    protected:
 	mutable float m_x0, m_y0, m_z0;
 	mutable float m_x1, m_y1, m_z1;

--- a/libs/opengl/include/mrpt/opengl/CCylinder.h
+++ b/libs/opengl/include/mrpt/opengl/CCylinder.h
@@ -30,6 +30,7 @@ class CCylinder;
 class CCylinder : public CRenderizableDisplayList
 {
 	DEFINE_SERIALIZABLE(CCylinder)
+	DEFINE_SCHEMA_SERIALIZABLE()
    protected:
 	/**
 	  * Cylinder's radii. If mBaseRadius==mTopRadius, then the object is an

--- a/libs/opengl/include/mrpt/opengl/CPointCloud.h
+++ b/libs/opengl/include/mrpt/opengl/CPointCloud.h
@@ -46,6 +46,7 @@ class CPointCloud : public CRenderizable,
 					public mrpt::opengl::PLY_Exporter
 {
 	DEFINE_SERIALIZABLE(CPointCloud)
+	DEFINE_SCHEMA_SERIALIZABLE()
    protected:
 	enum Axis
 	{

--- a/libs/opengl/src/CArrow.cpp
+++ b/libs/opengl/src/CArrow.cpp
@@ -13,6 +13,7 @@
 #include <mrpt/math/CMatrix.h>
 #include <mrpt/math/geometry.h>
 #include <mrpt/serialization/CArchive.h>
+#include <mrpt/serialization/CSchemeArchiveBase.h>
 
 #include "opengl_internals.h"
 
@@ -209,6 +210,47 @@ void CArrow::serializeFrom(mrpt::serialization::CArchive& in, uint8_t version)
 	CRenderizableDisplayList::notifyChange();
 }
 
+void CArrow::serializeTo(mrpt::serialization::CSchemeArchiveBase& out) const
+{
+	out["datatype"] = std::string(this->GetRuntimeClass()->className);
+	out["version"] = 1;
+	out["x0"] = m_x0;
+	out["y0"] = m_y0;
+	out["z0"] = m_z0;
+	out["x1"] = m_x1;
+	out["y1"] = m_y1;
+	out["z1"] = m_z1;
+	out["headRatio"] = m_headRatio;
+	out["smallRadius"] = m_smallRadius;
+	out["largeRadius"] = m_largeRadius;
+}
+
+void CArrow::serializeFrom(mrpt::serialization::CSchemeArchiveBase& in)
+{
+	uint8_t version = static_cast<int>(in["version"]);	// default is 0
+	if(static_cast<std::string>(in["datatype"]) ==
+		std::string(this->GetRuntimeClass()->className))	// match the class name
+	{
+		switch(version)
+		{
+			case 1:
+			{
+				m_x0 = static_cast<float>(in["x0"]);
+				m_y0 = static_cast<float>(in["y0"]);
+				m_z0 = static_cast<float>(in["z0"]);
+				m_x1 = static_cast<float>(in["x1"]);
+				m_y1 = static_cast<float>(in["y1"]);
+				m_z1 = static_cast<float>(in["z1"]);
+				m_headRatio = static_cast<float>(in["headRatio"]);
+				m_smallRadius = static_cast<float>(in["smallRadius"]);
+				m_largeRadius = static_cast<float>(in["largeRadius"]);
+			}
+			break;
+			default:
+				MRPT_THROW_UNKNOWN_SERIALIZATION_VERSION(version)
+		}
+	}
+}
 void CArrow::getBoundingBox(
 	mrpt::math::TPoint3D& bb_min, mrpt::math::TPoint3D& bb_max) const
 {

--- a/libs/opengl/src/CArrow.cpp
+++ b/libs/opengl/src/CArrow.cpp
@@ -31,10 +31,9 @@ CArrow::Ptr CArrow::Create(
 	float smallRadius, float largeRadius, float arrow_roll, float arrow_pitch,
 	float arrow_yaw)
 {
-	return CArrow::Ptr(
-		new CArrow(
-			x0, y0, z0, x1, y1, z1, headRatio, smallRadius, largeRadius,
-			arrow_roll, arrow_pitch, arrow_yaw));
+	return CArrow::Ptr(new CArrow(
+		x0, y0, z0, x1, y1, z1, headRatio, smallRadius, largeRadius, arrow_roll,
+		arrow_pitch, arrow_yaw));
 }
 /*---------------------------------------------------------------
 							render
@@ -140,7 +139,7 @@ void CArrow::render_dl() const
 		mat + 8,  // 1st vector
 		mat + 0,  // 2nd vector
 		out_v3  // Output cross product
-		);
+	);
 
 	glPushMatrix();
 
@@ -212,8 +211,7 @@ void CArrow::serializeFrom(mrpt::serialization::CArchive& in, uint8_t version)
 
 void CArrow::serializeTo(mrpt::serialization::CSchemeArchiveBase& out) const
 {
-	out["datatype"] = std::string(this->GetRuntimeClass()->className);
-	out["version"] = 1;
+	SCHEMA_SERIALIZE_DATATYPE_VERSION(1);
 	out["x0"] = m_x0;
 	out["y0"] = m_y0;
 	out["z0"] = m_z0;
@@ -227,28 +225,25 @@ void CArrow::serializeTo(mrpt::serialization::CSchemeArchiveBase& out) const
 
 void CArrow::serializeFrom(mrpt::serialization::CSchemeArchiveBase& in)
 {
-	uint8_t version = static_cast<int>(in["version"]);	// default is 0
-	if(static_cast<std::string>(in["datatype"]) ==
-		std::string(this->GetRuntimeClass()->className))	// match the class name
+	uint8_t version;
+	SCHEMA_DESERIALIZE_DATATYPE_VERSION();
+	switch (version)
 	{
-		switch(version)
+		case 1:
 		{
-			case 1:
-			{
-				m_x0 = static_cast<float>(in["x0"]);
-				m_y0 = static_cast<float>(in["y0"]);
-				m_z0 = static_cast<float>(in["z0"]);
-				m_x1 = static_cast<float>(in["x1"]);
-				m_y1 = static_cast<float>(in["y1"]);
-				m_z1 = static_cast<float>(in["z1"]);
-				m_headRatio = static_cast<float>(in["headRatio"]);
-				m_smallRadius = static_cast<float>(in["smallRadius"]);
-				m_largeRadius = static_cast<float>(in["largeRadius"]);
-			}
-			break;
-			default:
-				MRPT_THROW_UNKNOWN_SERIALIZATION_VERSION(version)
+			m_x0 = static_cast<float>(in["x0"]);
+			m_y0 = static_cast<float>(in["y0"]);
+			m_z0 = static_cast<float>(in["z0"]);
+			m_x1 = static_cast<float>(in["x1"]);
+			m_y1 = static_cast<float>(in["y1"]);
+			m_z1 = static_cast<float>(in["z1"]);
+			m_headRatio = static_cast<float>(in["headRatio"]);
+			m_smallRadius = static_cast<float>(in["smallRadius"]);
+			m_largeRadius = static_cast<float>(in["largeRadius"]);
 		}
+		break;
+		default:
+			MRPT_THROW_UNKNOWN_SERIALIZATION_VERSION(version)
 	}
 }
 void CArrow::getBoundingBox(

--- a/libs/opengl/src/CCylinder.cpp
+++ b/libs/opengl/src/CCylinder.cpp
@@ -11,7 +11,7 @@
 #include <mrpt/opengl/CCylinder.h>
 #include <mrpt/math/geometry.h>
 #include <mrpt/serialization/CArchive.h>
-
+#include <mrpt/serialization/CSchemeArchiveBase.h>
 #include "opengl_internals.h"
 
 using namespace mrpt;
@@ -59,7 +59,42 @@ void CCylinder::render_dl() const
 
 #endif
 }
-
+void CCylinder::serializeTo(mrpt::serialization::CSchemeArchiveBase& out) const
+{
+	out["datatype"] = std::string(this->GetRuntimeClass()->className);
+	out["version"] = 1;
+	out["baseRadius"] = mBaseRadius;
+	out["topRadius"] = mTopRadius;
+	out["height"] = mHeight;
+	out["slices"] = mSlices;
+	out["stacks"] = mStacks;
+	out["hasBottomBase"] = mHasBottomBase;
+	out["hasTopBase"] = mHasTopBase;
+}
+void CCylinder::serializeFrom(mrpt::serialization::CSchemeArchiveBase& in)
+{
+	uint8_t version = static_cast<int>(in["version"]);	// default is 0
+	if(static_cast<std::string>(in["datatype"]) ==
+		std::string(this->GetRuntimeClass()->className))	// match the class name
+	{
+		switch(version)
+		{
+			case 1:
+			{
+				mBaseRadius = static_cast<float>(in["baseRadius"]);
+				mTopRadius = static_cast<float>(in["topRadius"]);
+				mHeight = static_cast<float>(in["height"]);
+				mSlices = static_cast<uint32_t>(in["slices"]);
+				mStacks = static_cast<uint32_t>(in["stacks"]);
+				mHasBottomBase = static_cast<bool>(in["hasBottomBase"]);
+				mHasTopBase = static_cast<bool>(in["hasTopBase"]);
+			}
+			break;
+			default:
+				MRPT_THROW_UNKNOWN_SERIALIZATION_VERSION(version)
+		}
+	}
+}
 uint8_t CCylinder::serializeGetVersion() const { return 0; }
 void CCylinder::serializeTo(mrpt::serialization::CArchive& out) const
 {

--- a/libs/opengl/src/CCylinder.cpp
+++ b/libs/opengl/src/CCylinder.cpp
@@ -61,8 +61,7 @@ void CCylinder::render_dl() const
 }
 void CCylinder::serializeTo(mrpt::serialization::CSchemeArchiveBase& out) const
 {
-	out["datatype"] = std::string(this->GetRuntimeClass()->className);
-	out["version"] = 1;
+	SCHEMA_SERIALIZE_DATATYPE_VERSION(1);
 	out["baseRadius"] = mBaseRadius;
 	out["topRadius"] = mTopRadius;
 	out["height"] = mHeight;
@@ -73,26 +72,23 @@ void CCylinder::serializeTo(mrpt::serialization::CSchemeArchiveBase& out) const
 }
 void CCylinder::serializeFrom(mrpt::serialization::CSchemeArchiveBase& in)
 {
-	uint8_t version = static_cast<int>(in["version"]);	// default is 0
-	if(static_cast<std::string>(in["datatype"]) ==
-		std::string(this->GetRuntimeClass()->className))	// match the class name
+	uint8_t version;
+	SCHEMA_DESERIALIZE_DATATYPE_VERSION();
+	switch (version)
 	{
-		switch(version)
+		case 1:
 		{
-			case 1:
-			{
-				mBaseRadius = static_cast<float>(in["baseRadius"]);
-				mTopRadius = static_cast<float>(in["topRadius"]);
-				mHeight = static_cast<float>(in["height"]);
-				mSlices = static_cast<uint32_t>(in["slices"]);
-				mStacks = static_cast<uint32_t>(in["stacks"]);
-				mHasBottomBase = static_cast<bool>(in["hasBottomBase"]);
-				mHasTopBase = static_cast<bool>(in["hasTopBase"]);
-			}
-			break;
-			default:
-				MRPT_THROW_UNKNOWN_SERIALIZATION_VERSION(version)
+			mBaseRadius = static_cast<float>(in["baseRadius"]);
+			mTopRadius = static_cast<float>(in["topRadius"]);
+			mHeight = static_cast<float>(in["height"]);
+			mSlices = static_cast<uint32_t>(in["slices"]);
+			mStacks = static_cast<uint32_t>(in["stacks"]);
+			mHasBottomBase = static_cast<bool>(in["hasBottomBase"]);
+			mHasTopBase = static_cast<bool>(in["hasTopBase"]);
 		}
+		break;
+		default:
+			MRPT_THROW_UNKNOWN_SERIALIZATION_VERSION(version)
 	}
 }
 uint8_t CCylinder::serializeGetVersion() const { return 0; }

--- a/libs/opengl/src/CPointCloud.cpp
+++ b/libs/opengl/src/CPointCloud.cpp
@@ -12,6 +12,7 @@
 #include <mrpt/opengl/CPointCloud.h>
 #include <mrpt/math/ops_containers.h>
 #include <mrpt/serialization/CArchive.h>
+#include <mrpt/serialization/CSchemeArchiveBase.h>
 #include <mrpt/core/round.h>  // round()
 
 #include "opengl_internals.h"
@@ -213,7 +214,68 @@ void CPointCloud::render_subset(
 	MRPT_UNUSED_PARAM(render_area_sqpixels);
 #endif
 }
-
+void CPointCloud::serializeTo(mrpt::serialization::CSchemeArchiveBase& out) const
+{
+	out["datatype"] = std::string(this->GetRuntimeClass()->className);
+	out["version"] = 1;
+	out["colorFromDepth"] = static_cast<int32_t>(m_colorFromDepth);
+	out["pointSize"] = m_pointSize;
+	for(uint i = 0; i < m_xs.size(); i++) {
+		out["xs"][i] = m_xs[i];
+	}
+	for(uint i = 0; i < m_ys.size(); i++) {
+		out["ys"][i] = m_ys[i];
+	}
+	for(uint i = 0; i < m_zs.size(); i++) {
+		out["zs"][i] = m_zs[i];
+	}
+	out["colorFromDepth_min"]["R"] = m_colorFromDepth_min.R;
+	out["colorFromDepth_min"]["G"] = m_colorFromDepth_min.G;
+	out["colorFromDepth_min"]["B"] = m_colorFromDepth_min.B;
+	out["colorFromDepth_max"]["R"] = m_colorFromDepth_max.R;
+	out["colorFromDepth_max"]["G"] = m_colorFromDepth_max.G;
+	out["colorFromDepth_max"]["B"] = m_colorFromDepth_max.B;
+	out["pointSmooth"] = m_pointSmooth;
+}
+void CPointCloud::serializeFrom(mrpt::serialization::CSchemeArchiveBase& in)
+{
+	uint8_t version = static_cast<int>(in["version"]);	// default is 0
+	if(static_cast<std::string>(in["datatype"]) ==
+		std::string(this->GetRuntimeClass()->className))	// match the class name
+	{
+		switch(version)
+		{
+			case 1:
+			{
+				/**
+				 *  currently below is being left to what is being set by
+				 *  the default constructor i.e.,CPointCloud::colNone
+				 */
+				// m_colorFromDepth = static_cast<float>(in["colorDepth"]);
+				m_pointSize = static_cast<float>(in["pointSize"]);
+				for(uint i = 0; i < m_xs.size(); i++) {
+					m_xs[i] = static_cast<float>(in["xs"][i]);
+				}
+				for(uint i = 0; i < m_ys.size(); i++) {
+					m_ys[i] = static_cast<float>(in["ys"][i]);
+				}
+				for(uint i = 0; i < m_zs.size(); i++) {
+					m_zs[i] = static_cast<float>(in["zs"][i]);
+				}
+				m_colorFromDepth_min.R = static_cast<float>(in["colorFromDepth_min"]["R"]);
+				m_colorFromDepth_min.G = static_cast<float>(in["colorFromDepth_min"]["G"]);
+				m_colorFromDepth_min.B = static_cast<float>(in["colorFromDepth_min"]["B"]);
+				m_colorFromDepth_max.R = static_cast<float>(in["colorFromDepth_max"]["R"]);
+				m_colorFromDepth_max.G = static_cast<float>(in["colorFromDepth_max"]["G"]);
+				m_colorFromDepth_max.B = static_cast<float>(in["colorFromDepth_max"]["B"]);
+				m_pointSmooth = static_cast<bool>(in["pointSmooth"]);
+			}
+			break;
+			default:
+				MRPT_THROW_UNKNOWN_SERIALIZATION_VERSION(version)
+		}
+	}
+}
 uint8_t CPointCloud::serializeGetVersion() const { return 4; }
 void CPointCloud::serializeTo(mrpt::serialization::CArchive& out) const
 {

--- a/libs/opengl/src/CPointCloud.cpp
+++ b/libs/opengl/src/CPointCloud.cpp
@@ -190,11 +190,10 @@ void CPointCloud::render_subset(
 #if MRPT_HAS_OPENGL_GLUT
 
 	const size_t N = (all ? m_xs.size() : idxs.size());
-	const size_t decimation = mrpt::round(
-		std::max(
-			1.0f, static_cast<float>(
-					  N / (OCTREE_RENDER_MAX_DENSITY_POINTS_PER_SQPIXEL_value *
-						   render_area_sqpixels))));
+	const size_t decimation = mrpt::round(std::max(
+		1.0f, static_cast<float>(
+				  N / (OCTREE_RENDER_MAX_DENSITY_POINTS_PER_SQPIXEL_value *
+					   render_area_sqpixels))));
 
 	m_last_rendered_count_ongoing += N / decimation;
 
@@ -214,19 +213,22 @@ void CPointCloud::render_subset(
 	MRPT_UNUSED_PARAM(render_area_sqpixels);
 #endif
 }
-void CPointCloud::serializeTo(mrpt::serialization::CSchemeArchiveBase& out) const
+void CPointCloud::serializeTo(
+	mrpt::serialization::CSchemeArchiveBase& out) const
 {
-	out["datatype"] = std::string(this->GetRuntimeClass()->className);
-	out["version"] = 1;
+	SCHEMA_SERIALIZE_DATATYPE_VERSION(1);
 	out["colorFromDepth"] = static_cast<int32_t>(m_colorFromDepth);
 	out["pointSize"] = m_pointSize;
-	for(uint i = 0; i < m_xs.size(); i++) {
+	for (uint i = 0; i < m_xs.size(); i++)
+	{
 		out["xs"][i] = m_xs[i];
 	}
-	for(uint i = 0; i < m_ys.size(); i++) {
+	for (uint i = 0; i < m_ys.size(); i++)
+	{
 		out["ys"][i] = m_ys[i];
 	}
-	for(uint i = 0; i < m_zs.size(); i++) {
+	for (uint i = 0; i < m_zs.size(); i++)
+	{
 		out["zs"][i] = m_zs[i];
 	}
 	out["colorFromDepth_min"]["R"] = m_colorFromDepth_min.R;
@@ -239,41 +241,47 @@ void CPointCloud::serializeTo(mrpt::serialization::CSchemeArchiveBase& out) cons
 }
 void CPointCloud::serializeFrom(mrpt::serialization::CSchemeArchiveBase& in)
 {
-	uint8_t version = static_cast<int>(in["version"]);	// default is 0
-	if(static_cast<std::string>(in["datatype"]) ==
-		std::string(this->GetRuntimeClass()->className))	// match the class name
+	uint8_t version;
+	SCHEMA_DESERIALIZE_DATATYPE_VERSION();
+	switch (version)
 	{
-		switch(version)
+		case 1:
 		{
-			case 1:
+			/**
+			 *  currently below is being left to what is being set by
+			 *  the default constructor i.e.,CPointCloud::colNone
+			 */
+			// m_colorFromDepth = static_cast<float>(in["colorDepth"]);
+			m_pointSize = static_cast<float>(in["pointSize"]);
+			for (uint i = 0; i < m_xs.size(); i++)
 			{
-				/**
-				 *  currently below is being left to what is being set by
-				 *  the default constructor i.e.,CPointCloud::colNone
-				 */
-				// m_colorFromDepth = static_cast<float>(in["colorDepth"]);
-				m_pointSize = static_cast<float>(in["pointSize"]);
-				for(uint i = 0; i < m_xs.size(); i++) {
-					m_xs[i] = static_cast<float>(in["xs"][i]);
-				}
-				for(uint i = 0; i < m_ys.size(); i++) {
-					m_ys[i] = static_cast<float>(in["ys"][i]);
-				}
-				for(uint i = 0; i < m_zs.size(); i++) {
-					m_zs[i] = static_cast<float>(in["zs"][i]);
-				}
-				m_colorFromDepth_min.R = static_cast<float>(in["colorFromDepth_min"]["R"]);
-				m_colorFromDepth_min.G = static_cast<float>(in["colorFromDepth_min"]["G"]);
-				m_colorFromDepth_min.B = static_cast<float>(in["colorFromDepth_min"]["B"]);
-				m_colorFromDepth_max.R = static_cast<float>(in["colorFromDepth_max"]["R"]);
-				m_colorFromDepth_max.G = static_cast<float>(in["colorFromDepth_max"]["G"]);
-				m_colorFromDepth_max.B = static_cast<float>(in["colorFromDepth_max"]["B"]);
-				m_pointSmooth = static_cast<bool>(in["pointSmooth"]);
+				m_xs[i] = static_cast<float>(in["xs"][i]);
 			}
-			break;
-			default:
-				MRPT_THROW_UNKNOWN_SERIALIZATION_VERSION(version)
+			for (uint i = 0; i < m_ys.size(); i++)
+			{
+				m_ys[i] = static_cast<float>(in["ys"][i]);
+			}
+			for (uint i = 0; i < m_zs.size(); i++)
+			{
+				m_zs[i] = static_cast<float>(in["zs"][i]);
+			}
+			m_colorFromDepth_min.R =
+				static_cast<float>(in["colorFromDepth_min"]["R"]);
+			m_colorFromDepth_min.G =
+				static_cast<float>(in["colorFromDepth_min"]["G"]);
+			m_colorFromDepth_min.B =
+				static_cast<float>(in["colorFromDepth_min"]["B"]);
+			m_colorFromDepth_max.R =
+				static_cast<float>(in["colorFromDepth_max"]["R"]);
+			m_colorFromDepth_max.G =
+				static_cast<float>(in["colorFromDepth_max"]["G"]);
+			m_colorFromDepth_max.B =
+				static_cast<float>(in["colorFromDepth_max"]["B"]);
+			m_pointSmooth = static_cast<bool>(in["pointSmooth"]);
 		}
+		break;
+		default:
+			MRPT_THROW_UNKNOWN_SERIALIZATION_VERSION(version)
 	}
 }
 uint8_t CPointCloud::serializeGetVersion() const { return 4; }

--- a/libs/poses/include/mrpt/poses/CPoint2D.h
+++ b/libs/poses/include/mrpt/poses/CPoint2D.h
@@ -34,7 +34,7 @@ class CPoint2D : public CPoint<CPoint2D>,
 				 public mrpt::serialization::CSerializable
 {
 	DEFINE_SERIALIZABLE(CPoint2D)
-
+	DEFINE_SCHEMA_SERIALIZABLE()
    public:
 	/** [x,y] */
 	mrpt::math::CArrayDouble<2> m_coords;

--- a/libs/poses/include/mrpt/poses/CPoint2DPDFGaussian.h
+++ b/libs/poses/include/mrpt/poses/CPoint2DPDFGaussian.h
@@ -21,6 +21,7 @@ namespace mrpt::poses
 class CPoint2DPDFGaussian : public CPoint2DPDF
 {
 	DEFINE_SERIALIZABLE(CPoint2DPDFGaussian)
+	DEFINE_SCHEMA_SERIALIZABLE()
 
    public:
 	/** Default constructor */
@@ -59,46 +60,46 @@ class CPoint2DPDFGaussian : public CPoint2DPDF
 
 	/** this = p (+) this. This can be used to convert a PDF from local
 	 * coordinates to global, providing the point (newReferenceBase) from which
-	  *   "to project" the current pdf. Result PDF substituted the currently
+	 *   "to project" the current pdf. Result PDF substituted the currently
 	 * stored one in the object. Both the mean value and the covariance matrix
 	 * are updated correctly. */
 	void changeCoordinatesReference(const CPose3D& newReferenceBase) override;
 
 	/** Bayesian fusion of two points gauss. distributions, then save the result
-	  *in this object.
-	  *  The process is as follows:<br>
-	  *		- (x1,S1): Mean and variance of the p1 distribution.
-	  *		- (x2,S2): Mean and variance of the p2 distribution.
-	  *		- (x,S): Mean and variance of the resulting distribution.
-	  *
-	  *    S = (S1<sup>-1</sup> + S2<sup>-1</sup>)<sup>-1</sup>;
-	  *    x = S * ( S1<sup>-1</sup>*x1 + S2<sup>-1</sup>*x2 );
-	  */
+	 *in this object.
+	 *  The process is as follows:<br>
+	 *		- (x1,S1): Mean and variance of the p1 distribution.
+	 *		- (x2,S2): Mean and variance of the p2 distribution.
+	 *		- (x,S): Mean and variance of the resulting distribution.
+	 *
+	 *    S = (S1<sup>-1</sup> + S2<sup>-1</sup>)<sup>-1</sup>;
+	 *    x = S * ( S1<sup>-1</sup>*x1 + S2<sup>-1</sup>*x2 );
+	 */
 	void bayesianFusion(
 		const CPoint2DPDFGaussian& p1, const CPoint2DPDFGaussian& p2);
 
 	/** Computes the "correspondence likelihood" of this PDF with another one:
 	 * This is implemented as the integral from -inf to +inf of the product of
 	 * both PDF.
-	  * The resulting number is >=0.
-	  * \sa productIntegralNormalizedWith
-	  * \exception std::exception On errors like covariance matrix with null
+	 * The resulting number is >=0.
+	 * \sa productIntegralNormalizedWith
+	 * \exception std::exception On errors like covariance matrix with null
 	 * determinant, etc...
-	  */
+	 */
 	double productIntegralWith(const CPoint2DPDFGaussian& p) const;
 
 	/** Computes the "correspondence likelihood" of this PDF with another one:
 	 * This is implemented as the integral from -inf to +inf of the product of
 	 * both PDF.
-	  * The resulting number is in the range [0,1].
-	  *  Note that the resulting value is in fact
-	  *  \f[ exp( -\frac{1}{2} D^2 ) \f]
-	  *  , with \f$ D^2 \f$ being the square Mahalanobis distance between the
+	 * The resulting number is in the range [0,1].
+	 *  Note that the resulting value is in fact
+	 *  \f[ exp( -\frac{1}{2} D^2 ) \f]
+	 *  , with \f$ D^2 \f$ being the square Mahalanobis distance between the
 	 * two pdfs.
-	  * \sa productIntegralWith
-	  * \exception std::exception On errors like covariance matrix with null
+	 * \sa productIntegralWith
+	 * \exception std::exception On errors like covariance matrix with null
 	 * determinant, etc...
-	  */
+	 */
 	double productIntegralNormalizedWith(const CPoint2DPDFGaussian& p) const;
 
 	/** Draw a sample from the pdf */
@@ -108,12 +109,12 @@ class CPoint2DPDFGaussian : public CPoint2DPDF
 	 * distributions->new distribution), then save the result in this object
 	 * (WARNING: See implementing classes to see classes that can and cannot be
 	 * mixtured!)
-	  * \param p1 The first distribution to fuse
-	  * \param p2 The second distribution to fuse
-	  * \param minMahalanobisDistToDrop If set to different of 0, the result of
+	 * \param p1 The first distribution to fuse
+	 * \param p2 The second distribution to fuse
+	 * \param minMahalanobisDistToDrop If set to different of 0, the result of
 	 * very separate Gaussian modes (that will result in negligible components)
 	 * in SOGs will be dropped to reduce the number of modes in the output.
-	  */
+	 */
 	void bayesianFusion(
 		const CPoint2DPDF& p1, const CPoint2DPDF& p2,
 		const double minMahalanobisDistToDrop = 0) override;
@@ -125,7 +126,5 @@ class CPoint2DPDFGaussian : public CPoint2DPDF
 	double mahalanobisDistanceToPoint(const double x, const double y) const;
 
 };  // End of class def.
-}
+}  // namespace mrpt::poses
 #endif
-
-

--- a/libs/poses/include/mrpt/poses/CPoint3D.h
+++ b/libs/poses/include/mrpt/poses/CPoint3D.h
@@ -32,7 +32,7 @@ class CPoint3D : public CPoint<CPoint3D>,
 				 public mrpt::serialization::CSerializable
 {
 	DEFINE_SERIALIZABLE(CPoint3D)
-
+	DEFINE_SCHEMA_SERIALIZABLE()
    public:
 	/** [x,y,z] */
 	mrpt::math::CArrayDouble<3> m_coords;

--- a/libs/poses/include/mrpt/poses/CPointPDFGaussian.h
+++ b/libs/poses/include/mrpt/poses/CPointPDFGaussian.h
@@ -23,18 +23,19 @@ namespace mrpt::poses
 class CPointPDFGaussian : public CPointPDF
 {
 	DEFINE_SERIALIZABLE(CPointPDFGaussian)
+	DEFINE_SCHEMA_SERIALIZABLE()
 
    public:
 	/** Default constructor
-	  */
+	 */
 	CPointPDFGaussian();
 
 	/** Constructor
-	  */
+	 */
 	CPointPDFGaussian(const CPoint3D& init_Mean);
 
 	/** Constructor
-	  */
+	 */
 	CPointPDFGaussian(
 		const CPoint3D& init_Mean, const mrpt::math::CMatrixDouble33& init_Cov);
 
@@ -62,73 +63,73 @@ class CPointPDFGaussian : public CPointPDF
 
 	/** this = p (+) this. This can be used to convert a PDF from local
 	 * coordinates to global, providing the point (newReferenceBase) from which
-	  *   "to project" the current pdf. Result PDF substituted the currently
+	 *   "to project" the current pdf. Result PDF substituted the currently
 	 * stored one in the object. Both the mean value and the covariance matrix
 	 * are updated correctly. */
 	void changeCoordinatesReference(const CPose3D& newReferenceBase) override;
 
 	/** Bayesian fusion of two points gauss. distributions, then save the result
-	  *in this object.
-	  *  The process is as follows:<br>
-	  *		- (x1,S1): Mean and variance of the p1 distribution.
-	  *		- (x2,S2): Mean and variance of the p2 distribution.
-	  *		- (x,S): Mean and variance of the resulting distribution.
-	  *
-	  *    S = (S1<sup>-1</sup> + S2<sup>-1</sup>)<sup>-1</sup>;
-	  *    x = S * ( S1<sup>-1</sup>*x1 + S2<sup>-1</sup>*x2 );
-	  */
+	 *in this object.
+	 *  The process is as follows:<br>
+	 *		- (x1,S1): Mean and variance of the p1 distribution.
+	 *		- (x2,S2): Mean and variance of the p2 distribution.
+	 *		- (x,S): Mean and variance of the resulting distribution.
+	 *
+	 *    S = (S1<sup>-1</sup> + S2<sup>-1</sup>)<sup>-1</sup>;
+	 *    x = S * ( S1<sup>-1</sup>*x1 + S2<sup>-1</sup>*x2 );
+	 */
 	void bayesianFusion(
 		const CPointPDFGaussian& p1, const CPointPDFGaussian& p2);
 
 	/** Computes the "correspondence likelihood" of this PDF with another one:
 	 * This is implemented as the integral from -inf to +inf of the product of
 	 * both PDF.
-	  * The resulting number is >=0.
-	  * \sa productIntegralNormalizedWith
-	  * \exception std::exception On errors like covariance matrix with null
+	 * The resulting number is >=0.
+	 * \sa productIntegralNormalizedWith
+	 * \exception std::exception On errors like covariance matrix with null
 	 * determinant, etc...
-	  */
+	 */
 	double productIntegralWith(const CPointPDFGaussian& p) const;
 
 	/** Computes the "correspondence likelihood" of this PDF with another one:
 	 * This is implemented as the integral from -inf to +inf of the product of
 	 * both PDF.
-	  * The resulting number is >=0.
-	  * NOTE: This version ignores the "z" coordinates!!
-	  * \sa productIntegralNormalizedWith
-	  * \exception std::exception On errors like covariance matrix with null
+	 * The resulting number is >=0.
+	 * NOTE: This version ignores the "z" coordinates!!
+	 * \sa productIntegralNormalizedWith
+	 * \exception std::exception On errors like covariance matrix with null
 	 * determinant, etc...
-	  */
+	 */
 	double productIntegralWith2D(const CPointPDFGaussian& p) const;
 
 	/** Computes the "correspondence likelihood" of this PDF with another one:
 	 * This is implemented as the integral from -inf to +inf of the product of
 	 * both PDF.
-	  * The resulting number is in the range [0,1]
-	  *  Note that the resulting value is in fact
-	  *  \f[ exp( -\frac{1}{2} D^2 ) \f]
-	  *  , with \f$ D^2 \f$ being the square Mahalanobis distance between the
+	 * The resulting number is in the range [0,1]
+	 *  Note that the resulting value is in fact
+	 *  \f[ exp( -\frac{1}{2} D^2 ) \f]
+	 *  , with \f$ D^2 \f$ being the square Mahalanobis distance between the
 	 * two pdfs.
-	  * \sa productIntegralWith
-	  * \exception std::exception On errors like covariance matrix with null
+	 * \sa productIntegralWith
+	 * \exception std::exception On errors like covariance matrix with null
 	 * determinant, etc...
-	  */
+	 */
 	double productIntegralNormalizedWith(const CPointPDFGaussian& p) const;
 
 	/** Computes the "correspondence likelihood" of this PDF with another one:
 	 * This is implemented as the integral from -inf to +inf of the product of
 	 * both PDF.
-	  * The resulting number is in the range [0,1]. This versions ignores the
+	 * The resulting number is in the range [0,1]. This versions ignores the
 	 * "z" coordinate.
-	  *
-	  *  Note that the resulting value is in fact
-	  *  \f[ exp( -\frac{1}{2} D^2 ) \f]
-	  *  , with \f$ D^2 \f$ being the square Mahalanobis distance between the
+	 *
+	 *  Note that the resulting value is in fact
+	 *  \f[ exp( -\frac{1}{2} D^2 ) \f]
+	 *  , with \f$ D^2 \f$ being the square Mahalanobis distance between the
 	 * two pdfs.
-	  * \sa productIntegralWith
-	  * \exception std::exception On errors like covariance matrix with null
+	 * \sa productIntegralWith
+	 * \exception std::exception On errors like covariance matrix with null
 	 * determinant, etc...
-	  */
+	 */
 	double productIntegralNormalizedWith2D(const CPointPDFGaussian& p) const;
 
 	/** Draw a sample from the pdf */
@@ -138,12 +139,12 @@ class CPointPDFGaussian : public CPointPDF
 	 * distributions->new distribution), then save the result in this object
 	 * (WARNING: See implementing classes to see classes that can and cannot be
 	 * mixtured!)
-	  * \param p1 The first distribution to fuse
-	  * \param p2 The second distribution to fuse
-	  * \param minMahalanobisDistToDrop If set to different of 0, the result of
+	 * \param p1 The first distribution to fuse
+	 * \param p2 The second distribution to fuse
+	 * \param minMahalanobisDistToDrop If set to different of 0, the result of
 	 * very separate Gaussian modes (that will result in negligible components)
 	 * in SOGs will be dropped to reduce the number of modes in the output.
-	  */
+	 */
 	void bayesianFusion(
 		const CPointPDF& p1, const CPointPDF& p2,
 		const double minMahalanobisDistToDrop = 0) override;
@@ -154,7 +155,5 @@ class CPointPDFGaussian : public CPointPDF
 		const CPointPDFGaussian& other, bool only_2D = false) const;
 
 };  // End of class def.
-}
+}  // namespace mrpt::poses
 #endif
-
-

--- a/libs/poses/include/mrpt/poses/CPose2D.h
+++ b/libs/poses/include/mrpt/poses/CPose2D.h
@@ -39,6 +39,7 @@ class CPose2D : public CPose<CPose2D>, public mrpt::serialization::CSerializable
 {
    public:
 	DEFINE_SERIALIZABLE(CPose2D)
+	DEFINE_SCHEMA_SERIALIZABLE()
 
    public:
 	/** [x,y] */

--- a/libs/poses/include/mrpt/poses/CPose3D.h
+++ b/libs/poses/include/mrpt/poses/CPose3D.h
@@ -86,6 +86,7 @@ class CPose3DRotVec;
 class CPose3D : public CPose<CPose3D>, public mrpt::serialization::CSerializable
 {
 	DEFINE_SERIALIZABLE(CPose3D)
+	DEFINE_SCHEMA_SERIALIZABLE()
 
 	// This must be added for declaration of MEX-related functions
 	DECLARE_MEX_CONVERSION

--- a/libs/poses/include/mrpt/poses/CPose3DQuat.h
+++ b/libs/poses/include/mrpt/poses/CPose3DQuat.h
@@ -47,7 +47,7 @@ class CPose3DQuat : public CPose<CPose3DQuat>,
 					public mrpt::serialization::CSerializable
 {
 	DEFINE_SERIALIZABLE(CPose3DQuat)
-
+	DEFINE_SCHEMA_SERIALIZABLE()
    public:
 	/** The translation vector [x,y,z] */
 	mrpt::math::CArrayDouble<3> m_coords;

--- a/libs/poses/include/mrpt/poses/CPosePDFGaussian.h
+++ b/libs/poses/include/mrpt/poses/CPosePDFGaussian.h
@@ -29,11 +29,12 @@ class CPoint2DPDFGaussian;
 class CPosePDFGaussian : public CPosePDF
 {
 	DEFINE_SERIALIZABLE(CPosePDFGaussian)
+	DEFINE_SCHEMA_SERIALIZABLE()
 
    protected:
 	/** Assures the symmetry of the covariance matrix (eventually certain
 	 * operations in the math-coprocessor lead to non-symmetric matrixes!)
-	  */
+	 */
 	void assureSymmetry();
 
    public:
@@ -50,15 +51,15 @@ class CPosePDFGaussian : public CPosePDF
 	inline const CPose2D& getPoseMean() const { return mean; }
 	inline CPose2D& getPoseMean() { return mean; }
 	/** Default constructor
-	  */
+	 */
 	CPosePDFGaussian();
 
 	/** Constructor
-	  */
+	 */
 	explicit CPosePDFGaussian(const CPose2D& init_Mean);
 
 	/** Constructor
-	  */
+	 */
 	CPosePDFGaussian(
 		const CPose2D& init_Mean, const mrpt::math::CMatrixDouble33& init_Cov);
 
@@ -68,13 +69,13 @@ class CPosePDFGaussian : public CPosePDF
 	explicit CPosePDFGaussian(const CPose3DPDF& o) { copyFrom(o); }
 	/** Returns an estimate of the pose, (the mean, or mathematical expectation
 	 * of the PDF).
-	  * \sa getCovariance
-	  */
+	 * \sa getCovariance
+	 */
 	void getMean(CPose2D& mean_pose) const override { mean_pose = mean; }
 	/** Returns an estimate of the pose covariance matrix (3x3 cov matrix) and
 	 * the mean, both at once.
-	  * \sa getMean
-	  */
+	 * \sa getMean
+	 */
 	void getCovarianceAndMean(
 		mrpt::math::CMatrixDouble33& out_cov,
 		CPose2D& mean_point) const override
@@ -97,23 +98,23 @@ class CPosePDFGaussian : public CPosePDF
 
 	/** this = p (+) this. This can be used to convert a PDF from local
 	 * coordinates to global, providing the point (newReferenceBase) from which
-	  *   "to project" the current pdf. Result PDF substituted the currently
+	 *   "to project" the current pdf. Result PDF substituted the currently
 	 * stored one in the object.
-	  */
+	 */
 	void changeCoordinatesReference(const CPose3D& newReferenceBase) override;
 
 	/** this = p (+) this. This can be used to convert a PDF from local
 	 * coordinates to global, providing the point (newReferenceBase) from which
-	  *   "to project" the current pdf. Result PDF substituted the currently
+	 *   "to project" the current pdf. Result PDF substituted the currently
 	 * stored one in the object.
-	  */
+	 */
 	void changeCoordinatesReference(const CPose2D& newReferenceBase);
 
 	/** Rotate the covariance matrix by replacing it by \f$
 	 * \mathbf{R}~\mathbf{COV}~\mathbf{R}^t \f$, where \f$ \mathbf{R} = \left[
 	 * \begin{array}{ccc} \cos\alpha & -\sin\alpha & 0 \\ \sin\alpha &
 	 * \cos\alpha & 0 \\ 0 & 0 & 1 \end{array}\right] \f$.
-	  */
+	 */
 	void rotateCov(const double ang);
 
 	/** Set \f$ this = x1 \ominus x0 \f$ , computing the mean using the "-"
@@ -130,32 +131,32 @@ class CPosePDFGaussian : public CPosePDF
 		const mrpt::math::CMatrixDouble33& COV_01);
 
 	/** Draws a single sample from the distribution
-	  */
+	 */
 	void drawSingleSample(CPose2D& outPart) const override;
 
 	/** Draws a number of samples from the distribution, and saves as a list of
 	 * 1x3 vectors, where each row contains a (x,y,phi) datum.
-	  */
+	 */
 	void drawManySamples(
 		size_t N,
 		std::vector<mrpt::math::CVectorDouble>& outSamples) const override;
 
 	/** Bayesian fusion of two points gauss. distributions, then save the result
-	  *in this object.
-	  *  The process is as follows:<br>
-	  *		- (x1,S1): Mean and variance of the p1 distribution.
-	  *		- (x2,S2): Mean and variance of the p2 distribution.
-	  *		- (x,S): Mean and variance of the resulting distribution.
-	  *
-	  *    S = (S1<sup>-1</sup> + S2<sup>-1</sup>)<sup>-1</sup>;
-	  *    x = S * ( S1<sup>-1</sup>*x1 + S2<sup>-1</sup>*x2 );
-	  */
+	 *in this object.
+	 *  The process is as follows:<br>
+	 *		- (x1,S1): Mean and variance of the p1 distribution.
+	 *		- (x2,S2): Mean and variance of the p2 distribution.
+	 *		- (x,S): Mean and variance of the resulting distribution.
+	 *
+	 *    S = (S1<sup>-1</sup> + S2<sup>-1</sup>)<sup>-1</sup>;
+	 *    x = S * ( S1<sup>-1</sup>*x1 + S2<sup>-1</sup>*x2 );
+	 */
 	void bayesianFusion(
 		const CPosePDF& p1, const CPosePDF& p2,
 		const double minMahalanobisDistToDrop = 0) override;
 
 	/** Returns a new PDF such as: NEW_PDF = (0,0,0) - THIS_PDF
-	  */
+	 */
 	void inverse(CPosePDF& o) const override;
 
 	/** Makes: thisPDF = thisPDF + Ap, where "+" is pose composition (both the
@@ -217,7 +218,5 @@ poses::CPosePDFGaussian operator+(
 
 bool operator==(const CPosePDFGaussian& p1, const CPosePDFGaussian& p2);
 
-}
+}  // namespace mrpt::poses
 #endif
-
-

--- a/libs/poses/include/mrpt/poses/CPosePDFGaussianInf.h
+++ b/libs/poses/include/mrpt/poses/CPosePDFGaussianInf.h
@@ -35,12 +35,13 @@ class CPosePDFGaussianInf : public CPosePDF
 {
 	// This must be added to any CSerializable derived class:
 	DEFINE_SERIALIZABLE(CPosePDFGaussianInf)
+	DEFINE_SCHEMA_SERIALIZABLE()
 	using self_t = CPosePDFGaussianInf;
 
    protected:
 	/** Assures the symmetry of the covariance matrix (eventually certain
 	 * operations in the math-coprocessor lead to non-symmetric matrixes!)
-  */
+	 */
 	void assureSymmetry();
 
    public:
@@ -79,8 +80,8 @@ class CPosePDFGaussianInf : public CPosePDF
 	void getMean(CPose2D& mean_pose) const override { mean_pose = mean; }
 	bool isInfType() const override { return true; }
 	/** Returns an estimate of the pose covariance matrix (3x3 cov matrix) and
-   * the mean, both at once.
-   * \sa getMean */
+	 * the mean, both at once.
+	 * \sa getMean */
 	void getCovarianceAndMean(
 		mrpt::math::CMatrixDouble33& cov, CPose2D& mean_point) const override
 	{
@@ -109,15 +110,15 @@ class CPosePDFGaussianInf : public CPosePDF
 	bool saveToTextFile(const std::string& file) const override;
 
 	/** this = p (+) this. This can be used to convert a PDF from local
-   * coordinates to global, providing the point (newReferenceBase) from which
-   *   "to project" the current pdf. Result PDF substituted the currently stored
-   * one in the object */
+	 * coordinates to global, providing the point (newReferenceBase) from which
+	 *   "to project" the current pdf. Result PDF substituted the currently
+	 * stored one in the object */
 	void changeCoordinatesReference(const CPose3D& newReferenceBase) override;
 
 	/** this = p (+) this. This can be used to convert a PDF from local
-   * coordinates to global, providing the point (newReferenceBase) from which
-   *   "to project" the current pdf. Result PDF substituted the currently stored
-   * one in the object. */
+	 * coordinates to global, providing the point (newReferenceBase) from which
+	 *   "to project" the current pdf. Result PDF substituted the currently
+	 * stored one in the object. */
 	void changeCoordinatesReference(const CPose2D& newReferenceBase);
 
 	/** Rotate the covariance matrix by replacing it by \f$
@@ -149,15 +150,15 @@ class CPosePDFGaussianInf : public CPosePDF
 		std::vector<mrpt::math::CVectorDouble>& outSamples) const override;
 
 	/** Bayesian fusion of two points gauss. distributions, then save the result
-   *in this object.
-   *  The process is as follows:<br>
-   *		- (x1,S1): Mean and variance of the p1 distribution.
-   *		- (x2,S2): Mean and variance of the p2 distribution.
-   *		- (x,S): Mean and variance of the resulting distribution.
-   *
-   *    S = (S1<sup>-1</sup> + S2<sup>-1</sup>)<sup>-1</sup>;
-   *    x = S * ( S1<sup>-1</sup>*x1 + S2<sup>-1</sup>*x2 );
-   */
+	 *in this object.
+	 *  The process is as follows:<br>
+	 *		- (x1,S1): Mean and variance of the p1 distribution.
+	 *		- (x2,S2): Mean and variance of the p2 distribution.
+	 *		- (x,S): Mean and variance of the resulting distribution.
+	 *
+	 *    S = (S1<sup>-1</sup> + S2<sup>-1</sup>)<sup>-1</sup>;
+	 *    x = S * ( S1<sup>-1</sup>*x1 + S2<sup>-1</sup>*x2 );
+	 */
 	void bayesianFusion(
 		const CPosePDF& p1, const CPosePDF& p2,
 		const double minMahalanobisDistToDrop = 0) override;
@@ -211,7 +212,5 @@ poses::CPosePDFGaussianInf operator+(
 /** Dumps the mean and covariance matrix to a text stream. */
 std::ostream& operator<<(std::ostream& out, const CPosePDFGaussianInf& obj);
 
-}
+}  // namespace mrpt::poses
 #endif
-
-

--- a/libs/poses/src/CPoint2D.cpp
+++ b/libs/poses/src/CPoint2D.cpp
@@ -51,30 +51,25 @@ void CPoint2D::serializeFrom(mrpt::serialization::CArchive& in, uint8_t version)
 }
 void CPoint2D::serializeTo(mrpt::serialization::CSchemeArchiveBase& out) const
 {
-	out["datatype"] = std::string(this->GetRuntimeClass()->className);
-	out["version"] = 1;
+	SCHEMA_SERIALIZE_DATATYPE_VERSION(1);
 	out["x"] = m_coords[0];
 	out["y"] = m_coords[1];
 }
 void CPoint2D::serializeFrom(mrpt::serialization::CSchemeArchiveBase& in)
 {
-	uint8_t version = static_cast<int>(in["version"]);	//default is 0
-	if(static_cast<std::string>(in["datatype"]) == 
-		std::string(this->GetRuntimeClass()->className)) //match the classname
+	uint8_t version;
+	SCHEMA_DESERIALIZE_DATATYPE_VERSION();
+	switch (version)
 	{
-		switch(version)
+		case 1:
 		{
-			case 1:
-			{
-				m_coords[0] = static_cast<double>(in["x"]);
-				m_coords[1] = static_cast<double>(in["y"]);
-			}
-			break;
-			default:
-				MRPT_THROW_UNKNOWN_SERIALIZATION_VERSION(version)
+			m_coords[0] = static_cast<double>(in["x"]);
+			m_coords[1] = static_cast<double>(in["y"]);
 		}
+		break;
+		default:
+			MRPT_THROW_UNKNOWN_SERIALIZATION_VERSION(version)
 	}
-
 }
 /*---------------------------------------------------------------
 The operator D="this"-b is the pose inverse compounding operator.

--- a/libs/poses/src/CPoint2D.cpp
+++ b/libs/poses/src/CPoint2D.cpp
@@ -12,6 +12,7 @@
 #include <mrpt/poses/CPoint2D.h>
 #include <mrpt/poses/CPose2D.h>
 #include <mrpt/serialization/CArchive.h>
+#include <mrpt/serialization/CSchemeArchiveBase.h>
 #include <limits>
 
 using namespace mrpt::poses;
@@ -48,7 +49,33 @@ void CPoint2D::serializeFrom(mrpt::serialization::CArchive& in, uint8_t version)
 			MRPT_THROW_UNKNOWN_SERIALIZATION_VERSION(version)
 	};
 }
+void CPoint2D::serializeTo(mrpt::serialization::CSchemeArchiveBase& out) const
+{
+	out["datatype"] = std::string(this->GetRuntimeClass()->className);
+	out["version"] = 1;
+	out["x"] = m_coords[0];
+	out["y"] = m_coords[1];
+}
+void CPoint2D::serializeFrom(mrpt::serialization::CSchemeArchiveBase& in)
+{
+	uint8_t version = static_cast<int>(in["version"]);	//default is 0
+	if(static_cast<std::string>(in["datatype"]) == 
+		std::string(this->GetRuntimeClass()->className)) //match the classname
+	{
+		switch(version)
+		{
+			case 1:
+			{
+				m_coords[0] = static_cast<double>(in["x"]);
+				m_coords[1] = static_cast<double>(in["y"]);
+			}
+			break;
+			default:
+				MRPT_THROW_UNKNOWN_SERIALIZATION_VERSION(version)
+		}
+	}
 
+}
 /*---------------------------------------------------------------
 The operator D="this"-b is the pose inverse compounding operator.
    The resulting pose "D" is the diference between this pose and "b"

--- a/libs/poses/src/CPoint2DPDFGaussian.cpp
+++ b/libs/poses/src/CPoint2DPDFGaussian.cpp
@@ -15,6 +15,7 @@
 #include <mrpt/math/CMatrixD.h>
 #include <mrpt/math/matrix_serialization.h>
 #include <mrpt/serialization/CArchive.h>
+#include <mrpt/serialization/CSchemeArchiveBase.h>
 #include <mrpt/random/RandomGenerators.h>
 #include <mrpt/system/os.h>
 
@@ -65,6 +66,32 @@ void CPoint2DPDFGaussian::serializeFrom(
 		default:
 			MRPT_THROW_UNKNOWN_SERIALIZATION_VERSION(version)
 	};
+}
+void CPoint2DPDFGaussian::serializeTo(
+	mrpt::serialization::CSchemeArchiveBase& out) const
+{
+	SCHEMA_SERIALIZE_DATATYPE_VERSION(1);
+	out["mean"] = mean;
+	out["cov"] = CMatrixD(cov);
+}
+void CPoint2DPDFGaussian::serializeFrom(
+	mrpt::serialization::CSchemeArchiveBase& in)
+{
+	uint8_t version;
+	SCHEMA_DESERIALIZE_DATATYPE_VERSION();
+	switch (version)
+	{
+		case 1:
+		{
+			in["mean"].readTo(mean);
+			CMatrixD m;
+			in["cov"].readTo(m);
+			cov = m;
+		}
+		break;
+		default:
+			MRPT_THROW_UNKNOWN_SERIALIZATION_VERSION(version)
+	}
 }
 
 void CPoint2DPDFGaussian::copyFrom(const CPoint2DPDF& o)

--- a/libs/poses/src/CPoint3D.cpp
+++ b/libs/poses/src/CPoint3D.cpp
@@ -77,11 +77,10 @@ void CPoint3D::serializeFrom(mrpt::serialization::CArchive& in, uint8_t version)
 			MRPT_THROW_UNKNOWN_SERIALIZATION_VERSION(version)
 	};
 }
-/** Serialize CSerializable Object to CSchemeArchiveBase derived object*/ 
+/** Serialize CSerializable Object to CSchemeArchiveBase derived object*/
 void CPoint3D::serializeTo(mrpt::serialization::CSchemeArchiveBase& out) const
 {
-	out["datatype"] = std::string(this->GetRuntimeClass()->className);
-	out["version"] = 1;
+	SCHEMA_SERIALIZE_DATATYPE_VERSION(1);
 	out["x"] = m_coords[0];
 	out["y"] = m_coords[1];
 	out["z"] = m_coords[2];
@@ -89,22 +88,19 @@ void CPoint3D::serializeTo(mrpt::serialization::CSchemeArchiveBase& out) const
 /** Serialize CSchemeArchiveBase derived object to CSerializable Object*/
 void CPoint3D::serializeFrom(mrpt::serialization::CSchemeArchiveBase& in)
 {
-	uint8_t version = static_cast<int>(in["version"]);	//default is 0
-	if(static_cast<std::string>(in["datatype"]) == 
-		std::string(this->GetRuntimeClass()->className)) //match the classname
+	uint8_t version;
+	SCHEMA_DESERIALIZE_DATATYPE_VERSION();
+	switch (version)
 	{
-		switch(version)
+		case 1:
 		{
-			case 1:
-			{
-				m_coords[0] = static_cast<double>(in["x"]);
-				m_coords[1] = static_cast<double>(in["y"]);
-				m_coords[2] = static_cast<double>(in["z"]);
-			}
-			break;
-			default:
-				MRPT_THROW_UNKNOWN_SERIALIZATION_VERSION(version)
+			m_coords[0] = static_cast<double>(in["x"]);
+			m_coords[1] = static_cast<double>(in["y"]);
+			m_coords[2] = static_cast<double>(in["z"]);
 		}
+		break;
+		default:
+			MRPT_THROW_UNKNOWN_SERIALIZATION_VERSION(version)
 	}
 }
 /*---------------------------------------------------------------

--- a/libs/poses/src/CPoint3D.cpp
+++ b/libs/poses/src/CPoint3D.cpp
@@ -14,6 +14,7 @@
 #include <mrpt/poses/CPoint2D.h>
 #include <mrpt/poses/CPose2D.h>
 #include <mrpt/serialization/CArchive.h>
+#include <mrpt/serialization/CSchemeArchiveBase.h>
 #include <limits>
 
 using namespace mrpt;
@@ -76,7 +77,36 @@ void CPoint3D::serializeFrom(mrpt::serialization::CArchive& in, uint8_t version)
 			MRPT_THROW_UNKNOWN_SERIALIZATION_VERSION(version)
 	};
 }
-
+/** Serialize CSerializable Object to CSchemeArchiveBase derived object*/ 
+void CPoint3D::serializeTo(mrpt::serialization::CSchemeArchiveBase& out) const
+{
+	out["datatype"] = std::string(this->GetRuntimeClass()->className);
+	out["version"] = 1;
+	out["x"] = m_coords[0];
+	out["y"] = m_coords[1];
+	out["z"] = m_coords[2];
+}
+/** Serialize CSchemeArchiveBase derived object to CSerializable Object*/
+void CPoint3D::serializeFrom(mrpt::serialization::CSchemeArchiveBase& in)
+{
+	uint8_t version = static_cast<int>(in["version"]);	//default is 0
+	if(static_cast<std::string>(in["datatype"]) == 
+		std::string(this->GetRuntimeClass()->className)) //match the classname
+	{
+		switch(version)
+		{
+			case 1:
+			{
+				m_coords[0] = static_cast<double>(in["x"]);
+				m_coords[1] = static_cast<double>(in["y"]);
+				m_coords[2] = static_cast<double>(in["z"]);
+			}
+			break;
+			default:
+				MRPT_THROW_UNKNOWN_SERIALIZATION_VERSION(version)
+		}
+	}
+}
 /*---------------------------------------------------------------
 				point3D = point3D - pose3D
   ---------------------------------------------------------------*/

--- a/libs/poses/src/CPointPDFGaussian.cpp
+++ b/libs/poses/src/CPointPDFGaussian.cpp
@@ -15,6 +15,7 @@
 #include <mrpt/random/RandomGenerators.h>
 #include <mrpt/system/os.h>
 #include <mrpt/serialization/CArchive.h>
+#include <mrpt/serialization/CSchemeArchiveBase.h>
 
 using namespace mrpt::poses;
 
@@ -89,6 +90,32 @@ void CPointPDFGaussian::serializeFrom(
 		default:
 			MRPT_THROW_UNKNOWN_SERIALIZATION_VERSION(version)
 	};
+}
+void CPointPDFGaussian::serializeTo(
+	mrpt::serialization::CSchemeArchiveBase& out) const
+{
+	SCHEMA_SERIALIZE_DATATYPE_VERSION(1);
+	out["mean"] = mean;
+	out["cov"] = CMatrixD(cov);
+}
+void CPointPDFGaussian::serializeFrom(
+	mrpt::serialization::CSchemeArchiveBase& in)
+{
+	uint8_t version;
+	SCHEMA_DESERIALIZE_DATATYPE_VERSION();
+	switch (version)
+	{
+		case 1:
+		{
+			in["mean"].readTo(mean);
+			CMatrixD m;
+			in["cov"].readTo(m);
+			cov = m;
+		}
+		break;
+		default:
+			MRPT_THROW_UNKNOWN_SERIALIZATION_VERSION(version)
+	}
 }
 
 void CPointPDFGaussian::copyFrom(const CPointPDF& o)

--- a/libs/poses/src/CPose2D.cpp
+++ b/libs/poses/src/CPose2D.cpp
@@ -14,6 +14,7 @@
 #include <mrpt/poses/CPose3D.h>
 #include <mrpt/poses/CPoint3D.h>
 #include <mrpt/serialization/CArchive.h>
+#include <mrpt/serialization/CSchemeArchiveBase.h>
 #include <mrpt/math/wrap2pi.h>
 #include <mrpt/config.h>  // HAVE_SINCOS
 #include <limits>
@@ -82,6 +83,31 @@ void CPose2D::serializeFrom(mrpt::serialization::CArchive& in, uint8_t version)
 		default:
 			MRPT_THROW_UNKNOWN_SERIALIZATION_VERSION(version)
 	};
+}
+
+void CPose2D::serializeTo(mrpt::serialization::CSchemeArchiveBase& out) const
+{
+	SCHEMA_SERIALIZE_DATATYPE_VERSION(1);
+	out["x"] = m_coords[0];
+	out["y"] = m_coords[1];
+	out["phi"] = m_phi;
+}
+void CPose2D::serializeFrom(mrpt::serialization::CSchemeArchiveBase& in)
+{
+	uint8_t version;
+	SCHEMA_DESERIALIZE_DATATYPE_VERSION();
+	switch (version)
+	{
+		case 1:
+		{
+			m_coords[0] = static_cast<double>(in["x"]);
+			m_coords[1] = static_cast<double>(in["y"]);
+			m_phi = static_cast<double>(in["phi"]);
+		}
+		break;
+		default:
+			MRPT_THROW_UNKNOWN_SERIALIZATION_VERSION(version)
+	}
 }
 
 /**  Textual output stream function.
@@ -288,7 +314,7 @@ void CPose2D::getHomogeneousMatrix(CMatrixDouble44& m) const
 }
 
 /** Forces "phi" to be in the range [-pi,pi];
-*/
+ */
 void CPose2D::normalizePhi()
 {
 	m_phi = math::wrapToPi(m_phi);

--- a/libs/poses/src/CPose3DQuat.cpp
+++ b/libs/poses/src/CPose3DQuat.cpp
@@ -348,11 +348,11 @@ void CPose3DQuat::serializeFrom(
 			MRPT_THROW_UNKNOWN_SERIALIZATION_VERSION(version)
 	};
 }
-/** Serialize CSerializable Object to CSchemeArchiveBase derived object*/ 
-void CPose3DQuat::serializeTo(mrpt::serialization::CSchemeArchiveBase& out) const
+/** Serialize CSerializable Object to CSchemeArchiveBase derived object*/
+void CPose3DQuat::serializeTo(
+	mrpt::serialization::CSchemeArchiveBase& out) const
 {
-	out["datatype"] = std::string(this->GetRuntimeClass()->className);
-	out["version"] = 1;
+	SCHEMA_SERIALIZE_DATATYPE_VERSION(1);
 	CPoint3D point(m_coords[0], m_coords[1], m_coords[2]);
 	out["point"] = point;
 	out["orientation"]["r"] = m_quat[0];
@@ -363,28 +363,25 @@ void CPose3DQuat::serializeTo(mrpt::serialization::CSchemeArchiveBase& out) cons
 /** Serialize CSchemeArchiveBase derived object to CSerializable Object*/
 void CPose3DQuat::serializeFrom(mrpt::serialization::CSchemeArchiveBase& in)
 {
-	uint8_t version = static_cast<int>(in["version"]);	//default is 0
-	if(static_cast<std::string>(in["datatype"]) == 
-		std::string(this->GetRuntimeClass()->className)) //match the classname
+	uint8_t version;
+	SCHEMA_DESERIALIZE_DATATYPE_VERSION();
+	switch (version)
 	{
-		switch(version)
+		case 1:
 		{
-			case 1:
-			{
-				CPoint3D point;
-				in["point"].asSerializableObject(point);
-				m_coords[0] = point.x();
-				m_coords[1] = point.y();
-				m_coords[2] = point.z();
-				m_quat[0] = static_cast<double>(in["orientation"]["r"]);
-				m_quat[1] = static_cast<double>(in["orientation"]["x"]);
-				m_quat[2] = static_cast<double>(in["orientation"]["y"]);
-				m_quat[3] = static_cast<double>(in["orientation"]["z"]);
-			}
-			break;
-			default:
-				MRPT_THROW_UNKNOWN_SERIALIZATION_VERSION(version)
+			CPoint3D point;
+			in["point"].readTo(point);
+			m_coords[0] = point.x();
+			m_coords[1] = point.y();
+			m_coords[2] = point.z();
+			m_quat[0] = static_cast<double>(in["orientation"]["r"]);
+			m_quat[1] = static_cast<double>(in["orientation"]["x"]);
+			m_quat[2] = static_cast<double>(in["orientation"]["y"]);
+			m_quat[3] = static_cast<double>(in["orientation"]["z"]);
 		}
+		break;
+		default:
+			MRPT_THROW_UNKNOWN_SERIALIZATION_VERSION(version)
 	}
 }
 /*---------------------------------------------------------------

--- a/libs/poses/src/CPose3DQuat.cpp
+++ b/libs/poses/src/CPose3DQuat.cpp
@@ -11,6 +11,8 @@
 #include <mrpt/poses/CPose3D.h>
 #include <mrpt/poses/CPose3DQuat.h>
 #include <mrpt/serialization/CArchive.h>
+#include <mrpt/serialization/CSchemeArchiveBase.h>
+#include <mrpt/serialization/CSerializable.h>
 #include <iomanip>
 #include <limits>
 
@@ -346,7 +348,45 @@ void CPose3DQuat::serializeFrom(
 			MRPT_THROW_UNKNOWN_SERIALIZATION_VERSION(version)
 	};
 }
-
+/** Serialize CSerializable Object to CSchemeArchiveBase derived object*/ 
+void CPose3DQuat::serializeTo(mrpt::serialization::CSchemeArchiveBase& out) const
+{
+	out["datatype"] = std::string(this->GetRuntimeClass()->className);
+	out["version"] = 1;
+	CPoint3D point(m_coords[0], m_coords[1], m_coords[2]);
+	out["point"] = point;
+	out["orientation"]["r"] = m_quat[0];
+	out["orientation"]["x"] = m_quat[1];
+	out["orientation"]["y"] = m_quat[2];
+	out["orientation"]["z"] = m_quat[3];
+}
+/** Serialize CSchemeArchiveBase derived object to CSerializable Object*/
+void CPose3DQuat::serializeFrom(mrpt::serialization::CSchemeArchiveBase& in)
+{
+	uint8_t version = static_cast<int>(in["version"]);	//default is 0
+	if(static_cast<std::string>(in["datatype"]) == 
+		std::string(this->GetRuntimeClass()->className)) //match the classname
+	{
+		switch(version)
+		{
+			case 1:
+			{
+				CPoint3D point;
+				in["point"].asSerializableObject(point);
+				m_coords[0] = point.x();
+				m_coords[1] = point.y();
+				m_coords[2] = point.z();
+				m_quat[0] = static_cast<double>(in["orientation"]["r"]);
+				m_quat[1] = static_cast<double>(in["orientation"]["x"]);
+				m_quat[2] = static_cast<double>(in["orientation"]["y"]);
+				m_quat[3] = static_cast<double>(in["orientation"]["z"]);
+			}
+			break;
+			default:
+				MRPT_THROW_UNKNOWN_SERIALIZATION_VERSION(version)
+		}
+	}
+}
 /*---------------------------------------------------------------
 		sphericalCoordinates
 ---------------------------------------------------------------*/

--- a/libs/poses/src/CPosePDFGaussian.cpp
+++ b/libs/poses/src/CPosePDFGaussian.cpp
@@ -18,6 +18,7 @@
 #include <mrpt/math/wrap2pi.h>
 #include <mrpt/system/os.h>
 #include <mrpt/serialization/CArchive.h>
+#include <mrpt/serialization/CSchemeArchiveBase.h>
 #include <mrpt/math/matrix_serialization.h>
 
 #include <mrpt/random.h>
@@ -90,6 +91,33 @@ void CPosePDFGaussian::serializeFrom(
 		default:
 			MRPT_THROW_UNKNOWN_SERIALIZATION_VERSION(version)
 	};
+}
+
+void CPosePDFGaussian::serializeTo(
+	mrpt::serialization::CSchemeArchiveBase& out) const
+{
+	SCHEMA_SERIALIZE_DATATYPE_VERSION(1);
+	out["mean"] = mean;
+	out["cov"] = CMatrixD(cov);
+}
+void CPosePDFGaussian::serializeFrom(
+	mrpt::serialization::CSchemeArchiveBase& in)
+{
+	uint8_t version;
+	SCHEMA_DESERIALIZE_DATATYPE_VERSION();
+	switch (version)
+	{
+		case 1:
+		{
+			in["mean"].readTo(mean);
+			CMatrixD m;
+			in["cov"].readTo(m);
+			cov = m;
+		}
+		break;
+		default:
+			MRPT_THROW_UNKNOWN_SERIALIZATION_VERSION(version)
+	}
 }
 
 /*---------------------------------------------------------------
@@ -538,7 +566,7 @@ void CPosePDFGaussian::composePoint(
 		df_dx, df_du,
 		true,  // Eval df_dx
 		false  // Eval df_du (not needed)
-		);
+	);
 
 	const CMatrixFixedNumeric<double, 2, 3> dp_dx = df_dx.block<2, 3>(0, 0);
 	g.cov = dp_dx * this->cov * dp_dx.transpose();

--- a/libs/poses/src/CPosePDFGaussianInf.cpp
+++ b/libs/poses/src/CPosePDFGaussianInf.cpp
@@ -18,6 +18,7 @@
 #include <mrpt/math/wrap2pi.h>
 #include <mrpt/system/os.h>
 #include <mrpt/serialization/CArchive.h>
+#include <mrpt/serialization/CSchemeArchiveBase.h>
 #include <mrpt/random.h>
 
 using namespace mrpt;
@@ -76,6 +77,33 @@ void CPosePDFGaussianInf::serializeFrom(
 		default:
 			MRPT_THROW_UNKNOWN_SERIALIZATION_VERSION(version)
 	};
+}
+
+void CPosePDFGaussianInf::serializeTo(
+	mrpt::serialization::CSchemeArchiveBase& out) const
+{
+	SCHEMA_SERIALIZE_DATATYPE_VERSION(1);
+	out["mean"] = mean;
+	out["cov_inv"] = CMatrixD(cov_inv);
+}
+void CPosePDFGaussianInf::serializeFrom(
+	mrpt::serialization::CSchemeArchiveBase& in)
+{
+	uint8_t version;
+	SCHEMA_DESERIALIZE_DATATYPE_VERSION();
+	switch (version)
+	{
+		case 1:
+		{
+			in["mean"].readTo(mean);
+			CMatrixD m;
+			in["cov_inv"].readTo(m);
+			cov_inv = m;
+		}
+		break;
+		default:
+			MRPT_THROW_UNKNOWN_SERIALIZATION_VERSION(version)
+	}
 }
 
 /*---------------------------------------------------------------
@@ -224,9 +252,8 @@ void CPosePDFGaussianInf::drawSingleSample(CPose2D& outPart) const
 	// Range -pi,pi
 	outPart.normalizePhi();
 
-	MRPT_END_WITH_CLEAN_UP(
-		cov_inv.saveToTextFile(
-			"__DEBUG_EXC_DUMP_drawSingleSample_COV_INV.txt"););
+	MRPT_END_WITH_CLEAN_UP(cov_inv.saveToTextFile(
+		"__DEBUG_EXC_DUMP_drawSingleSample_COV_INV.txt"););
 }
 
 /*---------------------------------------------------------------

--- a/libs/serialization/CMakeLists.txt
+++ b/libs/serialization/CMakeLists.txt
@@ -1,5 +1,16 @@
-# extra dependencies required by unit tests in this module:
-set_property(GLOBAL PROPERTY mrpt_serialization_UNIT_TEST_EXTRA_DEPS mrpt-io)
+# Extra dependencies required by unit tests in this module:
+# Include jsoncpp only if present (optional)
+if (CMAKE_MRPT_HAS_JSONCPP)
+	if(TARGET "jsoncpp_lib")
+		set(tst_json_dep "jsoncpp_lib")
+	else()
+		set(tst_json_dep "jsoncpp_lib_static")
+	endif()
+else()
+	set(tst_json_dep "")
+endif()
+# define those deps:
+set_property(GLOBAL PROPERTY mrpt_serialization_UNIT_TEST_EXTRA_DEPS mrpt-io mrpt-poses ${tst_json_dep})
 
 #---------------------------------------------
 # Macro declared in "DeclareMRPTLib.cmake":
@@ -12,5 +23,5 @@ define_mrpt_lib(
 	)
 
 IF(BUILD_mrpt-serialization)
-
+	target_link_libraries(mrpt-serialization PRIVATE ${tst_json_dep})
 ENDIF( )

--- a/libs/serialization/include/mrpt/serialization/CSchemeArchive.h
+++ b/libs/serialization/include/mrpt/serialization/CSchemeArchive.h
@@ -1,0 +1,164 @@
+/* +------------------------------------------------------------------------+
+   |                     Mobile Robot Programming Toolkit (MRPT)            |
+   |                          http://www.mrpt.org/                          |
+   |                                                                        |
+   | Copyright (c) 2005-2018, Individual contributors, see AUTHORS file     |
+   | See: http://www.mrpt.org/Authors - All rights reserved.                |
+   | Released under BSD License. See details in http://www.mrpt.org/License |
+   +------------------------------------------------------------------------+ */
+#pragma once
+
+#include <mrpt/serialization/CSerializable.h>
+#include <mrpt/serialization/CSchemeArchiveBase.h>
+#include <string>
+#include <memory>
+#include <optional>
+#include <sstream>
+
+namespace mrpt::serialization
+{
+/** Base template class for schema-capable "archives", e.g. JSON, YAML,
+ * from which to (de)serialize objects.
+ *
+ * See \ref mrpt_serialization_grp for examples of use.
+ * \ingroup mrpt_serialization_grp
+ * \note Original version by https://github.com/rachit173 for GSoC 2018.
+ */
+template <typename SCHEME_CAPABLE>
+class CSchemeArchive : public mrpt::serialization::CSchemeArchiveBase_impl
+{
+	std::optional<SCHEME_CAPABLE> m_own_val;
+
+   public:
+	/** Ctor that creates an own SCHEME_CAPABLE object. */
+	CSchemeArchive() : m_own_val{SCHEME_CAPABLE()}, m_val{m_own_val.value()} {}
+	/** Ctor that uses user-providen SCHEME_CAPABLE object. */
+	CSchemeArchive(SCHEME_CAPABLE& val) : m_val(val) {}
+	// Virtual assignment operators
+	virtual mrpt::serialization::CSchemeArchiveBase& operator=(
+		const int32_t val) override
+	{
+		m_val = val;
+		return *m_parent;
+	}
+	virtual mrpt::serialization::CSchemeArchiveBase& operator=(
+		const uint32_t val) override
+	{
+		m_val = val;
+		return *m_parent;
+	}
+	virtual mrpt::serialization::CSchemeArchiveBase& operator=(
+		const int64_t val) override
+	{
+		m_val = typename SCHEME_CAPABLE::Int64(val);
+		return *m_parent;
+	}
+	virtual mrpt::serialization::CSchemeArchiveBase& operator=(
+		const uint64_t val) override
+	{
+		m_val = typename SCHEME_CAPABLE::UInt64(val);
+		return *m_parent;
+	}
+	virtual mrpt::serialization::CSchemeArchiveBase& operator=(
+		const float val) override
+	{
+		m_val = val;
+		return *m_parent;
+	}
+	virtual mrpt::serialization::CSchemeArchiveBase& operator=(
+		const double val) override
+	{
+		m_val = val;
+		return *m_parent;
+	}
+	virtual mrpt::serialization::CSchemeArchiveBase& operator=(
+		const std::nullptr_t val) override
+	{
+		m_val = val;
+		return *m_parent;
+	}
+	virtual mrpt::serialization::CSchemeArchiveBase& operator=(
+		const std::string val) override
+	{
+		m_val = val;
+		return *m_parent;
+	}
+	virtual mrpt::serialization::CSchemeArchiveBase& operator=(
+		const bool val) override
+	{
+		m_val = val;
+		return *m_parent;
+	}
+
+	virtual explicit operator int32_t() const override { return m_val.asInt(); }
+	virtual explicit operator uint32_t() const override
+	{
+		return m_val.asUInt();
+	}
+	virtual explicit operator int64_t() const override
+	{
+		return m_val.asInt64();
+	}
+	virtual explicit operator uint64_t() const override
+	{
+		return m_val.asUInt64();
+	}
+	virtual explicit operator float() const override { return m_val.asFloat(); }
+	virtual explicit operator double() const override
+	{
+		return m_val.asDouble();
+	}
+	virtual explicit operator bool() const override { return m_val.asBool(); }
+	virtual explicit operator std::string() const override
+	{
+		return m_val.asString();
+	}
+
+	virtual mrpt::serialization::CSchemeArchiveBase& operator=(
+		const mrpt::serialization::CSerializable& obj) override
+	{
+		ReadObject(*m_parent, obj);
+		return *m_parent;
+	}
+	virtual void readTo(mrpt::serialization::CSerializable& obj) override
+	{
+		WriteObject(*m_parent, obj);
+		return;
+	}
+
+	virtual mrpt::serialization::CSchemeArchiveBase operator[](
+		size_t idx) override
+	{
+		return mrpt::serialization::CSchemeArchiveBase(
+			std::make_unique<CSchemeArchive<SCHEME_CAPABLE>>(m_val[(int)idx]));
+	}
+	virtual mrpt::serialization::CSchemeArchiveBase operator[](
+		std::string str) override
+	{
+		return mrpt::serialization::CSchemeArchiveBase(
+			std::make_unique<CSchemeArchive<SCHEME_CAPABLE>>(
+				m_val[std::string(str)]));
+	}
+
+	virtual std::ostream& writeToStream(std::ostream& out) const override
+	{
+		out << m_val;
+		return out;
+	}
+	virtual std::istream& readFromStream(std::istream& in) override
+	{
+		in >> m_val;
+		return in;
+	}
+
+   private:
+	SCHEME_CAPABLE& m_val;
+};
+
+/** Returns an archive for reading/writing in JSON format.
+ * This feature requires compiling MRPT with jsoncpp support.
+ * See \ref mrpt_serialization_grp for examples of use.
+ * \ingroup mrpt_serialization_grp */
+CSchemeArchiveBase archiveJSON();
+
+}  // namespace mrpt::serialization

--- a/libs/serialization/include/mrpt/serialization/CSchemeArchiveBase.h
+++ b/libs/serialization/include/mrpt/serialization/CSchemeArchiveBase.h
@@ -18,168 +18,163 @@
 
 namespace mrpt::serialization
 {
-/** Pure virtual class carrying the implementation 
+/** Pure virtual class carrying the implementation
  * of CSchemeArchiveBase as per the PIMPL idiom.
+ * \ingroup mrpt_serialization_grp
  */
 class CSchemeArchiveBase_impl
 {
-  public:
-    virtual CSchemeArchiveBase &operator=(const int32_t) = 0;
-    virtual CSchemeArchiveBase &operator=(const uint32_t) = 0;
-    virtual CSchemeArchiveBase &operator=(const int64_t) = 0;
-    virtual CSchemeArchiveBase &operator=(const uint64_t) = 0;
-    virtual CSchemeArchiveBase &operator=(const float) = 0;
-    virtual CSchemeArchiveBase &operator=(const double) = 0;
-    virtual CSchemeArchiveBase &operator=(const std::nullptr_t) = 0;
-    virtual CSchemeArchiveBase &operator=(const std::string) = 0;
-    virtual CSchemeArchiveBase &operator=(bool) = 0;
+   public:
+	virtual CSchemeArchiveBase& operator=(const int32_t) = 0;
+	virtual CSchemeArchiveBase& operator=(const uint32_t) = 0;
+	virtual CSchemeArchiveBase& operator=(const int64_t) = 0;
+	virtual CSchemeArchiveBase& operator=(const uint64_t) = 0;
+	virtual CSchemeArchiveBase& operator=(const float) = 0;
+	virtual CSchemeArchiveBase& operator=(const double) = 0;
+	virtual CSchemeArchiveBase& operator=(const std::nullptr_t) = 0;
+	virtual CSchemeArchiveBase& operator=(const std::string) = 0;
+	virtual CSchemeArchiveBase& operator=(bool) = 0;
 
-    //Type conversion methods
-    virtual explicit operator int32_t() const = 0;
-    virtual explicit operator uint32_t() const = 0;
-    virtual explicit operator int64_t() const = 0;
-    virtual explicit operator uint64_t() const = 0;    
-    virtual explicit operator float() const = 0;
-    virtual explicit operator double() const = 0;
-    virtual explicit operator bool() const = 0;
-    virtual explicit operator std::string() const = 0;
-    virtual void asSerializableObject(CSerializable& obj) = 0;
-    //Converts CSerializable Objects to CSchemeArchiveBase based object 
-    virtual CSchemeArchiveBase &operator=(mrpt::serialization::CSerializable&) = 0;
-    
-    //List accessor
-    virtual CSchemeArchiveBase operator[](size_t) = 0;
-    //Dict accessor
-    virtual CSchemeArchiveBase operator[](std::string) = 0;
-  public:// should make it private by virtue of friend class
-    void setParent(CSchemeArchiveBase* parent)
-    {
-        m_parent = parent;
-    }
-  protected:
-    CSchemeArchiveBase* m_parent;
-    void ReadObject(CSchemeArchiveBase& out, CSerializable& obj);
-    void WriteObject(CSchemeArchiveBase& out, CSerializable& obj);
+	// Type conversion methods
+	virtual explicit operator int32_t() const = 0;
+	virtual explicit operator uint32_t() const = 0;
+	virtual explicit operator int64_t() const = 0;
+	virtual explicit operator uint64_t() const = 0;
+	virtual explicit operator float() const = 0;
+	virtual explicit operator double() const = 0;
+	virtual explicit operator bool() const = 0;
+	virtual explicit operator std::string() const = 0;
+	/** Reads object from the archive */
+	virtual void readTo(CSerializable& obj) = 0;
+	/** Writes object to archive, with synxtax `out["name"] = obj;`*/
+	virtual CSchemeArchiveBase& operator=(
+		const mrpt::serialization::CSerializable&) = 0;
+
+	/** Writes the scheme to a plain-text output */
+	virtual std::ostream& writeToStream(std::ostream& out) const = 0;
+	/** Reads the scheme from a plain-text input */
+	virtual std::istream& readFromStream(std::istream& in) = 0;
+
+	// List accessor
+	virtual CSchemeArchiveBase operator[](size_t) = 0;
+	// Dict accessor
+	virtual CSchemeArchiveBase operator[](std::string) = 0;
+
+   public:  // should make it private by virtue of friend class
+	void setParent(CSchemeArchiveBase* parent) { m_parent = parent; }
+
+   protected:
+	CSchemeArchiveBase* m_parent;
+	void ReadObject(CSchemeArchiveBase& out, const CSerializable& obj);
+	void WriteObject(CSchemeArchiveBase& in, CSerializable& obj);
 };
-/** Virtual base class for "schematic archives":classes abstracting json,(or xml) 
- * 
- * 
- * 
+/** Virtual base class for "schematic archives" (JSON, XML,...)
+ * \ingroup mrpt_serialization_grp
  */
 class CSchemeArchiveBase
 {
-  public:
-    friend class CSchemeArchiveBase_impl;
-    using Ptr = std::shared_ptr<CSchemeArchiveBase>;
-    /** @name Serialization API for schema based "archives"
-     * @{ */
-    //Constructor 
-    CSchemeArchiveBase(std::unique_ptr<CSchemeArchiveBase_impl> ptr) : pimpl(std::move(ptr)) 
-    {
-        pimpl->setParent(this);
-    }
-    CSchemeArchiveBase &operator=(const int32_t val)
-    {
-        return (*pimpl).operator=(val);
-    }
-    CSchemeArchiveBase &operator=(const uint32_t val)
-    {
-        return (*pimpl).operator=(val);
-    }
-    CSchemeArchiveBase &operator=(const int64_t val)
-    {
-        return (*pimpl).operator=(val);
-    }
-    CSchemeArchiveBase &operator=(const uint64_t val)
-    {
-        return (*pimpl).operator=(val);
-    }
-    CSchemeArchiveBase &operator=(const float val)
-    {
-        return (*pimpl).operator=(val);
-    }
-    CSchemeArchiveBase &operator=(const double val)
-    {
-        return (*pimpl).operator=(val);
-    }
-    CSchemeArchiveBase &operator=(const std::nullptr_t val)
-    {
-        return (*pimpl).operator=(val);
-    }
-    CSchemeArchiveBase &operator=(const std::string val)
-    {
-        return (*pimpl).operator=(val);
-    }
-    CSchemeArchiveBase &operator=(bool val)
-    {
-        return (*pimpl).operator=(val);
-    }
+   public:
+	friend class CSchemeArchiveBase_impl;
+	using Ptr = std::shared_ptr<CSchemeArchiveBase>;
+	/** @name Serialization API for schema based "archives"
+	 * @{ */
+	// Constructor
+	CSchemeArchiveBase(std::unique_ptr<CSchemeArchiveBase_impl> ptr)
+		: pimpl(std::move(ptr))
+	{
+		pimpl->setParent(this);
+	}
+	CSchemeArchiveBase& operator=(const int32_t val)
+	{
+		return (*pimpl).operator=(val);
+	}
+	CSchemeArchiveBase& operator=(const uint32_t val)
+	{
+		return (*pimpl).operator=(val);
+	}
+	CSchemeArchiveBase& operator=(const int64_t val)
+	{
+		return (*pimpl).operator=(val);
+	}
+	CSchemeArchiveBase& operator=(const uint64_t val)
+	{
+		return (*pimpl).operator=(val);
+	}
+	CSchemeArchiveBase& operator=(const float val)
+	{
+		return (*pimpl).operator=(val);
+	}
+	CSchemeArchiveBase& operator=(const double val)
+	{
+		return (*pimpl).operator=(val);
+	}
+	CSchemeArchiveBase& operator=(const std::nullptr_t val)
+	{
+		return (*pimpl).operator=(val);
+	}
+	CSchemeArchiveBase& operator=(const std::string val)
+	{
+		return (*pimpl).operator=(val);
+	}
+	CSchemeArchiveBase& operator=(bool val) { return (*pimpl).operator=(val); }
 
-    //Type conversion methods
-    explicit operator int32_t() const
-    {
-        return static_cast<int32_t>(*pimpl);
-    }
-    explicit operator uint32_t() const
-    {
-        return static_cast<uint32_t>(*pimpl);
-    }
-    explicit operator int64_t() const
-    {
-        return static_cast<int64_t>(*pimpl);
-    }
-    explicit operator uint64_t() const
-    {
-        return static_cast<uint64_t>(*pimpl);
-    }    
-    explicit operator float() const
-    {
-        return static_cast<float>(*pimpl);
-    }
-    explicit operator double() const
-    {
-        return static_cast<double>(*pimpl);
-    }
-    explicit operator bool() const
-    {
-        return static_cast<bool>(*pimpl);
-    }
-    explicit operator std::string() const
-    {
-        return static_cast<std::string>(*pimpl);
-    }
-    void asSerializableObject(CSerializable& obj)
-    {
-        pimpl->asSerializableObject(obj);
-    }
-    //Converts CSerializable Objects to CSchemeArchiveBase based object 
-    CSchemeArchiveBase &operator=(mrpt::serialization::CSerializable& obj)
-    {
-        return (*pimpl).operator=(obj);
-    }
-    //List accessor
-    CSchemeArchiveBase operator[](size_t val)
-    {
-        return (*pimpl).operator[](val);
-    }
-    //Dict accessor
-    CSchemeArchiveBase operator[](std::string val)
-    {
-        return (*pimpl).operator[](val);
-    }
-    // class CSchemeArchiveBase_impl;
-  protected:
-    //Read Object
-    static void ReadObject(CSchemeArchiveBase& out, CSerializable& obj)
-    {
-        obj.serializeTo(out);
-    }
-    //Write Object
-    static void WriteObject(CSchemeArchiveBase& in, CSerializable& obj)
-    {
-        obj.serializeFrom(in);
-    }
-  private:
-    std::unique_ptr<CSchemeArchiveBase_impl> pimpl;
+	// Type conversion methods
+	explicit operator int32_t() const { return static_cast<int32_t>(*pimpl); }
+	explicit operator uint32_t() const { return static_cast<uint32_t>(*pimpl); }
+	explicit operator int64_t() const { return static_cast<int64_t>(*pimpl); }
+	explicit operator uint64_t() const { return static_cast<uint64_t>(*pimpl); }
+	explicit operator float() const { return static_cast<float>(*pimpl); }
+	explicit operator double() const { return static_cast<double>(*pimpl); }
+	explicit operator bool() const { return static_cast<bool>(*pimpl); }
+	explicit operator std::string() const
+	{
+		return static_cast<std::string>(*pimpl);
+	}
+	void readTo(CSerializable& obj) { pimpl->readTo(obj); }
+	CSchemeArchiveBase& operator=(const mrpt::serialization::CSerializable& obj)
+	{
+		return (*pimpl).operator=(obj);
+	}
+	// List accessor
+	CSchemeArchiveBase operator[](size_t val)
+	{
+		return (*pimpl).operator[](val);
+	}
+	// Dict accessor
+	CSchemeArchiveBase operator[](std::string val)
+	{
+		return (*pimpl).operator[](val);
+	}
+
+	// class CSchemeArchiveBase_impl;
+   protected:
+	// Read Object
+	static void ReadObject(CSchemeArchiveBase& out, const CSerializable& obj)
+	{
+		obj.serializeTo(out);
+	}
+	// Write Object
+	static void WriteObject(CSchemeArchiveBase& in, CSerializable& obj)
+	{
+		obj.serializeFrom(in);
+	}
+
+   private:
+	std::unique_ptr<CSchemeArchiveBase_impl> pimpl;
+	friend std::ostream& operator<<(
+		std::ostream& out, const CSchemeArchiveBase& a);
+	friend std::istream& operator>>(std::istream& in, CSchemeArchiveBase& a);
 };
+
+inline std::ostream& operator<<(std::ostream& out, const CSchemeArchiveBase& a)
+{
+	a.pimpl->writeToStream(out);
+	return out;
 }
+inline std::istream& operator>>(std::istream& in, CSchemeArchiveBase& a)
+{
+	a.pimpl->readFromStream(in);
+	return in;
+}
+
+}  // namespace mrpt::serialization

--- a/libs/serialization/include/mrpt/serialization/CSchemeArchiveBase.h
+++ b/libs/serialization/include/mrpt/serialization/CSchemeArchiveBase.h
@@ -1,0 +1,185 @@
+/* +------------------------------------------------------------------------+
+   |                     Mobile Robot Programming Toolkit (MRPT)            |
+   |                          http://www.mrpt.org/                          |
+   |                                                                        |
+   | Copyright (c) 2005-2018, Individual contributors, see AUTHORS file     |
+   | See: http://www.mrpt.org/Authors - All rights reserved.                |
+   | Released under BSD License. See details in http://www.mrpt.org/License |
+   +------------------------------------------------------------------------+ */
+#pragma once
+
+#include <mrpt/serialization/CSerializable.h>
+#include <cstdint>
+#include <vector>
+#include <string>
+#include <stdexcept>
+#include <string_view>
+#include <memory>
+
+namespace mrpt::serialization
+{
+/** Pure virtual class carrying the implementation 
+ * of CSchemeArchiveBase as per the PIMPL idiom.
+ */
+class CSchemeArchiveBase_impl
+{
+  public:
+    virtual CSchemeArchiveBase &operator=(const int32_t) = 0;
+    virtual CSchemeArchiveBase &operator=(const uint32_t) = 0;
+    virtual CSchemeArchiveBase &operator=(const int64_t) = 0;
+    virtual CSchemeArchiveBase &operator=(const uint64_t) = 0;
+    virtual CSchemeArchiveBase &operator=(const float) = 0;
+    virtual CSchemeArchiveBase &operator=(const double) = 0;
+    virtual CSchemeArchiveBase &operator=(const std::nullptr_t) = 0;
+    virtual CSchemeArchiveBase &operator=(const std::string) = 0;
+    virtual CSchemeArchiveBase &operator=(bool) = 0;
+
+    //Type conversion methods
+    virtual explicit operator int32_t() const = 0;
+    virtual explicit operator uint32_t() const = 0;
+    virtual explicit operator int64_t() const = 0;
+    virtual explicit operator uint64_t() const = 0;    
+    virtual explicit operator float() const = 0;
+    virtual explicit operator double() const = 0;
+    virtual explicit operator bool() const = 0;
+    virtual explicit operator std::string() const = 0;
+    virtual void asSerializableObject(CSerializable& obj) = 0;
+    //Converts CSerializable Objects to CSchemeArchiveBase based object 
+    virtual CSchemeArchiveBase &operator=(mrpt::serialization::CSerializable&) = 0;
+    
+    //List accessor
+    virtual CSchemeArchiveBase operator[](size_t) = 0;
+    //Dict accessor
+    virtual CSchemeArchiveBase operator[](std::string) = 0;
+  public:// should make it private by virtue of friend class
+    void setParent(CSchemeArchiveBase* parent)
+    {
+        m_parent = parent;
+    }
+  protected:
+    CSchemeArchiveBase* m_parent;
+    void ReadObject(CSchemeArchiveBase& out, CSerializable& obj);
+    void WriteObject(CSchemeArchiveBase& out, CSerializable& obj);
+};
+/** Virtual base class for "schematic archives":classes abstracting json,(or xml) 
+ * 
+ * 
+ * 
+ */
+class CSchemeArchiveBase
+{
+  public:
+    friend class CSchemeArchiveBase_impl;
+    using Ptr = std::shared_ptr<CSchemeArchiveBase>;
+    /** @name Serialization API for schema based "archives"
+     * @{ */
+    //Constructor 
+    CSchemeArchiveBase(std::unique_ptr<CSchemeArchiveBase_impl> ptr) : pimpl(std::move(ptr)) 
+    {
+        pimpl->setParent(this);
+    }
+    CSchemeArchiveBase &operator=(const int32_t val)
+    {
+        return (*pimpl).operator=(val);
+    }
+    CSchemeArchiveBase &operator=(const uint32_t val)
+    {
+        return (*pimpl).operator=(val);
+    }
+    CSchemeArchiveBase &operator=(const int64_t val)
+    {
+        return (*pimpl).operator=(val);
+    }
+    CSchemeArchiveBase &operator=(const uint64_t val)
+    {
+        return (*pimpl).operator=(val);
+    }
+    CSchemeArchiveBase &operator=(const float val)
+    {
+        return (*pimpl).operator=(val);
+    }
+    CSchemeArchiveBase &operator=(const double val)
+    {
+        return (*pimpl).operator=(val);
+    }
+    CSchemeArchiveBase &operator=(const std::nullptr_t val)
+    {
+        return (*pimpl).operator=(val);
+    }
+    CSchemeArchiveBase &operator=(const std::string val)
+    {
+        return (*pimpl).operator=(val);
+    }
+    CSchemeArchiveBase &operator=(bool val)
+    {
+        return (*pimpl).operator=(val);
+    }
+
+    //Type conversion methods
+    explicit operator int32_t() const
+    {
+        return static_cast<int32_t>(*pimpl);
+    }
+    explicit operator uint32_t() const
+    {
+        return static_cast<uint32_t>(*pimpl);
+    }
+    explicit operator int64_t() const
+    {
+        return static_cast<int64_t>(*pimpl);
+    }
+    explicit operator uint64_t() const
+    {
+        return static_cast<uint64_t>(*pimpl);
+    }    
+    explicit operator float() const
+    {
+        return static_cast<float>(*pimpl);
+    }
+    explicit operator double() const
+    {
+        return static_cast<double>(*pimpl);
+    }
+    explicit operator bool() const
+    {
+        return static_cast<bool>(*pimpl);
+    }
+    explicit operator std::string() const
+    {
+        return static_cast<std::string>(*pimpl);
+    }
+    void asSerializableObject(CSerializable& obj)
+    {
+        pimpl->asSerializableObject(obj);
+    }
+    //Converts CSerializable Objects to CSchemeArchiveBase based object 
+    CSchemeArchiveBase &operator=(mrpt::serialization::CSerializable& obj)
+    {
+        return (*pimpl).operator=(obj);
+    }
+    //List accessor
+    CSchemeArchiveBase operator[](size_t val)
+    {
+        return (*pimpl).operator[](val);
+    }
+    //Dict accessor
+    CSchemeArchiveBase operator[](std::string val)
+    {
+        return (*pimpl).operator[](val);
+    }
+    // class CSchemeArchiveBase_impl;
+  protected:
+    //Read Object
+    static void ReadObject(CSchemeArchiveBase& out, CSerializable& obj)
+    {
+        obj.serializeTo(out);
+    }
+    //Write Object
+    static void WriteObject(CSchemeArchiveBase& in, CSerializable& obj)
+    {
+        obj.serializeFrom(in);
+    }
+  private:
+    std::unique_ptr<CSchemeArchiveBase_impl> pimpl;
+};
+}

--- a/libs/serialization/include/mrpt/serialization/CSerializable.h
+++ b/libs/serialization/include/mrpt/serialization/CSerializable.h
@@ -19,6 +19,14 @@ using mxArray = struct mxArray_tag;
 
 namespace mrpt::serialization
 {
+
+// /** Used in mrpt::serialization::CSerializable */
+// std::string notImplementedErrorString(const std::string& class_name)
+// {
+// 	return class_name + 
+// 			" : class does not support schema based serialization";
+// }
+
 /** The virtual base class which provides a unified interface for all persistent
  *objects in MRPT.
  *  Many important properties of this class are inherited from
@@ -30,6 +38,7 @@ namespace mrpt::serialization
 class CSerializable : public mrpt::rtti::CObject
 {
 	friend class CArchive;
+	friend class CSchemeArchiveBase;
 
 	// This must be added to any CObject derived class:
 	DEFINE_VIRTUAL_MRPT_OBJECT(CSerializable)
@@ -56,6 +65,24 @@ class CSerializable : public mrpt::rtti::CObject
 	 *data. \exception std::exception On any I/O error
 	 */
 	virtual void serializeFrom(CArchive& in, uint8_t serial_version) = 0;
+	/** Virtual method for writing (serializing) to an abstract
+	 *  schema based archive. 
+	 */
+	virtual void serializeTo(CSchemeArchiveBase& out) const
+	{
+		const std::string err = std::string(this->GetRuntimeClass()->className) +
+			std::string(" : class does not support schema based serialization");
+		THROW_EXCEPTION(err);
+	}
+	/** Virtual method for reading (deserializing) from an abstract
+	 *  schema based archive.
+	 */
+	virtual void serializeFrom(CSchemeArchiveBase& in)
+	{
+		const std::string err = std::string(this->GetRuntimeClass()->className) +
+			std::string(" : class does not support schema based serialization");
+		THROW_EXCEPTION(err);
+	}
 	/** @} */
 
    public:
@@ -94,6 +121,15 @@ void OctetVectorToObject(
 	const std::vector<uint8_t>& in_data, CSerializable::Ptr& obj);
 
 /** @} */
+/** This declaration must be inserted in all CSerializable classes definition,
+ * within the class declaration. */
+#define DEFINE_SCHEMA_SERIALIZABLE()                                              \
+   protected:                                                                     \
+	/*! @name CSerializable virtual methods for schema based archives*/           \
+	/*! @{ */                                                                	  \
+	void serializeTo(mrpt::serialization::CSchemeArchiveBase& out) const;		  \
+	void serializeFrom(mrpt::serialization::CSchemeArchiveBase& in);              \
+/*! @} */																		  \
 
 /** This declaration must be inserted in all CSerializable classes definition,
  * within the class declaration. */

--- a/libs/serialization/include/mrpt/serialization/serialization_frwds.h
+++ b/libs/serialization/include/mrpt/serialization/serialization_frwds.h
@@ -11,5 +11,6 @@
 namespace mrpt::serialization
 {
 class CArchive;
+class CSchemeArchiveBase;
 }
 

--- a/libs/serialization/src/CSchemeArchive.cpp
+++ b/libs/serialization/src/CSchemeArchive.cpp
@@ -1,0 +1,31 @@
+/* +------------------------------------------------------------------------+
+   |                     Mobile Robot Programming Toolkit (MRPT)            |
+   |                          http://www.mrpt.org/                          |
+   |                                                                        |
+   | Copyright (c) 2005-2018, Individual contributors, see AUTHORS file     |
+   | See: http://www.mrpt.org/Authors - All rights reserved.                |
+   | Released under BSD License. See details in http://www.mrpt.org/License |
+   +------------------------------------------------------------------------+ */
+
+#include "serialization-precomp.h"  // Precompiled headers
+
+#include <mrpt/serialization/CSchemeArchive.h>
+#include <mrpt/core/exceptions.h>
+
+// Check if we have jsoncpp to enable those tests:
+#include <mrpt/config.h>
+#if MRPT_HAS_JSONCPP
+#include <json/json.h>
+#endif
+
+using namespace mrpt::serialization;
+
+CSchemeArchiveBase mrpt::serialization::archiveJSON()
+{
+#if MRPT_HAS_JSONCPP
+	return mrpt::serialization::CSchemeArchiveBase(
+		std::make_unique<CSchemeArchive<Json::Value>>());
+#else
+	THROW_EXCEPTION("archiveJSON() requires building MRPT against jsoncpp");
+#endif
+}

--- a/libs/serialization/src/CSchemeArchiveBase.cpp
+++ b/libs/serialization/src/CSchemeArchiveBase.cpp
@@ -5,11 +5,13 @@
 #include <mrpt/serialization/CSchemeArchiveBase.h>
 
 using namespace mrpt::serialization;
-void CSchemeArchiveBase_impl::ReadObject(CSchemeArchiveBase& out, CSerializable& obj)
+void CSchemeArchiveBase_impl::ReadObject(
+	CSchemeArchiveBase& out, const CSerializable& obj)
 {
-    CSchemeArchiveBase::ReadObject(out, obj);
+	CSchemeArchiveBase::ReadObject(out, obj);
 }
-void CSchemeArchiveBase_impl::WriteObject(CSchemeArchiveBase& in, CSerializable& obj)
+void CSchemeArchiveBase_impl::WriteObject(
+	CSchemeArchiveBase& in, CSerializable& obj)
 {
-    CSchemeArchiveBase::WriteObject(in, obj);
+	CSchemeArchiveBase::WriteObject(in, obj);
 }

--- a/libs/serialization/src/CSchemeArchiveBase.cpp
+++ b/libs/serialization/src/CSchemeArchiveBase.cpp
@@ -1,0 +1,15 @@
+#include "serialization-precomp.h"  // Precompiled headers
+
+#include <mrpt/core/exceptions.h>
+#include <mrpt/serialization/CSerializable.h>
+#include <mrpt/serialization/CSchemeArchiveBase.h>
+
+using namespace mrpt::serialization;
+void CSchemeArchiveBase_impl::ReadObject(CSchemeArchiveBase& out, CSerializable& obj)
+{
+    CSchemeArchiveBase::ReadObject(out, obj);
+}
+void CSchemeArchiveBase_impl::WriteObject(CSchemeArchiveBase& in, CSerializable& obj)
+{
+    CSchemeArchiveBase::WriteObject(in, obj);
+}

--- a/libs/serialization/src/CSchemeArchive_unittest.cpp
+++ b/libs/serialization/src/CSchemeArchive_unittest.cpp
@@ -1,0 +1,161 @@
+// /* +------------------------------------------------------------------------+
+//    |                     Mobile Robot Programming Toolkit (MRPT)            |
+//    |                          http://www.mrpt.org/                          |
+//    |                                                                        |
+//    | Copyright (c) 2005-2018, Individual contributors, see AUTHORS file     |
+//    | See: http://www.mrpt.org/Authors - All rights reserved.                |
+//    | Released under BSD License. See details in http://www.mrpt.org/License |
+//    +------------------------------------------------------------------------+ */
+
+#include <mrpt/serialization/CSerializable.h>
+#include <mrpt/serialization/CArchive.h>
+#include <mrpt/serialization/CSchemeArchiveBase.h>
+#include <mrpt/io/CMemoryStream.h>
+#include <gtest/gtest.h>
+
+using namespace mrpt::serialization;
+namespace TestNS
+{   
+    template <typename SCHEME_CAPABLE>
+    class MockSchemeArchive : public CSchemeArchiveBase_impl
+    {
+		public:
+        MockSchemeArchive(SCHEME_CAPABLE& val):m_val(val) {}
+        //Virtual assignment operators
+        virtual mrpt::serialization::CSchemeArchiveBase &operator=(const int32_t val) override
+        {
+            m_val = val;
+            return *m_parent;
+        }
+        virtual mrpt::serialization::CSchemeArchiveBase &operator=(const uint32_t val) override
+        {
+            m_val = val;
+            return *m_parent;
+        }
+        virtual mrpt::serialization::CSchemeArchiveBase &operator=(const int64_t val) override
+        {
+            m_val = val;
+            return *m_parent;
+        }
+        virtual mrpt::serialization::CSchemeArchiveBase &operator=(const uint64_t val) override
+        {
+            m_val = val;
+            return *m_parent;
+        }
+        virtual mrpt::serialization::CSchemeArchiveBase &operator=(const float val) override
+        {
+            m_val = val;
+            return *m_parent;
+        }
+        virtual mrpt::serialization::CSchemeArchiveBase &operator=(const double val) override
+        {
+            m_val = val;
+            return *m_parent;
+        }
+        virtual mrpt::serialization::CSchemeArchiveBase &operator=(const std::nullptr_t val) override
+        {
+            // m_val = val;
+            return *m_parent;
+        }
+        virtual mrpt::serialization::CSchemeArchiveBase &operator=(const std::string val) override
+        {
+            // m_val = val;
+            return *m_parent;
+        }
+        virtual mrpt::serialization::CSchemeArchiveBase &operator=(const bool val) override
+        {
+            m_val = val;
+            return *m_parent;
+        }
+
+        virtual explicit operator int32_t() const override
+        {
+            return 1;
+        }
+        virtual explicit operator uint32_t() const override
+        {
+            return 1;
+        }
+        virtual explicit operator int64_t() const override
+        {
+            return 1;
+        }
+        virtual explicit operator uint64_t() const override
+        {
+            return 1;
+        }
+        virtual explicit operator float() const override
+        {
+            return 1.0;
+        }
+        virtual explicit operator double() const override
+        {
+            return 1.0;
+        }
+        virtual explicit operator bool() const override
+        {
+            return 1;
+        }
+        virtual explicit operator std::string() const override
+        {
+            return "str";
+        }
+
+        virtual mrpt::serialization::CSchemeArchiveBase &operator=(mrpt::serialization::CSerializable& obj) override
+        {
+            ReadObject(*m_parent, obj);
+            return *m_parent;
+        }
+        virtual void asSerializableObject(mrpt::serialization::CSerializable& obj) override
+        {
+            WriteObject(*m_parent, obj);
+            return;
+        }
+
+        virtual CSchemeArchiveBase operator[](size_t idx) override
+        {
+            return CSchemeArchiveBase(std::make_unique<MockSchemeArchive<SCHEME_CAPABLE>>(m_val));
+        }
+        virtual CSchemeArchiveBase operator[](std::string str) override
+        {  
+            return CSchemeArchiveBase(std::make_unique<MockSchemeArchive<SCHEME_CAPABLE>>(m_val));
+        }
+
+        private:
+            SCHEME_CAPABLE& m_val;
+    };
+    class Bar : public mrpt::serialization::CSerializable
+    {
+        DEFINE_SERIALIZABLE(Bar)
+        DEFINE_SCHEMA_SERIALIZABLE()
+        public:
+            int32_t value;
+    };
+}
+IMPLEMENTS_SERIALIZABLE(Bar, CSerializable, TestNS)
+
+uint8_t TestNS::Bar::serializeGetVersion() const { return 0; }
+void TestNS::Bar::serializeTo(CArchive& out) const { out << value; }
+void TestNS::Bar::serializeFrom(CArchive& in, uint8_t serial_version)
+{
+	in >> value;
+}
+void TestNS::Bar::serializeFrom(CSchemeArchiveBase& in)
+{
+    value = static_cast<int32_t>(in);
+}
+void TestNS::Bar::serializeTo(CSchemeArchiveBase& out) const
+{
+    out = value;
+}
+
+
+
+TEST(SchemaSerialization, CustomClassSchemeSerialize)
+{
+    int t;
+    CSchemeArchiveBase wrapper(std::make_unique<TestNS::MockSchemeArchive<int>>(t));
+    wrapper["foo"][1] = 1;
+    wrapper["bar"][3] = 3;
+    EXPECT_EQ(1,1);    
+}

--- a/libs/serialization/src/CSchemeArchive_unittest.cpp
+++ b/libs/serialization/src/CSchemeArchive_unittest.cpp
@@ -1,161 +1,73 @@
-// /* +------------------------------------------------------------------------+
-//    |                     Mobile Robot Programming Toolkit (MRPT)            |
-//    |                          http://www.mrpt.org/                          |
-//    |                                                                        |
-//    | Copyright (c) 2005-2018, Individual contributors, see AUTHORS file     |
-//    | See: http://www.mrpt.org/Authors - All rights reserved.                |
-//    | Released under BSD License. See details in http://www.mrpt.org/License |
-//    +------------------------------------------------------------------------+ */
+/* +------------------------------------------------------------------------+
+   |                     Mobile Robot Programming Toolkit (MRPT)            |
+   |                          http://www.mrpt.org/                          |
+   |                                                                        |
+   | Copyright (c) 2005-2018, Individual contributors, see AUTHORS file     |
+   | See: http://www.mrpt.org/Authors - All rights reserved.                |
+   | Released under BSD License. See details in http://www.mrpt.org/License |
+   +------------------------------------------------------------------------+ */
 
-#include <mrpt/serialization/CSerializable.h>
 #include <mrpt/serialization/CArchive.h>
 #include <mrpt/serialization/CSchemeArchiveBase.h>
-#include <mrpt/io/CMemoryStream.h>
+#include <mrpt/serialization/CSchemeArchive.h>
+#include <mrpt/poses/CPose2D.h>
+#include <sstream>
 #include <gtest/gtest.h>
 
+// Check if we have jsoncpp to enable those tests:
+#include <mrpt/config.h>
+#if MRPT_HAS_JSONCPP
+#include <json/json.h>
+#endif
+
 using namespace mrpt::serialization;
-namespace TestNS
-{   
-    template <typename SCHEME_CAPABLE>
-    class MockSchemeArchive : public CSchemeArchiveBase_impl
-    {
-		public:
-        MockSchemeArchive(SCHEME_CAPABLE& val):m_val(val) {}
-        //Virtual assignment operators
-        virtual mrpt::serialization::CSchemeArchiveBase &operator=(const int32_t val) override
-        {
-            m_val = val;
-            return *m_parent;
-        }
-        virtual mrpt::serialization::CSchemeArchiveBase &operator=(const uint32_t val) override
-        {
-            m_val = val;
-            return *m_parent;
-        }
-        virtual mrpt::serialization::CSchemeArchiveBase &operator=(const int64_t val) override
-        {
-            m_val = val;
-            return *m_parent;
-        }
-        virtual mrpt::serialization::CSchemeArchiveBase &operator=(const uint64_t val) override
-        {
-            m_val = val;
-            return *m_parent;
-        }
-        virtual mrpt::serialization::CSchemeArchiveBase &operator=(const float val) override
-        {
-            m_val = val;
-            return *m_parent;
-        }
-        virtual mrpt::serialization::CSchemeArchiveBase &operator=(const double val) override
-        {
-            m_val = val;
-            return *m_parent;
-        }
-        virtual mrpt::serialization::CSchemeArchiveBase &operator=(const std::nullptr_t val) override
-        {
-            // m_val = val;
-            return *m_parent;
-        }
-        virtual mrpt::serialization::CSchemeArchiveBase &operator=(const std::string val) override
-        {
-            // m_val = val;
-            return *m_parent;
-        }
-        virtual mrpt::serialization::CSchemeArchiveBase &operator=(const bool val) override
-        {
-            m_val = val;
-            return *m_parent;
-        }
 
-        virtual explicit operator int32_t() const override
-        {
-            return 1;
-        }
-        virtual explicit operator uint32_t() const override
-        {
-            return 1;
-        }
-        virtual explicit operator int64_t() const override
-        {
-            return 1;
-        }
-        virtual explicit operator uint64_t() const override
-        {
-            return 1;
-        }
-        virtual explicit operator float() const override
-        {
-            return 1.0;
-        }
-        virtual explicit operator double() const override
-        {
-            return 1.0;
-        }
-        virtual explicit operator bool() const override
-        {
-            return 1;
-        }
-        virtual explicit operator std::string() const override
-        {
-            return "str";
-        }
-
-        virtual mrpt::serialization::CSchemeArchiveBase &operator=(mrpt::serialization::CSerializable& obj) override
-        {
-            ReadObject(*m_parent, obj);
-            return *m_parent;
-        }
-        virtual void asSerializableObject(mrpt::serialization::CSerializable& obj) override
-        {
-            WriteObject(*m_parent, obj);
-            return;
-        }
-
-        virtual CSchemeArchiveBase operator[](size_t idx) override
-        {
-            return CSchemeArchiveBase(std::make_unique<MockSchemeArchive<SCHEME_CAPABLE>>(m_val));
-        }
-        virtual CSchemeArchiveBase operator[](std::string str) override
-        {  
-            return CSchemeArchiveBase(std::make_unique<MockSchemeArchive<SCHEME_CAPABLE>>(m_val));
-        }
-
-        private:
-            SCHEME_CAPABLE& m_val;
-    };
-    class Bar : public mrpt::serialization::CSerializable
-    {
-        DEFINE_SERIALIZABLE(Bar)
-        DEFINE_SCHEMA_SERIALIZABLE()
-        public:
-            int32_t value;
-    };
-}
-IMPLEMENTS_SERIALIZABLE(Bar, CSerializable, TestNS)
-
-uint8_t TestNS::Bar::serializeGetVersion() const { return 0; }
-void TestNS::Bar::serializeTo(CArchive& out) const { out << value; }
-void TestNS::Bar::serializeFrom(CArchive& in, uint8_t serial_version)
+#if MRPT_HAS_JSONCPP
+TEST(SchemaSerialization, JSON_archive)
 {
-	in >> value;
-}
-void TestNS::Bar::serializeFrom(CSchemeArchiveBase& in)
-{
-    value = static_cast<int32_t>(in);
-}
-void TestNS::Bar::serializeTo(CSchemeArchiveBase& out) const
-{
-    out = value;
+	auto arch = archiveJSON();
+	mrpt::poses::CPose2D pt1{1.0, 2.0, 3.0}, pt2;
+	arch = pt1;
+	std::stringstream ss;
+	ss << arch;
+	auto pos = ss.str().find("\"datatype\" : \"CPose2D\"");
+	EXPECT_TRUE(pos != std::string::npos);
+
+	// test deserializing:
+	ss.seekg(0);  // rewind for reading
+	auto arch2 = archiveJSON();
+	// Load the plain text representation into the archive:
+	ss >> arch2;
+	// Parse the JSON data into an MRPT object:
+	arch2.readTo(pt2);
+
+	EXPECT_NEAR(pt1.x(), pt2.x(), 1e-6);
+	EXPECT_NEAR(pt1.y(), pt2.y(), 1e-6);
+	EXPECT_NEAR(pt1.phi(), pt2.phi(), 1e-6);
 }
 
-
-
-TEST(SchemaSerialization, CustomClassSchemeSerialize)
+TEST(SchemaSerialization, JSON_raw)
 {
-    int t;
-    CSchemeArchiveBase wrapper(std::make_unique<TestNS::MockSchemeArchive<int>>(t));
-    wrapper["foo"][1] = 1;
-    wrapper["bar"][3] = 3;
-    EXPECT_EQ(1,1);    
+	Json::Value val;
+	auto arch = mrpt::serialization::CSchemeArchiveBase(
+		std::make_unique<CSchemeArchive<Json::Value>>(val));
+	mrpt::poses::CPose2D pt1{1.0, 2.0, 3.0}, pt2;
+	arch = pt1;
+	std::stringstream ss;
+	ss << val;
+	auto pos = ss.str().find("\"datatype\" : \"CPose2D\"");
+	EXPECT_TRUE(pos != std::string::npos);
+
+	// test deserializing:
+	Json::Value val2;
+	ss.seekg(0);  // rewind for reading
+	ss >> val2;
+	auto arch2 = mrpt::serialization::CSchemeArchiveBase(
+		std::make_unique<CSchemeArchive<Json::Value>>(val2));
+	arch2.readTo(pt2);
+	EXPECT_NEAR(pt1.x(), pt2.x(), 1e-6);
+	EXPECT_NEAR(pt1.y(), pt2.y(), 1e-6);
+	EXPECT_NEAR(pt1.phi(), pt2.phi(), 1e-6);
 }
+
+#endif

--- a/packaging/debian/control.in
+++ b/packaging/debian/control.in
@@ -31,7 +31,8 @@ Build-Depends: debhelper (>= 10),
 	libassimp-dev,
 	qtbase5-dev,
 	liboctomap-dev,
-	libqt5opengl5-dev
+	libqt5opengl5-dev,
+	libjsoncpp-dev
 Standards-Version: 4.1.1
 Homepage: https://www.mrpt.org/
 

--- a/packaging/ubuntu-ppa/control.in
+++ b/packaging/ubuntu-ppa/control.in
@@ -32,6 +32,7 @@ Build-Depends: debhelper (>= 9),
 	liboctomap-dev | perl,
 	qtbase5-dev,
 	libqt5opengl5-dev,
+	libjsoncpp-dev,
 	g++-7
 Standards-Version: 4.0.0
 Homepage: https://www.mrpt.org/

--- a/parse-files/config.h.in
+++ b/parse-files/config.h.in
@@ -99,6 +99,8 @@ ${CMAKE_MRPT_BUILD_SHARED_LIB}
 /** VTK libs are available */
 #define MRPT_HAS_VTK ${CMAKE_MRPT_HAS_VTK}
 
+/** jsoncpp is present */
+#define MRPT_HAS_JSONCPP ${CMAKE_MRPT_HAS_JSONCPP}
 
 /* Automatic definition of OS-macros */
 #if defined(_WIN32) || defined(_WIN32_)  || defined(WIN32) || defined(_WIN64)

--- a/samples/serialization_json_example/CMakeLists.txt
+++ b/samples/serialization_json_example/CMakeLists.txt
@@ -1,0 +1,55 @@
+#-----------------------------------------------------------------------------------------------
+# CMake file for the MRPT example:  /serialization_json_example
+#
+#  Run with "ccmake ." at the root directory, or use it as a template for
+#   starting your own programs
+#-----------------------------------------------------------------------------------------------
+SET(sampleName serialization_json_example)
+PROJECT(EXAMPLE_${sampleName})
+
+CMAKE_MINIMUM_REQUIRED(VERSION 3.1)
+cmake_policy(SET CMP0003 NEW)  # Required by CMake 2.7+
+
+# ---------------------------------------------------------------------------
+# Set the output directory of each example to its corresponding subdirectory
+#  in the binary tree:
+# ---------------------------------------------------------------------------
+SET(EXECUTABLE_OUTPUT_PATH ".")
+
+# The list of "libs" which can be included can be found in:
+#  http://www.mrpt.org/Libraries
+# Add the top-level dependencies only.
+# --------------------------------------------------------------------------
+FIND_PACKAGE(MRPT REQUIRED serialization;io;poses)
+
+# Define the executable target:
+ADD_EXECUTABLE(${sampleName} test.cpp  )
+
+ADD_DEPENDENCIES(examples ${sampleName})
+
+SET_TARGET_PROPERTIES(
+	${sampleName}
+	PROPERTIES
+	PROJECT_LABEL "(EXAMPLE) ${sampleName}")
+
+# Add special defines needed by this example, if any:
+SET(MY_DEFS )
+IF(MY_DEFS) # If not empty
+	ADD_DEFINITIONS("-D${MY_DEFS}")
+ENDIF()
+
+# Add the required libraries for linking:
+TARGET_LINK_LIBRARIES(${sampleName}
+	${MRPT_LIBRARIES}  # This is filled by FIND_PACKAGE(MRPT ...)
+	)
+
+# Set optimized building:
+IF((${CMAKE_CXX_COMPILER_ID} STREQUAL "Clang" OR CMAKE_COMPILER_IS_GNUCXX) AND NOT CMAKE_BUILD_TYPE MATCHES "Debug")
+	add_compile_options(-O3)
+ENDIF()
+
+# This part can be removed if you are compiling this program outside of
+#  the MRPT tree:
+IF(${CMAKE_PROJECT_NAME} STREQUAL "MRPT") # Fails if build outside of MRPT project.
+	DeclareAppDependencies(${sampleName} mrpt-serialization;mrpt-io;mrpt-poses) # Dependencies
+ENDIF()

--- a/samples/serialization_json_example/console.out
+++ b/samples/serialization_json_example/console.out
@@ -1,0 +1,32 @@
+{
+	"pose" : 
+	{
+		"datatype" : "CPose2D",
+		"phi" : 0,
+		"version" : 1,
+		"x" : 5,
+		"y" : 6
+	},
+	"pose_pdf" : 
+	{
+		"cov" : 
+		{
+			"data" : "[0.000000e+00 0.000000e+00 0.000000e+00 ;0.000000e+00 0.000000e+00 0.000000e+00 ;0.000000e+00 0.000000e+00 0.000000e+00 ]",
+			"datatype" : "CMatrixD",
+			"ncols" : 3,
+			"nrows" : 3,
+			"version" : 1
+		},
+		"datatype" : "CPosePDFGaussian",
+		"mean" : 
+		{
+			"datatype" : "CPose2D",
+			"phi" : 1.5707963267948966,
+			"version" : 1,
+			"x" : 1,
+			"y" : 2
+		},
+		"version" : 1
+	}
+}
+read pose:[5.000000 6.000000 0.000000deg]

--- a/samples/serialization_json_example/test.cpp
+++ b/samples/serialization_json_example/test.cpp
@@ -1,0 +1,110 @@
+/* +------------------------------------------------------------------------+
+   |                     Mobile Robot Programming Toolkit (MRPT)            |
+   |                          http://www.mrpt.org/                          |
+   |                                                                        |
+   | Copyright (c) 2005-2018, Individual contributors, see AUTHORS file     |
+   | See: http://www.mrpt.org/Authors - All rights reserved.                |
+   | Released under BSD License. See details in http://www.mrpt.org/License |
+   +------------------------------------------------------------------------+ */
+/** \example serialization_json_example/test.cpp */
+
+#include <iostream>  // cout
+#include <sstream>  // stringstream
+
+//! [example]
+#include <mrpt/serialization/CSchemeArchive.h>
+#include <mrpt/poses/CPosePDFGaussian.h>
+
+#include <iostream>  // cout
+
+void WriteAndReadExample()
+{
+	// Define the MRPT objects to be serialized:
+	mrpt::poses::CPosePDFGaussian pdf1{
+		mrpt::poses::CPose2D{1.0, 2.0, mrpt::DEG2RAD(90.0)},
+		mrpt::math::CMatrixDouble33()};
+	mrpt::poses::CPose2D p1{5.0, 6.0, mrpt::DEG2RAD(.0)};
+
+	// --------------------
+	// JSON Serialization
+	// --------------------
+	// Create a JSON archive:
+	auto arch = mrpt::serialization::archiveJSON();
+
+	// Writes the objects to the JSON archive:
+	arch["pose_pdf"] = pdf1;
+	arch["pose"] = p1;
+
+	// Writes the JSON representation to an std::ostream
+	std::stringstream ss;
+	ss << arch;
+
+	// also, print to cout for illustration purposes:
+	std::cout << arch << std::endl;
+
+	// --------------------
+	// JSON Deserialization
+	// --------------------
+	// rewind stream for reading from the start
+	ss.seekg(0);
+
+	// Create a new JSON archive for reading
+	auto arch2 = mrpt::serialization::archiveJSON();
+
+	// Load the plain text representation into the archive:
+	ss >> arch2;
+
+	// Parse the JSON data into an MRPT object:
+	mrpt::poses::CPosePDFGaussian pdf2;
+	arch2["pose_pdf"].readTo(pdf2);
+	mrpt::poses::CPose2D p2;
+	arch2["pose"].readTo(p2);
+
+	std::cout << "read pose:" << p2.asString() << std::endl;
+}
+//! [example]
+
+int main(int argc, char** argv)
+{
+	try
+	{
+		WriteAndReadExample();
+		return 0;
+	}
+	catch (std::exception& e)
+	{
+		std::cout << "Exception: " << e.what() << std::endl;
+		return -1;
+	}
+	catch (...)
+	{
+		printf("Untyped exception!");
+		return -1;
+	}
+}
+
+#if 0  // code disabled, only present as an example for the docs:
+
+//! [example_raw]
+#include <json/json.h>
+
+void test()
+{
+	Json::Value val;
+	auto arch = mrpt::serialization::CSchemeArchiveBase(
+		std::make_unique<CSchemeArchive<Json::Value>>(val));
+
+	mrpt::poses::CPose2D pt1{1.0, 2.0, 3.0};
+	// Store any CSerializable object into the JSON value:
+	arch = pt1;
+	// Alternative:
+	// arch["pose"] = pt1;
+
+	std::stringstream ss;
+	ss << val;
+	std::cout << val << std::endl;
+}
+
+//! [example_raw]
+
+#endif


### PR DESCRIPTION
By @rachit173 for GSOC 2018. See #783 

Additional tasks to be done before merging: 
* [x] Helper macros
* [x] Add serialization for CPose* classes.
* [x] Add serialization for, at least, some CObservation* classes. Moved to #820 
* [x] Add real unit tests?
* [x] Add examples + update dox docs with the 2 ways to use JSON serialization ("raw" and "opaque").
