### PR TITLE
Fix 32bit overflow error

### DIFF
--- a/libs/img/src/CImage.cpp
+++ b/libs/img/src/CImage.cpp
@@ -86,7 +86,7 @@ static int32_t pixelDepth2CvDepth(PixelDepth d)
 	return -1;
 }
 
-static PixelDepth cvDepth2PixelDepth(int32_t d)
+static PixelDepth cvDepth2PixelDepth(int64_t d)
 {
 	switch (d)
 	{


### PR DESCRIPTION
Fix errors like this (in Travis CI):

/mrpt/libs/img/src/CImage.cpp:101:8: error: case value evaluates to 2147483680, which cannot be narrowed to type 'int32_t' (aka 'int') [-Wc++11-narrowing]
                case IPL_DEPTH_32S:
