### PR TITLE
Fix compile errors introduced in #851 by CArchive changes

### DIFF
--- a/libs/hmtslam/src/CMHPropertiesValuesList.cpp
+++ b/libs/hmtslam/src/CMHPropertiesValuesList.cpp
@@ -62,10 +62,8 @@ void CMHPropertiesValuesList::serializeFrom(
 			m_properties.resize(n);
 			for (i = 0; i < n; i++)
 			{
-				char nameBuf[1024];
 				// Name:
-				in >> nameBuf;
-				m_properties[i].name = nameBuf;
+				in >> m_properties[i].name;
 
 				// Object:
 				in >> isNull;

--- a/libs/hmtslam/src/CPropertiesValuesList.cpp
+++ b/libs/hmtslam/src/CPropertiesValuesList.cpp
@@ -61,10 +61,8 @@ void CPropertiesValuesList::serializeFrom(
 			m_properties.resize(n);
 			for (i = 0; i < n; i++)
 			{
-				char nameBuf[1024];
 				// Name:
-				in >> nameBuf;
-				m_properties[i].name = nameBuf;
+				in >> m_properties[i].name;
 
 				// Object:
 				in >> isNull;

--- a/libs/nav/src/reactive/CLogFileRecord.cpp
+++ b/libs/nav/src/reactive/CLogFileRecord.cpp
@@ -174,9 +174,7 @@ void CLogFileRecord::serializeFrom(
 			for (i = 0; i < n; i++)
 			{
 				auto& ipp = infoPerPTG[i];
-				char str[256];
-				in >> str;
-				ipp.PTG_desc = std::string(str);
+				in >> ipp.PTG_desc;
 
 				int32_t m;
 				in >> m;


### PR DESCRIPTION
## Changed apps/libraries

* modified-libhmtslam
* modified-libnav

## PR Description

CArchive does not support parsing to char* anymore, only std::string. A couple libraries did not get updated in that change.

---

I acknowledge to have:
* Read the [`CONTRIBUTING`](https://github.com/MRPT/mrpt/blob/master/.github/CONTRIBUTING.md) page
* Updated [`doc/doxygen-pages/changeLog_doc.h`](https://github.com/MRPT/mrpt/blob/master/doc/doxygen-pages/changeLog_doc.h) to describe these changes (if applicable)
* Updated [`AUTHORS`](https://github.com/MRPT/mrpt/blob/master/AUTHORS) (if applicable)

(Notify: @MRPT/owners )
