### PR TITLE
WIP: CImage and mrpt-vision modernization

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,7 +3,7 @@ build*
 install*
 *.layout
 CMakeFiles/
-CMakeLists.txt.user
+CMakeLists.txt.user*
 SOURCE_DATE_EPOCH
 *.backup
 

--- a/apps/features-matching/features_matching_main.cpp
+++ b/apps/features-matching/features_matching_main.cpp
@@ -149,8 +149,6 @@ bool DemoFeatures()
 		archiveFrom(buf) >> img2;
 	}
 
-	// img2.rotateImage(DEG2RAD(20),img2.getWidth()/2,img2.getHeight()/2);
-
 	// Only extract patchs if we are using it: descAny means take the patch:
 	if (desc_to_compute != descAny)
 		fext.options.patchSize = 0;  // Do not extract patch:

--- a/libs/db/src/xmlparser/xmlParser.cpp
+++ b/libs/db/src/xmlparser/xmlParser.cpp
@@ -899,16 +899,16 @@ XMLSTR ToXMLStringTool::toXMLUnSafe(XMLSTR dest, XMLCSTR source)
 		{
 			case 4:
 				*(dest++) = *(source++);
-			/*FALLTHROUGH*/
+				[[fallthrough]];
 			case 3:
 				*(dest++) = *(source++);
-			/*FALLTHROUGH*/
+				[[fallthrough]];
 			case 2:
 				*(dest++) = *(source++);
-			/*FALLTHROUGH*/
+				[[fallthrough]];
 			case 1:
 				*(dest++) = *(source++);
-				/*FALLTHROUGH*/
+				[[fallthrough]];
 		}
 #endif
 	out_of_loop1:;

--- a/libs/graphslam/src/graph_slam_levmarq_unittest.cpp
+++ b/libs/graphslam/src/graph_slam_levmarq_unittest.cpp
@@ -12,12 +12,7 @@
 #include <gtest/gtest.h>
 #include <mrpt/serialization/CArchive.h>
 #include <mrpt/system/filesystem.h>
-
-// Defined in tests/test_main.cpp
-namespace mrpt
-{
-extern std::string MRPT_GLOBAL_UNITTEST_SRC_DIR;
-}
+#include <test_mrpt_common.h>
 
 using namespace mrpt;
 using namespace mrpt::random;
@@ -167,7 +162,7 @@ class GraphTester : public GraphSlamLevMarqTest<my_graph_t>,
 		if (files_it == inout_graph_files.end())
 			return;  // No tests for this type
 
-		const string prefix = MRPT_GLOBAL_UNITTEST_SRC_DIR + string("/tests/");
+		const string prefix = UNITTEST_BASEDIR + string("/tests/");
 		for (const auto& tst : files_it->second)
 		{
 			std::cout << "Testing graph type `" << type << "`, in_file=`"

--- a/libs/gui/include/mrpt/gui/CDisplayWindow.h
+++ b/libs/gui/include/mrpt/gui/CDisplayWindow.h
@@ -91,8 +91,7 @@ class CDisplayWindow : public mrpt::gui::CBaseGUIWindow
 		const bool& showIDs = false)
 	{
 		MRPT_START
-		mrpt::img::CImage imgColor(1, 1, CH_RGB);
-		img.colorImage(imgColor);  // Create a colorimage
+		mrpt::img::CImage imgColor = img.colorImage();
 		imgColor.drawFeatures(list, color, showIDs);
 		showImage(imgColor);
 		MRPT_END
@@ -110,8 +109,7 @@ class CDisplayWindow : public mrpt::gui::CBaseGUIWindow
 	{
 		MRPT_START
 		using mrpt::img::TColor;
-		mrpt::img::CImage imgColor(1, 1, 3);
-		img.colorImage(imgColor);  // Create a colorimage
+		mrpt::img::CImage imgColor = img.colorImage();
 
 		// Print the 4 tile lines
 		unsigned int w = imgColor.getWidth();

--- a/libs/gui/include/mrpt/gui/WxUtils.h
+++ b/libs/gui/include/mrpt/gui/WxUtils.h
@@ -101,14 +101,6 @@ wxImage* MRPTImage2wxImage(const mrpt::img::CImage& img);
  */
 wxBitmap* MRPTImage2wxBitmap(const mrpt::img::CImage& img);
 
-#if MRPT_HAS_OPENCV
-/** Create a wxImage from a IPL image. The new object must be freed by the user
- * when not required anymore.
- * \sa IplImage2wxImage
- */
-wxImage* IplImage2wxImage(void* img);
-#endif
-
 /** Create a MRPT image from a wxImage. The new object must be freed by the user
  * when not required anymore.
  *  It is recommended to use wxImage2MRPTImagePtr instead since smart pointers

--- a/libs/gui/src/CDisplayWindow.cpp
+++ b/libs/gui/src/CDisplayWindow.cpp
@@ -454,8 +454,7 @@ void CDisplayWindow::showImageAndPoints(
 	MRPT_START
 	ASSERT_(x.size() == y.size());
 
-	CImage imgColor(1, 1, 3);
-	img.colorImage(imgColor);  // Create a colorimage
+	CImage imgColor = img.colorImage();  // Create a colorimage
 	for (size_t i = 0; i < x.size(); i++)
 	{
 		imgColor.cross(round(x[i]), round(y[i]), color, '+');
@@ -491,9 +490,7 @@ void CDisplayWindow::plot(const CVectorFloat& x, const CVectorFloat& y)
 	const int oy = 40;
 
 	// Suboptimal but...
-	CImage imgColor(1, 1, 3);
-
-	imgColor.resize(640, 480, 3, false);
+	CImage imgColor(640, 480, mrpt::img::CH_RGB);
 	// Draw axis:
 	imgColor.filledRectangle(0, 0, 640, 480, TColor(255, 255, 255));
 	imgColor.line(40, 40, 560, 40, TColor::black(), 3);
@@ -544,9 +541,7 @@ void CDisplayWindow::plot(const CVectorFloat& y)
 	const int oy = 40;
 
 	// Suboptimal but...
-	CImage imgColor(1, 1, 3);
-
-	imgColor.resize(640, 480, 3, false);
+	CImage imgColor(640, 480, mrpt::img::CH_RGB);
 	// Draw axis:
 	imgColor.filledRectangle(0, 0, 640, 480, TColor::white());
 	imgColor.line(40, 40, 560, 40, TColor::black(), 3);

--- a/libs/gui/src/CDisplayWindow3D.cpp
+++ b/libs/gui/src/CDisplayWindow3D.cpp
@@ -241,7 +241,7 @@ void CMyGLCanvas_DisplayWindow3D::OnPostRenderSwapBuffers(
 
 		// Save image directly from OpenGL - It could also use 4 channels and
 		// save with GL_BGRA_EXT
-		CImage::Ptr frame(new CImage(w, h, 3, false));
+		auto frame = CImage::Create(w, h, mrpt::img::CH_RGB);
 		glReadBuffer(GL_FRONT);
 		glReadPixels(0, 0, w, h, GL_BGR_EXT, GL_UNSIGNED_BYTE, (*frame)(0, 0));
 

--- a/libs/gui/src/WxUtils.cpp
+++ b/libs/gui/src/WxUtils.cpp
@@ -21,256 +21,57 @@ using namespace mrpt;
 using namespace mrpt::gui;
 using namespace std;
 
-//------------------------------------------------------------------------
-// An auxiliary function for passing MRPT images to wxWidgets images.
-//   The returned object MUST be deleted by hand!
-//------------------------------------------------------------------------
 wxImage* mrpt::gui::MRPTImage2wxImage(const mrpt::img::CImage& img)
 {
 #if MRPT_HAS_OPENCV
-	auto* image = const_cast<IplImage*>(img.getAs<IplImage>());
-	bool free_image_at_end = false;
+	using namespace std::string_literals;
+
+	mrpt::img::CImage new_image(img, mrpt::img::SHALLOW_COPY);
 
 	// If the image is GRAYSCALE, we need to convert it into RGB, so do it
 	// manually:
-	if (image->nChannels == 1)
+	if (!new_image.isColor())
 	{
-		IplImage* new_image =
-			cvCreateImage(cvSize(image->width, image->height), image->depth, 3);
-		new_image->origin = image->origin;
-		cvCvtColor(image, new_image, CV_GRAY2RGB);
-		image = new_image;  // Use this new image instead
-		free_image_at_end = true;
+		new_image = new_image.colorImage();
 	}
 
-	int options = 0;
-	if (image->origin == 1) options |= CV_CVTIMG_FLIP;
-	if (image->nChannels == 3 && image->channelSeq[0] == 'B' &&
-		image->channelSeq[2] == 'R')
-		options |= CV_CVTIMG_SWAP_RB;
-	if (options)
-	{
-		IplImage* the_input_img = image;
+	if (new_image.getChannelsOrder() == "BGR"s) new_image.flipVertical();
 
-		image = cvCreateImage(
-			cvSize(the_input_img->width, the_input_img->height),
-			the_input_img->depth, 3);
-		if (the_input_img->width && the_input_img->height)
-			cvConvertImage(the_input_img, image, options);  // convert image
+	const int row_in_bytes =
+		new_image.getWidth() *
+		(new_image.getChannelCount() == mrpt::img::CH_RGB ? 3 : 1);
+	uint8_t* data =
+	    static_cast<uint8_t*>(malloc(row_in_bytes * new_image.getHeight());
 
-		if (free_image_at_end) cvReleaseImage(&the_input_img);
-		free_image_at_end = true;  // for "image"
-	}
-
-	int row_in_bytes = image->width * image->nChannels;
-	auto* data = (unsigned char*)malloc(row_in_bytes * image->height);
+	const int w = new_image.getWidth(), h = new_image.getHeight(),
+	          rs = new_image.getRowStride();
 
 	// Copy row by row only if necesary:
-	if (row_in_bytes != image->widthStep)
+	if (row_in_bytes != rs)
 	{
-		unsigned char* trg = data;
-		char* src = image->imageData;
-		for (int y = 0; y < image->height;
-			 y++, src += image->widthStep, trg += row_in_bytes)
+		auto* trg = data;
+		const auto* src = new_image.ptrLine<uint8_t>(0);
+		for (int y = 0; y < h; y++, src += rs, trg += row_in_bytes)
 			memcpy(trg, src, row_in_bytes);
 	}
 	else
 	{
-		memcpy(data, image->imageData, row_in_bytes * image->height);
-	}
-
-	int w = image->width;
-	int h = image->height;
-
-	if (free_image_at_end)
-	{
-		cvReleaseImage(&image);
+		memcpy(data, new_image.ptrLine<uint8_t>(0), row_in_bytes * h);
 	}
 
 	// create and return the object
-	return new wxImage(
-		w, h, data, false);  // memory "imgData" will be freed by the object.
-
-#else
-	int x, y, lx = img.getWidth(), ly = img.getHeight();
-	unsigned char* imgData = (unsigned char*)malloc(3 * lx * ly);
-	unsigned char* imgPtr = imgData;
-
-	if (img.isColor())
-	{
-		// Is COLOR
-		if (img.isOriginTopLeft())
-		{
-			for (y = 0; y < ly; y++)
-			{
-				for (x = 0; x < lx; x++)
-				{
-					*(imgPtr++) = *img(x, y, 2);
-					*(imgPtr++) = *img(x, y, 1);
-					*(imgPtr++) = *img(x, y, 0);
-				}
-			}
-		}
-		else
-		{
-			for (y = ly - 1; y >= 0; y--)
-			{
-				for (x = 0; x < lx; x++)
-				{
-					*(imgPtr++) = *img(x, y, 2);
-					*(imgPtr++) = *img(x, y, 1);
-					*(imgPtr++) = *img(x, y, 0);
-				}
-			}
-		}
-	}
-	else
-	{
-		// Is Grayscale:
-		if (img.isOriginTopLeft())
-		{
-			for (y = 0; y < ly; y++)
-			{
-				for (x = 0; x < lx; x++)
-				{
-					unsigned char c = *img(x, y);
-					*(imgPtr++) = c;
-					*(imgPtr++) = c;
-					*(imgPtr++) = c;
-				}
-			}
-		}
-		else
-		{
-			for (y = ly - 1; y >= 0; y--)
-			{
-				for (x = 0; x < lx; x++)
-				{
-					unsigned char c = *img(x, y);
-					*(imgPtr++) = c;
-					*(imgPtr++) = c;
-					*(imgPtr++) = c;
-				}
-			}
-		}
-	}
-	return new wxImage(
-		lx, ly, imgData,
-		false);  // memory "imgData" will be freed by the object.
+	return new wxImage(w, h, data, false /* false=transfer mem ownership */);
 #endif
 }
 
-//------------------------------------------------------------------------
-// An auxiliary function for passing MRPT images to wxWidgets images.
-//   The returned object MUST be deleted by hand!
-//------------------------------------------------------------------------
 wxBitmap* mrpt::gui::MRPTImage2wxBitmap(const mrpt::img::CImage& img)
 {
 #if MRPT_HAS_OPENCV
-	auto* image = const_cast<IplImage*>(img.getAs<IplImage>());
-	bool free_image_at_end = false;
-
-	// If the image is GRAYSCALE, we need to convert it into RGB, so do it
-	// manually:
-	if (image->nChannels == 1)
-	{
-		IplImage* new_image =
-			cvCreateImage(cvSize(image->width, image->height), image->depth, 3);
-		new_image->origin = image->origin;
-		cvCvtColor(image, new_image, CV_GRAY2RGB);
-		image = new_image;  // Use this new image instead
-		free_image_at_end = true;
-	}
-
-	int options = 0;
-	if (image->origin == 1) options |= CV_CVTIMG_FLIP;
-	if (image->nChannels == 3 && image->channelSeq[0] == 'B' &&
-		image->channelSeq[2] == 'R')
-		options |= CV_CVTIMG_SWAP_RB;
-	if (options)
-	{
-		IplImage* the_input_img = image;
-
-		image = cvCreateImage(
-			cvSize(the_input_img->width, the_input_img->height),
-			the_input_img->depth, 3);
-		cvConvertImage(the_input_img, image, options);  // convert image
-
-		if (free_image_at_end) cvReleaseImage(&the_input_img);
-		free_image_at_end = true;  // for "image"
-	}
-
-	int row_in_bytes = image->width * image->nChannels;
-	auto* data = (unsigned char*)malloc(row_in_bytes * image->height);
-
-	// Copy row by row only if necesary:
-	if (row_in_bytes != image->widthStep)
-	{
-		unsigned char* trg = data;
-		char* src = image->imageData;
-		for (int y = 0; y < image->height;
-			 y++, src += image->widthStep, trg += row_in_bytes)
-			memcpy(trg, src, row_in_bytes);
-	}
-	else
-	{
-		memcpy(data, image->imageData, row_in_bytes * image->height);
-	}
-
-	int w = image->width;
-	int h = image->height;
-
-	if (free_image_at_end)
-	{
-		cvReleaseImage(&image);
-	}
-
-	// create and return the object
-	return new wxBitmap(wxImage(w, h, data, false));
+	return new wxBitmap(MRPTImage2wxImage(img));
 #else
 	THROW_EXCEPTION("MRPT compiled without OpenCV");
 #endif
 }
-
-#if MRPT_HAS_OPENCV
-wxImage* mrpt::gui::IplImage2wxImage(void* img)
-{
-	auto* image = static_cast<IplImage*>(img);
-
-	ASSERT_(image);
-	ASSERT_(image->nChannels == 3);
-
-	// require conversion ?
-	int options = 0;
-	if (image->origin == 1) options |= CV_CVTIMG_FLIP;
-	if (image->channelSeq[0] == 'B' && image->channelSeq[2] == 'R')
-		options |= CV_CVTIMG_SWAP_RB;
-	if (options)
-		cvConvertImage(image, image, options);  // convert image "in place"
-
-	int row_bytes =
-		image->width * image->nChannels * ((image->depth & 255) >> 3);
-
-	auto* imageData = (unsigned char*)malloc(row_bytes * image->height);
-	ASSERT_(imageData);
-
-	// copy row by row only if necesary
-	if (row_bytes != image->widthStep)
-	{
-		for (int y = 0; y < image->height; y++)
-			memcpy(
-				(imageData + y * row_bytes),
-				(image->imageData + y * image->widthStep), row_bytes);
-	}
-	else
-	{
-		memcpy(imageData, image->imageData, row_bytes * image->height);
-	}
-
-	// create and return the object
-	return new wxImage(image->width, image->height, imageData, false);
-}
-#endif
 
 //------------------------------------------------------------------------
 // Convert wxImage -> MRPTImage

--- a/libs/gui/src/WxUtils.cpp
+++ b/libs/gui/src/WxUtils.cpp
@@ -41,10 +41,10 @@ wxImage* mrpt::gui::MRPTImage2wxImage(const mrpt::img::CImage& img)
 		new_image.getWidth() *
 		(new_image.getChannelCount() == mrpt::img::CH_RGB ? 3 : 1);
 	uint8_t* data =
-	    static_cast<uint8_t*>(malloc(row_in_bytes * new_image.getHeight());
+		static_cast<uint8_t*>(malloc(row_in_bytes * new_image.getHeight()));
 
 	const int w = new_image.getWidth(), h = new_image.getHeight(),
-	          rs = new_image.getRowStride();
+			  rs = new_image.getRowStride();
 
 	// Copy row by row only if necesary:
 	if (row_in_bytes != rs)
@@ -67,7 +67,10 @@ wxImage* mrpt::gui::MRPTImage2wxImage(const mrpt::img::CImage& img)
 wxBitmap* mrpt::gui::MRPTImage2wxBitmap(const mrpt::img::CImage& img)
 {
 #if MRPT_HAS_OPENCV
-	return new wxBitmap(MRPTImage2wxImage(img));
+	auto* i = MRPTImage2wxImage(img);
+	auto ret = new wxBitmap(*i);
+	delete i;
+	return ret;
 #else
 	THROW_EXCEPTION("MRPT compiled without OpenCV");
 #endif

--- a/libs/hwdrivers/src/CVelodyneScanner_unittest.cpp
+++ b/libs/hwdrivers/src/CVelodyneScanner_unittest.cpp
@@ -22,7 +22,7 @@ using namespace std;
 TEST(CVelodyneScanner, sample_vlp16_dataset)
 {
 	const string fil =
-	    UNITTEST_BASEDIR + string("/tests/sample_velodyne_vlp16_gps.pcap");
+		UNITTEST_BASEDIR + string("/tests/sample_velodyne_vlp16_gps.pcap");
 
 	if (!mrpt::system::fileExists(fil))
 	{
@@ -62,7 +62,7 @@ TEST(CVelodyneScanner, sample_vlp16_dataset)
 TEST(CVelodyneScanner, sample_hdl32_dataset)
 {
 	const string fil =
-	    UNITTEST_BASEDIR + string("/tests/sample_velodyne_hdl32.pcap");
+		UNITTEST_BASEDIR + string("/tests/sample_velodyne_hdl32.pcap");
 
 	if (!mrpt::system::fileExists(fil))
 	{

--- a/libs/hwdrivers/src/CVelodyneScanner_unittest.cpp
+++ b/libs/hwdrivers/src/CVelodyneScanner_unittest.cpp
@@ -10,24 +10,19 @@
 #include <mrpt/hwdrivers/CVelodyneScanner.h>
 #include <mrpt/system/filesystem.h>
 #include <gtest/gtest.h>
+#include <test_mrpt_common.h>
 
 using namespace mrpt;
 using namespace mrpt::hwdrivers;
 using namespace std;
-
-// Defined in tests/test_main.cpp
-namespace mrpt
-{
-extern std::string MRPT_GLOBAL_UNITTEST_SRC_DIR;
-}
 
 #include <mrpt/config.h>
 #if MRPT_HAS_LIBPCAP
 
 TEST(CVelodyneScanner, sample_vlp16_dataset)
 {
-	const string fil = MRPT_GLOBAL_UNITTEST_SRC_DIR +
-					   string("/tests/sample_velodyne_vlp16_gps.pcap");
+	const string fil =
+	    UNITTEST_BASEDIR + string("/tests/sample_velodyne_vlp16_gps.pcap");
 
 	if (!mrpt::system::fileExists(fil))
 	{
@@ -66,8 +61,8 @@ TEST(CVelodyneScanner, sample_vlp16_dataset)
 
 TEST(CVelodyneScanner, sample_hdl32_dataset)
 {
-	const string fil = MRPT_GLOBAL_UNITTEST_SRC_DIR +
-					   string("/tests/sample_velodyne_hdl32.pcap");
+	const string fil =
+	    UNITTEST_BASEDIR + string("/tests/sample_velodyne_hdl32.pcap");
 
 	if (!mrpt::system::fileExists(fil))
 	{

--- a/libs/img/include/mrpt/img/CImage.h
+++ b/libs/img/include/mrpt/img/CImage.h
@@ -103,33 +103,35 @@ class CExceptionExternalImageNotFound : public std::runtime_error
  * Additional notes:
  * - The OpenCV `cv::Mat` format is used internally for compatibility with
  * all OpenCV functions. Use CImage::asCvMat() to retrieve it. Example:
- *         \code
- *            CImage  img;
- *            ...
- *            // Call to OpenCV function expecting an "IplImage *" or a "void*
- *arr":
- *            cv::Mat cvImg = cv::cvarrToMat( img.getAs<IplImage>() );
- *            cvFunction( img.getAs<IplImage>(), ... );
- *         \endcode
- *		- Only the unsigned 8-bit storage format for pixels (on each channel) is
- *supported.
- *		- An external storage mode can be enabled by calling
+ * \code
+ * CImage  img;
+ * ...
+ * cv::Mat m = img.asCvMat()
+ * \endcode
+ * - By default, all images use unsigned 8-bit storage format for pixels (on
+ *each channel), but it can be changed by flags in the constructor.
+ * - An **external storage mode** can be enabled by calling
  *CImage::setExternalStorage, useful for storing large collections of image
  *objects in memory while loading the image data itself only for the relevant
- *images at any time.
- *		- Operator = and copy ctor makes shallow copies. For deep copies, see
- *clone() or CImage(const CImage&, copy_type_t)
- *		- If you are interested in a smart pointer to an image, use:
+ *images at any time. See CImage::forceLoad() and CImage::unload().
+ * - Operator = and copy ctor make shallow copies. For deep copies, see
+ * CImage::makeDeepCopy() or CImage(const CImage&, copy_type_t), e.g:
  * \code
- * CImage::Ptr myImg = CImage::Create();
+ * CImage a(20, 10, CH_GRAY);
+ * // Shallow copy ctor:
+ * CImage b(a, mrpt::img::SHALLOW_COPY);
+ * CImage c(a, mrpt::img::DEEP_COPY);
+ * \endcode
+ * - If you are interested in a smart pointer to an image, use:
+ * \code
+ * CImage::Ptr myImg = CImage::Create(); // optional ctor arguments
  * // or:
  * CImage::Ptr myImg = std::make_shared<CImage>(...);
  *  \endcode
+ * - To set a CImage from an OpenCV `cv::Mat` use
+ *CImage::CImage(cv::Mat,copy_type_t).
  *
- * - To set a CImage from an OpenCV `cv::Mat` use:
- *  - CImage::CImage(cv::Mat,copy_type_t)
- *
- *   Some functions are implemented in MRPT with highly optimized SSE2/SSE3
+ * Some functions are implemented in MRPT with highly optimized SSE2/SSE3
  *routines, in suitable platforms and compilers. To see the list of
  * optimizations refer to \ref sse_optimizations, falling back to default OpenCV
  *methods where unavailable.
@@ -494,7 +496,7 @@ class CImage : public mrpt::serialization::CSerializable, public CCanvas
 	/** @name Copy, move & swap operations
 		@{ */
 	[[deprecated("Use makeShallowCopy() instead")]]  //
-	inline void
+	    inline void
 		setFromImageReadOnly(const CImage& o)
 	{
 		*this = o.makeShallowCopy();

--- a/libs/img/include/mrpt/img/CImage.h
+++ b/libs/img/include/mrpt/img/CImage.h
@@ -328,8 +328,9 @@ class CImage : public mrpt::serialization::CSerializable, public CCanvas
 		return ret;
 	}
 
-	//! \overload
-	void scaleHalf(CImage& out_image, TInterpolationMethod interp) const;
+	/** \overload
+	 *  \return true if an optimized SSE2/SSE3 version could be used. */
+	bool scaleHalf(CImage& out_image, TInterpolationMethod interp) const;
 
 	/** Returns a new image scaled up to double its original size.
 	 * \exception std::exception On odd size
@@ -482,7 +483,7 @@ class CImage : public mrpt::serialization::CSerializable, public CCanvas
 	/** @name Copy, move & swap operations
 		@{ */
 	[[deprecated("Use makeShallowCopy() instead")]]  //
-		inline void
+	inline void
 		setFromImageReadOnly(const CImage& o)
 	{
 		*this = o.makeShallowCopy();
@@ -538,7 +539,8 @@ class CImage : public mrpt::serialization::CSerializable, public CCanvas
 	/** @name Access to image contents (OpenCV data structure, and raw pixels)
 		@{ */
 
-	/** Makes a shallow or deep copy of this image into the provided cv::Mat */
+	/** Makes a shallow or deep copy of this image into the provided cv::Mat.
+	 * \sa asCvMatRef */
 	void asCvMat(cv::Mat& out_img, copy_type_t copy_type) const;
 
 	template <typename CV_MAT>
@@ -548,6 +550,13 @@ class CImage : public mrpt::serialization::CSerializable, public CCanvas
 		asCvMat(ret, copy_type);
 		return ret;
 	}
+
+	/** Get a reference to the internal cv::Mat, which can be resized, etc. and
+	 * changes will be reflected in this CImage object. */
+	cv::Mat& asCvMatRef();
+
+	/** \overload  */
+	const cv::Mat& asCvMatRef() const;
 
 	/**  Access to pixels without checking boundaries - Use normally the ()
 	  operator better, which checks the coordinates.
@@ -985,8 +994,11 @@ class CImage : public mrpt::serialization::CSerializable, public CCanvas
 	CImage grayscale() const;
 
 	/** \overload.
-	 * In-place is supported by setting `ret=*this`. */
-	void grayscale(CImage& ret) const;
+	 * In-place is supported by setting `ret=*this`.
+	 * \return true if SSE2 version has been run (or if the image was already
+	 * grayscale)
+	 */
+	bool grayscale(CImage& ret) const;
 
 	/** Returns a color (RGB) version of the grayscale image, or a shallow copy
 	 * of itself if it is already a color image. \sa grayscale

--- a/libs/img/include/mrpt/img/CImage.h
+++ b/libs/img/include/mrpt/img/CImage.h
@@ -258,13 +258,11 @@ class CImage : public mrpt::serialization::CSerializable, public CCanvas
 	/** Changes the size of the image, erasing previous contents (does NOT scale
 	 * its current content, for that, see scaleImage).
 	 *  - nChannels: Can be 3 for RGB images or 1 for grayscale images.
-	 *  - originTopLeft: Is true if the top-left corner is (0,0). In other
-	 * case, the reference is the bottom-left corner.
 	 * \sa scaleImage
 	 */
 	void resize(
 		unsigned int width, unsigned int height, TImageChannels nChannels,
-		bool originTopLeft = true, PixelDepth depth = PixelDepth::D8U);
+		PixelDepth depth = PixelDepth::D8U);
 
 	PixelDepth getPixelDepth() const;
 

--- a/libs/img/include/mrpt/img/CImage.h
+++ b/libs/img/include/mrpt/img/CImage.h
@@ -43,6 +43,7 @@ enum class PixelDepth : int32_t
  *  Used for OpenCV related operations with images, but also with MRPT native
  * classes.
  * \sa mrpt::img::CMappedImage, CImage::scaleImage
+ * \note These are numerically compatible to cv::InterpolationFlags
  * \ingroup mrpt_img_grp
  */
 enum TInterpolationMethod
@@ -265,7 +266,7 @@ class CImage : public mrpt::serialization::CSerializable, public CCanvas
 	 * \sa scaleImage
 	 */
 	void resize(
-		unsigned int width, unsigned int height, TImageChannels nChannels,
+		std::size_t width, std::size_t height, TImageChannels nChannels,
 		PixelDepth depth = PixelDepth::D8U);
 
 	PixelDepth getPixelDepth() const;
@@ -650,8 +651,8 @@ class CImage : public mrpt::serialization::CSerializable, public CCanvas
 
 	/** Returns the row stride of the image: this is the number of *bytes*
 	 * between two consecutive rows. You can access the pointer to the first row
-	 * with get_unsafe(0,0)
-	 * \sa getSize, get_unsafe */
+	 * with ptrLine(0)
+	 * \sa getSize, as, ptr, ptrLine */
 	size_t getRowStride() const;
 
 	/** As of mrpt 2.0.0, this returns either "GRAY" or "BGR". */
@@ -836,20 +837,18 @@ class CImage : public mrpt::serialization::CSerializable, public CCanvas
 		{  // Matrix: [0,1]
 			for (unsigned int y = 0; y < ly; y++)
 			{
-				unsigned char* pixels = this->get_unsafe(0, y, 0);
+				auto* pixels = ptrLine<uint8_t>(y);
 				for (unsigned int x = 0; x < lx; x++)
-					(*pixels++) =
-						static_cast<unsigned char>(m.get_unsafe(y, x) * 255);
+					(*pixels++) = static_cast<uint8_t>(m.coeff(y, x) * 255);
 			}
 		}
 		else
 		{  // Matrix: [0,255]
 			for (unsigned int y = 0; y < ly; y++)
 			{
-				unsigned char* pixels = this->get_unsafe(0, y, 0);
+				auto* pixels = ptrLine<uint8_t>(y);
 				for (unsigned int x = 0; x < lx; x++)
-					(*pixels++) =
-						static_cast<unsigned char>(m.get_unsafe(y, x));
+					(*pixels++) = static_cast<uint8_t>(m.coeff(y, x));
 			}
 		}
 		MRPT_END
@@ -876,7 +875,7 @@ class CImage : public mrpt::serialization::CSerializable, public CCanvas
 		{  // Matrix: [0,1]
 			for (unsigned int y = 0; y < ly; y++)
 			{
-				unsigned char* pixels = this->get_unsafe(0, y, 0);
+				auto* pixels = ptrLine<uint8_t>(y);
 				for (unsigned int x = 0; x < lx; x++)
 				{
 					(*pixels++) = static_cast<uint8_t>(r.coeff(y, x) * 255);
@@ -889,7 +888,7 @@ class CImage : public mrpt::serialization::CSerializable, public CCanvas
 		{  // Matrix: [0,255]
 			for (unsigned int y = 0; y < ly; y++)
 			{
-				unsigned char* pixels = this->get_unsafe(0, y, 0);
+				auto* pixels = ptrLine<uint8_t>(y);
 				for (unsigned int x = 0; x < lx; x++)
 				{
 					(*pixels++) = static_cast<uint8_t>(r.coeff(y, x));

--- a/libs/img/include/mrpt/img/CImage.h
+++ b/libs/img/include/mrpt/img/CImage.h
@@ -513,7 +513,7 @@ class CImage : public mrpt::serialization::CSerializable, public CCanvas
 		inline void
 		setFromImageReadOnly(const CImage& o)
 	{
-		*this = makeShallowCopy(o);
+		*this = o.makeShallowCopy();
 	}
 
 	/** Returns a shallow copy of the original image */
@@ -824,18 +824,15 @@ class CImage : public mrpt::serialization::CSerializable, public CCanvas
 	 */
 	template <typename Derived>
 	void setFromRGBMatrices(
-		const Eigen::MatrixBase<Derived>& m_r,
-		const Eigen::MatrixBase<Derived>& m_g,
-		const Eigen::MatrixBase<Derived>& m_b, bool matrix_is_normalized = true)
+	    const Eigen::MatrixBase<Derived>& r,
+	    const Eigen::MatrixBase<Derived>& g,
+	    const Eigen::MatrixBase<Derived>& b, bool matrix_is_normalized = true)
 	{
 		MRPT_START
 		makeSureImageIsLoaded();  // For delayed loaded images stored externally
-		ASSERT_(img);
-		ASSERT_((m_r.size() == m_g.size()) && (m_r.size() == m_b.size()));
-		const unsigned int lx = m_r.cols();
-		const unsigned int ly = m_r.rows();
+		ASSERT_((r.size() == g.size()) && (r.size() == b.size()));
+		const unsigned int lx = r.cols(), ly = r.rows();
 		this->resize(lx, ly, CH_RGB);
-		this->setChannelsOrder_RGB();
 
 		if (matrix_is_normalized)
 		{  // Matrix: [0,1]
@@ -844,12 +841,9 @@ class CImage : public mrpt::serialization::CSerializable, public CCanvas
 				unsigned char* pixels = this->get_unsafe(0, y, 0);
 				for (unsigned int x = 0; x < lx; x++)
 				{
-					(*pixels++) =
-						static_cast<unsigned char>(m_r.get_unsafe(y, x) * 255);
-					(*pixels++) =
-						static_cast<unsigned char>(m_g.get_unsafe(y, x) * 255);
-					(*pixels++) =
-						static_cast<unsigned char>(m_b.get_unsafe(y, x) * 255);
+					(*pixels++) = static_cast<uint8_t>(r.coeff(y, x) * 255);
+					(*pixels++) = static_cast<uint8_t>(g.coeff(y, x) * 255);
+					(*pixels++) = static_cast<uint8_t>(b.coeff(y, x) * 255);
 				}
 			}
 		}
@@ -860,12 +854,9 @@ class CImage : public mrpt::serialization::CSerializable, public CCanvas
 				unsigned char* pixels = this->get_unsafe(0, y, 0);
 				for (unsigned int x = 0; x < lx; x++)
 				{
-					(*pixels++) =
-						static_cast<unsigned char>(m_r.get_unsafe(y, x));
-					(*pixels++) =
-						static_cast<unsigned char>(m_g.get_unsafe(y, x));
-					(*pixels++) =
-						static_cast<unsigned char>(m_b.get_unsafe(y, x));
+					(*pixels++) = static_cast<uint8_t>(r.coeff(y, x));
+					(*pixels++) = static_cast<uint8_t>(g.coeff(y, x));
+					(*pixels++) = static_cast<uint8_t>(b.coeff(y, x));
 				}
 			}
 		}

--- a/libs/img/include/mrpt/img/CImage.h
+++ b/libs/img/include/mrpt/img/CImage.h
@@ -517,13 +517,16 @@ class CImage : public mrpt::serialization::CSerializable, public CCanvas
 	}
 
 	/** Makes a deep copy from the input img */
-	[[deprecated("Prefer a ctor from a cv::Mat instead")]] void
-		loadFromIplImage(const IplImage* iplImage, copy_type_t c = DEEP_COPY);
+	[[deprecated("Prefer a ctor from a cv::Mat instead")]] inline void
+		loadFromIplImage(const IplImage* iplImage, copy_type_t c = DEEP_COPY)
+	{
+		internal_fromIPL(iplImage, c);
+	}
 
 	[[deprecated("Prefer a ctor from a cv::Mat instead")]] inline void
 		setFromIplImageReadOnly(IplImage* iplImage)
 	{
-		loadFromIplImage(iplImage, SHALLOW_COPY);
+		internal_fromIPL(iplImage, SHALLOW_COPY);
 	}
 
 	/** Efficiently swap of two images */
@@ -1009,5 +1012,6 @@ class CImage : public mrpt::serialization::CSerializable, public CCanvas
 	 * \exception CExceptionExternalImageNotFound */
 	void makeSureImageIsLoaded() const;
 	uint8_t* internal_get(int col, int row, uint8_t channel = 0) const;
+	void internal_fromIPL(const IplImage* iplImage, copy_type_t c);
 };  // End of class
 }  // namespace mrpt::img

--- a/libs/img/include/mrpt/img/CImage.h
+++ b/libs/img/include/mrpt/img/CImage.h
@@ -646,6 +646,9 @@ class CImage : public mrpt::serialization::CSerializable, public CCanvas
 	 * \sa getSize, get_unsafe */
 	size_t getRowStride() const;
 
+	/** As of mrpt 2.0.0, this returns either "GRAY" or "BGR". */
+	std::string getChannelsOrder() const;
+
 	/** Return the maximum pixel value of the image, as a float value in the
 	 * range [0,1]
 	 * \sa getAsFloat */

--- a/libs/img/include/mrpt/img/CImage.h
+++ b/libs/img/include/mrpt/img/CImage.h
@@ -61,12 +61,6 @@ enum TImageChannels : uint8_t
 };
 
 /** For usage in one of the CImage constructors */
-enum ctor_CImage_uninitialized
-{
-	UNINITIALIZED_IMAGE = 0
-};
-
-/** For usage in one of the CImage constructors */
 enum ctor_CImage_ref_or_gray
 {
 	FAST_REF_OR_CONVERT_TO_GRAY = 1
@@ -159,7 +153,11 @@ class CImage : public mrpt::serialization::CSerializable, public CCanvas
 	/** @name Constructors & destructor
 		@{ */
 
-	/** Default constructor: initialize to empty image. */
+	/** Default constructor: initialize to empty image. It's an error trying to
+	 * access the image in such a state. Either call resize(), assign from
+	 * another image, load from disk, deserialize from an archive, etc. to
+	 * properly initialize the image.
+	 */
 	CImage();
 
 	/** Constructor for a given image size and type.
@@ -171,26 +169,12 @@ class CImage : public mrpt::serialization::CSerializable, public CCanvas
 	 */
 	CImage(
 		unsigned int width, unsigned int height,
-		TImageChannels nChannels = CH_RGB, bool originTopLeft = true);
-
-	/** Fast constructor that leaves the image uninitialized (the internal
-	 * IplImage pointer set to nullptr).
-	 *  Use only when you know the image will be soon be assigned another
-	 * image.
-	 *  Example of usage:
-	 *   \code
-	 *    CImage myImg(UNINITIALIZED_IMAGE);
-	 *   \endcode
-	 */
-	inline CImage(ctor_CImage_uninitialized) {}
+		TImageChannels nChannels = CH_RGB);
 
 	/** Fast constructor of a grayscale version of another image, making a
-	 * <b>reference</b> to the original image if it already was in grayscale, or
+	 * **shallow copy** from the original image if it already was grayscale, or
 	 * otherwise creating a new grayscale image and converting the original
 	 * image into it.
-	 *   It's <b>very important to keep in mind</b> that the original image
-	 * can't be destroyed before the new object being created with this
-	 * constructor.
 	 * Example of usage:
 	 *   \code
 	 *     void my_func(const CImage &in_img) {
@@ -351,7 +335,7 @@ class CImage : public mrpt::serialization::CSerializable, public CCanvas
 	 */
 	inline CImage scaleHalf(TInterpolationMethod interp) const
 	{
-		CImage ret(UNINITIALIZED_IMAGE);
+		CImage ret;
 		this->scaleHalf(ret, interp);
 		return ret;
 	}
@@ -365,7 +349,7 @@ class CImage : public mrpt::serialization::CSerializable, public CCanvas
 	 */
 	inline CImage scaleDouble() const
 	{
-		CImage ret(UNINITIALIZED_IMAGE);
+		CImage ret;
 		this->scaleDouble(ret);
 		return ret;
 	}
@@ -824,9 +808,9 @@ class CImage : public mrpt::serialization::CSerializable, public CCanvas
 	 */
 	template <typename Derived>
 	void setFromRGBMatrices(
-	    const Eigen::MatrixBase<Derived>& r,
-	    const Eigen::MatrixBase<Derived>& g,
-	    const Eigen::MatrixBase<Derived>& b, bool matrix_is_normalized = true)
+		const Eigen::MatrixBase<Derived>& r,
+		const Eigen::MatrixBase<Derived>& g,
+		const Eigen::MatrixBase<Derived>& b, bool matrix_is_normalized = true)
 	{
 		MRPT_START
 		makeSureImageIsLoaded();  // For delayed loaded images stored externally

--- a/libs/img/include/mrpt/img/CImage.h
+++ b/libs/img/include/mrpt/img/CImage.h
@@ -540,6 +540,14 @@ class CImage : public mrpt::serialization::CSerializable, public CCanvas
 	/** Makes a shallow or deep copy of this image into the provided cv::Mat */
 	void asCvMat(cv::Mat& out_img, copy_type_t copy_type) const;
 
+	template <typename CV_MAT>
+	CV_MAT asCvMat(copy_type_t copy_type) const
+	{
+		CV_MAT ret;
+		asCvMat(ret, copy_type);
+		return ret;
+	}
+
 	/**  Access to pixels without checking boundaries - Use normally the ()
 	  operator better, which checks the coordinates.
 	  \sa CImage::operator()
@@ -972,21 +980,22 @@ class CImage : public mrpt::serialization::CSerializable, public CCanvas
 	/** @name Color/Grayscale conversion
 		@{ */
 
-	/** Returns a grayscale version of the image, or itself if it is already a
-	 * grayscale image.
+	/** Returns a grayscale version of the image, or a shallow copy of itself if
+	 * it is already a grayscale image.
 	 */
 	CImage grayscale() const;
 
-	/** Returns a grayscale version of the image, or itself if it is already a
-	 * grayscale image. In-place is supported by setting `ret=*this`.
-	 * \sa colorImage
-	 */
+	/** \overload.
+	 * In-place is supported by setting `ret=*this`. */
 	void grayscale(CImage& ret) const;
 
-	/** Returns a RGB version of the grayscale image, or itself if it is already
-	 * a RGB image. In-place is supported by setting `ret=*this`.
-	 * \sa grayscale
+	/** Returns a color (RGB) version of the grayscale image, or a shallow copy
+	 * of itself if it is already a color image. \sa grayscale
 	 */
+	CImage colorImage() const;
+
+	/** \overload.
+	 * In-place is supported by setting `ret=*this`. */
 	void colorImage(CImage& ret) const;
 
 	/** @} */

--- a/libs/img/include/mrpt/img/TPixelCoord.h
+++ b/libs/img/include/mrpt/img/TPixelCoord.h
@@ -43,6 +43,10 @@ struct TPixelCoord
 
 	TPixelCoord() = default;
 	TPixelCoord(const int _x, const int _y) : x(_x), y(_y) {}
+	inline bool operator==(const TPixelCoord& o)
+	{
+		return x == o.x && y == o.y;
+	}
 	int x{0}, y{0};
 };
 

--- a/libs/img/include/mrpt/otherlibs/do_opencv_includes.h
+++ b/libs/img/include/mrpt/otherlibs/do_opencv_includes.h
@@ -28,13 +28,13 @@
 #include <opencv2/opencv_modules.hpp>
 // Core:
 #include <opencv2/core.hpp>
-#include <opencv2/core_c.h>
+#include <opencv2/core/core_c.h>
 // Highgui:
 #include <opencv2/highgui.hpp>
-#include <opencv2/highgui_c.h>
+#include <opencv2/highgui/highgui_c.h>
 // imgproc:
 #include <opencv2/imgproc.hpp>
-#include <opencv2/imgproc_c.h>
+#include <opencv2/imgproc/imgproc_c.h>
 // features2d:
 #include <opencv2/features2d.hpp>
 // tracking:

--- a/libs/img/include/mrpt/otherlibs/do_opencv_includes.h
+++ b/libs/img/include/mrpt/otherlibs/do_opencv_includes.h
@@ -27,16 +27,16 @@
 #endif
 #include <opencv2/opencv_modules.hpp>
 // Core:
-#include <opencv2/core/core.hpp>
-#include <opencv2/core/core_c.h>
+#include <opencv2/core.hpp>
+#include <opencv2/core_c.h>
 // Highgui:
-#include <opencv2/highgui/highgui.hpp>
-#include <opencv2/highgui/highgui_c.h>
+#include <opencv2/highgui.hpp>
+#include <opencv2/highgui_c.h>
 // imgproc:
-#include <opencv2/imgproc/imgproc.hpp>
-#include <opencv2/imgproc/imgproc_c.h>
+#include <opencv2/imgproc.hpp>
+#include <opencv2/imgproc_c.h>
 // features2d:
-#include <opencv2/features2d/features2d.hpp>
+#include <opencv2/features2d.hpp>
 // tracking:
 #include <opencv2/video/tracking.hpp>
 /// start added by Raghavender Sahdev
@@ -57,7 +57,7 @@
 #if MRPT_OPENCV_VERSION_NUM >= 0x300
 #include <opencv2/video/tracking_c.h>
 #endif
-#include <opencv2/calib3d/calib3d.hpp>
-#include <opencv2/objdetect/objdetect.hpp>
+#include <opencv2/calib3d.hpp>
+#include <opencv2/objdetect.hpp>
 
 #endif  // MRPT_HAS_OPENCV

--- a/libs/img/src/CImage.cpp
+++ b/libs/img/src/CImage.cpp
@@ -1547,8 +1547,10 @@ void CImage::filterMedian(CImage& out_img, int W) const
 #if MRPT_HAS_OPENCV
 	makeSureImageIsLoaded();  // For delayed loaded images stored externally
 
-	auto& srcImg = const_cast<cv::Mat&>(m_impl->img);
-	if (this != &out_img)
+	auto srcImg = const_cast<cv::Mat&>(m_impl->img);
+	if (this == &out_img)
+		srcImg = srcImg.clone();
+	else
 		out_img.resize(srcImg.cols, srcImg.rows, getChannelCount());
 
 	cv::medianBlur(srcImg, out_img.m_impl->img, W);
@@ -1559,8 +1561,10 @@ void CImage::filterGaussian(CImage& out_img, int W, int H, double sigma) const
 {
 #if MRPT_HAS_OPENCV
 	makeSureImageIsLoaded();  // For delayed loaded images stored externally
-	auto& srcImg = const_cast<cv::Mat&>(m_impl->img);
-	if (this != &out_img)
+	auto srcImg = const_cast<cv::Mat&>(m_impl->img);
+	if (this == &out_img)
+		srcImg = srcImg.clone();
+	else
 		out_img.resize(srcImg.cols, srcImg.rows, getChannelCount());
 
 	cv::GaussianBlur(srcImg, out_img.m_impl->img, cv::Size(W, H), sigma);
@@ -1686,9 +1690,13 @@ bool CImage::drawChessboardCorners(
 #endif
 }
 
-/** Replaces this grayscale image with a RGB version of it.
- * \sa grayscaleInPlace
- */
+CImage CImage::colorImage() const
+{
+	CImage ret;
+	colorImage(ret);
+	return ret;
+}
+
 void CImage::colorImage(CImage& ret) const
 {
 #if MRPT_HAS_OPENCV

--- a/libs/img/src/CImage.cpp
+++ b/libs/img/src/CImage.cpp
@@ -180,7 +180,7 @@ CImage CImage::makeDeepCopy() const
 }
 
 void CImage::resize(
-	unsigned int width, unsigned int height, TImageChannels nChannels,
+	std::size_t width, std::size_t height, TImageChannels nChannels,
 	PixelDepth depth)
 {
 	MRPT_START

--- a/libs/img/src/CImage.cpp
+++ b/libs/img/src/CImage.cpp
@@ -765,6 +765,17 @@ size_t CImage::getWidth() const
 #endif
 }
 
+std::string CImage::getChannelsOrder() const
+{
+#if MRPT_HAS_OPENCV
+	makeSureImageIsLoaded();  // For delayed loaded images stored externally
+	IplImage ipl(m_impl->img);
+	return std::string(ipl.channelSeq);
+#else
+	return 0;
+#endif
+}
+
 size_t CImage::getRowStride() const
 {
 #if MRPT_HAS_OPENCV

--- a/libs/img/src/CImage.cpp
+++ b/libs/img/src/CImage.cpp
@@ -217,8 +217,8 @@ void CImage::resize(
 	alloc_tims.enter(sLog.c_str());
 #endif
 	m_impl->img = cv::Mat(
-	    static_cast<int>(height), static_cast<int>(width),
-	    pixelDepth2CvDepth(depth));
+		static_cast<int>(height), static_cast<int>(width),
+		pixelDepth2CvDepth(depth));
 
 #if IMAGE_ALLOC_PERFLOG
 	alloc_tims.leave(sLog.c_str());
@@ -357,7 +357,7 @@ void CImage::loadFromMemoryBuffer(
 }
 
 unsigned char* CImage::operator()(
-    unsigned int ucol, unsigned int urow, unsigned int uchannel) const
+	unsigned int ucol, unsigned int urow, unsigned int uchannel) const
 {
 #if MRPT_HAS_OPENCV
 
@@ -373,7 +373,7 @@ unsigned char* CImage::operator()(
 #if defined(_DEBUG) || (MRPT_ALWAYS_CHECKS_DEBUG)
 	ASSERT_(m_impl && !m_impl->img.empty());
 	if (row >= m_impl->img.rows || col >= m_impl->img.cols ||
-	    channel >= m_impl->img.channels())
+		channel >= m_impl->img.channels())
 	{
 		THROW_EXCEPTION(format(
 			"Pixel coordinates/channel out of bounds: row=%u/%u col=%u/%u "
@@ -613,14 +613,14 @@ void CImage::serializeFrom(mrpt::serialization::CArchive& in, uint8_t version)
 						depth = PixelDepth(tempdepth);
 					}
 					resize(
-					    static_cast<uint32_t>(width),
-					    static_cast<uint32_t>(height), CH_GRAY, origin == 0,
-					    depth);
+						static_cast<uint32_t>(width),
+						static_cast<uint32_t>(height), CH_GRAY, origin == 0,
+						depth);
 					ASSERT_(
-					    static_cast<uint32_t>(imageSize) ==
-					    static_cast<uint32_t>(width) *
-					        static_cast<uint32_t>(height) *
-					        m_impl->img.step[0]);
+						static_cast<uint32_t>(imageSize) ==
+						static_cast<uint32_t>(width) *
+							static_cast<uint32_t>(height) *
+							m_impl->img.step[0]);
 
 					if (version == 2)
 					{
@@ -878,12 +878,12 @@ static void my_img_to_grayscale(const cv::Mat& src, cv::Mat& dest)
 // If possible, use SSE optimized version:
 #if MRPT_HAS_SSE3
 	if (is_aligned<16>(src.data) && (src.cols & 0xF) == 0 &&
-	    static_cast<int>(src.step[0]) == src.cols * src.channels() &&
-	    static_cast<int>(dest.step[0]) == dest.cols * dest.channels())
+		static_cast<int>(src.step[0]) == src.cols * src.channels() &&
+		static_cast<int>(dest.step[0]) == dest.cols * dest.channels())
 	{
 		ASSERT_(is_aligned<16>(dest.data));
 		image_SSSE3_bgr_to_gray_8u(
-		    src.ptr<uint8_t>(), dest.ptr<uint8_t>(), src.cols, src.rows);
+			src.ptr<uint8_t>(), dest.ptr<uint8_t>(), src.cols, src.rows);
 		return;
 	}
 #endif
@@ -925,9 +925,9 @@ void CImage::scaleHalf(CImage& out, TInterpolationMethod interp) const
 
 	// If possible, use SSE optimized version:
 	if (is_aligned<16>(img.data) && is_aligned<16>(img_out.data) &&
-	    (w & 0xF) == 0 &&
-	    static_cast<int>(img.step[0]) == img.cols * img.channels() &&
-	    static_cast<int>(img_out.step[0]) == img_out.cols * img_out.channels())
+		(w & 0xF) == 0 &&
+		static_cast<int>(img.step[0]) == img.cols * img.channels() &&
+		static_cast<int>(img_out.step[0]) == img_out.cols * img_out.channels())
 	{
 #if MRPT_HAS_SSE3
 		if (img.channels() == 3 && interp == IMG_INTERP_NN)
@@ -1727,8 +1727,8 @@ void CImage::equalizeHist(CImage& out_img) const
 }
 template <unsigned int HALF_WIN_SIZE>
 void image_KLT_response_template(
-    const uint8_t* in, const unsigned widthStep, unsigned int x, unsigned int y,
-    int32_t& _gxx, int32_t& _gyy, int32_t& _gxy)
+	const uint8_t* in, const unsigned widthStep, unsigned int x, unsigned int y,
+	int32_t& _gxx, int32_t& _gyy, int32_t& _gxy)
 {
 	const auto min_x = x - HALF_WIN_SIZE;
 	const auto min_y = y - HALF_WIN_SIZE;
@@ -1766,7 +1766,7 @@ float CImage::KLT_response(
 
 	const auto& im1 = m_impl->img;
 	const auto img_w = static_cast<unsigned int>(im1.cols),
-	           img_h = static_cast<unsigned int>(im1.rows);
+			   img_h = static_cast<unsigned int>(im1.rows);
 	const auto widthStep = im1.step[0];
 
 	// If any of those predefined values worked, do the generic way:

--- a/libs/img/src/CImage.cpp
+++ b/libs/img/src/CImage.cpp
@@ -273,7 +273,7 @@ bool CImage::saveToFile(const std::string& fileName, int jpeg_quality) const
 	MRPT_END
 }
 
-void CImage::loadFromIplImage(const IplImage* iplImage, copy_type_t c)
+void CImage::internal_fromIPL(const IplImage* iplImage, copy_type_t c)
 {
 	MRPT_START
 #if MRPT_HAS_OPENCV

--- a/libs/img/src/CImage_JPEG_streams.cpp
+++ b/libs/img/src/CImage_JPEG_streams.cpp
@@ -493,7 +493,7 @@ void CImage::loadFromStreamAsJPEG(CStream& in)
 	// Resize the CImage now:
 	this->resize(
 		cinfo.output_width, cinfo.output_height,
-		cinfo.out_color_components == 1 ? CH_GRAY : CH_RGB, true);
+		cinfo.out_color_components == 1 ? CH_GRAY : CH_RGB);
 	auto& img = m_impl->img;
 
 	/* Step 6: while (scan lines remain to be read) */

--- a/libs/img/src/CImage_JPEG_streams.cpp
+++ b/libs/img/src/CImage_JPEG_streams.cpp
@@ -11,6 +11,7 @@
 
 #include <mrpt/img/CImage.h>
 #include <mrpt/io/CStream.h>
+#include "CImage_impl.h"
 
 // Universal include for all versions of OpenCV
 #include <mrpt/otherlibs/do_opencv_includes.h>
@@ -54,12 +55,13 @@ using mrpt_dest_ptr = mrpt_destination_mgr*;
 METHODDEF(void)
 init_destination(j_compress_ptr cinfo)
 {
-	auto dest = (mrpt_dest_ptr)cinfo->dest;
+	auto dest = reinterpret_cast<mrpt_dest_ptr>(cinfo->dest);
 
 	/* Allocate the output buffer --- it will be released when done with image
 	 */
-	dest->buffer = (JOCTET*)(*cinfo->mem->alloc_small)(
-		(j_common_ptr)cinfo, JPOOL_IMAGE, OUTPUT_BUF_SIZE * sizeof(JOCTET));
+	dest->buffer = reinterpret_cast<JOCTET*>(((*cinfo->mem->alloc_small)(
+	    reinterpret_cast<j_common_ptr>(cinfo), JPOOL_IMAGE,
+	    OUTPUT_BUF_SIZE * sizeof(JOCTET))));
 
 	dest->pub.next_output_byte = dest->buffer;
 	dest->pub.free_in_buffer = OUTPUT_BUF_SIZE;
@@ -342,9 +344,6 @@ jpeg_stdio_src(j_decompress_ptr cinfo, CStream* in)
 //							END OF JPEG FUNCTIONS PART
 // ---------------------------------------------------------------------------------------
 
-/*---------------------------------------------------------------
-					saveToStreamAsJPEG
- ---------------------------------------------------------------*/
 void CImage::saveToStreamAsJPEG(CStream& out, const int jpeg_quality) const
 {
 #if MRPT_HAS_OPENCV
@@ -355,16 +354,14 @@ void CImage::saveToStreamAsJPEG(CStream& out, const int jpeg_quality) const
 	struct jpeg_compress_struct cinfo;
 	struct jpeg_error_mgr jerr;
 
-	const auto* ipl = static_cast<const IplImage*>(img);
+	const auto& img = m_impl->img;
 
-	const unsigned int nCols = ipl->width;
-	const unsigned int nRows = ipl->height;
-	const bool is_color = (ipl->nChannels == 3);
+	const unsigned int nCols = img.cols, nRows = img.rows;
+	const bool is_color = (img.channels() == 3);
 
 	// Some previous verification:
 	ASSERT_(nCols >= 1 && nRows >= 1);
-	ASSERT_(ipl);
-	ASSERT_(ipl->nChannels == 1 || ipl->nChannels == 3);
+	ASSERT_(img.channels() == 1 || img.channels() == 3);
 
 	// 1) Initialization of the JPEG compresion object:
 	// --------------------------------------------------
@@ -400,17 +397,13 @@ void CImage::saveToStreamAsJPEG(CStream& out, const int jpeg_quality) const
 	if (is_color)
 	{
 		JSAMPROW row_pointer[1]; /* pointer to a single row */
-		row_pointer[0] = (JSAMPROW) new char[ipl->widthStep];
+		row_pointer[0] = new uint8_t[img.step[0]];
 
 		for (unsigned int row = 0; row < nRows; row++)
 		{
 			// Flip RGB bytes order!
-			char* src;
-			if (ipl->origin == 0)
-				src = &ipl->imageData[row * ipl->widthStep];
-			else
-				src = &ipl->imageData[(nRows - 1 - row) * ipl->widthStep];
-			char* target = (char*)row_pointer[0];
+			const uint8_t* src = img.ptr<uint8_t>(row);
+			uint8_t* target = row_pointer[0];
 			for (unsigned int col = 0; col < nCols; col++)
 			{
 				target[0] = src[2];
@@ -435,13 +428,7 @@ void CImage::saveToStreamAsJPEG(CStream& out, const int jpeg_quality) const
 
 		for (unsigned int row = 0; row < nRows; row++)
 		{
-			if (ipl->origin == 0)
-				row_pointer[0] =
-					(JSAMPROW)&ipl->imageData[row * ipl->widthStep];
-			else
-				row_pointer[0] =
-					(JSAMPROW)&ipl
-						->imageData[(nRows - 1 - row) * ipl->widthStep];
+			row_pointer[0] = const_cast<JSAMPROW>(img.ptr<uint8_t>(row));
 
 			// Gray scale:
 			if (1 != jpeg_write_scanlines(&cinfo, row_pointer, 1))
@@ -461,9 +448,6 @@ void CImage::saveToStreamAsJPEG(CStream& out, const int jpeg_quality) const
 #endif
 }
 
-/*---------------------------------------------------------------
-					saveToStreamAsJPEG
- ---------------------------------------------------------------*/
 void CImage::loadFromStreamAsJPEG(CStream& in)
 {
 #if MRPT_HAS_OPENCV
@@ -507,10 +491,10 @@ void CImage::loadFromStreamAsJPEG(CStream& in)
 		(j_common_ptr)&cinfo, JPOOL_IMAGE, row_stride, 1);
 
 	// Resize the CImage now:
-	this->changeSize(
-		cinfo.output_width, cinfo.output_height, cinfo.out_color_components,
-		true);
-	auto* ipl = static_cast<IplImage*>(img);
+	this->resize(
+	    cinfo.output_width, cinfo.output_height,
+	    cinfo.out_color_components == 1 ? CH_GRAY : CH_RGB, true);
+	auto& img = m_impl->img;
 
 	/* Step 6: while (scan lines remain to be read) */
 	/*           jpeg_read_scanlines(...); */
@@ -518,8 +502,7 @@ void CImage::loadFromStreamAsJPEG(CStream& in)
 	/* Here we use the library's state variable cinfo.output_scanline as the
 	 * loop counter, so that we don't have to keep track ourselves.
 	 */
-	const unsigned int nCols = cinfo.output_width;
-	const unsigned int nRows = cinfo.output_height;
+	const unsigned int nCols = cinfo.output_width, nRows = cinfo.output_height;
 
 	for (unsigned int row = 0; row < nRows; row++)
 	{
@@ -533,8 +516,8 @@ void CImage::loadFromStreamAsJPEG(CStream& in)
 		if (isColor())
 		{
 			// Flip RGB bytes order!
-			char* target = &ipl->imageData[row * ipl->widthStep];
-			const char* src = (char*)buffer[0];
+			auto target = img.ptr<uint8_t>(row);
+			const auto* src = buffer[0];
 			for (unsigned int col = 0; col < nCols; col++)
 			{
 				target[0] = src[2];
@@ -548,8 +531,7 @@ void CImage::loadFromStreamAsJPEG(CStream& in)
 		else
 		{
 			// Gray scale:
-			memcpy(
-				&ipl->imageData[row * ipl->widthStep], buffer[0], row_stride);
+			std::memcpy(img.ptr<uint8_t>(row), buffer[0], row_stride);
 		}
 	}
 

--- a/libs/img/src/CImage_JPEG_streams.cpp
+++ b/libs/img/src/CImage_JPEG_streams.cpp
@@ -60,8 +60,8 @@ init_destination(j_compress_ptr cinfo)
 	/* Allocate the output buffer --- it will be released when done with image
 	 */
 	dest->buffer = reinterpret_cast<JOCTET*>(((*cinfo->mem->alloc_small)(
-	    reinterpret_cast<j_common_ptr>(cinfo), JPOOL_IMAGE,
-	    OUTPUT_BUF_SIZE * sizeof(JOCTET))));
+		reinterpret_cast<j_common_ptr>(cinfo), JPOOL_IMAGE,
+		OUTPUT_BUF_SIZE * sizeof(JOCTET))));
 
 	dest->pub.next_output_byte = dest->buffer;
 	dest->pub.free_in_buffer = OUTPUT_BUF_SIZE;
@@ -492,8 +492,8 @@ void CImage::loadFromStreamAsJPEG(CStream& in)
 
 	// Resize the CImage now:
 	this->resize(
-	    cinfo.output_width, cinfo.output_height,
-	    cinfo.out_color_components == 1 ? CH_GRAY : CH_RGB, true);
+		cinfo.output_width, cinfo.output_height,
+		cinfo.out_color_components == 1 ? CH_GRAY : CH_RGB, true);
 	auto& img = m_impl->img;
 
 	/* Step 6: while (scan lines remain to be read) */

--- a/libs/img/src/CImage_impl.h
+++ b/libs/img/src/CImage_impl.h
@@ -15,7 +15,6 @@
 struct mrpt::img::CImage::Impl
 {
 #if MRPT_HAS_OPENCV
-    cv::Mat img;
+	cv::Mat img;
 #endif
 };
-

--- a/libs/img/src/CImage_impl.h
+++ b/libs/img/src/CImage_impl.h
@@ -1,0 +1,21 @@
+/* +------------------------------------------------------------------------+
+   |                     Mobile Robot Programming Toolkit (MRPT)            |
+   |                          http://www.mrpt.org/                          |
+   |                                                                        |
+   | Copyright (c) 2005-2018, Individual contributors, see AUTHORS file     |
+   | See: http://www.mrpt.org/Authors - All rights reserved.                |
+   | Released under BSD License. See details in http://www.mrpt.org/License |
+   +------------------------------------------------------------------------+ */
+
+#include <mrpt/img/CImage.h>
+
+// Universal include for all versions of OpenCV
+#include <mrpt/otherlibs/do_opencv_includes.h>
+
+struct mrpt::img::CImage::Impl
+{
+#if MRPT_HAS_OPENCV
+    cv::Mat img;
+#endif
+};
+

--- a/libs/img/src/CImage_loadXPM.cpp
+++ b/libs/img/src/CImage_loadXPM.cpp
@@ -510,7 +510,7 @@ bool mrpt::img::CImage::loadFromXPM(const char* const* xpm_data, bool swap_rb)
 		ASSERTMSG_(
 			chars_per_pixel < 64, "XPM colormaps this large not supported.");
 
-		this->resize(width, height, CH_RGB, true /*originTopLeft*/);
+		this->resize(width, height, CH_RGB);
 		key[chars_per_pixel] = '\0';
 
 		/*

--- a/libs/img/src/CImage_loadXPM.cpp
+++ b/libs/img/src/CImage_loadXPM.cpp
@@ -90,7 +90,7 @@ static const char* ParseColor(const char* data)
 		for (q = targets[i]; *r != '\0'; r++)
 		{
 			if (*r != *q) continue;
-			if (!isspace((int)(*(r - 1)))) continue;
+			if (!isspace(*(r - 1))) continue;
 			p = r;
 			for (;;)
 			{
@@ -123,7 +123,9 @@ typedef struct
 	uint32_t rgb;
 } rgbRecord;
 
-#define myRGB(r, g, b) ((uint32_t)r << 16 | (uint32_t)g << 8 | (uint32_t)b)
+#define myRGB(r, g, b)                                                \
+	(static_cast<uint32_t>(r) << 16 | static_cast<uint32_t>(g) << 8 | \
+	 static_cast<uint32_t>(b))
 
 static const rgbRecord theRGBRecords[] = {
 	{"aliceblue", myRGB(240, 248, 255)},
@@ -500,7 +502,6 @@ bool mrpt::img::CImage::loadFromXPM(const char* const* xpm_data, bool swap_rb)
 		if (count != 4 || width * height * colors_cnt == 0)
 		{
 			THROW_EXCEPTION("XPM: incorrect header format!");
-			return false;
 		}
 
 		// VS: XPM color map this large would be insane, since XPMs are encoded
@@ -509,7 +510,7 @@ bool mrpt::img::CImage::loadFromXPM(const char* const* xpm_data, bool swap_rb)
 		ASSERTMSG_(
 			chars_per_pixel < 64, "XPM colormaps this large not supported.");
 
-		this->changeSize(width, height, CH_RGB, true /*originTopLeft*/);
+		this->resize(width, height, CH_RGB, true /*originTopLeft*/);
 		key[chars_per_pixel] = '\0';
 
 		/*
@@ -526,7 +527,6 @@ bool mrpt::img::CImage::loadFromXPM(const char* const* xpm_data, bool swap_rb)
 				THROW_EXCEPTION_FMT(
 					"XPM: incorrect colour description in line %d",
 					(int)(1 + i));
-				return false;
 			}
 
 			for (size_t i_key = 0; i_key < chars_per_pixel; i_key++)
@@ -538,7 +538,6 @@ bool mrpt::img::CImage::loadFromXPM(const char* const* xpm_data, bool swap_rb)
 				THROW_EXCEPTION_FMT(
 					"XPM: malformed colour definition '%s' at line %d!",
 					xmpColLine, (int)(1 + i));
-				return false;
 			}
 
 			bool isNone = false;
@@ -548,7 +547,6 @@ bool mrpt::img::CImage::loadFromXPM(const char* const* xpm_data, bool swap_rb)
 				THROW_EXCEPTION_FMT(
 					"XPM: malformed colour definition '%s' at line %d!",
 					xmpColLine, (int)(1 + i));
-				return false;
 			}
 
 			keyString = key;
@@ -576,7 +574,6 @@ bool mrpt::img::CImage::loadFromXPM(const char* const* xpm_data, bool swap_rb)
 			if (rgb > 0xffffff)
 			{
 				THROW_EXCEPTION("XPM: no colors left to use for mask!");
-				return false;
 			}
 
 			XPMColorMapData& maskData = clr_tbl[maskKey];

--- a/libs/img/src/CImage_unittest.cpp
+++ b/libs/img/src/CImage_unittest.cpp
@@ -8,6 +8,8 @@
    +------------------------------------------------------------------------+ */
 
 #include <mrpt/img/CImage.h>
+#include <mrpt/img/TColor.h>
+#include <mrpt/math/CMatrixTemplateNumeric.h>
 #include <CTraitsTest.h>
 #include <gtest/gtest.h>
 
@@ -37,5 +39,83 @@ TEST(CImage, CtorSized)
 		EXPECT_EQ(img.getChannelCount(), 1U);
 		EXPECT_EQ(img.getPixelDepth(), PixelDepth::D8U);
 		EXPECT_FALSE(img.isColor());
+	}
+}
+
+TEST(CImage, GetSetPixel)
+{
+	using namespace mrpt::img;
+	CImage img(20, 10, CH_GRAY);
+	img.setPixel(10, 2, TColor(0x80, 0x80, 0x80));
+	EXPECT_EQ(img.at<uint8_t>(10, 2), 0x80);
+
+	img.setPixel(11, 2, TColor(0x0, 0x0, 0x0));
+	EXPECT_EQ(img.at<uint8_t>(11, 2), 0x00);
+
+	img.setPixel(12, 2, TColor(0xff, 0xff, 0xff));
+	EXPECT_EQ(img.at<uint8_t>(12, 2), 0xff);
+
+	img.at<uint8_t>(13, 2) = 0x70;
+	EXPECT_EQ(img.at<uint8_t>(13, 2), 0x70);
+
+	auto* line = img.ptrLine<uint8_t>(5);
+	for (uint8_t i = 0; i < 20; i++)
+	{
+		line[i] = i;
+		EXPECT_EQ(img.at<uint8_t>(i, 5), i);
+	}
+
+	mrpt::math::CMatrixFloat M;
+	img.getAsMatrix(M, true, 0, 0, -1, -1, false /* dont normalize (0,1) */);
+	for (uint8_t i = 0; i < 20; i++)
+	{
+		EXPECT_NEAR(static_cast<double>(M(5, i)), i, 1e-8);
+	}
+}
+
+TEST(CImage, CopyMoveSwap)
+{
+	using namespace mrpt::img;
+	{
+		CImage a(20, 10, CH_GRAY);
+		a.at<uint8_t>(1, 2) = 0x80;
+		// Shallow copy:
+		CImage b = a;
+		EXPECT_EQ(b.at<uint8_t>(1, 2), 0x80);
+
+		a.at<uint8_t>(1, 3) = 0x81;
+		EXPECT_EQ(b.at<uint8_t>(1, 3), 0x81);
+
+		// Deep copy:
+		CImage c = a.makeDeepCopy();
+		EXPECT_EQ(c.at<uint8_t>(1, 2), 0x80);
+
+		c.at<uint8_t>(1, 3) = 0x0;
+		a.at<uint8_t>(1, 3) = 0x81;
+		EXPECT_NE(c.at<uint8_t>(1, 3), 0x81);
+	}
+
+	{
+		CImage a(20, 10, CH_GRAY);
+		a.at<uint8_t>(1, 2) = 0x80;
+		// Deep copy:
+		CImage b = a.makeDeepCopy();
+		EXPECT_EQ(b.at<uint8_t>(1, 2), 0x80);
+
+		a.clear();
+		a.resize(30, 30, CH_RGB);
+		b.at<uint8_t>(1, 3) = 0x0;
+		a.at<uint8_t>(1, 3) = 0x81;
+		EXPECT_NE(b.at<uint8_t>(1, 3), 0x81);
+	}
+
+	{
+		CImage a(20, 10, CH_GRAY);
+		a.at<uint8_t>(1, 2) = 0x80;
+		// move:
+		CImage b = std::move(a);
+		EXPECT_EQ(b.getWidth(), 20U);
+		EXPECT_EQ(b.getHeight(), 10U);
+		EXPECT_EQ(b.at<uint8_t>(1, 2), 0x80);
 	}
 }

--- a/libs/img/src/CImage_unittest.cpp
+++ b/libs/img/src/CImage_unittest.cpp
@@ -244,5 +244,19 @@ TEST(CImage, HalfAndDouble)
 		EXPECT_EQ(imgD.isColor(), a.isColor());
 	}
 }
+TEST(CImage, getChannelsOrder)
+{
+	using namespace mrpt::img;
+	{
+		CImage a;
+		bool load_ok = a.loadFromFile(tstImgFileColor);
+		EXPECT_TRUE(load_ok);
+		EXPECT_EQ(std::string("BGR"), a.getChannelsOrder());
+	}
+	{
+		CImage a(32, 10, CH_GRAY);
+		EXPECT_EQ(std::string("GRAY"), a.getChannelsOrder());
+	}
+}
 
 #endif  // MRPT_HAS_OPENCV

--- a/libs/img/src/CImage_unittest.cpp
+++ b/libs/img/src/CImage_unittest.cpp
@@ -1,0 +1,41 @@
+/* +------------------------------------------------------------------------+
+   |                     Mobile Robot Programming Toolkit (MRPT)            |
+   |                          http://www.mrpt.org/                          |
+   |                                                                        |
+   | Copyright (c) 2005-2018, Individual contributors, see AUTHORS file     |
+   | See: http://www.mrpt.org/Authors - All rights reserved.                |
+   | Released under BSD License. See details in http://www.mrpt.org/License |
+   +------------------------------------------------------------------------+ */
+
+#include <mrpt/img/CImage.h>
+#include <CTraitsTest.h>
+#include <gtest/gtest.h>
+
+template class mrpt::CTraitsTest<mrpt::img::CImage>;
+
+TEST(CImage, CtorDefault)
+{
+	mrpt::img::CImage img;
+	EXPECT_THROW(img.getWidth(), std::exception);
+}
+
+TEST(CImage, CtorSized)
+{
+	using namespace mrpt::img;
+	{
+		CImage img(64, 48, CH_RGB);
+		EXPECT_EQ(img.getWidth(), 64U);
+		EXPECT_EQ(img.getHeight(), 48U);
+		EXPECT_EQ(img.getChannelCount(), 3U);
+		EXPECT_EQ(img.getPixelDepth(), PixelDepth::D8U);
+		EXPECT_TRUE(img.isColor());
+	}
+	{
+		CImage img(64, 48, CH_GRAY);
+		EXPECT_EQ(img.getWidth(), 64U);
+		EXPECT_EQ(img.getHeight(), 48U);
+		EXPECT_EQ(img.getChannelCount(), 1U);
+		EXPECT_EQ(img.getPixelDepth(), PixelDepth::D8U);
+		EXPECT_FALSE(img.isColor());
+	}
+}

--- a/libs/img/src/CImage_unittest.cpp
+++ b/libs/img/src/CImage_unittest.cpp
@@ -259,4 +259,46 @@ TEST(CImage, getChannelsOrder)
 	}
 }
 
+TEST(CImage, ChangeCvMatCopies)
+{
+	using namespace mrpt::img;
+
+	{
+		CImage a(20, 10, CH_GRAY);
+		a.at<uint8_t>(1, 2) = 0x80;
+		// change shallow copy:
+		cv::Mat m = a.asCvMat<cv::Mat>(SHALLOW_COPY);
+		m.at<uint8_t>(2, 1) = 0x70;
+		// Expect change in source:
+		EXPECT_EQ(a.at<uint8_t>(1, 2), 0x70);
+
+		// size:
+		cv::Mat& m2 = a.asCvMatRef();
+		cv::Mat& m3 = a.asCvMatRef();
+		EXPECT_EQ(&m2, &m3);
+
+		m2 = cv::Mat(40, 40, CV_8UC1);
+
+		cv::Mat& m4 = a.asCvMatRef();
+		EXPECT_EQ(&m2, &m4);
+
+		EXPECT_EQ(a.getWidth(), 40U);
+		EXPECT_EQ(a.getHeight(), 40U);
+	}
+	{
+		CImage a(20, 10, CH_GRAY);
+		a.at<uint8_t>(1, 2) = 0x80;
+		// change deep copy:
+		cv::Mat m = a.asCvMat<cv::Mat>(DEEP_COPY);
+		m.at<uint8_t>(2, 1) = 0x70;
+		// Expect NO change in source:
+		EXPECT_EQ(a.at<uint8_t>(1, 2), 0x80);
+
+		// size:
+		m = cv::Mat(40, 40, CV_8UC1);
+		EXPECT_EQ(a.getWidth(), 20U);
+		EXPECT_EQ(a.getHeight(), 10U);
+	}
+}
+
 #endif  // MRPT_HAS_OPENCV

--- a/libs/img/src/CImage_unittest.cpp
+++ b/libs/img/src/CImage_unittest.cpp
@@ -21,7 +21,7 @@ template class mrpt::CTraitsTest<mrpt::img::CImage>;
 
 using namespace std::string_literals;
 const auto tstImgFileColor =
-    mrpt::UNITTEST_BASEDIR + "/samples/img_basic_example/frame_color.jpg"s;
+	mrpt::UNITTEST_BASEDIR + "/samples/img_basic_example/frame_color.jpg"s;
 
 TEST(CImage, CtorDefault)
 {
@@ -168,6 +168,80 @@ TEST(CImage, ExternalImage)
 		// Test automatic load-on-the-fly:
 		EXPECT_EQ(a.getWidth(), 320U);
 		EXPECT_EQ(a.getHeight(), 240U);
+	}
+
+	{
+		CImage a;
+		a.setExternalStorage("./foo_61717181.png");
+		// Test exception on not found
+		EXPECT_THROW(a.getWidth(), mrpt::img::CExceptionExternalImageNotFound);
+	}
+}
+
+TEST(CImage, ConvertGray)
+{
+	using namespace mrpt::img;
+	{
+		CImage a;
+		bool load_ok = a.loadFromFile(tstImgFileColor);
+		EXPECT_TRUE(load_ok);
+
+		CImage b = a.grayscale();
+		EXPECT_EQ(b.getWidth(), a.getWidth());
+		EXPECT_EQ(b.getHeight(), a.getHeight());
+		EXPECT_FALSE(b.isColor());
+	}
+}
+
+TEST(CImage, CtorRefOrGray)
+{
+	using namespace mrpt::img;
+	{
+		CImage a;
+		bool load_ok = a.loadFromFile(tstImgFileColor);
+		EXPECT_TRUE(load_ok);
+
+		const CImage b(a, FAST_REF_OR_CONVERT_TO_GRAY);
+		EXPECT_EQ(b.getWidth(), a.getWidth());
+		EXPECT_EQ(b.getHeight(), a.getHeight());
+		EXPECT_FALSE(b.isColor());
+	}
+	{
+		CImage a(20, 10, CH_GRAY);
+		a.at<uint8_t>(1, 2) = 0x80;
+
+		const CImage b(a, FAST_REF_OR_CONVERT_TO_GRAY);
+		EXPECT_EQ(b.getWidth(), a.getWidth());
+		EXPECT_EQ(b.getHeight(), a.getHeight());
+		EXPECT_FALSE(b.isColor());
+		EXPECT_EQ(b.at<uint8_t>(1, 2), 0x80);
+	}
+}
+
+TEST(CImage, HalfAndDouble)
+{
+	using namespace mrpt::img;
+
+	CImage a(32, 10, CH_GRAY);
+	a.at<uint8_t>(0, 0) = 0x80;
+	a.at<uint8_t>(0, 1) = 0x80;
+	a.at<uint8_t>(1, 0) = 0x80;
+	a.at<uint8_t>(1, 1) = 0x80;
+
+	// Half:
+	{
+		const CImage imgH = a.scaleHalf(mrpt::img::IMG_INTERP_NN);
+		EXPECT_EQ(imgH.getWidth(), a.getWidth() / 2);
+		EXPECT_EQ(imgH.getHeight(), a.getHeight() / 2);
+		EXPECT_EQ(imgH.isColor(), a.isColor());
+		EXPECT_EQ(imgH.at<uint8_t>(0, 0), a.at<uint8_t>(0, 0));
+	}
+	// Double:
+	{
+		const CImage imgD = a.scaleDouble(mrpt::img::IMG_INTERP_NN);
+		EXPECT_EQ(imgD.getWidth(), a.getWidth() * 2);
+		EXPECT_EQ(imgD.getHeight(), a.getHeight() * 2);
+		EXPECT_EQ(imgD.isColor(), a.isColor());
 	}
 }
 

--- a/libs/img/src/CMappedImage.cpp
+++ b/libs/img/src/CMappedImage.cpp
@@ -90,9 +90,9 @@ double CMappedImage::getPixel(double x, double y) const
 		case IMG_INTERP_NN:
 		{
 			// The closest pixel:
-			const int px0 = mrpt::round(px);
-			const int py0 = mrpt::round(py);
-			return static_cast<double>(*m_img->get_unsafe(px0, py0));
+			const unsigned int px0 = mrpt::round(px);
+			const unsigned int py0 = mrpt::round(py);
+			return static_cast<double>((*m_img).at<uint8_t>(px0, py0));
 		}
 		break;
 		case IMG_INTERP_LINEAR:
@@ -105,10 +105,14 @@ double CMappedImage::getPixel(double x, double y) const
 			const int py0 = (int)floor(py);
 			const int py1 = (int)ceil(py);
 
-			const auto P11 = static_cast<double>(*m_img->get_unsafe(px0, py0));
-			const auto P12 = static_cast<double>(*m_img->get_unsafe(px0, py1));
-			const auto P21 = static_cast<double>(*m_img->get_unsafe(px1, py0));
-			const auto P22 = static_cast<double>(*m_img->get_unsafe(px1, py1));
+			const auto P11 =
+				static_cast<double>((*m_img).at<uint8_t>(px0, py0));
+			const auto P12 =
+				static_cast<double>((*m_img).at<uint8_t>(px0, py1));
+			const auto P21 =
+				static_cast<double>((*m_img).at<uint8_t>(px1, py0));
+			const auto P22 =
+				static_cast<double>((*m_img).at<uint8_t>(px1, py1));
 
 			const double R1 = P11 * (px1 - px) /* /(px1-px0)*/ +
 							  P21 * (px - px0) /* /(px1-px0) */;
@@ -120,11 +124,6 @@ double CMappedImage::getPixel(double x, double y) const
 		break;
 
 		case IMG_INTERP_CUBIC:
-		{
-			THROW_EXCEPTION("TO DO!");
-		}
-		break;
-
 		case IMG_INTERP_AREA:
 		default:
 			THROW_EXCEPTION(

--- a/libs/io/src/CFileGZStreams_unittest.cpp
+++ b/libs/io/src/CFileGZStreams_unittest.cpp
@@ -14,12 +14,7 @@
 #include <gtest/gtest.h>
 #include <random>
 #include <algorithm>  // std::equal
-
-// Defined in tests/test_main.cpp
-namespace mrpt
-{
-extern std::string MRPT_GLOBAL_UNITTEST_SRC_DIR;
-}
+#include <test_mrpt_common.h>
 
 const size_t tst_data_len = 1000U;
 
@@ -82,8 +77,8 @@ TEST(CFileGZStreams, compareWithTestGZFiles)
 	for (int compress_level = 1; compress_level <= 9; compress_level++)
 	{
 		const std::string fil = mrpt::format(
-			"%s/tests/gz-tests/%i.gz",
-			mrpt::MRPT_GLOBAL_UNITTEST_SRC_DIR.c_str(), compress_level);
+		    "%s/tests/gz-tests/%i.gz", mrpt::UNITTEST_BASEDIR.c_str(),
+		    compress_level);
 		if (!mrpt::system::fileExists(fil))
 		{
 			GTEST_FAIL() << "ERROR: test due to missing file: " << fil << "\n";

--- a/libs/io/src/CFileGZStreams_unittest.cpp
+++ b/libs/io/src/CFileGZStreams_unittest.cpp
@@ -77,8 +77,8 @@ TEST(CFileGZStreams, compareWithTestGZFiles)
 	for (int compress_level = 1; compress_level <= 9; compress_level++)
 	{
 		const std::string fil = mrpt::format(
-		    "%s/tests/gz-tests/%i.gz", mrpt::UNITTEST_BASEDIR.c_str(),
-		    compress_level);
+			"%s/tests/gz-tests/%i.gz", mrpt::UNITTEST_BASEDIR.c_str(),
+			compress_level);
 		if (!mrpt::system::fileExists(fil))
 		{
 			GTEST_FAIL() << "ERROR: test due to missing file: " << fil << "\n";

--- a/libs/maps/src/maps/CColouredPointsMap.cpp
+++ b/libs/maps/src/maps/CColouredPointsMap.cpp
@@ -972,18 +972,17 @@ struct pointmap_traits<CColouredPointsMap>
 					}
 				}
 
+				const auto& ii = lric.rangeScan.intensityImage;
 				if (hasValidColor && hasColorIntensityImg)
 				{
-					const uint8_t* c = lric.rangeScan.intensityImage.get_unsafe(
-						img_idx_x, img_idx_y, 0);
+					const auto* c = ii.ptr<uint8_t>(img_idx_x, img_idx_y);
 					pR = c[2] * K_8u;
 					pG = c[1] * K_8u;
 					pB = c[0] * K_8u;
 				}
 				else if (hasValidColor && hasValidIntensityImage)
 				{
-					uint8_t c = *lric.rangeScan.intensityImage.get_unsafe(
-						img_idx_x, img_idx_y, 0);
+					const auto c = ii.at<uint8_t>(img_idx_x, img_idx_y);
 					pR = pG = pB = c * K_8u;
 				}
 				else

--- a/libs/maps/src/maps/COccupancyGridMap2D_getAs.cpp
+++ b/libs/maps/src/maps/COccupancyGridMap2D_getAs.cpp
@@ -33,7 +33,7 @@ void COccupancyGridMap2D::getAsImage(
 	{
 		if (!forceRGB)
 		{  // 8bit gray-scale
-			img.resize(size_x, size_y, 1, true);  // verticalFlip);
+			img.resize(size_x, size_y, mrpt::img::CH_GRAY);
 			const cellType* srcPtr = &map[0];
 			unsigned char* destPtr;
 			for (unsigned int y = 0; y < size_y; y++)
@@ -50,7 +50,7 @@ void COccupancyGridMap2D::getAsImage(
 		}
 		else
 		{  // 24bit RGB:
-			img.resize(size_x, size_y, 3, true);  // verticalFlip);
+			img.resize(size_x, size_y, mrpt::img::CH_RGB);
 			const cellType* srcPtr = &map[0];
 			unsigned char* destPtr;
 			for (unsigned int y = 0; y < size_y; y++)
@@ -74,7 +74,7 @@ void COccupancyGridMap2D::getAsImage(
 		// TRICOLOR: 0, 0.5, 1
 		if (!forceRGB)
 		{  // 8bit gray-scale
-			img.resize(size_x, size_y, 1, true);  // verticalFlip);
+			img.resize(size_x, size_y, mrpt::img::CH_GRAY);
 			const cellType* srcPtr = &map[0];
 			unsigned char* destPtr;
 			for (unsigned int y = 0; y < size_y; y++)
@@ -98,7 +98,7 @@ void COccupancyGridMap2D::getAsImage(
 		}
 		else
 		{  // 24bit RGB:
-			img.resize(size_x, size_y, 3, true);  // verticalFlip);
+			img.resize(size_x, size_y, mrpt::img::CH_RGB);
 			const cellType* srcPtr = &map[0];
 			unsigned char* destPtr;
 			for (unsigned int y = 0; y < size_y; y++)
@@ -134,20 +134,12 @@ void COccupancyGridMap2D::getAsImageFiltered(
 {
 	getAsImage(img, verticalFlip, forceRGB);
 
-// Do filtering to improve the noisy peaks in grids:
-// ----------------------------------------------------
-#if 0
-	CTicTac  t;
-#endif
+	// Do filtering to improve the noisy peaks in grids:
 	if (insertionOptions.CFD_features_gaussian_size != 0)
-		img.filterGaussianInPlace(
-			round(insertionOptions.CFD_features_gaussian_size));
+		img.filterGaussian(
+			img, round(insertionOptions.CFD_features_gaussian_size));
 	if (insertionOptions.CFD_features_median_size != 0)
-		img.filterMedianInPlace(
-			round(insertionOptions.CFD_features_median_size));
-#if 0
-	cout << "[COccupancyGridMap2D::getAsImageFiltered] Filtered in: " << t.Tac()*1000 << " ms" << endl;
-#endif
+		img.filterMedian(img, round(insertionOptions.CFD_features_median_size));
 }
 
 /*---------------------------------------------------------------
@@ -168,8 +160,8 @@ void COccupancyGridMap2D::getAs3DObject(
 	outObj->setLocation(0, 0, insertionOptions.mapAltitude);
 
 	// Create the color & transparecy (alpha) images:
-	CImage imgColor(size_x, size_y, 1);
-	CImage imgTrans(size_x, size_y, 1);
+	CImage imgColor(size_x, size_y, mrpt::img::CH_GRAY);
+	CImage imgTrans(size_x, size_y, mrpt::img::CH_GRAY);
 
 	const cellType* srcPtr = &map[0];
 

--- a/libs/maps/src/maps/COccupancyGridMap2D_io.cpp
+++ b/libs/maps/src/maps/COccupancyGridMap2D_io.cpp
@@ -330,7 +330,6 @@ bool COccupancyGridMap2D::saveAsBitmapTwoMapsWithCorrespondences(
 	MRPT_START
 
 	CImage img1, img2;
-	CImage img(10, 10, 3, true);
 	unsigned int i, n, Ay1, Ay2;
 	unsigned int px, py;
 
@@ -358,7 +357,7 @@ bool COccupancyGridMap2D::saveAsBitmapTwoMapsWithCorrespondences(
 
 	// Compute the size of the composite image:
 	// ---------------------------------------------
-	img.resize(lx1 + lx2 + 1, max(ly1, ly2), 3, true);
+	CImage img(lx1 + lx2 + 1, max(ly1, ly2), mrpt::img::CH_RGB);
 	img.filledRectangle(
 		0, 0, img.getWidth() - 1, img.getHeight() - 1,
 		TColor::black());  // background: black

--- a/libs/maps/src/maps/CPointsMapXYZI_unittest.cpp
+++ b/libs/maps/src/maps/CPointsMapXYZI_unittest.cpp
@@ -11,18 +11,13 @@
 #include <mrpt/system/filesystem.h>
 #include <gtest/gtest.h>
 #include <iostream>
-
-// Defined in tests/test_main.cpp
-namespace mrpt
-{
-extern std::string MRPT_GLOBAL_UNITTEST_SRC_DIR;
-}
+#include <test_mrpt_common.h>
 
 TEST(CPointsMapXYZI, loadFromKittiVelodyneFile)
 {
 	using namespace std;
-	const string kitti_fil = mrpt::MRPT_GLOBAL_UNITTEST_SRC_DIR +
-							 string("/tests/kitti_00_000000.bin.gz");
+	const string kitti_fil =
+	    mrpt::UNITTEST_BASEDIR + string("/tests/kitti_00_000000.bin.gz");
 	if (!mrpt::system::fileExists(kitti_fil))
 	{
 		cerr << "WARNING: Skipping test due to missing file: " << kitti_fil

--- a/libs/maps/src/maps/CPointsMapXYZI_unittest.cpp
+++ b/libs/maps/src/maps/CPointsMapXYZI_unittest.cpp
@@ -17,7 +17,7 @@ TEST(CPointsMapXYZI, loadFromKittiVelodyneFile)
 {
 	using namespace std;
 	const string kitti_fil =
-	    mrpt::UNITTEST_BASEDIR + string("/tests/kitti_00_000000.bin.gz");
+		mrpt::UNITTEST_BASEDIR + string("/tests/kitti_00_000000.bin.gz");
 	if (!mrpt::system::fileExists(kitti_fil))
 	{
 		cerr << "WARNING: Skipping test due to missing file: " << kitti_fil

--- a/libs/maps/src/maps/CRandomFieldGridMap2D.cpp
+++ b/libs/maps/src/maps/CRandomFieldGridMap2D.cpp
@@ -2522,7 +2522,7 @@ void CRandomFieldGridMap2D::insertObservation_GMRF(
 		m_gmrf.addConstraint(
 			*m_mrf_factors_activeObs[cellIdx].rbegin());  // add to graph
 	}
-	catch (std::exception e)
+	catch (const std::exception& e)
 	{
 		cerr << "Exception while Inserting new Observation: " << e.what()
 			 << endl;

--- a/libs/maps/src/maps/CReflectivityGridMap2D.cpp
+++ b/libs/maps/src/maps/CReflectivityGridMap2D.cpp
@@ -314,7 +314,7 @@ void CReflectivityGridMap2D::getAsImage(
 {
 	if (!forceRGB)
 	{  // 8bit gray-scale
-		img.resize(m_size_x, m_size_y, 1, true);
+		img.resize(m_size_x, m_size_y, CH_GRAY);
 		const cell_t* srcPtr = &m_map[0];
 		unsigned char* destPtr;
 		for (unsigned int y = 0; y < m_size_y; y++)
@@ -331,7 +331,7 @@ void CReflectivityGridMap2D::getAsImage(
 	}
 	else
 	{  // 24bit RGB:
-		img.resize(m_size_x, m_size_y, 3, true);
+		img.resize(m_size_x, m_size_y, CH_RGB);
 		const cell_t* srcPtr = &m_map[0];
 		unsigned char* destPtr;
 		for (unsigned int y = 0; y < m_size_y; y++)
@@ -367,8 +367,8 @@ void CReflectivityGridMap2D::getAs3DObject(
 	outObj->setPlaneCorners(m_x_min, m_x_max, m_y_min, m_y_max);
 
 	// Create the color & transparecy (alpha) images:
-	CImage imgColor(m_size_x, m_size_y, 1);
-	CImage imgTrans(m_size_x, m_size_y, 1);
+	CImage imgColor(m_size_x, m_size_y, CH_GRAY);
+	CImage imgTrans(m_size_x, m_size_y, CH_GRAY);
 
 	const cell_t* srcPtr = &m_map[0];
 	unsigned char* destPtr_color;

--- a/libs/nav/src/reactive/CLogFileRecord_unittest.cpp
+++ b/libs/nav/src/reactive/CLogFileRecord_unittest.cpp
@@ -12,18 +12,13 @@
 #include <mrpt/system/filesystem.h>
 #include <mrpt/serialization/CArchive.h>
 #include <gtest/gtest.h>
+#include <test_mrpt_common.h>
 
 using namespace mrpt;
 using namespace mrpt::nav;
 using namespace mrpt::io;
 using namespace mrpt::serialization;
 using namespace std;
-
-// Defined in tests/test_main.cpp
-namespace mrpt
-{
-extern std::string MRPT_GLOBAL_UNITTEST_SRC_DIR;
-}
 
 const mrpt::rtti::TRuntimeClassId* lstClasses[] = {
 	CLASS_ID(CLogFileRecord),
@@ -90,8 +85,7 @@ TEST(SerializeTestObs, WriteReadToOctectVectors)
 TEST(NavTests, NavLogLoadFromTestFile)
 {
 	const string navlog_file =
-		MRPT_GLOBAL_UNITTEST_SRC_DIR +
-		string("/tests/serialize_test_data.reactivenavlog");
+	    UNITTEST_BASEDIR + string("/tests/serialize_test_data.reactivenavlog");
 	if (!mrpt::system::fileExists(navlog_file))
 	{
 		cerr << "WARNING: Skipping test due to missing file: " << navlog_file

--- a/libs/nav/src/reactive/CLogFileRecord_unittest.cpp
+++ b/libs/nav/src/reactive/CLogFileRecord_unittest.cpp
@@ -85,7 +85,7 @@ TEST(SerializeTestObs, WriteReadToOctectVectors)
 TEST(NavTests, NavLogLoadFromTestFile)
 {
 	const string navlog_file =
-	    UNITTEST_BASEDIR + string("/tests/serialize_test_data.reactivenavlog");
+		UNITTEST_BASEDIR + string("/tests/serialize_test_data.reactivenavlog");
 	if (!mrpt::system::fileExists(navlog_file))
 	{
 		cerr << "WARNING: Skipping test due to missing file: " << navlog_file

--- a/libs/nav/src/tpspace/PTGs_unittest.cpp
+++ b/libs/nav/src/tpspace/PTGs_unittest.cpp
@@ -20,7 +20,7 @@ TEST(NavTests, PTGs_tests)
 	using namespace mrpt::nav;
 
 	const string sFil =
-	    mrpt::UNITTEST_BASEDIR + string("/tests/PTGs_for_tests.ini");
+		mrpt::UNITTEST_BASEDIR + string("/tests/PTGs_for_tests.ini");
 	if (!mrpt::system::fileExists(sFil))
 	{
 		cerr << "**WARNING* Skipping tests since file cannot be found: '"

--- a/libs/nav/src/tpspace/PTGs_unittest.cpp
+++ b/libs/nav/src/tpspace/PTGs_unittest.cpp
@@ -11,12 +11,7 @@
 #include <mrpt/config/CConfigFile.h>
 #include <mrpt/system/filesystem.h>
 #include <gtest/gtest.h>
-
-// Defined in tests/test_main.cpp
-namespace mrpt
-{
-extern std::string MRPT_GLOBAL_UNITTEST_SRC_DIR;
-}
+#include <test_mrpt_common.h>
 
 TEST(NavTests, PTGs_tests)
 {
@@ -24,8 +19,8 @@ TEST(NavTests, PTGs_tests)
 	using namespace mrpt;
 	using namespace mrpt::nav;
 
-	const string sFil = mrpt::MRPT_GLOBAL_UNITTEST_SRC_DIR +
-						string("/tests/PTGs_for_tests.ini");
+	const string sFil =
+	    mrpt::UNITTEST_BASEDIR + string("/tests/PTGs_for_tests.ini");
 	if (!mrpt::system::fileExists(sFil))
 	{
 		cerr << "**WARNING* Skipping tests since file cannot be found: '"

--- a/libs/obs/include/mrpt/obs/CObservation3DRangeScan_project3D_impl.h
+++ b/libs/obs/include/mrpt/obs/CObservation3DRangeScan_project3D_impl.h
@@ -236,6 +236,7 @@ void project3DPointsFromDepthImageInto(
 
 			// For each local point:
 			const size_t nPts = pca.size();
+			const auto& iimg = src_obs.intensityImage;
 			for (size_t i = 0; i < nPts; i++)
 			{
 				int img_idx_x,
@@ -273,16 +274,14 @@ void project3DPointsFromDepthImageInto(
 				{
 					if (hasColorIntensityImg)
 					{
-						const uint8_t* c = src_obs.intensityImage.get_unsafe(
-							img_idx_x, img_idx_y, 0);
+						const auto* c = iimg.ptr<uint8_t>(img_idx_x, img_idx_y);
 						pCol.R = c[2];
 						pCol.G = c[1];
 						pCol.B = c[0];
 					}
 					else
 					{
-						uint8_t c = *src_obs.intensityImage.get_unsafe(
-							img_idx_x, img_idx_y, 0);
+						const auto c = iimg.at<uint8_t>(img_idx_x, img_idx_y);
 						pCol.R = pCol.G = pCol.B = c;
 					}
 				}

--- a/libs/obs/include/mrpt/obs/CObservationImage.h
+++ b/libs/obs/include/mrpt/obs/CObservationImage.h
@@ -56,10 +56,10 @@ class CObservationImage : public CObservation
 	 * of this observation. */
 	mrpt::img::CImage image;
 
-	/** Computes the rectified (un-distorted) image, using the embeded
-	 * distortion parameters.
+	/** Computes the un-distorted image, using the embeded camera
+	 * intrinsic & distortion parameters.
 	 */
-	void getRectifiedImage(mrpt::img::CImage& out_img) const;
+	void getUndistortedImage(mrpt::img::CImage& out_img) const;
 
 	// See base class docs
 	void getSensorPose(mrpt::poses::CPose3D& out_sensorPose) const override

--- a/libs/obs/include/mrpt/obs/CObservationImage.h
+++ b/libs/obs/include/mrpt/obs/CObservationImage.h
@@ -42,9 +42,6 @@ class CObservationImage : public CObservation
 	 *
 	 */
 	CObservationImage() = default;
-#ifdef MRPT_HAS_OPENCV
-	CObservationImage(const IplImage* ipl);
-#endif
 	/** The pose of the camera on the robot
 	 */
 	mrpt::poses::CPose3D cameraPose;

--- a/libs/obs/include/mrpt/obs/CObservationStereoImages.h
+++ b/libs/obs/include/mrpt/obs/CObservationStereoImages.h
@@ -44,21 +44,6 @@ class CObservationStereoImages : public mrpt::obs::CObservation
    public:
 	CObservationStereoImages() = default;
 
-#ifdef MRPT_HAS_OPENCV
-	/** Constructor from "IplImage*" images, which could be NULL.
-	 *  The fields hasImageDisparity and hasImageRight will be set to
-	 * true/false depending on them being !=nullptr.
-	 * Note that the IplImage's will be COPIED, so it's still the caller's
-	 * reponsibility to free the original images,
-	 *  unless ownMemory is set to true: in that case the IplImage pointers are
-	 * copied and those IplImage's will be automatically freed by this object.
-	 *
-	 */
-	CObservationStereoImages(
-		IplImage* iplImageLeft, IplImage* iplImageRight,
-		IplImage* iplImageDisparity = nullptr, bool ownMemory = false);
-#endif
-
 	/** @name Main observation data members
 		@{ */
 

--- a/libs/obs/src/CObservation3DRangeScan_unittest.cpp
+++ b/libs/obs/src/CObservation3DRangeScan_unittest.cpp
@@ -17,12 +17,7 @@
 #include <mrpt/math/CHistogram.h>
 #include <mrpt/config.h>
 #include <gtest/gtest.h>
-
-// Defined in tests/test_main.cpp
-namespace mrpt
-{
-extern std::string MRPT_GLOBAL_UNITTEST_SRC_DIR;
-}
+#include <test_mrpt_common.h>
 
 using namespace mrpt;
 using namespace std;
@@ -203,8 +198,8 @@ TEST(CObservation3DRangeScan, Project3D_filterMax)
 
 TEST(CObservation3DRangeScan, LoadAndCheckFloorPoints)
 {
-	const string rawlog_fil = MRPT_GLOBAL_UNITTEST_SRC_DIR +
-							  string("/tests/test-3d-obs-ground.rawlog");
+	const string rawlog_fil =
+	    UNITTEST_BASEDIR + string("/tests/test-3d-obs-ground.rawlog");
 	if (!mrpt::system::fileExists(rawlog_fil))
 	{
 		GTEST_FAIL() << "ERROR: test due to missing file: " << rawlog_fil

--- a/libs/obs/src/CObservation3DRangeScan_unittest.cpp
+++ b/libs/obs/src/CObservation3DRangeScan_unittest.cpp
@@ -199,7 +199,7 @@ TEST(CObservation3DRangeScan, Project3D_filterMax)
 TEST(CObservation3DRangeScan, LoadAndCheckFloorPoints)
 {
 	const string rawlog_fil =
-	    UNITTEST_BASEDIR + string("/tests/test-3d-obs-ground.rawlog");
+		UNITTEST_BASEDIR + string("/tests/test-3d-obs-ground.rawlog");
 	if (!mrpt::system::fileExists(rawlog_fil))
 	{
 		GTEST_FAIL() << "ERROR: test due to missing file: " << rawlog_fil

--- a/libs/obs/src/CObservationImage.cpp
+++ b/libs/obs/src/CObservationImage.cpp
@@ -116,9 +116,9 @@ mxArray* CObservationImage::writeToMatlab() const
 #endif
 }
 
-void CObservationImage::getRectifiedImage(CImage& out_img) const
+void CObservationImage::getUndistortedImage(CImage& out_img) const
 {
-	image.rectifyImage(out_img, cameraParams);
+	image.undistort(out_img, cameraParams);
 }
 
 void CObservationImage::getDescriptionAsText(std::ostream& o) const

--- a/libs/obs/src/CObservationImage.cpp
+++ b/libs/obs/src/CObservationImage.cpp
@@ -25,16 +25,6 @@ using namespace mrpt::img;
 // This must be added to any CSerializable class implementation file.
 IMPLEMENTS_SERIALIZABLE(CObservationImage, CObservation, mrpt::obs)
 
-#if MRPT_HAS_OPENCV
-/** Constructor
- */
-CObservationImage::CObservationImage(const IplImage* iplImage)
-	: cameraPose(), image(iplImage)
-{
-}
-
-#endif
-
 uint8_t CObservationImage::serializeGetVersion() const { return 4; }
 void CObservationImage::serializeTo(mrpt::serialization::CArchive& out) const
 {

--- a/libs/obs/src/CObservationStereoImages.cpp
+++ b/libs/obs/src/CObservationStereoImages.cpp
@@ -25,31 +25,6 @@ using namespace mrpt::img;
 // This must be added to any CSerializable class implementation file.
 IMPLEMENTS_SERIALIZABLE(CObservationStereoImages, CObservation, mrpt::obs)
 
-#if MRPT_HAS_OPENCV
-/*---------------------------------------------------------------
-					Constructor
- ---------------------------------------------------------------*/
-CObservationStereoImages::CObservationStereoImages(
-	IplImage* iplImageLeft, IplImage* iplImageRight,
-	IplImage* iplImageDisparity, bool ownMemory)
-	: imageLeft(),
-	  imageRight(),
-	  imageDisparity(),
-	  hasImageDisparity(iplImageDisparity != nullptr),
-	  hasImageRight(iplImageRight != nullptr)
-{
-	if (iplImageLeft)
-		ownMemory ? imageLeft.setFromIplImage(iplImageLeft)
-				  : imageLeft.loadFromIplImage(iplImageLeft);
-	if (iplImageRight)
-		ownMemory ? imageRight.setFromIplImage(iplImageRight)
-				  : imageRight.loadFromIplImage(iplImageRight);
-	if (iplImageDisparity)
-		ownMemory ? imageDisparity.setFromIplImage(iplImageDisparity)
-				  : imageDisparity.loadFromIplImage(iplImageDisparity);
-}
-#endif
-
 uint8_t CObservationStereoImages::serializeGetVersion() const { return 6; }
 void CObservationStereoImages::serializeTo(
 	mrpt::serialization::CArchive& out) const

--- a/libs/obs/src/CObservationStereoImages.cpp
+++ b/libs/obs/src/CObservationStereoImages.cpp
@@ -32,9 +32,9 @@ IMPLEMENTS_SERIALIZABLE(CObservationStereoImages, CObservation, mrpt::obs)
 CObservationStereoImages::CObservationStereoImages(
 	IplImage* iplImageLeft, IplImage* iplImageRight,
 	IplImage* iplImageDisparity, bool ownMemory)
-	: imageLeft(UNINITIALIZED_IMAGE),
-	  imageRight(UNINITIALIZED_IMAGE),
-	  imageDisparity(UNINITIALIZED_IMAGE),
+	: imageLeft(),
+	  imageRight(),
+	  imageDisparity(),
 	  hasImageDisparity(iplImageDisparity != nullptr),
 	  hasImageRight(iplImageRight != nullptr)
 {

--- a/libs/obs/src/CSimpleMap_unittest.cpp
+++ b/libs/obs/src/CSimpleMap_unittest.cpp
@@ -9,12 +9,7 @@
 
 #include <mrpt/maps/CSimpleMap.h>
 #include <gtest/gtest.h>
-
-// Defined in tests/test_main.cpp
-namespace mrpt
-{
-extern std::string MRPT_GLOBAL_UNITTEST_SRC_DIR;
-}
+#include <test_mrpt_common.h>
 
 TEST(CSimpleMap, ParseFileInFormat_v1_5)
 {
@@ -24,7 +19,7 @@ TEST(CSimpleMap, ParseFileInFormat_v1_5)
 #endif
 
 	const std::string fil =
-		mrpt::MRPT_GLOBAL_UNITTEST_SRC_DIR +
+		mrpt::UNITTEST_BASEDIR +
 		std::string("/share/mrpt/datasets/localization_demo.simplemap.gz");
 
 	mrpt::maps::CSimpleMap sm;

--- a/libs/opengl/src/CAssimpModel.cpp
+++ b/libs/opengl/src/CAssimpModel.cpp
@@ -629,7 +629,7 @@ void load_textures(
 			glTexImage2D(
 				GL_TEXTURE_2D, 0 /*level*/, 3 /* RGB components */, width,
 				height, 0 /*border*/, img_format, img_type,
-				img_rgb->get_unsafe(0, 0));
+				img_rgb->ptrLine<uint8_t>(0));
 			glPixelStorei(GL_UNPACK_ROW_LENGTH, 0);  // Reset
 		}
 		else

--- a/libs/opengl/src/CAssimpModel.cpp
+++ b/libs/opengl/src/CAssimpModel.cpp
@@ -616,9 +616,8 @@ void load_textures(
 			// Prepare image data types:
 			const GLenum img_type = GL_UNSIGNED_BYTE;
 			const int nBytesPerPixel = img_rgb->isColor() ? 3 : 1;
-			const bool is_RGB_order = (!::strcmp(
-				img_rgb->getChannelsOrder(),
-				"RGB"));  // Reverse RGB <-> BGR order?
+			// Reverse RGB <-> BGR order?
+			const bool is_RGB_order = (img_rgb->getChannelsOrder() == "RGB");
 			const GLenum img_format = nBytesPerPixel == 3
 										  ? (is_RGB_order ? GL_RGB : GL_BGR)
 										  : GL_LUMINANCE;

--- a/libs/opengl/src/CFBORender.cpp
+++ b/libs/opengl/src/CFBORender.cpp
@@ -164,7 +164,7 @@ void CFBORender::getFrame(const COpenGLScene& scene, CImage& buffer)
 		buffer.getHeight() != static_cast<size_t>(m_height) ||
 		buffer.getChannelCount() != 3 || buffer.isOriginTopLeft() != false)
 	{
-		buffer.resize(m_width, m_height, 3, false);
+		buffer.resize(m_width, m_height, mrpt::img::CH_RGB);
 	}
 
 	// Go on.

--- a/libs/opengl/src/COpenGLViewport.cpp
+++ b/libs/opengl/src/COpenGLViewport.cpp
@@ -271,9 +271,9 @@ void COpenGLViewport::render(
 					// Prepare image data types:
 					const GLenum img_type = GL_UNSIGNED_BYTE;
 					const int nBytesPerPixel = img->isColor() ? 3 : 1;
-					const bool is_RGB_order = (!::strcmp(
-						img->getChannelsOrder(),
-						"RGB"));  // Reverse RGB <-> BGR order?
+					// Reverse RGB <-> BGR order?
+					const bool is_RGB_order =
+						(img->getChannelsOrder() == std::string("RGB"));
 					const GLenum img_format =
 						nBytesPerPixel == 3 ? (is_RGB_order ? GL_RGB : GL_BGR)
 											: GL_LUMINANCE;
@@ -284,7 +284,7 @@ void COpenGLViewport::render(
 						img->getRowStride() / nBytesPerPixel);
 					glDrawPixels(
 						img_w, img_h, img_format, img_type,
-						img->get_unsafe(0, 0));
+						img->ptrLine<uint8_t>(0));
 					glPixelStorei(GL_UNPACK_ROW_LENGTH, 0);  // Reset
 					CRenderizable::checkOpenGLError();
 				}
@@ -886,7 +886,7 @@ void COpenGLViewport::internal_setImageView_fast(
 	if (!is_fast)
 		*my_img = img;
 	else
-		my_img->copyFastFrom(*const_cast<mrpt::img::CImage*>(&img));
+		*my_img = std::move(*const_cast<mrpt::img::CImage*>(&img));
 }
 
 /** Evaluates the bounding box of this object (including possible children) in

--- a/libs/slam/src/slam/CGridMapAligner.cpp
+++ b/libs/slam/src/slam/CGridMapAligner.cpp
@@ -182,7 +182,7 @@ CPosePDF::Ptr CGridMapAligner::AlignPDF_robustMatch(
 		// Compute correlation between landmarks:
 		// ---------------------------------------------
 		CMatrixFloat CORR(lm1->size(), lm2->size()), auxCorr;
-		CImage im1(1, 1, 1), im2(1, 1, 1);  // Grayscale
+		CImage im1, im2;  // Grayscale
 		CVectorFloat corr;
 		unsigned int corrsCount = 0;
 		std::vector<bool> hasCorr(nLM1, false);
@@ -245,25 +245,6 @@ CPosePDF::Ptr CGridMapAligner::AlignPDF_robustMatch(
 						idx1, corrs_indiv[w].first, corrs_indiv[w].second);
 				}
 			}
-
-#if 0
-			if (options.debug_show_corrs)
-			{
-				auxWin->setWindowTitle(format("Corr: %i - rest", int(idx1)));
-
-				auxWin->plot(corrs_indiv_only,".3","the_corr");
-
-				CVectorFloat xs(2), ys(2);
-				xs[0]=0; xs[1]=corrs_indiv_only.size()+1;
-
-				ys[0]=ys[1] = corr_best+thres_delta;
-				auxWin->plot(xs,ys,"g","the_thres");
-
-				if (idx1==0) auxWin->axis_fit();
-				auxWin->waitForKey();
-			}
-#endif
-
 		}  // end for idx1
 
 		// Save an image with each feature and its matches:

--- a/libs/slam/src/slam/CIncrementalMapPartitioner_unittest.cpp
+++ b/libs/slam/src/slam/CIncrementalMapPartitioner_unittest.cpp
@@ -9,16 +9,11 @@
 
 #include <mrpt/slam/CIncrementalMapPartitioner.h>
 #include <gtest/gtest.h>
+#include <test_mrpt_common.h>
 
 using namespace mrpt;
 using namespace mrpt::slam;
 using namespace std;
-
-// Defined in tests/test_main.cpp
-namespace mrpt
-{
-extern std::string MRPT_GLOBAL_UNITTEST_SRC_DIR;
-}
 
 // TEST =================
 TEST(CIncrementalMapPartitioner, test_dataset) { MRPT_TODO("Write me"); }

--- a/libs/slam/src/slam/CMetricMapBuilderRBPF.cpp
+++ b/libs/slam/src/slam/CMetricMapBuilderRBPF.cpp
@@ -404,12 +404,10 @@ void CMetricMapBuilderRBPF::drawCurrentEstimationToImage(CCanvas* img)
 
 	// Adapt the canvas size:
 	bool alreadyCopiedImage = false;
+	auto g = currentMetricMapEstimation->m_gridMaps[0];
 	{
 		auto* obj = dynamic_cast<CImage*>(img);
-		if (obj)
-			obj->resize(
-				currentMetricMapEstimation->m_gridMaps[0]->getSizeX(),
-				currentMetricMapEstimation->m_gridMaps[0]->getSizeY(), 1, true);
+		if (obj) obj->resize(g->getSizeX(), g->getSizeY(), mrpt::img::CH_GRAY);
 	}
 	if (!alreadyCopiedImage)
 	{
@@ -417,17 +415,16 @@ void CMetricMapBuilderRBPF::drawCurrentEstimationToImage(CCanvas* img)
 
 		// grid map as bitmap:
 		// ----------------------------------
-		currentMetricMapEstimation->m_gridMaps[0]->getAsImage(imgGrid);
+		g->getAsImage(imgGrid);
 
 		img->drawImage(0, 0, imgGrid);
 		imgHeight = imgGrid.getHeight();
 	}
 
 	int x1 = 0, x2 = 0, y1 = 0, y2 = 0;
-	float x_min = currentMetricMapEstimation->m_gridMaps[0]->getXMin();
-	float y_min = currentMetricMapEstimation->m_gridMaps[0]->getYMin();
-	float resolution =
-		currentMetricMapEstimation->m_gridMaps[0]->getResolution();
+	float x_min = g->getXMin();
+	float y_min = g->getYMin();
+	float resolution = g->getResolution();
 
 	// Paths hypothesis:
 	// ----------------------------------

--- a/libs/slam/src/slam/CMonteCarloLocalization2D_unittest.cpp
+++ b/libs/slam/src/slam/CMonteCarloLocalization2D_unittest.cpp
@@ -17,6 +17,7 @@
 #include <mrpt/system/os.h>
 #include <mrpt/random.h>
 #include <gtest/gtest.h>
+#include <test_mrpt_common.h>
 
 using namespace mrpt;
 using namespace mrpt::bayes;
@@ -31,19 +32,13 @@ using namespace mrpt::system;
 using namespace mrpt::obs;
 using namespace std;
 
-// Defined in tests/test_main.cpp
-namespace mrpt
-{
-extern std::string MRPT_GLOBAL_UNITTEST_SRC_DIR;
-}
-
 void run_test_pf_localization(CPose2D& meanPose, CMatrixDouble33& cov)
 {
 	// ------------------------------------------------------
 	// The code below is a simplification of the program "pf-localization"
 	// ------------------------------------------------------
 	const string ini_fil =
-		MRPT_GLOBAL_UNITTEST_SRC_DIR + string("/tests/montecarlo_test1.ini");
+		UNITTEST_BASEDIR + string("/tests/montecarlo_test1.ini");
 	if (!mrpt::system::fileExists(ini_fil))
 	{
 		cerr << "WARNING: Skipping test due to missing file: " << ini_fil
@@ -68,12 +63,12 @@ void run_test_pf_localization(CPose2D& meanPose, CMatrixDouble33& cov)
 	string RAWLOG_FILE = iniFile.read_string(
 		iniSectionName, "rawlog_file", "", /*Fail if not found*/ true);
 
-	RAWLOG_FILE = MRPT_GLOBAL_UNITTEST_SRC_DIR + string("/") + RAWLOG_FILE;
+	RAWLOG_FILE = UNITTEST_BASEDIR + string("/") + RAWLOG_FILE;
 
 	// Non-mandatory entries:
 	string MAP_FILE = iniFile.read_string(iniSectionName, "map_file", "");
 
-	MAP_FILE = MRPT_GLOBAL_UNITTEST_SRC_DIR + string("/") + MAP_FILE;
+	MAP_FILE = UNITTEST_BASEDIR + string("/") + MAP_FILE;
 
 	size_t rawlog_offset = iniFile.read_int(iniSectionName, "rawlog_offset", 0);
 	int NUM_REPS = iniFile.read_int(iniSectionName, "experimentRepetitions", 1);

--- a/libs/slam/src/slam/COccupancyGridMapFeatureExtractor.cpp
+++ b/libs/slam/src/slam/COccupancyGridMapFeatureExtractor.cpp
@@ -27,7 +27,7 @@ void COccupancyGridMapFeatureExtractor::uncached_extractFeatures(
 	MRPT_START
 
 	// get the gridmap as an image:
-	CImage img(1, 1, 1);
+	CImage img;
 	grid.getAsImageFiltered(img, true /*vertical flip*/, false /* force RGB */);
 
 	// Detect features:

--- a/libs/topography/src/path_from_rtk_gps_unittest.cpp
+++ b/libs/topography/src/path_from_rtk_gps_unittest.cpp
@@ -26,7 +26,7 @@ TEST(TopographyReconstructPathFrom3RTK, sampleDataset)
 	mrpt::obs::CRawlog rawlog;
 
 	const string dataset_fil =
-	    UNITTEST_BASEDIR + string("/share/mrpt/datasets/test_rtk_path.rawlog");
+		UNITTEST_BASEDIR + string("/share/mrpt/datasets/test_rtk_path.rawlog");
 	if (!mrpt::system::fileExists(dataset_fil))
 	{
 		cerr << "WARNING: Skipping test due to missing file: " << dataset_fil

--- a/libs/topography/src/path_from_rtk_gps_unittest.cpp
+++ b/libs/topography/src/path_from_rtk_gps_unittest.cpp
@@ -11,18 +11,13 @@
 #include <mrpt/poses/CPose3DInterpolator.h>
 #include <mrpt/system/filesystem.h>
 #include <gtest/gtest.h>
+#include <test_mrpt_common.h>
 
 using namespace mrpt;
 using namespace mrpt::math;
 using namespace mrpt::poses;
 using namespace mrpt::topography;
 using namespace std;
-
-// Defined in tests/test_main.cpp
-namespace mrpt
-{
-extern std::string MRPT_GLOBAL_UNITTEST_SRC_DIR;
-}
 
 TEST(TopographyReconstructPathFrom3RTK, sampleDataset)
 {
@@ -31,8 +26,7 @@ TEST(TopographyReconstructPathFrom3RTK, sampleDataset)
 	mrpt::obs::CRawlog rawlog;
 
 	const string dataset_fil =
-		MRPT_GLOBAL_UNITTEST_SRC_DIR +
-		string("/share/mrpt/datasets/test_rtk_path.rawlog");
+	    UNITTEST_BASEDIR + string("/share/mrpt/datasets/test_rtk_path.rawlog");
 	if (!mrpt::system::fileExists(dataset_fil))
 	{
 		cerr << "WARNING: Skipping test due to missing file: " << dataset_fil

--- a/libs/vision/include/mrpt/vision/CFeatureExtraction.h
+++ b/libs/vision/include/mrpt/vision/CFeatureExtraction.h
@@ -10,7 +10,7 @@
 #pragma once
 
 #include <mrpt/img/CImage.h>
-#include <mrpt/system/CTicTac.h>
+#include <mrpt/system/CTimeLogger.h>
 #include <mrpt/vision/utils.h>
 #include <mrpt/vision/CFeature.h>
 #include <mrpt/vision/TSimpleFeature.h>
@@ -76,7 +76,7 @@ namespace mrpt::vision
  * \sa mrpt::vision::CFeature
  * \ingroup mrptvision_features
  */
-class CFeatureExtraction
+class CFeatureExtraction : public mrpt::system::CTimeLogger
 {
    public:
 	enum TSIFTImplementation
@@ -146,9 +146,6 @@ class CFeatureExtraction
 			// function
 			int radius;  // size of the block of pixels used
 			float min_distance;  // minimum distance between features
-			bool tile_image;  // splits the image into 8 tiles and search for
-			// the best points in all of them (distribute the
-			// features over all the image)
 		} harrisOptions;
 
 		/** BCD Options */
@@ -295,12 +292,9 @@ class CFeatureExtraction
 		} LATCHOptions;
 	};
 
-	TOptions options;  //!< Set all the parameters of the desired method here
-	//! before calling "detectFeatures"
-
-	/** Virtual destructor.
-	 */
-	virtual ~CFeatureExtraction();
+	/** Set all the parameters of the desired method here before calling
+	 * detectFeatures() */
+	TOptions options;
 
 	/** Extract features from the image based on the method defined in TOptions.
 	 * \param img (input) The image from where to extract the images.
@@ -343,21 +337,6 @@ class CFeatureExtraction
 	void computeDescriptors(
 		const mrpt::img::CImage& in_img, CFeatureList& inout_features,
 		TDescriptorType in_descriptor_list) const;
-
-#if 0  // Delete? see comments in .cpp
-			/** Extract more features from the image (apart from the provided ones) based on the method defined in TOptions.
-			* \param img (input) The image from where to extract the images.
-			* \param inList (input) The actual features in the image.
-			* \param outList (output) The list of new features (containing a patch for each one of them if options.patchsize > 0).
-			* \param nDesiredFeatures (op. input) Number of features to be extracted. Default: all possible.
-			*
-			*  \sa The more powerful class: mrpt::vision::CGenericFeatureTracker
-			*/
-			void  findMoreFeatures( const mrpt::img::CImage &img,
-									const CFeatureList &inList,
-									CFeatureList &outList,
-									unsigned int nDesiredFeats = 0) const;
-#endif
 
 	/** @name Static methods with low-level detector functionality
 		@{ */
@@ -587,9 +566,7 @@ class CFeatureExtraction
 	 */
 	void extractFeaturesFAST(
 		const mrpt::img::CImage& img, CFeatureList& feats,
-		unsigned int init_ID = 0, unsigned int nDesiredFeatures = 0,
-		const TImageROI& ROI = TImageROI(),
-		const mrpt::math::CMatrixBool* mask = nullptr) const;
+		unsigned int init_ID = 0, unsigned int nDesiredFeatures = 0) const;
 
 	/** Edward's "FASTER & Better" detector, N=9,10,12 */
 	void extractFeaturesFASTER_N(

--- a/libs/vision/include/mrpt/vision/CStereoRectifyMap.h
+++ b/libs/vision/include/mrpt/vision/CStereoRectifyMap.h
@@ -74,8 +74,7 @@ namespace mrpt::vision
 class CStereoRectifyMap
 {
    public:
-	/** Default ctor */
-	CStereoRectifyMap();
+	CStereoRectifyMap() = default;
 
 	/** @name Rectify map preparation and setting/getting of parameters
 		@{ */
@@ -153,7 +152,7 @@ class CStereoRectifyMap
 	bool isEnabledResizeOutput() const { return m_resize_output; }
 	/** Only when \a isEnabledResizeOutput() returns true, this gets the target
 	 * size  \sa enableResizeOutput */
-	mrpt::img::TImageSize getResizeOutputSize() const
+	inline mrpt::img::TImageSize getResizeOutputSize() const
 	{
 		return m_resize_output_value;
 	}
@@ -233,19 +232,6 @@ class CStereoRectifyMap
 		mrpt::img::CImage& out_left_image,
 		mrpt::img::CImage& out_right_image) const;
 
-	/** Overloaded version for in-place rectification: replace input images with
-	 * their rectified versions
-	 * If \a use_internal_mem_cache is set to \a true (recommended), will reuse
-	 * over and over again the same
-	 * auxiliary images (kept internally to this object) needed for in-place
-	 * rectification.
-	 * The only reason not to enable this cache is when multiple threads can
-	 * invoke this method simultaneously.
-	 */
-	void rectify(
-		mrpt::img::CImage& left_image, mrpt::img::CImage& right_image,
-		const bool use_internal_mem_cache = true) const;
-
 	/** Overloaded version for in-place rectification of image pairs stored in a
 	 * mrpt::obs::CObservationStereoImages.
 	 *  Upon return, the new camera intrinsic parameters will be already stored
@@ -267,25 +253,15 @@ class CStereoRectifyMap
 		mrpt::obs::CObservationStereoImages& stereo_image_observation,
 		const bool use_internal_mem_cache = true) const;
 
-	/** Just like rectify() but directly works with OpenCV's "IplImage*", which
-	 * must be passed as "void*" to avoid header dependencies
-	 *  Output images CANNOT coincide with the input images. */
-	void rectify_IPL(
-		const void* in_left_image, const void* in_right_image,
-		void* out_left_image, void* out_right_image) const;
-
 	/** @} */
 
    private:
 	double m_alpha{-1};
 	bool m_resize_output{false};
 	bool m_enable_both_centers_coincide{false};
-	mrpt::img::TImageSize m_resize_output_value;
+	mrpt::img::TImageSize m_resize_output_value{0, 0};
 	mrpt::img::TInterpolationMethod m_interpolation_method{
 		mrpt::img::IMG_INTERP_LINEAR};
-
-	/** Memory caches for in-place rectification speed-up. */
-	mutable mrpt::img::CImage m_cache1, m_cache2;
 
 	std::vector<int16_t> m_dat_mapx_left, m_dat_mapx_right;
 	std::vector<uint16_t> m_dat_mapy_left, m_dat_mapy_right;

--- a/libs/vision/include/mrpt/vision/TSimpleFeature.h
+++ b/libs/vision/include/mrpt/vision/TSimpleFeature.h
@@ -194,11 +194,11 @@ struct TSimpleFeatureList_templ
 		m_feats.push_back(FEATURE(x, y));
 	}
 
-	inline FEATURE& operator[](const unsigned int index)
+	inline FEATURE& operator[](const std::size_t index)
 	{
 		return m_feats[index];
 	}
-	inline const FEATURE& operator[](const unsigned int index) const
+	inline const FEATURE& operator[](const std::size_t index) const
 	{
 		return m_feats[index];
 	}

--- a/libs/vision/include/mrpt/vision/utils.h
+++ b/libs/vision/include/mrpt/vision/utils.h
@@ -65,11 +65,6 @@ void openCV_cross_correlation(
 	size_t& x_max, size_t& y_max, double& max_val, int x_search_ini = -1,
 	int y_search_ini = -1, int x_search_size = -1, int y_search_size = -1);
 
-/**	Invert an image using OpenCV function
- *
- */
-void flip(mrpt::img::CImage& img);
-
 /** Extract a UNITARY 3D vector in the direction of a 3D point, given from its
  * (x,y) pixels coordinates, and the camera intrinsic coordinates.
  *  \param xy  [IN]   Pixels coordinates, from the top-left corner of the

--- a/libs/vision/src/CFeature.cpp
+++ b/libs/vision/src/CFeature.cpp
@@ -16,6 +16,7 @@
 #include <mrpt/serialization/stl_serialization.h>
 #include <mrpt/vision/CFeature.h>
 #include <mrpt/vision/types.h>
+#include <mrpt/vision/utils.h>
 #include <mrpt/serialization/stl_serialization.h>
 #include <mrpt/math/data_utils.h>
 #include <mrpt/system/os.h>
@@ -490,7 +491,8 @@ float CFeature::patchCorrelationTo(const CFeature& oFeature) const
 	ASSERT_(patch.getHeight() > 0 && patch.getWidth() > 0);
 	size_t x_max, y_max;
 	double max_val;
-	patch.cross_correlation(oFeature.patch, x_max, y_max, max_val);
+	mrpt::vision::openCV_cross_correlation(
+		patch, oFeature.patch, x_max, y_max, max_val);
 
 	return 0.5 -
 		   0.5 * max_val;  // Value as "distance" in the range [0,1], best = 0

--- a/libs/vision/src/CFeatureExtraction_AKAZE.cpp
+++ b/libs/vision/src/CFeatureExtraction_AKAZE.cpp
@@ -46,7 +46,7 @@ void CFeatureExtraction::extractFeaturesAKAZE(
 
 #if MRPT_OPENCV_VERSION_NUM >= 0x300
 
-	const Mat theImg = cvarrToMat(inImg_gray.getAs<IplImage>());
+	Mat theImg = inImg_gray.asCvMat<Mat>(SHALLOW_COPY);
 	Ptr<AKAZE> akaze = AKAZE::create(
 		options.AKAZEOptions.descriptor_type,
 		options.AKAZEOptions.descriptor_size,

--- a/libs/vision/src/CFeatureExtraction_FAST.cpp
+++ b/libs/vision/src/CFeatureExtraction_FAST.cpp
@@ -47,7 +47,7 @@ void CFeatureExtraction::extractFeaturesFAST(
 	//  It's better to use an adaptive threshold, controlled from our caller
 	//  outside.
 
-	const Mat theImg = cvarrToMat(inImg_gray.getAs<IplImage>());
+	const Mat theImg = inImg_gray.asCvMat<cv::Mat>(SHALLOW_COPY);
 
 	cv::Mat cvMask;
 	if (options.useMask)

--- a/libs/vision/src/CFeatureExtraction_FAST.cpp
+++ b/libs/vision/src/CFeatureExtraction_FAST.cpp
@@ -28,10 +28,8 @@ using namespace std;
  ************************************************************************************************/
 void CFeatureExtraction::extractFeaturesFAST(
 	const mrpt::img::CImage& inImg, CFeatureList& feats, unsigned int init_ID,
-	unsigned int nDesiredFeatures, const TImageROI& ROI,
-	const CMatrixBool* mask) const
+	unsigned int nDesiredFeatures) const
 {
-	MRPT_UNUSED_PARAM(ROI);
 	MRPT_START
 
 #if MRPT_HAS_OPENCV
@@ -41,33 +39,7 @@ void CFeatureExtraction::extractFeaturesFAST(
 
 	// Make sure we operate on a gray-scale version of the image:
 	const CImage inImg_gray(inImg, FAST_REF_OR_CONVERT_TO_GRAY);
-
-	// JL: Instead of
-	//	int aux = options.FASTOptions.threshold; ....
-	//  It's better to use an adaptive threshold, controlled from our caller
-	//  outside.
-
 	const Mat theImg = inImg_gray.asCvMat<cv::Mat>(SHALLOW_COPY);
-
-	cv::Mat cvMask;
-	if (options.useMask)
-	{
-		cout << "using mask" << endl;
-		size_t maskW = mask->cols(), maskH = mask->rows();
-		ASSERT_(
-			maskW == inImg_gray.getWidth() && maskH == inImg_gray.getHeight());
-
-		// Convert Mask into CV type
-		cvMask = cv::Mat::ones(maskH, maskW, CV_8UC1);
-		for (int ii = 0; ii < int(maskW); ++ii)
-			for (int jj = 0; jj < int(maskH); ++jj)
-			{
-				if (!mask->get_unsafe(jj, ii))
-				{
-					cvMask.at<char>(ii, jj) = (char)0;
-				}
-			}
-	}
 
 #if MRPT_OPENCV_VERSION_NUM < 0x300
 	FastFeatureDetector fastDetector(
@@ -220,7 +192,6 @@ void CFeatureExtraction::extractFeaturesFAST(
 		feats.push_back(ft);
 		++cont;
 	}
-	// feats.resize( cont );  // JL: really needed???
 
 #endif
 	MRPT_END

--- a/libs/vision/src/CFeatureExtraction_FASTER.cpp
+++ b/libs/vision/src/CFeatureExtraction_FASTER.cpp
@@ -13,6 +13,7 @@
 
 // Universal include for all versions of OpenCV
 #include <mrpt/otherlibs/do_opencv_includes.h>
+#include <numeric>  // iota
 
 #if MRPT_HAS_OPENCV
 #include "faster_corner_prototypes.h"
@@ -32,12 +33,12 @@ void CFeatureExtraction::detectFeatures_SSE2_FASTER9(
 	std::vector<size_t>* out_feats_index_by_row)
 {
 #if MRPT_HAS_OPENCV
-	const auto* IPL = img.getAs<IplImage>();
-	ASSERTDEB_(IPL && IPL->nChannels == 1);
+	ASSERT_(!img.isColor());
 	if (!append_to_list) corners.clear();
 
 	fast_corner_detect_9(
-		IPL, corners, threshold, octave, out_feats_index_by_row);
+		img.asCvMat<cv::Mat>(SHALLOW_COPY), corners, threshold, octave,
+		out_feats_index_by_row);
 #else
 	THROW_EXCEPTION("MRPT built without OpenCV support!");
 #endif
@@ -48,12 +49,12 @@ void CFeatureExtraction::detectFeatures_SSE2_FASTER10(
 	std::vector<size_t>* out_feats_index_by_row)
 {
 #if MRPT_HAS_OPENCV
-	const auto* IPL = img.getAs<IplImage>();
-	ASSERTDEB_(IPL && IPL->nChannels == 1);
+	ASSERT_(!img.isColor());
 	if (!append_to_list) corners.clear();
 
 	fast_corner_detect_10(
-		IPL, corners, threshold, octave, out_feats_index_by_row);
+		img.asCvMat<cv::Mat>(SHALLOW_COPY), corners, threshold, octave,
+		out_feats_index_by_row);
 #else
 	THROW_EXCEPTION("MRPT built without OpenCV support!");
 #endif
@@ -64,12 +65,12 @@ void CFeatureExtraction::detectFeatures_SSE2_FASTER12(
 	std::vector<size_t>* out_feats_index_by_row)
 {
 #if MRPT_HAS_OPENCV
-	const auto* IPL = img.getAs<IplImage>();
-	ASSERTDEB_(IPL && IPL->nChannels == 1);
+	ASSERT_(!img.isColor());
 	if (!append_to_list) corners.clear();
 
 	fast_corner_detect_12(
-		IPL, corners, threshold, octave, out_feats_index_by_row);
+		img.asCvMat<cv::Mat>(SHALLOW_COPY), corners, threshold, octave,
+		out_feats_index_by_row);
 #else
 	THROW_EXCEPTION("MRPT built without OpenCV support!");
 #endif
@@ -91,8 +92,7 @@ void CFeatureExtraction::extractFeaturesFASTER_N(
 #if MRPT_HAS_OPENCV
 	// Make sure we operate on a gray-scale version of the image:
 	const CImage inImg_gray(inImg, FAST_REF_OR_CONVERT_TO_GRAY);
-
-	const auto* IPL = inImg_gray.getAs<IplImage>();
+	cv::Mat img = inImg_gray.asCvMat<cv::Mat>(SHALLOW_COPY);
 
 	TSimpleFeatureList corners;
 	TFeatureType type_of_this_feature;
@@ -101,23 +101,22 @@ void CFeatureExtraction::extractFeaturesFASTER_N(
 	{
 		case 9:
 			fast_corner_detect_9(
-				IPL, corners, options.FASTOptions.threshold, 0, nullptr);
+				img, corners, options.FASTOptions.threshold, 0, nullptr);
 			type_of_this_feature = featFASTER9;
 			break;
 		case 10:
 			fast_corner_detect_10(
-				IPL, corners, options.FASTOptions.threshold, 0, nullptr);
+				img, corners, options.FASTOptions.threshold, 0, nullptr);
 			type_of_this_feature = featFASTER10;
 			break;
 		case 12:
 			fast_corner_detect_12(
-				IPL, corners, options.FASTOptions.threshold, 0, nullptr);
+				img, corners, options.FASTOptions.threshold, 0, nullptr);
 			type_of_this_feature = featFASTER12;
 			break;
 		default:
 			THROW_EXCEPTION(
 				"Only the 9,10,12 FASTER detectors are implemented.")
-			break;
 	};
 
 	// *All* the features have been extracted.
@@ -128,23 +127,21 @@ void CFeatureExtraction::extractFeaturesFASTER_N(
 	//      indices "sorted_indices" than sorting directly the actual list of
 	//      features "corners"
 	std::vector<size_t> sorted_indices(N);
-	for (size_t i = 0; i < N; i++) sorted_indices[i] = i;
+	std::iota(sorted_indices.begin(), sorted_indices.end(), 0);
 
 	// Use KLT response
-	if (options.FASTOptions.use_KLT_response ||
-		nDesiredFeatures != 0  // If the user wants us to limit the number of
-		// features, we need to do it according to some
-		// quality measure
-	)
+	// If the user wants us to limit the number of features, we need to do it
+	// according to some quality measure
+	if (options.FASTOptions.use_KLT_response || nDesiredFeatures != 0)
 	{
-		const int KLT_half_win = 4;
-		const int max_x = inImg_gray.getWidth() - 1 - KLT_half_win;
-		const int max_y = inImg_gray.getHeight() - 1 - KLT_half_win;
+		const auto KLT_half_win = 4U;
+		const auto max_x = inImg_gray.getWidth() - 1 - KLT_half_win;
+		const auto max_y = inImg_gray.getHeight() - 1 - KLT_half_win;
 
 		for (size_t i = 0; i < N; i++)
 		{
-			const int x = corners[i].pt.x;
-			const int y = corners[i].pt.y;
+			const auto x = corners[i].pt.x;
+			const auto y = corners[i].pt.y;
 			if (x > KLT_half_win && y > KLT_half_win && x <= max_x &&
 				y <= max_y)
 				corners[i].response =
@@ -191,8 +188,8 @@ void CFeatureExtraction::extractFeaturesFASTER_N(
 			? 1
 			: (unsigned int)(1 + inImg.getHeight() * occupied_grid_cell_size_inv);
 
-	mrpt::math::CMatrixBool occupied_sections(
-		grid_lx, grid_ly);  // See the comments above for an explanation.
+	// See the comments above for an explanation.
+	mrpt::math::CMatrixBool occupied_sections(grid_lx, grid_ly);
 	occupied_sections.fillAll(false);
 
 	unsigned int nMax =
@@ -209,7 +206,7 @@ void CFeatureExtraction::extractFeaturesFASTER_N(
 
 	while (cont != nMax && i != N)
 	{
-		// Take the next feature fromt the ordered list of good features:
+		// Take the next feature from the ordered list of good features:
 		const TSimpleFeature& feat = corners[sorted_indices[i]];
 		i++;
 

--- a/libs/vision/src/CFeatureExtraction_FASTER.cpp
+++ b/libs/vision/src/CFeatureExtraction_FASTER.cpp
@@ -134,14 +134,14 @@ void CFeatureExtraction::extractFeaturesFASTER_N(
 	// according to some quality measure
 	if (options.FASTOptions.use_KLT_response || nDesiredFeatures != 0)
 	{
-		const auto KLT_half_win = 4U;
+		const auto KLT_half_win = 4;
 		const auto max_x = inImg_gray.getWidth() - 1 - KLT_half_win;
 		const auto max_y = inImg_gray.getHeight() - 1 - KLT_half_win;
 
 		for (size_t i = 0; i < N; i++)
 		{
-			const auto x = corners[i].pt.x;
-			const auto y = corners[i].pt.y;
+			const auto x = static_cast<unsigned int>(corners[i].pt.x);
+			const auto y = static_cast<unsigned int>(corners[i].pt.y);
 			if (x > KLT_half_win && y > KLT_half_win && x <= max_x &&
 				y <= max_y)
 				corners[i].response =

--- a/libs/vision/src/CFeatureExtraction_ORB.cpp
+++ b/libs/vision/src/CFeatureExtraction_ORB.cpp
@@ -53,7 +53,7 @@ void CFeatureExtraction::extractFeaturesORB(
 
 	// Make sure we operate on a gray-scale version of the image:
 	const CImage inImg_gray(inImg, FAST_REF_OR_CONVERT_TO_GRAY);
-	const Mat cvImg = cv::cvarrToMat(inImg_gray.getAs<IplImage>());
+	const Mat cvImg = inImg_gray.asCvMat<Mat>(SHALLOW_COPY);
 
 // The detector and descriptor
 #if MRPT_OPENCV_VERSION_NUM < 0x300
@@ -250,7 +250,7 @@ void CFeatureExtraction::internal_computeORBDescriptors(
 		kp.size = in_features[k]->scale;
 	}  // end-for
 
-	Mat cvImg(cv::cvarrToMat(inImg_gray.getAs<IplImage>()));
+	Mat cvImg = inImg_gray.asCvMat<Mat>(SHALLOW_COPY);
 	Mat cv_descs;
 
 #if MRPT_OPENCV_VERSION_NUM < 0x300

--- a/libs/vision/src/CFeatureExtraction_harris_KLT.cpp
+++ b/libs/vision/src/CFeatureExtraction_harris_KLT.cpp
@@ -28,8 +28,6 @@ void CFeatureExtraction::extractFeaturesKLT(
 	const mrpt::img::CImage& inImg, CFeatureList& feats, unsigned int init_ID,
 	unsigned int nDesiredFeatures, const TImageROI& ROI) const
 {
-	//#define VERBOSE_TIMING
-
 #ifdef VERBOSE_TIMING
 	CTicTac tictac;
 #endif
@@ -41,21 +39,18 @@ void CFeatureExtraction::extractFeaturesKLT(
 	// -----------------------------------------------------------------
 	// Create OpenCV Local Variables
 	// -----------------------------------------------------------------
-	int count = 0;
-	int nPts;
-
 #ifdef VERBOSE_TIMING
 	tictac.Tic();
 #endif
-	const cv::Mat img(cv::cvarrToMat(inImg.getAs<IplImage>()));
+	const cv::Mat img = inImg.asCvMat<cv::Mat>(SHALLOW_COPY);
 
 #ifdef VERBOSE_TIMING
 	cout << "[KLT] Attach: " << tictac.Tac() * 1000.0f << endl;
 #endif
 	const CImage inImg_gray(inImg, FAST_REF_OR_CONVERT_TO_GRAY);
-	const cv::Mat cGrey(cv::cvarrToMat(inImg_gray.getAs<IplImage>()));
+	const cv::Mat cGrey = inImg_gray.asCvMat<cv::Mat>(SHALLOW_COPY);
 
-	nDesiredFeatures <= 0 ? nPts = MAX_COUNT : nPts = nDesiredFeatures;
+	const auto nPts = (nDesiredFeatures <= 0) ? MAX_COUNT : nDesiredFeatures;
 
 #ifdef VERBOSE_TIMING
 	tictac.Tic();
@@ -64,7 +59,7 @@ void CFeatureExtraction::extractFeaturesKLT(
 #ifdef VERBOSE_TIMING
 	cout << "[KLT] Create: " << tictac.Tac() * 1000.0f << endl;
 #endif
-	count = nPts;  // Number of points to find
+	const auto count = nPts;  // Number of points to find
 
 	// -----------------------------------------------------------------
 	// Select good features with subpixel accuracy (USING HARRIS OR KLT)

--- a/libs/vision/src/CFeatureExtraction_logPolarImg.cpp
+++ b/libs/vision/src/CFeatureExtraction_logPolarImg.cpp
@@ -49,9 +49,10 @@ void CFeatureExtraction::internal_computeLogPolarImageDescriptors(
 		(*it)->scale = radius;
 
 		// Use OpenCV to convert:
-		cvLogPolar(
-			in_img.getAs<IplImage>(), logpolar_frame.getAs<IplImage>(),
-			cvPoint2D32f((*it)->x, (*it)->y), rho_scale,
+		cv::logPolar(
+			in_img.asCvMat<cv::Mat>(SHALLOW_COPY),
+			logpolar_frame.asCvMat<cv::Mat>(SHALLOW_COPY),
+			cv::Point2f((*it)->x, (*it)->y), rho_scale,
 			CV_INTER_LINEAR + CV_WARP_FILL_OUTLIERS);
 
 		// Get the image as a matrix and save as patch:

--- a/libs/vision/src/CFeatureExtraction_polarImg.cpp
+++ b/libs/vision/src/CFeatureExtraction_polarImg.cpp
@@ -46,9 +46,10 @@ void CFeatureExtraction::internal_computePolarImageDescriptors(
 		// Overwrite scale with the descriptor scale:
 		(*it)->scale = radius;
 
-		cvLinearPolar(  // Use version sent to OpenCV
-			in_img.getAs<IplImage>(), linpolar_frame.getAs<IplImage>(),
-			cvPoint2D32f((*it)->x, (*it)->y), radius,
+		cv::linearPolar(
+			in_img.asCvMat<cv::Mat>(SHALLOW_COPY),
+			linpolar_frame.asCvMat<cv::Mat>(SHALLOW_COPY),
+			cv::Point2f((*it)->x, (*it)->y), radius,
 			CV_INTER_LINEAR + CV_WARP_FILL_OUTLIERS);
 
 		// Get the image as a matrix and save as patch:

--- a/libs/vision/src/CFeatureLines.cpp
+++ b/libs/vision/src/CFeatureLines.cpp
@@ -249,7 +249,7 @@ void CFeatureLines::extractLines(
 
 	using namespace cv;
 	using namespace std;
-	const Mat image = cv::cvarrToMat(img_in.getAs<IplImage>());
+	const Mat image = img_in.asCvMat<Mat>(mrpt::img::SHALLOW_COPY);
 
 	// Canny edge detector
 	cv::Mat canny_img;
@@ -325,9 +325,6 @@ void CFeatureLines::extractLines(
 		image.convertTo(image_lines, CV_8UC1, 1.0 / 2);
 		for (auto line = begin(segments); line != end(segments); ++line)
 		{
-			// cout << "line: " << (*line)[0] << " " << (*line)[1] << " " <<
-			// (*line)[2] << " " << (*line)[3] << " \n";
-			// image.convertTo(image_lines, CV_8UC1, 1.0 / 2);
 			cv::line(
 				image_lines, cv::Point((*line)[0], (*line)[1]),
 				cv::Point((*line)[2], (*line)[3]), cv::Scalar(255, 0, 255), 1);
@@ -340,10 +337,7 @@ void CFeatureLines::extractLines(
 					((*line)[0] + (*line)[2]) / 2,
 					((*line)[1] + (*line)[3]) / 2),
 				0, 1.2, cv::Scalar(200, 0, 0), 3);
-			// cv::imshow("lines", image_lines); cv::moveWindow("lines",
-			// 20,100+700);  cv::waitKey(0);
 		}
-		// cv::imwrite("/home/efernand/lines.png", image_lines);
 		cv::imshow("lines", image_lines);
 		cv::moveWindow("lines", 20, 100 + 700);
 		cv::waitKey(0);

--- a/libs/vision/src/CImagePyramid.cpp
+++ b/libs/vision/src/CImagePyramid.cpp
@@ -41,9 +41,9 @@ void buildPyramid_templ(
 	else
 	{
 		// No need to convert to grayscale OR image already is grayscale:
+		// Fast copy -> "move", destroying source.
 		if (FASTLOAD)
-			obj.images[0].copyFastFrom(
-				img);  // Fast copy -> "move", destroying source.
+			obj.images[0] = std::move(img);
 		else
 			obj.images[0] = img;  // Normal copy
 	}
@@ -51,10 +51,8 @@ void buildPyramid_templ(
 	// Rest of octaves, if any:
 	for (size_t o = 1; o < nOctaves; o++)
 	{
-		if (smooth_halves)
-			obj.images[o - 1].scaleHalfSmooth(obj.images[o]);
-		else
-			obj.images[o - 1].scaleHalf(obj.images[o]);
+		obj.images[o] = obj.images[o - 1].scaleHalf(
+			smooth_halves ? IMG_INTERP_LINEAR : IMG_INTERP_NN);
 	}
 }
 

--- a/libs/vision/src/CImagePyramid.cpp
+++ b/libs/vision/src/CImagePyramid.cpp
@@ -51,8 +51,8 @@ void buildPyramid_templ(
 	// Rest of octaves, if any:
 	for (size_t o = 1; o < nOctaves; o++)
 	{
-		obj.images[o] = obj.images[o - 1].scaleHalf(
-			smooth_halves ? IMG_INTERP_LINEAR : IMG_INTERP_NN);
+		obj.images[o - 1].scaleHalf(
+			obj.images[o], smooth_halves ? IMG_INTERP_LINEAR : IMG_INTERP_NN);
 	}
 }
 

--- a/libs/vision/src/CStereoRectifyMap.cpp
+++ b/libs/vision/src/CStereoRectifyMap.cpp
@@ -19,13 +19,54 @@ using namespace mrpt::vision;
 using namespace mrpt::img;
 using namespace mrpt::math;
 
-// Ctor: Leave all vectors empty
-CStereoRectifyMap::CStereoRectifyMap() : m_resize_output_value(0, 0) {}
+#if MRPT_HAS_OPENCV
+static void do_rectify(
+	CStereoRectifyMap& me, const cv::Mat& src_left, const cv::Mat& src_right,
+	cv::Mat& out_left, cv::Mat& out_right, int16_t* map_xl, int16_t* map_xr,
+	uint16_t* map_yl, uint16_t* map_yr, int interp_method)
+{
+	MRPT_START
+	ASSERT_(
+		srcImg_left.data != outImg_left.data &&
+		srcImg_right.data != outImg_right.data);
+
+	if (!me.isSet())
+		THROW_EXCEPTION(
+			"Error: setFromCamParams() must be called prior to rectify().")
+
+	const uint32_t ncols = me.getCameraParams().leftCamera.ncols;
+	const uint32_t nrows = me.getCameraParams().leftCamera.nrows;
+
+	const int ncols_out =
+		me.isEnabledResizeOutput() ? me.getResizeOutputSize().x : ncols;
+	const int nrows_out =
+		me.isEnabledResizeOutput() ? me.getResizeOutputSize().y : nrows;
+
+	const CvMat mapx_left = cvMat(nrows_out, ncols_out, CV_16SC2, map_xl);
+	const CvMat mapy_left = cvMat(nrows_out, ncols_out, CV_16UC1, map_yl);
+	const CvMat mapx_right = cvMat(nrows_out, ncols_out, CV_16SC2, map_xr);
+	const CvMat mapy_right = cvMat(nrows_out, ncols_out, CV_16UC1, map_yr);
+
+	const cv::Mat mapx1 = cv::cvarrToMat(&mapx_left);
+	const cv::Mat mapy1 = cv::cvarrToMat(&mapy_left);
+	const cv::Mat mapx2 = cv::cvarrToMat(&mapx_right);
+	const cv::Mat mapy2 = cv::cvarrToMat(&mapy_right);
+
+	cv::remap(
+		src_left, out_left, mapx1, mapy1, interp_method, cv::BORDER_CONSTANT,
+		cvScalarAll(0));
+	cv::remap(
+		src_right, out_right, mapx2, mapy2, interp_method, cv::BORDER_CONSTANT,
+		cvScalarAll(0));
+	MRPT_END
+}
+#endif
+
 void CStereoRectifyMap::internal_invalidate()
 {
-	m_dat_mapx_left
-		.clear();  // don't do a "strong clear" since memory is likely
-	m_dat_mapx_right.clear();  // to be reasigned soon.
+	// don't do a "strong clear" since memory is likely to be reasigned soon.
+	m_dat_mapx_left.clear();
+	m_dat_mapx_right.clear();
 	m_dat_mapy_left.clear();
 	m_dat_mapy_right.clear();
 }
@@ -228,97 +269,28 @@ void CStereoRectifyMap::rectify(
 			: cvSize(ncols, nrows);
 
 	out_left_image.resize(
-		trg_size.width, trg_size.height, in_left_image.isColor() ? 3 : 1,
-		in_left_image.isOriginTopLeft());
+		trg_size.width, trg_size.height, in_left_image.getChannelCount());
 	out_right_image.resize(
-		trg_size.width, trg_size.height, in_left_image.isColor() ? 3 : 1,
-		in_left_image.isOriginTopLeft());
+		trg_size.width, trg_size.height, in_left_image.getChannelCount());
 
-	const auto* in_left = in_left_image.getAs<IplImage>();
-	const auto* in_right = in_right_image.getAs<IplImage>();
+	const cv::Mat in_left = in_left_image.asCvMat<cv::Mat>(SHALLOW_COPY);
+	const cv::Mat in_right = in_right_image.asCvMat<cv::Mat>(SHALLOW_COPY);
 
-	auto* out_left = out_left_image.getAs<IplImage>();
-	auto* out_right = out_right_image.getAs<IplImage>();
+	cv::Mat out_left = out_left_image.asCvMat<cv::Mat>(SHALLOW_COPY);
+	cv::Mat out_right = out_right_image.asCvMat<cv::Mat>(SHALLOW_COPY);
 
-	this->rectify_IPL(in_left, in_right, out_left, out_right);
-
-#endif
-	MRPT_END
-}
-
-// In place:
-void CStereoRectifyMap::rectify(
-	mrpt::img::CImage& left_image, mrpt::img::CImage& right_image,
-	const bool use_internal_mem_cache) const
-{
-	MRPT_START
-
-#if MRPT_HAS_OPENCV
-	const uint32_t ncols = m_camera_params.leftCamera.ncols;
-	const uint32_t nrows = m_camera_params.leftCamera.nrows;
-
-	const CvSize trg_size =
-		m_resize_output
-			? cvSize(m_resize_output_value.x, m_resize_output_value.y)
-			: cvSize(ncols, nrows);
-
-	const IplImage* in_left = left_image.getAs<IplImage>();
-	const IplImage* in_right = right_image.getAs<IplImage>();
-
-	IplImage *out_left_image, *out_right_image;
-	if (use_internal_mem_cache)
-	{
-		m_cache1.resize(
-			trg_size.width, trg_size.height, left_image.isColor() ? 3 : 1,
-			left_image.isOriginTopLeft());
-		m_cache2.resize(
-			trg_size.width, trg_size.height, right_image.isColor() ? 3 : 1,
-			right_image.isOriginTopLeft());
-
-		out_left_image = m_cache1.getAs<IplImage>();
-		out_right_image = m_cache2.getAs<IplImage>();
-	}
-	else
-	{
-		out_left_image =
-			cvCreateImage(trg_size, in_left->depth, in_left->nChannels);
-		out_right_image =
-			cvCreateImage(trg_size, in_right->depth, in_right->nChannels);
-	}
-
-	this->rectify_IPL(in_left, in_right, out_left_image, out_right_image);
-
-	if (use_internal_mem_cache)
-	{
-		// Copy the data: we have avoided one allocation & one deallocation
-		// (If the sizes match, these calls have no effects)
-		left_image.resize(
-			trg_size.width, trg_size.height, left_image.isColor() ? 3 : 1,
-			left_image.isOriginTopLeft());
-		right_image.resize(
-			trg_size.width, trg_size.height, right_image.isColor() ? 3 : 1,
-			right_image.isOriginTopLeft());
-
-		cvCopy(out_left_image, left_image.getAs<IplImage>());
-		cvCopy(out_right_image, right_image.getAs<IplImage>());
-	}
-	else
-	{
-		// Move the internal pointers: but we deallocate the old contents and
-		// needed to allocate this one
-		left_image.setFromIplImage(out_left_image);
-		right_image.setFromIplImage(out_right_image);
-	}
+	do_rectify(
+		*this, in_left, in_right, out_left, out_right,
+		const_cast<int16_t*>(&m_dat_mapx_left[0]),
+		const_cast<int16_t*>(&m_dat_mapx_right[0]),
+		const_cast<uint16_t*>(&m_dat_mapy_left[0]),
+		const_cast<uint16_t*>(&m_dat_mapy_right[0]),
+		static_cast<int>(m_interpolation_method));
 
 #endif
 	MRPT_END
 }
 
-/** Overloaded version for in-place rectification of image pairs stored in a
- * mrpt::obs::CObservationStereoImages.
- *  Upon return, the new camera intrinsic parameters will be already stored in
- * the observation object.
- */
 void CStereoRectifyMap::rectify(
 	mrpt::obs::CObservationStereoImages& stereo_image_observation,
 	const bool use_internal_mem_cache) const
@@ -343,61 +315,6 @@ void CStereoRectifyMap::rectify(
 	stereo_image_observation.rightCameraPose =
 		CPose3DQuat(d, .0, .0, mrpt::math::CQuaternionDouble());
 
-	MRPT_END
-}
-
-/** Just like rectify() but directly works with OpenCV's "IplImage*", which must
- * be passed as "void*" to avoid header dependencies */
-void CStereoRectifyMap::rectify_IPL(
-	const void* srcImg_left, const void* srcImg_right, void* outImg_left,
-	void* outImg_right) const
-{
-	MRPT_START
-	ASSERT_(srcImg_left != outImg_left && srcImg_right != outImg_right);
-
-	if (!isSet())
-		THROW_EXCEPTION(
-			"Error: setFromCamParams() must be called prior to rectify().")
-
-#if MRPT_HAS_OPENCV
-	const uint32_t ncols = m_camera_params.leftCamera.ncols;
-	const uint32_t nrows = m_camera_params.leftCamera.nrows;
-
-	const uint32_t ncols_out =
-		m_resize_output ? m_resize_output_value.x : ncols;
-	const uint32_t nrows_out =
-		m_resize_output ? m_resize_output_value.y : nrows;
-
-	const CvMat mapx_left = cvMat(
-		nrows_out, ncols_out, CV_16SC2,
-		const_cast<int16_t*>(&m_dat_mapx_left[0]));
-	const CvMat mapy_left = cvMat(
-		nrows_out, ncols_out, CV_16UC1,
-		const_cast<uint16_t*>(&m_dat_mapy_left[0]));
-	const CvMat mapx_right = cvMat(
-		nrows_out, ncols_out, CV_16SC2,
-		const_cast<int16_t*>(&m_dat_mapx_right[0]));
-	const CvMat mapy_right = cvMat(
-		nrows_out, ncols_out, CV_16UC1,
-		const_cast<uint16_t*>(&m_dat_mapy_right[0]));
-
-	const cv::Mat mapx1 = cv::cvarrToMat(&mapx_left);
-	const cv::Mat mapy1 = cv::cvarrToMat(&mapy_left);
-	const cv::Mat mapx2 = cv::cvarrToMat(&mapx_right);
-	const cv::Mat mapy2 = cv::cvarrToMat(&mapy_right);
-
-	const cv::Mat src1 = cv::cvarrToMat(srcImg_left);
-	const cv::Mat src2 = cv::cvarrToMat(srcImg_right);
-	cv::Mat dst1 = cv::cvarrToMat(outImg_left);
-	cv::Mat dst2 = cv::cvarrToMat(outImg_right);
-
-	cv::remap(
-		src1, dst1, mapx1, mapy1, static_cast<int>(m_interpolation_method),
-		cv::BORDER_CONSTANT, cvScalarAll(0));
-	cv::remap(
-		src2, dst2, mapx2, mapy2, static_cast<int>(m_interpolation_method),
-		cv::BORDER_CONSTANT, cvScalarAll(0));
-#endif
 	MRPT_END
 }
 

--- a/libs/vision/src/CUndistortMap.cpp
+++ b/libs/vision/src/CUndistortMap.cpp
@@ -67,21 +67,20 @@ void CUndistortMap::undistort(
 			"Error: setFromCamParams() must be called prior to undistort().")
 
 #if MRPT_HAS_OPENCV
-	CvMat mapx = cvMat(
+	using namespace cv;
+	Mat mapx(
 		m_camera_params.nrows, m_camera_params.ncols, CV_16SC2,
-		const_cast<int16_t*>(
-			&m_dat_mapx[0]));  // Wrappers on the data as a CvMat's.
-	CvMat mapy = cvMat(
+		const_cast<int16_t*>(&m_dat_mapx[0]));
+	Mat mapy(
 		m_camera_params.nrows, m_camera_params.ncols, CV_16UC1,
 		const_cast<uint16_t*>(&m_dat_mapy[0]));
 
-	const auto* srcImg = in_img.getAs<IplImage>();  // Source Image
-	IplImage* outImg =
-		cvCreateImage(cvGetSize(srcImg), srcImg->depth, srcImg->nChannels);
-	cvRemap(srcImg, outImg, &mapx, &mapy);  // cv::remap(src, dst_part,
-	// map1_part, map2_part,
-	// INTER_LINEAR, BORDER_CONSTANT );
-	out_img.setFromIplImage(outImg);
+	out_img.resize(
+		in_img.getWidth(), in_img.getHeight(), in_img.getChannelCount());
+
+	cv::remap(
+		in_img.asCvMat<Mat>(SHALLOW_COPY), out_img.asCvMat<Mat>(SHALLOW_COPY),
+		mapx, mapy, INTER_LINEAR);
 #endif
 	MRPT_END
 }

--- a/libs/vision/src/CUndistortMap.cpp
+++ b/libs/vision/src/CUndistortMap.cpp
@@ -40,15 +40,11 @@ void CUndistortMap::setFromCamParams(const mrpt::img::TCamera& campar)
 	m_dat_mapx.resize(2 * campar.nrows * campar.ncols);
 	m_dat_mapy.resize(campar.nrows * campar.ncols);
 
-	CvMat mapx = cvMat(campar.nrows, campar.ncols, CV_16SC2, &m_dat_mapx[0]);
-	CvMat mapy = cvMat(campar.nrows, campar.ncols, CV_16UC1, &m_dat_mapy[0]);
-
-	cv::Mat _mapx = cv::cvarrToMat(&mapx, false);
-	cv::Mat _mapy = cv::cvarrToMat(&mapy, false);
+	cv::Mat mapx(campar.nrows, campar.ncols, CV_16SC2, &m_dat_mapx[0]);
+	cv::Mat mapy(campar.nrows, campar.ncols, CV_16UC1, &m_dat_mapy[0]);
 
 	cv::initUndistortRectifyMap(
-		inMat, distM, cv::Mat(), inMat, _mapx.size(), _mapx.type(), _mapx,
-		_mapy);
+		inMat, distM, cv::Mat(), inMat, mapx.size(), mapx.type(), mapx, mapy);
 #else
 	THROW_EXCEPTION("MRPT built without OpenCV >=2.0.0!");
 #endif
@@ -96,21 +92,19 @@ void CUndistortMap::undistort(mrpt::img::CImage& in_out_img) const
 			"Error: setFromCamParams() must be called prior to undistort().")
 
 #if MRPT_HAS_OPENCV
-	CvMat mapx = cvMat(
+	cv::Mat mapx(
 		m_camera_params.nrows, m_camera_params.ncols, CV_16SC2,
-		const_cast<int16_t*>(
-			&m_dat_mapx[0]));  // Wrappers on the data as a CvMat's.
-	CvMat mapy = cvMat(
+		const_cast<int16_t*>(&m_dat_mapx[0]));
+	cv::Mat mapy(
 		m_camera_params.nrows, m_camera_params.ncols, CV_16UC1,
 		const_cast<uint16_t*>(&m_dat_mapy[0]));
 
-	const IplImage* srcImg = in_out_img.getAs<IplImage>();  // Source Image
-	IplImage* outImg =
-		cvCreateImage(cvGetSize(srcImg), srcImg->depth, srcImg->nChannels);
-	cvRemap(srcImg, outImg, &mapx, &mapy);  // cv::remap(src, dst_part,
-	// map1_part, map2_part,
-	// INTER_LINEAR, BORDER_CONSTANT );
-	in_out_img.setFromIplImage(outImg);
+	cv::Mat in = in_out_img.asCvMat<cv::Mat>(SHALLOW_COPY);
+	cv::Mat out(in.size(), in.type());
+
+	cv::remap(in, out, mapx, mapy, cv::INTER_LINEAR);
+
+	in_out_img = CImage(out, SHALLOW_COPY);
 #endif
 	MRPT_END
 }

--- a/libs/vision/src/CVideoFileWriter.cpp
+++ b/libs/vision/src/CVideoFileWriter.cpp
@@ -119,7 +119,9 @@ const CVideoFileWriter& CVideoFileWriter::operator<<(
 			m_img_size.y, (unsigned)img.getWidth(), (unsigned)img.getHeight()));
 
 #if MRPT_HAS_OPENCV
-	if (!cvWriteFrame(M_WRITER, img.getAs<IplImage>()))
+	cv::Mat m = img.asCvMat<cv::Mat>(SHALLOW_COPY);
+	IplImage ipl(m);
+	if (!cvWriteFrame(M_WRITER, &ipl))
 		THROW_EXCEPTION("Error writing image frame to video file");
 #endif
 	return *this;
@@ -145,7 +147,9 @@ bool CVideoFileWriter::writeImage(const mrpt::img::CImage& img) const
 	}
 
 #if MRPT_HAS_OPENCV
-	return 0 != cvWriteFrame(M_WRITER, img.getAs<IplImage>());
+	cv::Mat m = img.asCvMat<cv::Mat>(SHALLOW_COPY);
+	IplImage ipl(m);
+	return 0 != cvWriteFrame(M_WRITER, &ipl);
 #else
 	return false;
 #endif

--- a/libs/vision/src/checkerboard_cam_calib.cpp
+++ b/libs/vision/src/checkerboard_cam_calib.cpp
@@ -269,26 +269,26 @@ bool mrpt::vision::checkerBoardCameraCalibration(
 					// Checkboad as color image:
 					dat.img_original.colorImage(dat.img_checkboard);
 
-					void* rgb_img = dat.img_checkboard.getAs<IplImage>();
+					cv::Mat rgb_img =
+						dat.img_checkboard.asCvMat<cv::Mat>(SHALLOW_COPY);
 
 					for (y = 0, k = 0; y < check_size.height; y++)
 					{
-						CvScalar color = line_colors[y % line_max];
+						cv::Scalar color = line_colors[y % line_max];
 						for (x = 0; x < check_size.width; x++, k++)
 						{
-							CvPoint pt;
-							pt.x = cvRound(this_img_pts[k].x);
-							pt.y = cvRound(this_img_pts[k].y);
+							cv::Point pt{cvRound(this_img_pts[k].x),
+										 cvRound(this_img_pts[k].y)};
 
-							if (k != 0) cvLine(rgb_img, prev_pt, pt, color);
+							if (k != 0) cv::line(rgb_img, prev_pt, pt, color);
 
-							cvLine(
-								rgb_img, cvPoint(pt.x - r, pt.y - r),
-								cvPoint(pt.x + r, pt.y + r), color);
-							cvLine(
-								rgb_img, cvPoint(pt.x - r, pt.y + r),
-								cvPoint(pt.x + r, pt.y - r), color);
-							cvCircle(rgb_img, pt, r + 1, color);
+							cv::line(
+								rgb_img, cv::Point(pt.x - r, pt.y - r),
+								cv::Point(pt.x + r, pt.y + r), color);
+							cv::line(
+								rgb_img, cv::Point(pt.x - r, pt.y + r),
+								cv::Point(pt.x + r, pt.y - r), color);
+							cv::circle(rgb_img, pt, r + 1, color);
 							prev_pt = pt;
 						}
 					}
@@ -377,7 +377,7 @@ bool mrpt::vision::checkerBoardCameraCalibration(
 		{
 			TImageCalibData& dat = it->second;
 			if (!dat.img_original.isExternallyStored())
-				dat.img_original.rectifyImage(
+				dat.img_original.undistort(
 					dat.img_rectified, out_camera_params);
 		}  // end undistort
 
@@ -436,9 +436,9 @@ bool mrpt::vision::checkerBoardCameraCalibration(
 				{
 					if (px >= 0 && px < imgSize.width && py >= 0 &&
 						py < imgSize.height)
-						cvCircle(
-							dat.img_rectified.getAs<IplImage>(),
-							cvPoint(px, py), 4, CV_RGB(0, 0, 255));
+						cv::circle(
+							dat.img_rectified.asCvMat<cv::Mat>(SHALLOW_COPY),
+							cv::Point(px, py), 4, CV_RGB(0, 0, 255));
 				}
 
 				// Accumulate error:

--- a/libs/vision/src/checkerboard_find_corners.cpp
+++ b/libs/vision/src/checkerboard_find_corners.cpp
@@ -63,10 +63,9 @@ bool mrpt::vision::findChessboardCorners(
 	int find_chess_flags = cv::CALIB_CB_ADAPTIVE_THRESH;
 	if (normalize_image) find_chess_flags |= cv::CALIB_CB_NORMALIZE_IMAGE;
 
+	cv::Mat cvImg = img.asCvMat<cv::Mat>(SHALLOW_COPY);
 	if (!useScaramuzzaMethod)
 	{
-		cv::Mat cvImg = cv::cvarrToMat(img.getAs<IplImage>());
-
 		vector<cv::Point2f> pointbuf;
 
 		// Standard OpenCV's function:
@@ -92,10 +91,10 @@ bool mrpt::vision::findChessboardCorners(
 
 	if (corners_found)
 	{
+		IplImage iplImg(cvImg);
 		// Refine corners:
 		cvFindCornerSubPix(
-			img.getAs<IplImage>(), &corners_list[0], corners_count,
-			cvSize(5, 5),  // window
+			&iplImg, &corners_list[0], corners_count, cvSize(5, 5),  // window
 			cvSize(-1, -1),
 			cvTermCriteria(CV_TERMCRIT_ITER | CV_TERMCRIT_EPS, 10, 0.01f));
 
@@ -139,6 +138,8 @@ void mrpt::vision::findMultipleChessboardsCorners(
 #if MRPT_HAS_OPENCV
 	// Grayscale version:
 	const CImage img(in_img, FAST_REF_OR_CONVERT_TO_GRAY);
+	const cv::Mat img_m = img.asCvMat<cv::Mat>(SHALLOW_COPY);
+	const IplImage img_ipl(img_m);
 
 	std::vector<std::vector<CvPoint2D32f>> corners_list;
 
@@ -157,8 +158,8 @@ void mrpt::vision::findMultipleChessboardsCorners(
 			ASSERT_(corners_list[i].size() == check_size_x * check_size_y);
 
 			cvFindCornerSubPix(
-				img.getAs<IplImage>(), &corners_list[i][0],
-				check_size_x * check_size_y, cvSize(5, 5),  // window
+				&img_ipl, &corners_list[i][0], check_size_x * check_size_y,
+				cvSize(5, 5),  // window
 				cvSize(-1, -1),
 				cvTermCriteria(CV_TERMCRIT_ITER | CV_TERMCRIT_EPS, 10, 0.01f));
 

--- a/libs/vision/src/checkerboard_ocamcalib_detector.cpp
+++ b/libs/vision/src/checkerboard_ocamcalib_detector.cpp
@@ -85,28 +85,9 @@ bool do_special_dilation(
 	IplConvKernel* kernel_diag2, IplConvKernel* kernel_horz,
 	IplConvKernel* kernel_vert)
 {
-#if 0
-	// MARTIN's Code
-	// Use both a rectangular and a cross kernel. In this way, a more
-	// homogeneous dilation is performed, which is crucial for small,
-	// distorted checkers. Use the CROSS kernel first, since its action
-	// on the image is more subtle
-	if (dilations >= 1)
-		cvDilate( thresh_img.getAs<IplImage>(), thresh_img.getAs<IplImage>(), kernel_cross, 1);
-	if (dilations >= 2)
-		cvDilate( thresh_img.getAs<IplImage>(), thresh_img.getAs<IplImage>(), kernel_rect, 1);
-	if (dilations >= 3)
-		cvDilate( thresh_img.getAs<IplImage>(), thresh_img.getAs<IplImage>(), kernel_cross, 1);
-	if (dilations >= 4)
-		cvDilate( thresh_img.getAs<IplImage>(), thresh_img.getAs<IplImage>(), kernel_rect, 1);
-	if (dilations >= 5)
-		cvDilate( thresh_img.getAs<IplImage>(), thresh_img.getAs<IplImage>(), kernel_cross, 1);
-	if (dilations >= 6)
-		cvDilate( thresh_img.getAs<IplImage>(), thresh_img.getAs<IplImage>(), kernel_rect, 1);
-
-	return dilations==6; // Last dilation?
-#else
-	auto* ipl = thresh_img.getAs<IplImage>();
+	cv::Mat m = thresh_img.asCvMat<cv::Mat>(SHALLOW_COPY);
+	IplImage i(m);
+	IplImage* ipl = &i;
 
 	bool isLast = false;
 
@@ -115,128 +96,126 @@ bool do_special_dilation(
 		case 37:
 			cvDilate(ipl, ipl, kernel_cross, 1);
 			isLast = true;
-		// fall through
+			[[fallthrough]];
 		case 36:
 			cvErode(ipl, ipl, kernel_rect, 1);
-		// fall through
+			[[fallthrough]];
 		case 35:
 			cvDilate(ipl, ipl, kernel_vert, 1);
-		// fall through
+			[[fallthrough]];
 		case 34:
 			cvDilate(ipl, ipl, kernel_vert, 1);
-		// fall through
+			[[fallthrough]];
 		case 33:
 			cvDilate(ipl, ipl, kernel_vert, 1);
-		// fall through
+			[[fallthrough]];
 		case 32:
 			cvDilate(ipl, ipl, kernel_vert, 1);
-		// fall through
+			[[fallthrough]];
 		case 31:
 			cvDilate(ipl, ipl, kernel_vert, 1);
 			break;
 
 		case 30:
 			cvDilate(ipl, ipl, kernel_cross, 1);
-		// fall through
+			[[fallthrough]];
 		case 29:
 			cvErode(ipl, ipl, kernel_rect, 1);
-		// fall through
+			[[fallthrough]];
 		case 28:
 			cvDilate(ipl, ipl, kernel_horz, 1);
-		// fall through
+			[[fallthrough]];
 		case 27:
 			cvDilate(ipl, ipl, kernel_horz, 1);
-		// fall through
+			[[fallthrough]];
 		case 26:
 			cvDilate(ipl, ipl, kernel_horz, 1);
-		// fall through
+			[[fallthrough]];
 		case 25:
 			cvDilate(ipl, ipl, kernel_horz, 1);
-		// fall through
+			[[fallthrough]];
 		case 24:
 			cvDilate(ipl, ipl, kernel_horz, 1);
 			break;
 
 		case 23:
 			cvDilate(ipl, ipl, kernel_diag2, 1);
-		// fall through
+			[[fallthrough]];
 		case 22:
 			cvDilate(ipl, ipl, kernel_diag1, 1);
-		// fall through
+			[[fallthrough]];
 		case 21:
 			cvDilate(ipl, ipl, kernel_diag2, 1);
-		// fall through
+			[[fallthrough]];
 		case 20:
 			cvDilate(ipl, ipl, kernel_diag1, 1);
-		// fall through
+			[[fallthrough]];
 		case 19:
 			cvDilate(ipl, ipl, kernel_diag2, 1);
-		// fall through
+			[[fallthrough]];
 		case 18:
 			cvDilate(ipl, ipl, kernel_diag1, 1);
 			break;
 
 		case 17:
 			cvDilate(ipl, ipl, kernel_diag2, 1);
-		// fall through
+			[[fallthrough]];
 		case 16:
 			cvDilate(ipl, ipl, kernel_diag2, 1);
-		// fall through
+			[[fallthrough]];
 		case 15:
 			cvDilate(ipl, ipl, kernel_diag2, 1);
-		// fall through
+			[[fallthrough]];
 		case 14:
 			cvDilate(ipl, ipl, kernel_diag2, 1);
 			break;
 
 		case 13:
 			cvDilate(ipl, ipl, kernel_diag1, 1);
-		// fall through
+			[[fallthrough]];
 		case 12:
 			cvDilate(ipl, ipl, kernel_diag1, 1);
-		// fall through
+			[[fallthrough]];
 		case 11:
 			cvDilate(ipl, ipl, kernel_diag1, 1);
-		// fall through
+			[[fallthrough]];
 		case 10:
 			cvDilate(ipl, ipl, kernel_diag1, 1);
 			break;
 
 		case 9:
 			cvDilate(ipl, ipl, kernel_cross, 1);
-		// fall through
+			[[fallthrough]];
 		case 8:
 			cvErode(ipl, ipl, kernel_rect, 1);
-		// fall through
+			[[fallthrough]];
 		case 7:
 			cvDilate(ipl, ipl, kernel_cross, 1);
-		// fall through
+			[[fallthrough]];
 		case 6:
 			cvDilate(ipl, ipl, kernel_diag2, 1);
 			isLast = true;
-		// fall through
+			[[fallthrough]];
 		case 5:
 			cvDilate(ipl, ipl, kernel_diag1, 1);
-		// fall through
+			[[fallthrough]];
 		case 4:
 			cvDilate(ipl, ipl, kernel_rect, 1);
-		// fall through
+			[[fallthrough]];
 		case 3:
 			cvErode(ipl, ipl, kernel_cross, 1);
-		// fall through
+			[[fallthrough]];
 		case 2:
 			cvDilate(ipl, ipl, kernel_rect, 1);
-		// fall through
+			[[fallthrough]];
 		case 1:
 			cvDilate(ipl, ipl, kernel_cross, 1);
-		// fall through
+			[[fallthrough]];
 		case 0: /* first try: do nothing to the image */
 			break;
 	};
 
 	return isLast;
-
-#endif
 }
 
 //===========================================================================
@@ -316,18 +295,12 @@ int cvFindChessboardCorners3(
 	// thresholding!
 	block_size = cvRound(MIN(img.getWidth(), img.getHeight()) * 0.2) | 1;
 
-	cvAdaptiveThreshold(
-		img.getAs<IplImage>(), thresh_img.getAs<IplImage>(), 255,
+	cv::adaptiveThreshold(
+		img.asCvMat<cv::Mat>(SHALLOW_COPY),
+		thresh_img.asCvMat<cv::Mat>(SHALLOW_COPY), 255,
 		CV_ADAPTIVE_THRESH_GAUSSIAN_C, CV_THRESH_BINARY, block_size, 0);
 
-	cvCopy(thresh_img.getAs<IplImage>(), thresh_img_save.getAs<IplImage>());
-
-// VISUALIZATION--------------------------------------------------------------
-#if VIS
-	// mrpt::system::deleteFiles("./DBG_*.png");
-	img.saveToFile("./DBG_OrigImg.png");
-#endif
-	// END------------------------------------------------------------------------
+	thresh_img_save = thresh_img.makeDeepCopy();
 
 	// PART 1: FIND LARGEST PATTERN
 	//-----------------------------------------------------------------------
@@ -344,25 +317,20 @@ int cvFindChessboardCorners3(
 	{
 		// Calling "cvCopy" again is much faster than rerunning
 		// "cvAdaptiveThreshold"
-		cvCopy(thresh_img_save.getAs<IplImage>(), thresh_img.getAs<IplImage>());
+		thresh_img = thresh_img_save.makeDeepCopy();
 
 		// Dilate squares:
 		last_dilation = do_special_dilation(
 			thresh_img, dilations, kernel_cross, kernel_rect, kernel_diag1,
 			kernel_diag2, kernel_horz, kernel_vert);
 
-#if VIS
-		thresh_img.saveToFile(
-			mrpt::format("./DBG_dilation=%i.png", (int)dilations));
-#endif
-
 		// In order to find rectangles that go to the edge, we draw a white
 		// line around the image edge. Otherwise FindContours will miss those
 		// clipped rectangle contours. The border color will be the image mean,
 		// because otherwise we risk screwing up filters like cvSmooth()
-		cvRectangle(
-			thresh_img.getAs<IplImage>(), cvPoint(0, 0),
-			cvPoint(thresh_img.getWidth() - 1, thresh_img.getHeight() - 1),
+		cv::rectangle(
+			thresh_img.asCvMat<cv::Mat>(SHALLOW_COPY), cv::Point(0, 0),
+			cv::Point(thresh_img.getWidth() - 1, thresh_img.getHeight() - 1),
 			CV_RGB(255, 255, 255), 3, 8);
 
 		// Generate quadrangles in the following function
@@ -375,69 +343,6 @@ int cvFindChessboardCorners3(
 		// quadrangle in the immediate vicinity fulfilling certain
 		// prerequisites
 		mrFindQuadNeighbors2(quads, dilations);
-
-// VISUALIZATION--------------------------------------------------------------
-#if VIS
-		IplImage* imageCopy22 =
-			cvCreateImage(cvGetSize(thresh_img.getAs<IplImage>()), 8, 3);
-		{
-			// cvNamedWindow( "all found quads per dilation run", 1 );
-			IplImage* imageCopy2 =
-				cvCreateImage(cvGetSize(thresh_img.getAs<IplImage>()), 8, 1);
-			cvCopy(thresh_img.getAs<IplImage>(), imageCopy2);
-			cvCvtColor(imageCopy2, imageCopy22, CV_GRAY2BGR);
-
-			for (int kkk = 0; kkk < quad_count; kkk++)
-			{
-				const CvCBQuad::Ptr& print_quad = quads[kkk];
-				CvPoint pt[4];
-				pt[0].x = (int)print_quad->corners[0]->pt.x;
-				pt[0].y = (int)print_quad->corners[0]->pt.y;
-				pt[1].x = (int)print_quad->corners[1]->pt.x;
-				pt[1].y = (int)print_quad->corners[1]->pt.y;
-				pt[2].x = (int)print_quad->corners[2]->pt.x;
-				pt[2].y = (int)print_quad->corners[2]->pt.y;
-				pt[3].x = (int)print_quad->corners[3]->pt.x;
-				pt[3].y = (int)print_quad->corners[3]->pt.y;
-				cvLine(imageCopy22, pt[0], pt[1], CV_RGB(255, 255, 0), 1, 8);
-				cvLine(imageCopy22, pt[1], pt[2], CV_RGB(255, 255, 0), 1, 8);
-				cvLine(imageCopy22, pt[2], pt[3], CV_RGB(255, 255, 0), 1, 8);
-				cvLine(imageCopy22, pt[3], pt[0], CV_RGB(255, 255, 0), 1, 8);
-			}
-			static int cnt = 0;
-			cnt++;
-			cvSaveImage(
-				mrpt::format("./DBG_dilation=%i_quads.png", (int)dilations)
-					.c_str(),
-				imageCopy22);
-
-			// cvNamedWindow( "quads with neighbors", 1 );
-			IplImage* imageCopy3 =
-				cvCreateImage(cvGetSize(thresh_img.getAs<IplImage>()), 8, 3);
-			cvCopy(imageCopy22, imageCopy3);
-			CvPoint pt;
-			int scale = 0;
-			int line_type = CV_AA;
-			CvScalar color = {{0, 0, 255}};
-			for (int kkk = 0; kkk < quad_count; kkk++)
-			{
-				const CvCBQuad::Ptr& print_quad2 = quads[kkk];
-				for (int kkkk = 0; kkkk < 4; kkkk++)
-				{
-					if (print_quad2->neighbors[kkkk])
-					{
-						pt.x = (int)(print_quad2->corners[kkkk]->pt.x);
-						pt.y = (int)(print_quad2->corners[kkkk]->pt.y);
-						cvCircle(imageCopy3, pt, 3, color, 1, line_type, scale);
-					}
-				}
-			}
-			cvSaveImage(
-				mrpt::format("./DBG_allFoundNeighbors_%05i.png", cnt).c_str(),
-				imageCopy3);
-		}
-#endif
-		// END------------------------------------------------------------------------
 
 		// The connected quads will be organized in groups. The following loop
 		// increases a "group_idx" identifier.
@@ -478,73 +383,6 @@ int cvFindChessboardCorners3(
 				// made.
 				mrLabelQuadGroup(quad_group, pattern_size, true);
 
-// VISUALIZATION--------------------------------------------------------------
-#if VIS
-				// display all corners in INCREASING ROW AND COLUMN ORDER
-				// cvNamedWindow( "Corners in increasing order", 1 );
-				IplImage* imageCopy11 = cvCreateImage(
-					cvGetSize(thresh_img.getAs<IplImage>()), 8, 3);
-				cvCopy(imageCopy22, imageCopy11);
-				// Assume min and max rows here, since we are outside of the
-				// relevant function
-				int min_row = -15;
-				int max_row = 15;
-				int min_column = -15;
-				int max_column = 15;
-				for (int i = min_row; i <= max_row; i++)
-				{
-					for (int j = min_column; j <= max_column; j++)
-					{
-						for (size_t k = 0; k < count; k++)
-						{
-							for (size_t l = 0; l < 4; l++)
-							{
-								if (((quad_group[k])->corners[l]->row == i) &&
-									((quad_group[k])->corners[l]->column == j))
-								{
-									// draw the row and column numbers
-									char str[255];
-									sprintf(str, "%i/%i", i, j);
-									CvFont font;
-									cvInitFont(
-										&font, CV_FONT_HERSHEY_SIMPLEX, 0.2,
-										0.2, 0, 1);
-									CvPoint ptt;
-									ptt.x =
-										(int)quad_group[k]->corners[l]->pt.x;
-									ptt.y =
-										(int)quad_group[k]->corners[l]->pt.y;
-									// Mark central corners with a different
-									// color than
-									// border corners
-									if ((quad_group[k])
-											->corners[l]
-											->needsNeighbor == false)
-									{
-										cvPutText(
-											imageCopy11, str, ptt, &font,
-											CV_RGB(0, 255, 0));
-									}
-									else
-									{
-										cvPutText(
-											imageCopy11, str, ptt, &font,
-											CV_RGB(255, 0, 0));
-									}
-									// cvShowImage( "Corners in increasing
-									// order", imageCopy11);
-								}
-							}
-						}
-					}
-				}
-				static int cnt = 0;
-				cvSaveImage(
-					format("./DBG_CornersIncreasingOrder_%05i.png", cnt++)
-						.c_str(),
-					imageCopy11);
-// cvWaitKey(0);
-#endif
 				// END------------------------------------------------------------------------
 
 				// Allocate memory
@@ -570,8 +408,6 @@ int cvFindChessboardCorners3(
 	// "CvPoint2D32f *out_corners":
 	// Return true on success in finding all the quads.
 	found = myQuads2Points(output_quad_group, pattern_size, out_corners);
-	// found = mrWriteCorners( output_quad_group, max_count, pattern_size,
-	// min_number_of_corners);
 
 	if (found != -1 && found != 1)
 	{
@@ -593,130 +429,23 @@ int cvFindChessboardCorners3(
 
 			// Calling "cvCopy" again is much faster than rerunning
 			// "cvAdaptiveThreshold"
-			cvCopy(
-				thresh_img_save.getAs<IplImage>(),
-				thresh_img.getAs<IplImage>());
+			thresh_img = thresh_img_save.makeDeepCopy();
 
 			// Dilate squares:
 			last_dilation = do_special_dilation(
 				thresh_img, dilations, kernel_cross, kernel_rect, kernel_diag1,
 				kernel_diag2, kernel_horz, kernel_vert);
 
-			cvRectangle(
-				thresh_img.getAs<IplImage>(), cvPoint(0, 0),
-				cvPoint(thresh_img.getWidth() - 1, thresh_img.getHeight() - 1),
+			cv::rectangle(
+				thresh_img.asCvMat<cv::Mat>(SHALLOW_COPY), cv::Point(0, 0),
+				cv::Point(
+					thresh_img.getWidth() - 1, thresh_img.getHeight() - 1),
 				CV_RGB(255, 255, 255), 3, 8);
-
-// VISUALIZATION--------------------------------------------------------------
-#if VIS
-			// cvNamedWindow( "PART2: Starting Point", 1 );
-			IplImage* imageCopy23 =
-				cvCreateImage(cvGetSize(thresh_img.getAs<IplImage>()), 8, 3);
-			cvCvtColor(thresh_img.getAs<IplImage>(), imageCopy23, CV_GRAY2BGR);
-
-			CvPoint pt[4];
-			for (size_t kkk = 0; kkk < max_count; kkk++)
-			{
-				const CvCBQuad::Ptr& print_quad2 = output_quad_group[kkk];
-				for (size_t kkkk = 0; kkkk < 4; kkkk++)
-				{
-					pt[kkkk].x = (int)print_quad2->corners[kkkk]->pt.x;
-					pt[kkkk].y = (int)print_quad2->corners[kkkk]->pt.y;
-				}
-				// draw a filled polygon
-				cvFillConvexPoly(
-					imageCopy23, pt, 4,
-					CV_RGB(255 * 0.1, 255 * 0.25, 255 * 0.6));
-			}
-			// indicate the dilation run
-			char str[255];
-			sprintf(str, "Dilation Run No.: %i", dilations);
-			CvFont font;
-			cvInitFont(&font, CV_FONT_HERSHEY_SIMPLEX, 0.5, 0.5, 0, 2);
-			// cvPutText(imageCopy23, str, cvPoint(20,20), &font,
-			// CV_RGB(0,255,0));
-
-			// cvShowImage( "PART2: Starting Point", imageCopy23);
-			cvSaveImage("./DBG_part2Start.png", imageCopy23);
-// cvWaitKey(0);
-#endif
-			// END------------------------------------------------------------------------
 
 			quad_count = icvGenerateQuads(
 				quads, corners, thresh_img, flags, dilations, false);
 			if (quad_count <= 0) continue;
 
-// VISUALIZATION--------------------------------------------------------------
-#if VIS
-			// draw on top of previous image
-			for (int kkk = 0; kkk < quad_count; kkk++)
-			{
-				const CvCBQuad::Ptr& print_quad = quads[kkk];
-
-				CvPoint pt[4];
-				pt[0].x = (int)print_quad->corners[0]->pt.x;
-				pt[0].y = (int)print_quad->corners[0]->pt.y;
-				pt[1].x = (int)print_quad->corners[1]->pt.x;
-				pt[1].y = (int)print_quad->corners[1]->pt.y;
-				pt[2].x = (int)print_quad->corners[2]->pt.x;
-				pt[2].y = (int)print_quad->corners[2]->pt.y;
-				pt[3].x = (int)print_quad->corners[3]->pt.x;
-				pt[3].y = (int)print_quad->corners[3]->pt.y;
-				cvLine(imageCopy23, pt[0], pt[1], CV_RGB(255, 0, 0), 1, 8);
-				cvLine(imageCopy23, pt[1], pt[2], CV_RGB(255, 0, 0), 1, 8);
-				cvLine(imageCopy23, pt[2], pt[3], CV_RGB(255, 0, 0), 1, 8);
-				cvLine(imageCopy23, pt[3], pt[0], CV_RGB(255, 0, 0), 1, 8);
-				// compute center of print_quad
-				//				int x1 = (pt[0].x + pt[1].x)/2;
-				//				int y1 = (pt[0].y + pt[1].y)/2;
-				//				int x2 = (pt[2].x + pt[3].x)/2;
-				//				int y2 = (pt[2].y + pt[3].y)/2;
-
-				// int x3 = (x1 + x2)/2;
-				// int y3 = (y1 + y2)/2;
-				// indicate the quad number in the image
-				// char str[255];
-				// sprintf(str,"%i",kkk);
-				// CvFont font;
-				// cvInitFont(&font, CV_FONT_HERSHEY_SIMPLEX, 0.5, 0.5, 0, 1);
-				// cvPutText(imageCopy23, str, cvPoint(x3,y3), &font,
-				// CV_RGB(0,255,255));
-			}
-
-			for (size_t kkk = 0; kkk < max_count; kkk++)
-			{
-				const CvCBQuad::Ptr& print_quad = output_quad_group[kkk];
-
-				CvPoint pt[4];
-				pt[0].x = (int)print_quad->corners[0]->pt.x;
-				pt[0].y = (int)print_quad->corners[0]->pt.y;
-				pt[1].x = (int)print_quad->corners[1]->pt.x;
-				pt[1].y = (int)print_quad->corners[1]->pt.y;
-				pt[2].x = (int)print_quad->corners[2]->pt.x;
-				pt[2].y = (int)print_quad->corners[2]->pt.y;
-				pt[3].x = (int)print_quad->corners[3]->pt.x;
-				pt[3].y = (int)print_quad->corners[3]->pt.y;
-				// compute center of print_quad
-				//				int x1 = (pt[0].x + pt[1].x)/2;
-				//				int y1 = (pt[0].y + pt[1].y)/2;
-				//				int x2 = (pt[2].x + pt[3].x)/2;
-				//				int y2 = (pt[2].y + pt[3].y)/2;
-				//
-				//				int x3 = (x1 + x2)/2;
-				//				int y3 = (y1 + y2)/2;
-				// indicate the quad number in the image
-				//				char str[255];
-				//				sprintf(str,"%i",kkk);
-				// CvFont font;
-				// cvInitFont(&font, CV_FONT_HERSHEY_SIMPLEX, 0.5, 0.5, 0, 1);
-				// cvPutText(imageCopy23, str, cvPoint(x3,y3), &font,
-				// CV_RGB(0,0,0));
-			}
-
-			// cvShowImage( "PART2: Starting Point", imageCopy23);
-			cvSaveImage("./DBG_part2StartAndNewQuads.png", imageCopy23);
-// cvWaitKey(0);
-#endif
 			// END------------------------------------------------------------------------
 
 			// MARTIN's Code
@@ -734,78 +463,6 @@ int cvFindChessboardCorners3(
 			{
 				feedBack = mrAugmentBestRun(
 					quads, dilations, output_quad_group, max_dilation_run_ID);
-
-// VISUALIZATION--------------------------------------------------------------
-#if VIS
-				if (feedBack == -1)
-				{
-					CvCBQuad::Ptr remember_quad;
-					for (size_t kkk = max_count; kkk < max_count + 1; kkk++)
-					{
-						CvCBQuad::Ptr print_quad = output_quad_group[kkk];
-						remember_quad = print_quad;
-						CvPoint pt[4];
-						pt[0].x = (int)print_quad->corners[0]->pt.x;
-						pt[0].y = (int)print_quad->corners[0]->pt.y;
-						pt[1].x = (int)print_quad->corners[1]->pt.x;
-						pt[1].y = (int)print_quad->corners[1]->pt.y;
-						pt[2].x = (int)print_quad->corners[2]->pt.x;
-						pt[2].y = (int)print_quad->corners[2]->pt.y;
-						pt[3].x = (int)print_quad->corners[3]->pt.x;
-						pt[3].y = (int)print_quad->corners[3]->pt.y;
-						cvLine(
-							imageCopy23, pt[0], pt[1], CV_RGB(255, 0, 0), 2, 8);
-						cvLine(
-							imageCopy23, pt[1], pt[2], CV_RGB(255, 0, 0), 2, 8);
-						cvLine(
-							imageCopy23, pt[2], pt[3], CV_RGB(255, 0, 0), 2, 8);
-						cvLine(
-							imageCopy23, pt[3], pt[0], CV_RGB(255, 0, 0), 2, 8);
-					}
-
-					cvWaitKey(0);
-					// also draw the corner to which it is connected
-					// Remember it is not yet completely linked!!!
-					for (size_t kkk = 0; kkk < max_count; kkk++)
-					{
-						const CvCBQuad::Ptr& print_quad =
-							output_quad_group[kkk];
-
-						for (size_t kkkk = 0; kkkk < 4; kkkk++)
-						{
-							if (print_quad->neighbors[kkkk] == remember_quad)
-							{
-								CvPoint pt[4];
-								pt[0].x = (int)print_quad->corners[0]->pt.x;
-								pt[0].y = (int)print_quad->corners[0]->pt.y;
-								pt[1].x = (int)print_quad->corners[1]->pt.x;
-								pt[1].y = (int)print_quad->corners[1]->pt.y;
-								pt[2].x = (int)print_quad->corners[2]->pt.x;
-								pt[2].y = (int)print_quad->corners[2]->pt.y;
-								pt[3].x = (int)print_quad->corners[3]->pt.x;
-								pt[3].y = (int)print_quad->corners[3]->pt.y;
-								cvLine(
-									imageCopy23, pt[0], pt[1],
-									CV_RGB(255, 0, 0), 2, 8);
-								cvLine(
-									imageCopy23, pt[1], pt[2],
-									CV_RGB(255, 0, 0), 2, 8);
-								cvLine(
-									imageCopy23, pt[2], pt[3],
-									CV_RGB(255, 0, 0), 2, 8);
-								cvLine(
-									imageCopy23, pt[3], pt[0],
-									CV_RGB(255, 0, 0), 2, 8);
-							}
-						}
-					}
-					// cvShowImage( "PART2: Starting Point", imageCopy23);
-					cvSaveImage(
-						"./DBG_part2StartAndSelectedQuad.png", imageCopy23);
-					// cvWaitKey(0);
-				}
-#endif
-				// END------------------------------------------------------------------------
 
 				// if we have found a new matching quad
 				if (feedBack == -1)
@@ -888,11 +545,7 @@ double median(const std::vector<double>& vec)
 void icvCleanFoundConnectedQuads(
 	std::vector<CvCBQuad::Ptr>& quad_group, const CvSize& pattern_size)
 {
-#if CV_MAJOR_VERSION == 1
-	CvMemStorage* temp_storage = nullptr;
-#else
 	cv::MemStorage temp_storage;  // JL: "Modernized" to use C++ STL stuff.
-#endif
 
 	CvPoint2D32f center = cvPoint2D32f(0, 0);
 
@@ -908,11 +561,7 @@ void icvCleanFoundConnectedQuads(
 
 	// Create an array of quadrangle centers
 	vector<CvPoint2D32f> centers(nQuads);
-#if CV_MAJOR_VERSION == 1
-	temp_storage = cvCreateMemStorage(0);
-#else
 	temp_storage = cv::MemStorage(cvCreateMemStorage(0));
-#endif
 
 	// make also the list of squares areas, so we can discriminate by
 	// too-large/small quads:
@@ -1058,11 +707,6 @@ void icvCleanFoundConnectedQuads(
 		quad_group.erase(quad_group.begin() + min_box_area_index);
 		centers.erase(centers.begin() + min_box_area_index);
 	}
-
-// done.
-#if CV_MAJOR_VERSION == 1
-	cvReleaseMemStorage(&temp_storage);
-#endif
 }
 
 //===========================================================================
@@ -2239,13 +1883,9 @@ int icvGenerateQuads(
 	// Initializations
 	int quad_count = 0;
 
-// Create temporary storage for contours and the sequence of pointers to
-// found quadrangles
-#if CV_MAJOR_VERSION == 1
-	CvMemStorage* temp_storage = cvCreateMemStorage(0);
-#else
+	// Create temporary storage for contours and the sequence of pointers to
+	// found quadrangles
 	cv::MemStorage temp_storage = cv::MemStorage(cvCreateMemStorage(0));
-#endif
 
 	CvSeq* src_contour = nullptr;
 	CvSeq* root;  // cv::Seq<> root;  //
@@ -2260,9 +1900,11 @@ int icvGenerateQuads(
 	root = cvCreateSeq(0, sizeof(CvSeq), sizeof(CvSeq*), temp_storage);
 
 	// Initialize contour retrieving routine
+	cv::Mat im_mat = image.asCvMat<cv::Mat>(SHALLOW_COPY);
+	IplImage im_ipl(im_mat);
 	scanner = cvStartFindContours(
-		const_cast<IplImage*>(image.getAs<IplImage>()), temp_storage,
-		sizeof(CvContourEx), CV_RETR_CCOMP, CV_CHAIN_APPROX_SIMPLE);
+		&im_ipl, temp_storage, sizeof(CvContourEx), CV_RETR_CCOMP,
+		CV_CHAIN_APPROX_SIMPLE);
 
 	// Get all the contours one by one
 	while ((src_contour = cvFindNextContour(scanner)) != nullptr)
@@ -2406,10 +2048,6 @@ int icvGenerateQuads(
 	}
 
 	cvClearSeq(root);
-
-#if CV_MAJOR_VERSION == 1
-	cvReleaseMemStorage(&temp_storage);
-#endif
 
 	return quad_count;
 }

--- a/libs/vision/src/faster_corner_impl.cpp
+++ b/libs/vision/src/faster_corner_impl.cpp
@@ -23,12 +23,12 @@ void fast_corner_detect(
 	const cv::Mat& I, TSimpleFeatureList& corners, int barrier, uint8_t octave,
 	std::vector<size_t>* out_feats_index_by_row)
 {
-	auto ptr = reinterpret_cast<CVD::byte*>(I->imageData);
-	CVD::BasicImage<CVD::byte> img(ptr, {I->width, I->height}, I->widthStep);
+	auto ptr = I.data;
+	CVD::BasicImage<CVD::byte> img(ptr, {I.cols, I.rows}, I.step[0]);
 
 	std::vector<CVD::ImageRef> outputs;
 	// reerve enough corners for every pixel
-	outputs.reserve(I->width * I->height);
+	outputs.reserve(I.cols * I.rows);
 	F(img, outputs, barrier);
 	for (auto& output : outputs)
 	{
@@ -37,7 +37,7 @@ void fast_corner_detect(
 	if (out_feats_index_by_row)
 	{
 		auto& counters = *out_feats_index_by_row;
-		counters.assign(I->height, 0);
+		counters.assign(I.rows, 0);
 		for (auto& output : outputs)
 		{
 			counters[output.y]++;

--- a/libs/vision/src/faster_corner_impl.cpp
+++ b/libs/vision/src/faster_corner_impl.cpp
@@ -20,7 +20,7 @@ template <void (*F)(
 	const CVD::BasicImage<CVD::byte>& I, std::vector<CVD::ImageRef>& corners,
 	int barrier)>
 void fast_corner_detect(
-	const IplImage* I, TSimpleFeatureList& corners, int barrier, uint8_t octave,
+	const cv::Mat& I, TSimpleFeatureList& corners, int barrier, uint8_t octave,
 	std::vector<size_t>* out_feats_index_by_row)
 {
 	auto ptr = reinterpret_cast<CVD::byte*>(I->imageData);
@@ -46,7 +46,7 @@ void fast_corner_detect(
 }
 
 void fast_corner_detect_9(
-	const IplImage* I, TSimpleFeatureList& corners, int barrier, uint8_t octave,
+	const cv::Mat& I, TSimpleFeatureList& corners, int barrier, uint8_t octave,
 	std::vector<size_t>* out_feats_index_by_row)
 {
 	fast_corner_detect<CVD::fast_corner_detect_9>(
@@ -54,7 +54,7 @@ void fast_corner_detect_9(
 }
 
 void fast_corner_detect_10(
-	const IplImage* I, TSimpleFeatureList& corners, int barrier, uint8_t octave,
+	const cv::Mat& I, TSimpleFeatureList& corners, int barrier, uint8_t octave,
 	std::vector<size_t>* out_feats_index_by_row)
 {
 	fast_corner_detect<CVD::fast_corner_detect_10>(
@@ -62,7 +62,7 @@ void fast_corner_detect_10(
 }
 
 void fast_corner_detect_12(
-	const IplImage* I, TSimpleFeatureList& corners, int barrier, uint8_t octave,
+	const cv::Mat& I, TSimpleFeatureList& corners, int barrier, uint8_t octave,
 	std::vector<size_t>* out_feats_index_by_row)
 {
 	fast_corner_detect<CVD::fast_corner_detect_12>(

--- a/libs/vision/src/faster_corner_prototypes.h
+++ b/libs/vision/src/faster_corner_prototypes.h
@@ -22,13 +22,13 @@ using std::vector;
 // Prototypes of functions exported from "vision/src/faster/*" to
 // "vision/src/*":
 void fast_corner_detect_9(
-	const IplImage* I, TSimpleFeatureList& corners, int barrier, uint8_t octave,
+	const cv::Mat& I, TSimpleFeatureList& corners, int barrier, uint8_t octave,
 	std::vector<size_t>* out_feats_index_by_row);
 void fast_corner_detect_10(
-	const IplImage* I, TSimpleFeatureList& corners, int barrier, uint8_t octave,
+	const cv::Mat& I, TSimpleFeatureList& corners, int barrier, uint8_t octave,
 	std::vector<size_t>* out_feats_index_by_row);
 void fast_corner_detect_12(
-	const IplImage* I, TSimpleFeatureList& corners, int barrier, uint8_t octave,
+	const cv::Mat& I, TSimpleFeatureList& corners, int barrier, uint8_t octave,
 	std::vector<size_t>* out_feats_index_by_row);
 
 #endif

--- a/libs/vision/src/tracking_KL.cpp
+++ b/libs/vision/src/tracking_KL.cpp
@@ -40,9 +40,8 @@ void CFeatureTracker_KL::trackFeatures_impl_templ(
 	MRPT_START
 
 #if MRPT_HAS_OPENCV
-	const unsigned int window_width =
-		extra_params.getWithDefaultVal("window_width", 15);
-	const unsigned int window_height =
+	const int window_width = extra_params.getWithDefaultVal("window_width", 15);
+	const int window_height =
 		extra_params.getWithDefaultVal("window_height", 15);
 
 	const int LK_levels = extra_params.getWithDefaultVal("LK_levels", 3);
@@ -68,73 +67,47 @@ void CFeatureTracker_KL::trackFeatures_impl_templ(
 	// Array conversion MRPT->OpenCV
 	if (nFeatures > 0)
 	{
-		CvPoint2D32f* points[2];
-
-		points[0] = reinterpret_cast<CvPoint2D32f*>(
-			mrpt_alloca(sizeof(CvPoint2D32f) * nFeatures));
-		points[1] = reinterpret_cast<CvPoint2D32f*>(
-			mrpt_alloca(sizeof(CvPoint2D32f) * nFeatures));
-
-		std::vector<char> status(nFeatures);
+		std::vector<cv::Point2f> points_prev(nFeatures), points_cur;
+		std::vector<uchar> status(nFeatures);
+		std::vector<float> track_error(nFeatures);
 
 		for (size_t i = 0; i < nFeatures; ++i)
 		{
-			points[0][i].x = featureList.getFeatureX(i);
-			points[0][i].y = featureList.getFeatureY(i);
-		}  // end for
+			points_prev[i].x = featureList.getFeatureX(i);
+			points_prev[i].y = featureList.getFeatureY(i);
+		}
 
-		// local scope for auxiliary variables around cvCalcOpticalFlowPyrLK()
-		const auto* prev_gray_ipl = prev_gray.getAs<IplImage>();
-		const auto* cur_gray_ipl = cur_gray.getAs<IplImage>();
-
-		// Pyramids
-		// JL: It seems that cache'ing the pyramids of previous images doesn't
-		// really improve the efficiency (!?!?)
-		IplImage* pPyr = nullptr;
-		IplImage* cPyr = nullptr;
-
-		int flags = 0;
-
-		auto* track_error =
-			reinterpret_cast<float*>(mrpt_alloca(sizeof(float) * nFeatures));
-
-		cvCalcOpticalFlowPyrLK(
-			prev_gray_ipl, cur_gray_ipl, pPyr, cPyr, &points[0][0],
-			&points[1][0], nFeatures, cvSize(window_width, window_height),
-			LK_levels, &status[0], track_error,
-			cvTermCriteria(
-				CV_TERMCRIT_ITER | CV_TERMCRIT_EPS, LK_max_iters, LK_epsilon),
-			flags);
-
-		cvReleaseImage(&pPyr);
-		cvReleaseImage(&cPyr);
+		cv::calcOpticalFlowPyrLK(
+			prev_gray.asCvMat<cv::Mat>(SHALLOW_COPY),
+			cur_gray.asCvMat<cv::Mat>(SHALLOW_COPY), points_prev, points_cur,
+			status, track_error, cv::Size(window_width, window_height),
+			LK_levels,
+			cv::TermCriteria(
+				cv::TermCriteria::MAX_ITER | cv::TermCriteria::EPS,
+				LK_max_iters, LK_epsilon));
 
 		for (size_t i = 0; i < nFeatures; ++i)
 		{
 			const bool trck_err_too_large =
 				track_error[i] > LK_max_tracking_error;
 
-			if (status[i] == 1 && !trck_err_too_large && points[1][i].x > 0 &&
-				points[1][i].y > 0 && points[1][i].x < img_width &&
-				points[1][i].y < img_height)
+			if (status[i] == 1 && !trck_err_too_large && points_cur[i].x > 0 &&
+				points_cur[i].y > 0 && points_cur[i].x < img_width &&
+				points_cur[i].y < img_height)
 			{
 				// Feature could be tracked
-				featureList.setFeatureXf(i, points[1][i].x);
-				featureList.setFeatureYf(i, points[1][i].y);
+				featureList.setFeatureXf(i, points_cur[i].x);
+				featureList.setFeatureYf(i, points_cur[i].y);
 				featureList.setTrackStatus(i, status_TRACKED);
-			}  // end if
+			}
 			else  // Feature could not be tracked
 			{
 				featureList.setFeatureX(i, -1);
 				featureList.setFeatureY(i, -1);
 				featureList.setTrackStatus(
 					i, trck_err_too_large ? status_LOST : status_OOB);
-			}  // end else
-		}  // end for
-
-		mrpt_alloca_free(points[0]);
-		mrpt_alloca_free(points[1]);
-		mrpt_alloca_free(track_error);
+			}
+		}
 
 		// In case it needs to rebuild a kd-tree or whatever
 		featureList.mark_as_outdated();

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -19,7 +19,7 @@ if (UNIX)
 endif()
 
 
-add_definitions(-DCMAKE_MRPT_GLOBAL_UNITTEST_SRC_DIR="${MRPT_SOURCE_DIR}")
+add_definitions(-DCMAKE_UNITTEST_BASEDIR="${MRPT_SOURCE_DIR}")
 
 # Allow tests to include sources from examples directory:
 include_directories("${MRPT_SOURCE_DIR}")

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -112,3 +112,10 @@ foreach(_TSTLIB ${LST_LIB_TESTS})
 	set_target_properties(run_tests_${_TSTLIB} PROPERTIES FOLDER "unit tests")
 
 endforeach(_TSTLIB)
+
+# Special dependencies:
+if (TARGET test_mrpt_img)
+    if(CMAKE_MRPT_HAS_OPENCV)
+	target_link_libraries(test_mrpt_img ${OpenCV_LIBRARIES})
+    endif()
+endif()

--- a/tests/include/test_mrpt_common.h
+++ b/tests/include/test_mrpt_common.h
@@ -8,16 +8,11 @@
    +---------------------------------------------------------------------------+
  */
 
-#include <gtest/gtest.h>
-#include <test_mrpt_common.h>
+#pragma once
 
-std::string mrpt::UNITTEST_BASEDIR = CMAKE_UNITTEST_BASEDIR;
+#include <string>
 
-int main(int argc, char** argv)
+namespace mrpt
 {
-	testing::InitGoogleTest(&argc, argv);
-
-	if (argc > 1) mrpt::UNITTEST_BASEDIR = std::string(argv[1]);
-
-	return RUN_ALL_TESTS();
+    extern std::string UNITTEST_BASEDIR;
 }


### PR DESCRIPTION
Main changes: 
* Totally remove IplImage as an image container, moved to cv::Mat
* CImage API redesigned to make it crystal clear what operations make shallow vs. deep copies. 
* Slight clean-up of mrpt-vision (related to #860 ).

## Changed apps/libraries

* mrpt-img
* mrpt-vision
* mrpt-hwdrivers
* ...
