### PR TITLE
Remove useless param in THROW_STACKED_EXCEPTION

### DIFF
--- a/libs/core/include/mrpt/core/exceptions.h
+++ b/libs/core/include/mrpt/core/exceptions.h
@@ -115,7 +115,7 @@ inline std::string exception_to_str(const std::exception& e)
 /** \def THROW_STACKED_EXCEPTION
  * \sa MRPT_TRY_START, MRPT_TRY_END
  */
-#define THROW_STACKED_EXCEPTION(e)                           \
+#define THROW_STACKED_EXCEPTION                              \
 	std::throw_with_nested(                                  \
 		std::logic_error(mrpt::internal::exception_line_msg( \
 			"Called from here.", __FILE__, __LINE__,         \
@@ -126,10 +126,10 @@ inline std::string exception_to_str(const std::exception& e)
  *	\param stuff Is a printf-like sequence of params, e.g: "The error happens
  *for x=%i",x
  */
-#define THROW_STACKED_EXCEPTION_CUSTOM_MSG2(e, stuff, param1) \
-	std::throw_with_nested(                                   \
-		std::logic_error(mrpt::internal::exception_line_msg(  \
-			mrpt::format(stuff, param1), __FILE__, __LINE__,  \
+#define THROW_STACKED_EXCEPTION_CUSTOM_MSG2(stuff, param1)   \
+	std::throw_with_nested(                                  \
+		std::logic_error(mrpt::internal::exception_line_msg( \
+			mrpt::format(stuff, param1), __FILE__, __LINE__, \
 			__CURRENT_FUNCTION_NAME__)))
 
 /** For use in CSerializable implementations */
@@ -249,24 +249,20 @@ inline std::string exception_to_str(const std::exception& e)
  * the call stack after an exception.
  * \sa MRPT_TRY_START,MRPT_TRY_END_WITH_CLEAN_UP
  */
-#define MRPT_TRY_END                                                       \
-	}                                                                      \
-	catch (std::bad_alloc&) { throw; }                                     \
-	catch (std::exception & __excep) { THROW_STACKED_EXCEPTION(__excep); } \
-	catch (...) { THROW_EXCEPTION("Unexpected runtime error!"); }
+#define MRPT_TRY_END                   \
+	}                                  \
+	catch (std::bad_alloc&) { throw; } \
+	catch (...) { THROW_STACKED_EXCEPTION; }
+
 /** The end of a standard MRPT "try...catch()" block that allows tracing throw
  * the call stack after an exception, including a "clean up" piece of code to be
  * run before throwing the exceptions.
  * \sa MRPT_TRY_END,MRPT_TRY_START
  */
-#define MRPT_TRY_END_WITH_CLEAN_UP(stuff)         \
-	}                                             \
-	catch (std::bad_alloc&) { throw; }            \
-	catch (std::exception & __excep)              \
-	{                                             \
-		{stuff} THROW_STACKED_EXCEPTION(__excep); \
-	}                                             \
-	catch (...) { {stuff} THROW_EXCEPTION("Unexpected runtime error!"); }
+#define MRPT_TRY_END_WITH_CLEAN_UP(stuff) \
+	}                                     \
+	catch (std::bad_alloc&) { throw; }    \
+	catch (...) { {stuff} THROW_STACKED_EXCEPTION; }
 
 #if MRPT_ENABLE_EMBEDDED_GLOBAL_PROFILER
 #define MRPT_PROFILE_FUNC_START               \

--- a/libs/core/src/exception_unittest.cpp
+++ b/libs/core/src/exception_unittest.cpp
@@ -14,9 +14,7 @@
 
 TEST(exception, stackedExceptionBasic)
 {
-	EXPECT_THROW(
-		{ THROW_STACKED_EXCEPTION(std::runtime_error("stacked")); },
-		std::logic_error);
+	EXPECT_THROW({ THROW_STACKED_EXCEPTION; }, std::logic_error);
 }
 
 void test_except_3rd_lvl()
@@ -66,9 +64,6 @@ TEST(exception, assertException)
 TEST(exception, stackedExceptionCustomMsg)
 {
 	EXPECT_THROW(
-		{
-			THROW_STACKED_EXCEPTION_CUSTOM_MSG2(
-				std::runtime_error("stacked"), "Foo %s\n", "bar");
-		},
+		{ THROW_STACKED_EXCEPTION_CUSTOM_MSG2("Foo %s\n", "bar"); },
 		std::logic_error);
 }

--- a/libs/hwdrivers/src/CImageGrabber_dc1394.cpp
+++ b/libs/hwdrivers/src/CImageGrabber_dc1394.cpp
@@ -852,12 +852,11 @@ void CImageGrabber_dc1394::enumerateCameras(TCameraInfoList& out_list)
 		dc1394_camera_free_list(list);
 		list = nullptr;
 	}
-	catch (const std::exception& e)
+	catch (...)
 	{
 		if (list) dc1394_camera_free_list(list);
 		if (lib_context) dc1394_free(lib_context);
-
-		THROW_STACKED_EXCEPTION(e);
+		THROW_STACKED_EXCEPTION;
 	}
 #else
 	THROW_EXCEPTION("The MRPT has been compiled with MRPT_HAS_LIBDC1394_2=0 !");

--- a/libs/serialization/src/CArchive.cpp
+++ b/libs/serialization/src/CArchive.cpp
@@ -409,7 +409,7 @@ void CArchive::internal_ReadObjectHeader(
 	{
 		throw;
 	}
-	catch (const std::exception& e)
+	catch (...)
 	{
 		if (lengthReadClassName == 255)
 		{
@@ -419,13 +419,9 @@ void CArchive::internal_ReadObjectHeader(
 		else
 		{
 			THROW_STACKED_EXCEPTION_CUSTOM_MSG2(
-				e, "Exception while parsing typed object '%s' from stream!\n",
+				"Exception while parsing typed object '%s' from stream!\n",
 				readClassName);
 		}
-	}
-	catch (...)
-	{
-		THROW_EXCEPTION("Unexpected runtime error!");
 	}
 }  // end method
 
@@ -461,15 +457,11 @@ void CArchive::internal_ReadObject(
 	{
 		throw;
 	}
-	catch (const std::exception& e)
-	{
-		THROW_STACKED_EXCEPTION_CUSTOM_MSG2(
-			e, "Exception while parsing typed object '%s' from stream!\n",
-			strClassName.c_str());
-	}
 	catch (...)
 	{
-		THROW_EXCEPTION("Unexpected runtime error!");
+		THROW_STACKED_EXCEPTION_CUSTOM_MSG2(
+			"Exception while parsing typed object '%s' from stream!\n",
+			strClassName.c_str());
 	}
 }
 


### PR DESCRIPTION
A follow-up to #857

