### PR TITLE
Velodyne laser_id number in pointclouds

### DIFF
--- a/libs/containers/include/mrpt/containers/stl_containers_utils.h
+++ b/libs/containers/include/mrpt/containers/stl_containers_utils.h
@@ -143,5 +143,14 @@ void printMap(const std::map<T1, T2>& m)
 	std::cout << getMapAsString(m) << std::endl;
 }
 
+/**\brief Deep clear for a std vector container
+ */
+template <class CONTAINER>
+void deep_clear(CONTAINER& c)
+{
+	CONTAINER empty;
+	c.swap(empty);
+}
+
 /** @} */  // end of grouping
 }  // namespace mrpt::containers


### PR DESCRIPTION
Velodyne scans can generate per-point ring-number.

This enables quickly accessing velodyne pointclouds indexed by laser_id,
which is a significant speed-up for some algorithms.