### PR TITLE
Image SIMD functions work w/o aligned memory

### DIFF
--- a/doc/doxygen-pages/lib_mrpt_img.h
+++ b/doc/doxygen-pages/lib_mrpt_img.h
@@ -32,9 +32,5 @@ extra functionality such as on-the-fly loading of images stored in disk upon
 first usage. The `cv::Mat` object is always available so
 OpenCV's functions can be still used to operate on MRPT images.
 
-MRPT replaces OpenCV's default `cv::Mat` memory allocator with a custom version
-that guarantees that all image rows start at a 16-byte aligned memory address,
-enabling faster SIMD algorithms.
-
 
 */

--- a/libs/core/include/mrpt/core/SSE_macros.h
+++ b/libs/core/include/mrpt/core/SSE_macros.h
@@ -23,11 +23,11 @@
 #elif defined(__GNUC__)
 #define SSE_DISABLE_WARNINGS       \
 	_Pragma("GCC diagnostic push") \
-	    _Pragma("GCC diagnostic ignored \"-Wsign-conversion\"")
+		_Pragma("GCC diagnostic ignored \"-Wsign-conversion\"")
 #elif defined(__clang__)
 #define SSE_DISABLE_WARNINGS         \
 	_Pragma("clang diagnostic push") \
-	    _Pragma("clang diagnostic ignored \"-Wsign-conversion\"")
+		_Pragma("clang diagnostic ignored \"-Wsign-conversion\"")
 #endif
 
 #if defined(_MSC_VER)

--- a/libs/core/include/mrpt/core/SSE_macros.h
+++ b/libs/core/include/mrpt/core/SSE_macros.h
@@ -16,3 +16,24 @@
 	alignas(MRPT_MAX_ALIGN_BYTES) const __m128i _name = _mm_setr_epi8(        \
 		0x##B15, 0x##B14, 0x##B13, 0x##B12, 0x##B11, 0x##B10, 0x##B9, 0x##B8, \
 		0x##B7, 0x##B6, 0x##B5, 0x##B4, 0x##B3, 0x##B2, 0x##B1, 0x##B0);
+
+#if defined(_MSC_VER)
+#define SSE_DISABLE_WARNINGS \
+	_Pragma("warning(push))") _Pragma("warning(disable : 4309)")
+#elif defined(__GNUC__)
+#define SSE_DISABLE_WARNINGS       \
+	_Pragma("GCC diagnostic push") \
+	    _Pragma("GCC diagnostic ignored \"-Wsign-conversion\"")
+#elif defined(__clang__)
+#define SSE_DISABLE_WARNINGS         \
+	_Pragma("clang diagnostic push") \
+	    _Pragma("clang diagnostic ignored \"-Wsign-conversion\"")
+#endif
+
+#if defined(_MSC_VER)
+#define SSE_RESTORE_SIGN_WARNINGS _Pragma("warning(pop)")
+#elif defined(__GNUC__)
+#define SSE_RESTORE_SIGN_WARNINGS _Pragma("GCC diagnostic pop")
+#elif defined(__clang__)
+#define SSE_RESTORE_SIGN_WARNINGS _Pragma("clang diagnostic pop")
+#endif

--- a/libs/core/include/mrpt/core/SSE_types.h
+++ b/libs/core/include/mrpt/core/SSE_types.h
@@ -37,3 +37,22 @@ extern "C"
 #include <smmintrin.h>
 #endif
 #endif
+
+// Helpers:
+#if MRPT_HAS_SSE2
+template <bool ALIGNED>
+__m128i mm_load_si128(__m128i const* ptr);
+
+template <>
+inline __m128i mm_load_si128<true>(__m128i const* ptr)
+{
+	return _mm_load_si128(ptr);
+}
+
+template <>
+inline __m128i mm_load_si128<false>(__m128i const* ptr)
+{
+	return _mm_loadu_si128(ptr);
+}
+
+#endif

--- a/libs/core/include/mrpt/core/SSE_types.h
+++ b/libs/core/include/mrpt/core/SSE_types.h
@@ -55,4 +55,11 @@ inline __m128i mm_load_si128<false>(__m128i const* ptr)
 	return _mm_loadu_si128(ptr);
 }
 
+/** Use to check for 2^N multiples `is_multiple<16>(v)`, etc. */
+template <int k, typename T>
+bool is_multiple(const T val)
+{
+	return (val & (k - 1)) == 0;
+}
+
 #endif

--- a/libs/img/include/mrpt/img/CImage.h
+++ b/libs/img/include/mrpt/img/CImage.h
@@ -606,7 +606,7 @@ class CImage : public mrpt::serialization::CSerializable, public CCanvas
 		return reinterpret_cast<T*>(internal_get(col, row, channel));
 	}
 
-    /** Returns a pointer to the first pixel of the given line.\sa ptr, at */
+	/** Returns a pointer to the first pixel of the given line.\sa ptr, at */
 	template <typename T>
 	const T* ptrLine(unsigned int row) const
 	{
@@ -1007,14 +1007,14 @@ class CImage : public mrpt::serialization::CSerializable, public CCanvas
 	bool grayscale(CImage& ret) const;
 
 	/** Returns a color (RGB) version of the grayscale image, or a shallow copy
-     * of itself if it is already a color image.
+	 * of itself if it is already a color image.
 	 * \sa grayscale
 	 */
-    CImage colorImage() const;
+	CImage colorImage() const;
 
 	/** \overload.
 	 * In-place is supported by setting `ret=*this`. */
-    void colorImage(CImage& ret) const;
+	void colorImage(CImage& ret) const;
 
 	/** @} */
 

--- a/libs/img/include/mrpt/img/CImage.h
+++ b/libs/img/include/mrpt/img/CImage.h
@@ -131,8 +131,6 @@ class CExceptionExternalImageNotFound : public std::runtime_error
  *  \endcode
  * - To set a CImage from an OpenCV `cv::Mat` use
  *CImage::CImage(cv::Mat,copy_type_t).
- * - Unless set from an external cv::Mat object, CImage ensures that all image
- *rows start at 16-byte aligned memory (this requires OpenCV>=3.0).
  *
  * Some functions are implemented in MRPT with highly optimized SSE2/SSE3
  *routines, in suitable platforms and compilers. To see the list of
@@ -253,10 +251,6 @@ class CImage : public mrpt::serialization::CSerializable, public CCanvas
 	 *  (Default = 95) */
 	static void SERIALIZATION_JPEG_QUALITY(int q);
 	static int SERIALIZATION_JPEG_QUALITY();
-
-	/** Memory alignment of all image rows (Default = 16) */
-	static void ROW_MEM_ALIGNMENT(std::size_t a);
-	static std::size_t ROW_MEM_ALIGNMENT();
 
 	/** @} */
 
@@ -612,9 +606,7 @@ class CImage : public mrpt::serialization::CSerializable, public CCanvas
 		return reinterpret_cast<T*>(internal_get(col, row, channel));
 	}
 
-	/** Returns a pointer to the first pixel of the given line. It is guaranteed
-	 * to be 16-byte aligned memory. \sa ptr, at, InstallOpenCVAlignedAllocator
-	 */
+    /** Returns a pointer to the first pixel of the given line.\sa ptr, at */
 	template <typename T>
 	const T* ptrLine(unsigned int row) const
 	{
@@ -1015,32 +1007,16 @@ class CImage : public mrpt::serialization::CSerializable, public CCanvas
 	bool grayscale(CImage& ret) const;
 
 	/** Returns a color (RGB) version of the grayscale image, or a shallow copy
-	 * of itself if it is already a color image.
-	 * \param desired_row_mem_align Default if =0. Otherwise, can be 1,2,4,8.
-	 * Specifies the row memory alignment of the returned image.
+     * of itself if it is already a color image.
 	 * \sa grayscale
 	 */
-	CImage colorImage(std::size_t desired_row_mem_align = 0) const;
+    CImage colorImage() const;
 
 	/** \overload.
 	 * In-place is supported by setting `ret=*this`. */
-	void colorImage(CImage& ret, std::size_t desired_row_mem_align = 0) const;
+    void colorImage(CImage& ret) const;
 
 	/** @} */
-
-	/** Install the MRPT custom memory allocator for cv::Mat images, which
-	 * guarantees 16 (or higher)-byte memory aligned for each image row.
-	 * This method is automatically called upon the first time an CImage object
-	 * is ever constructed, but it is exposed for convenience of the user just
-	 * in case the allocator needs to be re-installed again.
-	 * \note This feature requires OpenCV>=3.0
-	 */
-	static void InstallOpenCVAlignedAllocator();
-
-	/** By looking at row_stride and image width, finds the **smallest**
-	 * possible value for row alignment in bytes. Useful for interfacing OpenGL
-	 * functions. */
-	std::size_t guessRowAlignment() const;
 
    protected:
 	/** @name Data members

--- a/libs/img/src/CImage.cpp
+++ b/libs/img/src/CImage.cpp
@@ -49,15 +49,8 @@ IMPLEMENTS_SERIALIZABLE(CImage, CSerializable, mrpt::img)
 static bool DISABLE_ZIP_COMPRESSION_value = false;
 static bool DISABLE_JPEG_COMPRESSION_value = true;
 static int SERIALIZATION_JPEG_QUALITY_value = 95;
-static std::size_t ROW_MEM_ALIGNMENT_value = 16;
 static std::string IMAGES_PATH_BASE(".");
 
-void CImage::ROW_MEM_ALIGNMENT(std::size_t a)
-{
-	ASSERTMSG_(a > 0 && (a & (a - 1)) == 0, "alignment must be a power of 2");
-	ROW_MEM_ALIGNMENT_value = a;
-}
-std::size_t CImage::ROW_MEM_ALIGNMENT() { return ROW_MEM_ALIGNMENT_value; }
 void CImage::DISABLE_ZIP_COMPRESSION(bool val)
 {
 	DISABLE_ZIP_COMPRESSION_value = val;
@@ -166,114 +159,10 @@ static PixelDepth cvDepth2PixelDepth(int64_t d)
 	return PixelDepth::D8U;
 }
 
-#if MRPT_OPENCV_VERSION_NUM >= 0x300
-// Custom memory allocator for cv::Mat matrices in MRPT:
-// The goal is to ensure that all image **rows** start at 16-byte aligned
-// memory, to enable the application of SSE* code.
-// JLBC, 3/Jan/2019
-class mrpt_MatAllocator : public cv::MatAllocator
-{
-   public:
-	static mrpt_MatAllocator& Instance()
-	{
-		static mrpt_MatAllocator o;
-		return o;
-	}
-
-#if MRPT_OPENCV_VERSION_NUM >= 0x400
-	using AccessFlag = cv::AccessFlag;
-#else
-	using AccessFlag = int;
-#endif
-
-	cv::UMatData* allocate(
-		int dims, const int* sizes, int type, void* data0, size_t* step,
-		AccessFlag /*flags*/, cv::UMatUsageFlags /*usageFlags*/) const override
-	{
-		using namespace cv;
-		// Start with the size of each "pixel" (typ: 1 or 3)
-		size_t total = CV_ELEM_SIZE(type);
-
-		for (int i = dims - 1; i >= 0; i--)
-		{
-			if (step)
-			{
-				// If we are using user-provided data buffer, respect its
-				// step:
-				if (data0 && step[i] != CV_AUTOSTEP)
-				{
-					CV_Assert(total <= step[i]);
-					total = step[i];
-				}
-				else
-				{
-					step[i] = total;
-				}
-			}
-			total *= sizes[i];
-			// In the "dim-1" dimension (rows), ensure we have a
-			// multiple of 16:
-			if (i == dims - 1)
-			{
-				if ((total & (ROW_MEM_ALIGNMENT_value - 1)) != 0)
-				{
-					total = (total & ~(ROW_MEM_ALIGNMENT_value - 1)) +
-							ROW_MEM_ALIGNMENT_value;
-					// "total" will become step[0] in the next "for" iter
-				}
-			}
-		}
-		uchar* data = data0 ? static_cast<uchar*>(data0)
-							: static_cast<uchar*>(cv::fastMalloc(total));
-		UMatData* u = new UMatData(this);
-		u->data = u->origdata = data;
-		u->size = total;
-		if (data0) u->flags |= UMatData::USER_ALLOCATED;
-
-		return u;
-	}
-
-	bool allocate(
-		cv::UMatData* u, AccessFlag /*accessFlags*/,
-		cv::UMatUsageFlags /*usageFlags*/) const override
-	{
-		if (!u) return false;
-		return true;
-	}
-
-	void deallocate(cv::UMatData* u) const override
-	{
-		if (!u) return;
-
-		CV_Assert(u->urefcount == 0);
-		CV_Assert(u->refcount == 0);
-		if (!(u->flags & cv::UMatData::USER_ALLOCATED))
-		{
-			cv::fastFree(u->origdata);
-			u->origdata = nullptr;
-		}
-		delete u;
-	}
-};
-#endif  // MRPT_OPENCV_VERSION_NUM>=0x300
-
 #endif  // MRPT_HAS_OPENCV
 
 // Default ctor
-CImage::CImage() : m_impl(mrpt::make_impl<CImage::Impl>())
-{
-#if MRPT_HAS_OPENCV && MRPT_OPENCV_VERSION_NUM >= 0x300
-	static bool init_cv_alloc = false;
-
-	// Replace default OpenCV memory allocator with MRPT custom version
-	// to enable memory pooling and/or 16-byte aligned rows in images.
-	if (!init_cv_alloc)
-	{
-		init_cv_alloc = true;
-		InstallOpenCVAlignedAllocator();
-	}
-#endif
-}
+CImage::CImage() : m_impl(mrpt::make_impl<CImage::Impl>()) {}
 
 // Ctor with size
 CImage::CImage(
@@ -391,7 +280,6 @@ void CImage::resize(
 	alloc_tims.enter(sLog.c_str());
 #endif
 
-	// Use custom allocator to ensure mem aligned rows:
 	m_impl->img = cv::Mat(
 		static_cast<int>(height), static_cast<int>(width),
 		pixelDepth2CvDepth<int>(depth) + ((nChannels - 1) << CV_CN_SHIFT));
@@ -434,20 +322,6 @@ bool CImage::loadFromFile(const std::string& fileName, int isColor)
 	m_impl->img = cv::cvarrToMat(newImg);
 #endif
 	if (m_impl->img.empty()) return false;
-
-#if MRPT_OPENCV_VERSION_NUM >= 0x300
-	// Our custom cvMat allocator should ensure that the loaded image
-	// has aligned rows:
-	if ((m_impl->img.step[0] & (ROW_MEM_ALIGNMENT_value - 1)) != 0)
-	{
-		std::cerr << "[CImage::loadFromFile()] Performance warning: OpenCV "
-					 "load returned an unaligned image. Making a copy.\n";
-		// Make a copy to ensure alignment (via our custom mem allocator):
-		cv::Mat c(m_impl->img.size(), m_impl->img.type());
-		m_impl->img.copyTo(c);
-		m_impl->img = std::move(c);
-	}
-#endif
 
 	return true;
 #else
@@ -1087,20 +961,15 @@ static bool my_img_to_grayscale(const cv::Mat& src, cv::Mat& dest)
 
 // If possible, use SSE optimized version:
 #if MRPT_HAS_SSE3
-	if (is_aligned<16>(src.data) && ((src.step[0] & 0x0f) == 0) &&
-		((dest.step[0] & 0x0f) == 0))
-	{
-		ASSERT_(is_aligned<16>(dest.data));
-		image_SSSE3_bgr_to_gray_8u(
-			src.ptr<uint8_t>(), dest.ptr<uint8_t>(), src.cols, src.rows,
-			src.step[0], dest.step[0]);
-		return true;
-	}
-#endif
-
+	image_SSSE3_bgr_to_gray_8u(
+	    src.ptr<uint8_t>(), dest.ptr<uint8_t>(), src.cols, src.rows,
+	    src.step[0], dest.step[0]);
+	return true;
+#else
 	// OpenCV Method:
 	cv::cvtColor(src, dest, CV_BGR2GRAY);
 	return false;
+#endif
 }
 #endif
 
@@ -1141,35 +1010,31 @@ bool CImage::scaleHalf(CImage& out, TInterpolationMethod interp) const
 	auto& img_out = out.m_impl->img;
 
 	// If possible, use SSE optimized version:
-	if (is_aligned<16>(img.data) && is_aligned<16>(img_out.data) &&
-		((img.step[0] & 0x0f) == 0) && ((img_out.step[0] & 0x0f) == 0))
-	{
 #if MRPT_HAS_SSE3
-		if (img.channels() == 3 && interp == IMG_INTERP_NN)
+	if (img.channels() == 3 && interp == IMG_INTERP_NN)
+	{
+		image_SSSE3_scale_half_3c8u(
+		    img.data, img_out.data, w, h, img.step[0], img_out.step[0]);
+		return true;
+	}
+#endif
+#if MRPT_HAS_SSE2
+	if (img.channels() == 1)
+	{
+		if (interp == IMG_INTERP_NN)
 		{
-			image_SSSE3_scale_half_3c8u(
+			image_SSE2_scale_half_1c8u(
 				img.data, img_out.data, w, h, img.step[0], img_out.step[0]);
 			return true;
 		}
-#endif
-#if MRPT_HAS_SSE2
-		if (img.channels() == 1)
+		else if (interp == IMG_INTERP_LINEAR)
 		{
-			if (interp == IMG_INTERP_NN)
-			{
-				image_SSE2_scale_half_1c8u(
-					img.data, img_out.data, w, h, img.step[0], img_out.step[0]);
-				return true;
-			}
-			else if (interp == IMG_INTERP_LINEAR)
-			{
-				image_SSE2_scale_half_smooth_1c8u(
-					img.data, img_out.data, w, h, img.step[0], img_out.step[0]);
-				return true;
-			}
+			image_SSE2_scale_half_smooth_1c8u(
+			    img.data, img_out.data, w, h, img.step[0], img_out.step[0]);
+			return true;
 		}
-#endif
 	}
+#endif
 
 	// Fall back to slow method:
 	cv::resize(
@@ -1930,14 +1795,14 @@ bool CImage::drawChessboardCorners(
 #endif
 }
 
-CImage CImage::colorImage(std::size_t desired_row_mem_align) const
+CImage CImage::colorImage() const
 {
 	CImage ret;
-	colorImage(ret, desired_row_mem_align);
+	colorImage(ret);
 	return ret;
 }
 
-void CImage::colorImage(CImage& ret, std::size_t desired_row_mem_align) const
+void CImage::colorImage(CImage& ret) const
 {
 #if MRPT_HAS_OPENCV
 	if (this->isColor())
@@ -1946,10 +1811,6 @@ void CImage::colorImage(CImage& ret, std::size_t desired_row_mem_align) const
 		return;
 	}
 
-	const auto prev_align = CImage::ROW_MEM_ALIGNMENT();
-	if (desired_row_mem_align != 0)
-		CImage::ROW_MEM_ALIGNMENT(desired_row_mem_align);
-
 	auto srcImg = m_impl->img;
 	// Detect in-place op. and make deep copy:
 	if (srcImg.data == ret.m_impl->img.data) srcImg = srcImg.clone();
@@ -1957,8 +1818,6 @@ void CImage::colorImage(CImage& ret, std::size_t desired_row_mem_align) const
 	ret.resize(getWidth(), getHeight(), CH_RGB);
 
 	cv::cvtColor(srcImg, ret.m_impl->img, cv::COLOR_GRAY2BGR);
-
-	if (desired_row_mem_align != 0) CImage::ROW_MEM_ALIGNMENT(prev_align);
 #endif
 }
 
@@ -2244,38 +2103,6 @@ bool CImage::loadTGA(
 #else
 	return false;
 #endif  // MRPT_HAS_OPENCV
-}
-
-void CImage::InstallOpenCVAlignedAllocator()
-{
-#if MRPT_HAS_OPENCV && MRPT_OPENCV_VERSION_NUM >= 0x300
-	auto& alloc = mrpt_MatAllocator::Instance();
-	cv::Mat::setDefaultAllocator(&alloc);
-#endif
-}
-
-std::size_t CImage::guessRowAlignment() const
-{
-#if MRPT_HAS_OPENCV
-	const size_t rs = getRowStride();
-	const size_t w = m_impl->img.cols;
-	const size_t chs = static_cast<size_t>(getChannelCount());
-	const auto bytes_per_row = chs * w;
-
-	for (std::size_t align_bits = 0; align_bits < 5; align_bits++)
-	{
-		const auto align_value = (1U << align_bits);
-		auto guess_rs = bytes_per_row;
-		if ((guess_rs & (align_value - 1)) != 0)
-			guess_rs = (guess_rs & ~(align_value - 1)) + align_value;
-
-		if (guess_rs == rs) return align_value;
-	}
-
-	THROW_EXCEPTION("Could not guess row memory alignment!");
-#else
-	return 0;
-#endif
 }
 
 std::ostream& mrpt::img::operator<<(std::ostream& o, const TPixelCoordf& p)

--- a/libs/img/src/CImage_SSE2.cpp
+++ b/libs/img/src/CImage_SSE2.cpp
@@ -51,16 +51,13 @@ void image_SSE2_scale_half_1c8u(
 	ASSERTMSG_((step_in & 0x0f) == 0, "step of input image must be 16*k");
 	ASSERTMSG_((step_out & 0x0f) == 0, "step of output image must be 16*k");
 
+	SSE_DISABLE_WARNINGS
 	// clang-format off
-#if defined(_MSC_VER)
-#pragma warning( disable : 4309 ) // Yes, we know 0x80 is a "negative char"
-#endif
+
 	const __m128i m = _mm_set_epi8(0x00, 0xff, 0x00, 0xff, 0x00, 0xff, 0x00, 0xff, 0x00, 0xff, 0x00, 0xff, 0x00, 0xff, 0x00, 0xff);
 
 	// clang-format on
-#if defined(_MSC_VER)
-#pragma warning(default : 4309)
-#endif
+	SSE_RESTORE_SIGN_WARNINGS
 
 	int sw = w >> 4;
 	int sh = h >> 1;
@@ -100,16 +97,13 @@ void image_SSE2_scale_half_smooth_1c8u(
 	ASSERTMSG_((step_in & 0x0f) == 0, "step of input image must be 16*k");
 	ASSERTMSG_((step_out & 0x0f) == 0, "step of output image must be 16*k");
 
+	SSE_DISABLE_WARNINGS
 	// clang-format off
-#if defined(_MSC_VER)
-#pragma warning( disable : 4309 ) // Yes, we know 0x80 is a "negative char"
-#endif
+
 	const __m128i m = _mm_set_epi8(0x00, 0xff, 0x00, 0xff, 0x00, 0xff, 0x00, 0xff, 0x00, 0xff, 0x00, 0xff, 0x00, 0xff, 0x00, 0xff);
 
 	// clang-format on
-#if defined(_MSC_VER)
-#pragma warning(default : 4309)
-#endif
+	SSE_RESTORE_SIGN_WARNINGS
 
 	int sw = w >> 4;
 	int sh = h >> 1;

--- a/libs/img/src/CImage_SSE2.cpp
+++ b/libs/img/src/CImage_SSE2.cpp
@@ -44,6 +44,8 @@ void image_SSE2_scale_half_1c8u(
 	const uint8_t* in, uint8_t* out, int w, int h, size_t step_in,
 	size_t step_out)
 {
+	MRPT_TODO("Fix: allow unaligned");
+
 	ASSERT_(mrpt::system::is_aligned<16>(in));
 	ASSERT_(mrpt::system::is_aligned<16>(out));
 	ASSERTMSG_((step_in & 0x0f) == 0, "step of input image must be 16*k");
@@ -92,6 +94,8 @@ void image_SSE2_scale_half_smooth_1c8u(
 	const uint8_t* in, uint8_t* out, int w, int h, size_t step_in,
 	size_t step_out)
 {
+	MRPT_TODO("Fix: allow unaligned");
+
 	ASSERT_(mrpt::system::is_aligned<16>(in));
 	ASSERT_(mrpt::system::is_aligned<16>(out));
 	ASSERTMSG_((step_in & 0x0f) == 0, "step of input image must be 16*k");

--- a/libs/img/src/CImage_SSE2.cpp
+++ b/libs/img/src/CImage_SSE2.cpp
@@ -31,26 +31,11 @@
  *  @{
  */
 
-/** Subsample each 2x2 pixel block into 1x1 pixel, taking the first pixel &
- * ignoring the other 3
- *  - <b>Input format:</b> uint8_t, 1 channel
- *  - <b>Output format:</b> uint8_t, 1 channel
- *  - <b>Preconditions:</b> in & out aligned to 16bytes, step = k*16
- *  - <b>Notes:</b>
- *  - <b>Requires:</b> SSE2
- *  - <b>Invoked from:</b> mrpt::img::CImage::scaleHalf()
- */
-void image_SSE2_scale_half_1c8u(
+template <bool MemIsAligned>
+void impl_image_SSE2_scale_half_1c8u(
 	const uint8_t* in, uint8_t* out, int w, int h, size_t step_in,
 	size_t step_out)
 {
-	MRPT_TODO("Fix: allow unaligned");
-
-	ASSERT_(mrpt::system::is_aligned<16>(in));
-	ASSERT_(mrpt::system::is_aligned<16>(out));
-	ASSERTMSG_((step_in & 0x0f) == 0, "step of input image must be 16*k");
-	ASSERTMSG_((step_out & 0x0f) == 0, "step of output image must be 16*k");
-
 	SSE_DISABLE_WARNINGS
 	// clang-format off
 
@@ -59,44 +44,43 @@ void image_SSE2_scale_half_1c8u(
 	// clang-format on
 	SSE_RESTORE_SIGN_WARNINGS
 
-	int sw = w >> 4;
-	int sh = h >> 1;
+	const int sw = w / 16;
+	const int sh = h / 2;
+	const int rest_w = w - (16 * w);
 
 	for (int i = 0; i < sh; i++)
 	{
+		auto inp = reinterpret_cast<const __m128i*>(in);
+		uint8_t* outp = out;
 		for (int j = 0; j < sw; j++)
 		{
-			auto inp = reinterpret_cast<const __m128i*>(in);
-			uint8_t* outp = out;
-			const __m128i x = _mm_and_si128(_mm_load_si128(inp++), m);
+			const __m128i x =
+				_mm_and_si128(mm_load_si128<MemIsAligned>(inp++), m);
 			auto o = reinterpret_cast<__m128i*>(outp);
 			_mm_storel_epi64(o, _mm_packus_epi16(x, x));
 			outp += 8;
 		}
+		// Extra pixels? (w mod 16 != 0)
+		if (rest_w != 0)
+		{
+			const uint8_t* in_rest = in + 16 * sw;
+			for (int p = 0; p < rest_w / 2; p++)
+			{
+				*outp++ = in_rest[0];
+				in_rest += 2;
+			}
+		}
+
 		in += 2 * step_in;  // Skip one row
 		out += step_out;
 	}
 }
 
-/** Average each 2x2 pixels into 1x1 pixel (arithmetic average)
- *  - <b>Input format:</b> uint8_t, 1 channel
- *  - <b>Output format:</b> uint8_t, 1 channel
- *  - <b>Preconditions:</b> in & out aligned to 16bytes, step = k*16
- *  - <b>Notes:</b>
- *  - <b>Requires:</b> SSE2
- *  - <b>Invoked from:</b> mrpt::img::CImage::scaleHalfSmooth()
- */
-void image_SSE2_scale_half_smooth_1c8u(
+template <bool MemIsAligned>
+void impl_image_SSE2_scale_half_smooth_1c8u(
 	const uint8_t* in, uint8_t* out, int w, int h, size_t step_in,
 	size_t step_out)
 {
-	MRPT_TODO("Fix: allow unaligned");
-
-	ASSERT_(mrpt::system::is_aligned<16>(in));
-	ASSERT_(mrpt::system::is_aligned<16>(out));
-	ASSERTMSG_((step_in & 0x0f) == 0, "step of input image must be 16*k");
-	ASSERTMSG_((step_out & 0x0f) == 0, "step of output image must be 16*k");
-
 	SSE_DISABLE_WARNINGS
 	// clang-format off
 
@@ -105,8 +89,9 @@ void image_SSE2_scale_half_smooth_1c8u(
 	// clang-format on
 	SSE_RESTORE_SIGN_WARNINGS
 
-	int sw = w >> 4;
-	int sh = h >> 1;
+	const int sw = w / 16;
+	const int sh = h / 2;
+	const int rest_w = w - (16 * w);
 
 	for (int i = 0; i < sh; i++)
 	{
@@ -116,8 +101,8 @@ void image_SSE2_scale_half_smooth_1c8u(
 
 		for (int j = 0; j < sw; j++)
 		{
-			__m128i here = _mm_load_si128(inp++);
-			__m128i next = _mm_load_si128(nextRow++);
+			__m128i here = mm_load_si128<MemIsAligned>(inp++);
+			__m128i next = mm_load_si128<MemIsAligned>(nextRow++);
 			here = _mm_avg_epu8(here, next);
 			next = _mm_and_si128(_mm_srli_si128(here, 1), m);
 			here = _mm_and_si128(here, m);
@@ -126,8 +111,74 @@ void image_SSE2_scale_half_smooth_1c8u(
 				reinterpret_cast<__m128i*>(outp), _mm_packus_epi16(here, here));
 			outp += 8;
 		}
+
+		// Extra pixels? (w mod 16 != 0)
+		if (rest_w != 0)
+		{
+			const uint8_t* ir = in + 16 * sw;
+			const uint8_t* irr = in + step_in;
+			for (int p = 0; p < rest_w / 2; p++)
+			{
+				*outp++ = (ir[0] + ir[1] + irr[0] + irr[1]) / 4;
+				ir += 2;
+				irr += 2;
+			}
+		}
+
 		in += 2 * step_in;  // Skip one row
 		out += step_out;
+	}
+}
+
+/** Subsample each 2x2 pixel block into 1x1 pixel, taking the first pixel &
+ * ignoring the other 3
+ *  - <b>Input format:</b> uint8_t, 1 channel
+ *  - <b>Output format:</b> uint8_t, 1 channel
+ *  - <b>Preconditions:</b> in & out aligned to 16bytes (faster) or not, step =
+ * k*16 (faster) or not
+ *  - <b>Notes:</b>
+ *  - <b>Requires:</b> SSE2
+ *  - <b>Invoked from:</b> mrpt::img::CImage::scaleHalf()
+ */
+void image_SSE2_scale_half_1c8u(
+	const uint8_t* in, uint8_t* out, int w, int h, size_t step_in,
+	size_t step_out)
+{
+	if (mrpt::system::is_aligned<16>(in) && mrpt::system::is_aligned<16>(out) &&
+		is_multiple<16>(step_in) && is_multiple<16>(step_out))
+	{
+		impl_image_SSE2_scale_half_1c8u<true>(in, out, w, h, step_in, step_out);
+	}
+	else
+	{
+		impl_image_SSE2_scale_half_1c8u<false>(
+			in, out, w, h, step_in, step_out);
+	}
+}
+
+/** Average each 2x2 pixels into 1x1 pixel (arithmetic average)
+ *  - <b>Input format:</b> uint8_t, 1 channel
+ *  - <b>Output format:</b> uint8_t, 1 channel
+ *  - <b>Preconditions:</b> in & out aligned to 16bytes (faster) or not, step =
+ * k*16 (faster) or not
+ *  - <b>Notes:</b>
+ *  - <b>Requires:</b> SSE2
+ *  - <b>Invoked from:</b> mrpt::img::CImage::scaleHalfSmooth()
+ */
+void image_SSE2_scale_half_smooth_1c8u(
+	const uint8_t* in, uint8_t* out, int w, int h, size_t step_in,
+	size_t step_out)
+{
+	if (mrpt::system::is_aligned<16>(in) && mrpt::system::is_aligned<16>(out) &&
+		is_multiple<16>(step_in) && is_multiple<16>(step_out))
+	{
+		impl_image_SSE2_scale_half_smooth_1c8u<true>(
+			in, out, w, h, step_in, step_out);
+	}
+	else
+	{
+		impl_image_SSE2_scale_half_smooth_1c8u<false>(
+			in, out, w, h, step_in, step_out);
 	}
 }
 

--- a/libs/img/src/CImage_SSE2.cpp
+++ b/libs/img/src/CImage_SSE2.cpp
@@ -71,7 +71,6 @@ void image_SSE2_scale_half_1c8u(
 		{
 			auto inp = reinterpret_cast<const __m128i*>(in);
 			uint8_t* outp = out;
-
 			const __m128i x = _mm_and_si128(_mm_load_si128(inp++), m);
 			auto o = reinterpret_cast<__m128i*>(outp);
 			_mm_storel_epi64(o, _mm_packus_epi16(x, x));

--- a/libs/img/src/CImage_SSE3.cpp
+++ b/libs/img/src/CImage_SSE3.cpp
@@ -41,6 +41,8 @@ void image_SSSE3_scale_half_3c8u(
 	const uint8_t* in, uint8_t* out, int w, int h, size_t step_in,
 	size_t step_out)
 {
+	MRPT_TODO("Fix: allow unaligned");
+
 	// clang-format off
 #if defined(_MSC_VER)
 #pragma warning( disable : 4309 ) // Yes, we know 0x80 is a "negative char"
@@ -99,6 +101,8 @@ void private_image_SSSE3_rgb_or_bgr_to_gray_8u(
 	const uint8_t* in, uint8_t* out, int w, int h, size_t step_in,
 	size_t step_out)
 {
+	MRPT_TODO("Fix: allow unaligned");
+
 	// clang-format off
 #if defined(_MSC_VER)
 #pragma warning( disable : 4309 ) // Yes, we know 0x80 is a "negative char"
@@ -238,6 +242,8 @@ void image_SSSE3_bgr_to_gray_8u(
 	const uint8_t* in, uint8_t* out, int w, int h, size_t step_in,
 	size_t step_out)
 {
+	MRPT_TODO("Fix: allow unaligned");
+
 	ASSERT_(mrpt::system::is_aligned<16>(in));
 	ASSERT_(mrpt::system::is_aligned<16>(out));
 	ASSERTMSG_((step_in & 0x0f) == 0, "step of input image must be 16*k");

--- a/libs/img/src/CImage_SSE3.cpp
+++ b/libs/img/src/CImage_SSE3.cpp
@@ -28,21 +28,12 @@
  *  @{
  */
 
-/** Subsample each 2x2 pixel block into 1x1 pixel, taking the first pixel &
- * ignoring the other 3
- *  - <b>Input format:</b> uint8_t, 3 channels (RGB or BGR)
- *  - <b>Output format:</b> uint8_t, 3 channels (RGB or BGR)
- *  - <b>Preconditions:</b> in & out aligned to 16bytes, step = k*16
- *  - <b>Notes:</b>
- *  - <b>Requires:</b> SSSE3
- *  - <b>Invoked from:</b> mrpt::img::CImage::scaleHalf()
- */
-void image_SSSE3_scale_half_3c8u(
+// This is the actual function behind image_SSSE3_scale_half_3c8u():
+template <bool MemIsAligned>
+void impl_image_SSSE3_scale_half_3c8u(
 	const uint8_t* in, uint8_t* out, int w, int h, size_t step_in,
 	size_t step_out)
 {
-	MRPT_TODO("Fix: allow unaligned");
-
 	SSE_DISABLE_WARNINGS
 	// clang-format off
 
@@ -54,8 +45,9 @@ void image_SSSE3_scale_half_3c8u(
 	// clang-format on
 	SSE_RESTORE_SIGN_WARNINGS
 
-	const int sw = w >> 4;  // This are the number of 3*16 blocks in each row
-	const int sh = h >> 1;
+	const int sw = w / 16;  // This are the number of 3*16 blocks in each row
+	const int sh = h / 2;
+	const int rest_w = w - (16 * w);
 
 	for (int i = 0; i < sh; i++)
 	{
@@ -65,8 +57,8 @@ void image_SSSE3_scale_half_3c8u(
 		for (int j = 0; j < sw; j++)
 		{
 			// 16-byte blocks #0,#1,#2:
-			__m128i d0 = _mm_load_si128(inp++);
-			__m128i d1 = _mm_load_si128(inp++);
+			__m128i d0 = mm_load_si128<MemIsAligned>(inp++);
+			__m128i d1 = mm_load_si128<MemIsAligned>(inp++);
 
 			// First 16 bytes:
 			__m128i shuf0 = _mm_shuffle_epi8(d0, m0);
@@ -74,32 +66,74 @@ void image_SSSE3_scale_half_3c8u(
 
 			__m128i res0 = _mm_or_si128(shuf0, shuf1);
 
-			_mm_storeu_si128((__m128i*)outp, res0);  // aligned output
+			_mm_storeu_si128(
+				reinterpret_cast<__m128i*>(outp), res0);  // aligned output
 			outp += 16;
 
 			// Last 8 bytes:
-			__m128i d2 = _mm_load_si128(inp++);
+			__m128i d2 = mm_load_si128<MemIsAligned>(inp++);
 
-			_mm_storel_epi64(  // Write lower 8 bytes only
-				(__m128i*)outp,
+			// Write lower 8 bytes only
+			_mm_storel_epi64(
+				reinterpret_cast<__m128i*>(outp),
 				_mm_or_si128(
 					_mm_shuffle_epi8(d2, m2), _mm_shuffle_epi8(d1, m3)));
 			outp += 8;
 		}
+
+		// Extra pixels? (w mod 16 != 0)
+		if (rest_w != 0)
+		{
+			const uint8_t* in_rest = in + 3 * 16 * sw;
+			for (int p = 0; p < rest_w / 2; p++)
+			{
+				outp[0] = in_rest[0];
+				outp[1] = in_rest[1];
+				outp[2] = in_rest[2];
+				in_rest += 6;
+				outp += 3;
+			}
+		}
+
 		in += 2 * step_in;  // Skip one row
 		out += step_out;
 	}
 }
 
-// This is the actual function behind both: image_SSSE3_rgb_to_gray_8u() and
-// image_SSSE3_bgr_to_gray_8u():
-template <bool IS_RGB>
-void private_image_SSSE3_rgb_or_bgr_to_gray_8u(
+/** Subsample each 2x2 pixel block into 1x1 pixel, taking the first pixel &
+ * ignoring the other 3
+ *  - <b>Input format:</b> uint8_t, 3 channels (RGB or BGR)
+ *  - <b>Output format:</b> uint8_t, 3 channels (RGB or BGR)
+ *  - <b>Preconditions:</b> in & out may be aligned to 16bytes (faster) or not,
+ * step may be k*16 (faster) or not.
+ *  - <b>Notes:</b>
+ *  - <b>Requires:</b> SSSE3
+ *  - <b>Invoked from:</b> mrpt::img::CImage::scaleHalf()
+ */
+void image_SSSE3_scale_half_3c8u(
 	const uint8_t* in, uint8_t* out, int w, int h, size_t step_in,
 	size_t step_out)
 {
-	MRPT_TODO("Fix: allow unaligned");
+	if (mrpt::system::is_aligned<16>(in) && mrpt::system::is_aligned<16>(out) &&
+		is_multiple<16>(step_in) && is_multiple<16>(step_out))
+	{
+		impl_image_SSSE3_scale_half_3c8u<true>(
+			in, out, w, h, step_in, step_out);
+	}
+	else
+	{
+		impl_image_SSSE3_scale_half_3c8u<false>(
+			in, out, w, h, step_in, step_out);
+	}
+}
 
+// This is the actual function behind both: image_SSSE3_rgb_to_gray_8u() and
+// image_SSSE3_bgr_to_gray_8u():
+template <bool IS_RGB, bool MemIsAligned>
+void impl_image_SSSE3_rgb_or_bgr_to_gray_8u(
+	const uint8_t* in, uint8_t* out, int w, int h, size_t step_in,
+	size_t step_out)
+{
 	SSE_DISABLE_WARNINGS
 	// clang-format off
 
@@ -162,9 +196,9 @@ void private_image_SSSE3_rgb_or_bgr_to_gray_8u(
 		for (int j = 0; j < sw; j++)
 		{
 			// We process RGB data in blocks of 3 x 16byte blocks:
-			const __m128i d0 = _mm_load_si128(inp++);
-			const __m128i d1 = _mm_load_si128(inp++);
-			const __m128i d2 = _mm_load_si128(inp++);
+			const __m128i d0 = mm_load_si128<MemIsAligned>(inp++);
+			const __m128i d1 = mm_load_si128<MemIsAligned>(inp++);
+			const __m128i d2 = mm_load_si128<MemIsAligned>(inp++);
 
 			// First 8 bytes of gray levels:
 			{
@@ -219,13 +253,14 @@ void private_image_SSSE3_rgb_or_bgr_to_gray_8u(
 		out += step_out;
 	}
 
-}  // end private_image_SSSE3_rgb_or_bgr_to_gray_8u()
+}  // end impl_image_SSSE3_rgb_or_bgr_to_gray_8u()
 
 /** Convert a RGB image (3cu8) into a GRAYSCALE (1c8u) image, using
  * Y=77*R+150*G+29*B
  *  - <b>Input format:</b> uint8_t, 3 channels (BGR order)
  *  - <b>Output format:</b> uint8_t, 1 channel
- *  - <b>Preconditions:</b> in & out aligned to 16bytes, step = k*16
+ *  - <b>Preconditions:</b> in & out aligned to 16bytes (faster) or not, step =
+ * k*16
  *  - <b>Notes:</b>
  *  - <b>Requires:</b> SSSE3
  *  - <b>Invoked from:</b> mrpt::img::CImage::grayscale(),
@@ -235,22 +270,27 @@ void image_SSSE3_bgr_to_gray_8u(
 	const uint8_t* in, uint8_t* out, int w, int h, size_t step_in,
 	size_t step_out)
 {
-	MRPT_TODO("Fix: allow unaligned");
-
-	ASSERT_(mrpt::system::is_aligned<16>(in));
-	ASSERT_(mrpt::system::is_aligned<16>(out));
 	ASSERTMSG_((step_in & 0x0f) == 0, "step of input image must be 16*k");
 	ASSERTMSG_((step_out & 0x0f) == 0, "step of output image must be 16*k");
 
-	private_image_SSSE3_rgb_or_bgr_to_gray_8u<false>(
-		in, out, w, h, step_in, step_out);
+	if (mrpt::system::is_aligned<16>(in) && mrpt::system::is_aligned<16>(out))
+	{
+		impl_image_SSSE3_rgb_or_bgr_to_gray_8u<false, true>(
+			in, out, w, h, step_in, step_out);
+	}
+	else
+	{
+		impl_image_SSSE3_rgb_or_bgr_to_gray_8u<false, false>(
+			in, out, w, h, step_in, step_out);
+	}
 }
 
 /** Convert a RGB image (3cu8) into a GRAYSCALE (1c8u) image, using
  * Y=77*R+150*G+29*B
  *  - <b>Input format:</b> uint8_t, 3 channels (RGB order)
  *  - <b>Output format:</b> uint8_t, 1 channel
- *  - <b>Preconditions:</b> in & out aligned to 16bytes, step = k*16
+ *  - <b>Preconditions:</b> in & out aligned to 16bytes (faster) or not, step =
+ * k*16
  *  - <b>Notes:</b>
  *  - <b>Requires:</b> SSSE3
  *  - <b>Invoked from:</b> mrpt::img::CImage::grayscale(),
@@ -260,13 +300,19 @@ void image_SSSE3_rgb_to_gray_8u(
 	const uint8_t* in, uint8_t* out, int w, int h, size_t step_in,
 	size_t step_out)
 {
-	ASSERT_(mrpt::system::is_aligned<16>(in));
-	ASSERT_(mrpt::system::is_aligned<16>(out));
 	ASSERTMSG_((step_in & 0x0f) == 0, "step of input image must be 16*k");
 	ASSERTMSG_((step_out & 0x0f) == 0, "step of output image must be 16*k");
 
-	private_image_SSSE3_rgb_or_bgr_to_gray_8u<true>(
-		in, out, w, h, step_in, step_out);
+	if (mrpt::system::is_aligned<16>(in) && mrpt::system::is_aligned<16>(out))
+	{
+		impl_image_SSSE3_rgb_or_bgr_to_gray_8u<true, true>(
+			in, out, w, h, step_in, step_out);
+	}
+	else
+	{
+		impl_image_SSSE3_rgb_or_bgr_to_gray_8u<true, false>(
+			in, out, w, h, step_in, step_out);
+	}
 }
 
 /**  @} */

--- a/libs/img/src/CImage_SSE3.cpp
+++ b/libs/img/src/CImage_SSE3.cpp
@@ -43,19 +43,16 @@ void image_SSSE3_scale_half_3c8u(
 {
 	MRPT_TODO("Fix: allow unaligned");
 
+	SSE_DISABLE_WARNINGS
 	// clang-format off
-#if defined(_MSC_VER)
-#pragma warning( disable : 4309 ) // Yes, we know 0x80 is a "negative char"
-#endif
+
 	const __m128i m0 = _mm_set_epi8(0x80, 0x80, 0x80, 0x80, 0x80, 0x80, 0x80, 0x0E, 0x0D, 0x0C, 0x08, 0x07, 0x06, 0x02, 0x01, 0x00);
 	const __m128i m1 = _mm_set_epi8(0x0E, 0x0A, 0x09, 0x08, 0x04, 0x03, 0x02, 0x80, 0x80, 0x80, 0x80, 0x80, 0x80, 0x80, 0x80, 0x80);
 	const __m128i m2 = _mm_set_epi8(0x80, 0x80, 0x80, 0x80, 0x80, 0x80, 0x80, 0x80, 0x0C, 0x0B, 0x0A, 0x06, 0x05, 0x04, 0x00, 0x80);
 	const __m128i m3 = _mm_set_epi8(0x80, 0x80, 0x80, 0x80, 0x80, 0x80, 0x80, 0x80, 0x80, 0x80, 0x80, 0x80, 0x80, 0x80, 0x80, 0x0F);
 
 	// clang-format on
-#if defined(_MSC_VER)
-#pragma warning(default : 4309)
-#endif
+	SSE_RESTORE_SIGN_WARNINGS
 
 	const int sw = w >> 4;  // This are the number of 3*16 blocks in each row
 	const int sh = h >> 1;
@@ -103,10 +100,8 @@ void private_image_SSSE3_rgb_or_bgr_to_gray_8u(
 {
 	MRPT_TODO("Fix: allow unaligned");
 
+	SSE_DISABLE_WARNINGS
 	// clang-format off
-#if defined(_MSC_VER)
-#pragma warning( disable : 4309 ) // Yes, we know 0x80 is a "negative char"
-#endif
 
 	// Masks:                            0       1    2    3     4      5     6    7     8      9     A     B      C    D    E     F
 	// reds[0-7] from D0
@@ -141,9 +136,7 @@ void private_image_SSSE3_rgb_or_bgr_to_gray_8u(
 	const __m128i mask_low = _mm_setr_epi8(0x01, 0x03, 0x05, 0x07, 0x09, 0x0B, 0x0D, 0x0F, 0x80, 0x80, 0x80, 0x80, 0x80, 0x80, 0x80, 0x80);
 
 	// clang-format on
-#if defined(_MSC_VER)
-#pragma warning(default : 4309)
-#endif
+	SSE_RESTORE_SIGN_WARNINGS
 
 	const __m128i m0 = IS_RGB ? mask4 : mask0;
 	const __m128i m1 = IS_RGB ? mask5 : mask1;

--- a/libs/img/src/CImage_SSEx.h
+++ b/libs/img/src/CImage_SSEx.h
@@ -9,6 +9,7 @@
 #pragma once
 
 #include <mrpt/config.h>
+#include <cstdint>
 
 // See documentation in the .cpp files CImage_SSE*.cpp
 

--- a/libs/img/src/CImage_unittest.cpp
+++ b/libs/img/src/CImage_unittest.cpp
@@ -358,53 +358,65 @@ TEST(CImage, ScaleImage)
 		EXPECT_EQ(a.getWidth(), 320U);
 		EXPECT_EQ(a.getHeight(), 240U);
 	}
+
+	for (int pass = 0; pass < 2; pass++)
 	{
-		CImage b;
-		a.scaleHalf(b, IMG_INTERP_NN);
-		EXPECT_EQ(b.getWidth(), 160U);
-		EXPECT_EQ(b.getHeight(), 120U);
-		EXPECT_EQ(a.getWidth(), 320U);
-		EXPECT_EQ(a.getHeight(), 240U);
-	}
-	{
-		CImage ag = a.grayscale();
-		CImage b;
-		ag.scaleHalf(b, IMG_INTERP_LINEAR);
-		EXPECT_EQ(b.getWidth(), 160U);
-		EXPECT_EQ(b.getHeight(), 120U);
-		EXPECT_EQ(ag.getWidth(), 320U);
-		EXPECT_EQ(ag.getHeight(), 240U);
-	}
-	{
-		CImage ag = a.grayscale();
-		CImage b;
-		ag.scaleHalf(b, IMG_INTERP_NN);
-		EXPECT_EQ(b.getWidth(), 160U);
-		EXPECT_EQ(b.getHeight(), 120U);
-		EXPECT_EQ(ag.getWidth(), 320U);
-		EXPECT_EQ(ag.getHeight(), 240U);
-	}
+		CImage c;
+		if (pass == 0)
+			c = a.makeDeepCopy();
+		else
+			a.scaleImage(c, 311, 211);
+		const auto cw = c.getWidth(), ch = c.getHeight();
+
+		{
+			CImage b;
+			c.scaleHalf(b, IMG_INTERP_NN);
+			EXPECT_EQ(b.getWidth(), cw / 2);
+			EXPECT_EQ(b.getHeight(), ch / 2);
+			EXPECT_EQ(c.getWidth(), cw);
+			EXPECT_EQ(c.getHeight(), ch);
+		}
+		{
+			CImage ag = c.grayscale();
+			CImage b;
+			ag.scaleHalf(b, IMG_INTERP_LINEAR);
+			EXPECT_EQ(b.getWidth(), cw / 2);
+			EXPECT_EQ(b.getHeight(), ch / 2);
+			EXPECT_EQ(ag.getWidth(), cw);
+			EXPECT_EQ(ag.getHeight(), ch);
+		}
+		{
+			CImage ag = c.grayscale();
+			CImage b;
+			ag.scaleHalf(b, IMG_INTERP_NN);
+			EXPECT_EQ(b.getWidth(), cw / 2);
+			EXPECT_EQ(b.getHeight(), ch / 2);
+			EXPECT_EQ(ag.getWidth(), cw);
+			EXPECT_EQ(ag.getHeight(), ch);
+		}
+	}  // two passes
+
 	{
 		CImage b;
 		a.scaleHalf(b, IMG_INTERP_LINEAR);
-		EXPECT_EQ(b.getWidth(), 160U);
-		EXPECT_EQ(b.getHeight(), 120U);
+		EXPECT_EQ(b.getWidth(), a.getWidth() / 2);
+		EXPECT_EQ(b.getHeight(), a.getHeight() / 2);
 		EXPECT_EQ(a.getWidth(), 320U);
 		EXPECT_EQ(a.getHeight(), 240U);
 	}
 	{
 		CImage b;
 		a.scaleDouble(b, IMG_INTERP_NN);
-		EXPECT_EQ(b.getWidth(), 640U);
-		EXPECT_EQ(b.getHeight(), 480U);
+		EXPECT_EQ(b.getWidth(), a.getWidth() * 2);
+		EXPECT_EQ(b.getHeight(), a.getHeight() * 2);
 		EXPECT_EQ(a.getWidth(), 320U);
 		EXPECT_EQ(a.getHeight(), 240U);
 	}
 	{
 		CImage b;
 		a.scaleDouble(b, IMG_INTERP_LINEAR);
-		EXPECT_EQ(b.getWidth(), 640U);
-		EXPECT_EQ(b.getHeight(), 480U);
+		EXPECT_EQ(b.getWidth(), a.getWidth() * 2);
+		EXPECT_EQ(b.getHeight(), a.getHeight() * 2);
 		EXPECT_EQ(a.getWidth(), 320U);
 		EXPECT_EQ(a.getHeight(), 240U);
 	}

--- a/libs/img/src/CImage_unittest.cpp
+++ b/libs/img/src/CImage_unittest.cpp
@@ -28,16 +28,6 @@ using namespace std::string_literals;
 const auto tstImgFileColor =
 	mrpt::UNITTEST_BASEDIR + "/samples/img_basic_example/frame_color.jpg"s;
 
-// Expect image rows to be aligned:
-static void expect_rows_aligned(
-	const mrpt::img::CImage& a, const std::string& s = std::string())
-{
-#if MRPT_HAS_OPENCV && MRPT_OPENCV_VERSION_NUM >= 0x300
-	for (unsigned int y = 0; y < a.getHeight(); y++)
-		EXPECT_TRUE(mrpt::system::is_aligned<16>(a.ptrLine<uint8_t>(y))) << s;
-#endif
-}
-
 // Generate random img:
 static void fillImagePseudoRandom(uint32_t seed, mrpt::img::CImage& img)
 {
@@ -85,7 +75,6 @@ static void CtorSized_gray(unsigned int w, unsigned int h)
 	EXPECT_EQ(img.getChannelCount(), 1U);
 	EXPECT_EQ(img.getPixelDepth(), PixelDepth::D8U);
 	EXPECT_FALSE(img.isColor());
-	expect_rows_aligned(img, mrpt::format("CtorSized_gray w=%u h=%u", w, h));
 }
 
 TEST(CImage, CtorSized)
@@ -98,31 +87,10 @@ TEST(CImage, CtorSized)
 		EXPECT_EQ(img.getChannelCount(), 3U);
 		EXPECT_EQ(img.getPixelDepth(), PixelDepth::D8U);
 		EXPECT_TRUE(img.isColor());
-		expect_rows_aligned(img);
 	}
 	for (unsigned w = 64; w < 70; w++)
 	{
 		CtorSized_gray(w, 48);
-	}
-}
-
-TEST(CImage, DeepCopyStillMemAligned)
-{
-	using namespace mrpt::img;
-	unsigned h = 70;
-	for (unsigned w = 64; w < 70; w++)
-	{
-		CImage a(w, h, CH_GRAY);
-		EXPECT_EQ(a.getWidth(), w);
-		EXPECT_EQ(a.getHeight(), h);
-		expect_rows_aligned(
-			a, mrpt::format("DeepCopyStillMemAligned (a) w=%u h=%u", w, h));
-
-		CImage b = a.makeDeepCopy();
-		EXPECT_EQ(b.getWidth(), w);
-		EXPECT_EQ(b.getHeight(), h);
-		expect_rows_aligned(
-			b, mrpt::format("DeepCopyStillMemAligned (b) w=%u h=%u", w, h));
 	}
 }
 
@@ -264,8 +232,6 @@ TEST(CImage, ConvertGray)
 		EXPECT_EQ(b.getWidth(), a.getWidth());
 		EXPECT_EQ(b.getHeight(), a.getHeight());
 		EXPECT_FALSE(b.isColor());
-
-		expect_rows_aligned(b);
 	}
 }
 
@@ -304,8 +270,6 @@ TEST(CImage, HalfAndDouble)
 	a.at<uint8_t>(1, 0) = 0x80;
 	a.at<uint8_t>(1, 1) = 0x80;
 
-	expect_rows_aligned(a);
-
 	// Half:
 	{
 		const CImage imgH = a.scaleHalf(mrpt::img::IMG_INTERP_NN);
@@ -313,8 +277,6 @@ TEST(CImage, HalfAndDouble)
 		EXPECT_EQ(imgH.getHeight(), a.getHeight() / 2);
 		EXPECT_EQ(imgH.isColor(), a.isColor());
 		EXPECT_EQ(imgH.at<uint8_t>(0, 0), a.at<uint8_t>(0, 0));
-
-		expect_rows_aligned(imgH);
 	}
 	// Double:
 	{
@@ -322,8 +284,6 @@ TEST(CImage, HalfAndDouble)
 		EXPECT_EQ(imgD.getWidth(), a.getWidth() * 2);
 		EXPECT_EQ(imgD.getHeight(), a.getHeight() * 2);
 		EXPECT_EQ(imgD.isColor(), a.isColor());
-
-		expect_rows_aligned(imgD);
 	}
 }
 TEST(CImage, getChannelsOrder)
@@ -389,8 +349,6 @@ TEST(CImage, ScaleImage)
 	CImage a;
 	bool load_ok = a.loadFromFile(tstImgFileColor);
 	EXPECT_TRUE(load_ok);
-
-	expect_rows_aligned(a);
 
 	{
 		CImage b;
@@ -516,7 +474,6 @@ TEST(CImage, LoadAndSave)
 			bool load_ok = b.loadFromFile(f);
 			EXPECT_TRUE(load_ok) << tstName;
 
-			expect_rows_aligned(b, tstName);
 			if (!expect_identical(a, b, tstName))
 			{
 				GTEST_FAIL() << "a:\n"

--- a/libs/opengl/src/COpenGLViewport.cpp
+++ b/libs/opengl/src/COpenGLViewport.cpp
@@ -269,19 +269,6 @@ void COpenGLViewport::render(
 					glPixelZoom(vw / float(ortho_w), -vh / float(ortho_h));
 
 					// Prepare image data types:
-					auto row_align = img->guessRowAlignment();
-					if (row_align > 8)
-					{
-						// Not supported by OpenGL: we need to make a copy of
-						// the image!
-						const auto prev_align =
-							mrpt::img::CImage::ROW_MEM_ALIGNMENT();
-						mrpt::img::CImage::ROW_MEM_ALIGNMENT(1);
-						*img = img->makeDeepCopy();
-						mrpt::img::CImage::ROW_MEM_ALIGNMENT(prev_align);
-						row_align = 1;
-					}
-
 					const GLenum img_type = GL_UNSIGNED_BYTE;
 					const int nBytesPerPixel = img->isColor() ? 3 : 1;
 					// Reverse RGB <-> BGR order?
@@ -292,7 +279,7 @@ void COpenGLViewport::render(
 											: GL_LUMINANCE;
 
 					// Send image data to OpenGL:
-					glPixelStorei(GL_UNPACK_ALIGNMENT, row_align);
+					glPixelStorei(GL_UNPACK_ALIGNMENT, 1);
 					glPixelStorei(GL_UNPACK_ROW_LENGTH, img->getWidth());
 					glDrawPixels(
 						img_w, img_h, img_format, img_type,


### PR DESCRIPTION
## Changed apps/libraries

* mrpt-img
* mrpt-vision

## PR Description

It turned out OpenCV **requires** continuous memory for some important functions, so I have to undo the addition of the special cv::Mat memory allocator (sigh...). OTOH, with!=16*k is now supported in the special SSE* functions.
