### PR TITLE
ROS2 no longer uses catkin for the build system

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -29,13 +29,12 @@
   <depend>wxwidgets</depend>
   <depend>zlib</depend>
   <depend>assimp-dev</depend>
-  <depend>octomap</depend>
+  <!-- <depend>octomap</depend> -->
 
   <doc_depend>doxygen</doc_depend>
 
   <!-- Minimum entries to release non-catkin pkgs: -->
   <buildtool_depend>cmake</buildtool_depend>
-  <exec_depend>catkin</exec_depend>
   <export>
     <build_type>cmake</build_type>
     <rosdoc config="doc/rosdoc.yaml" />


### PR DESCRIPTION
Disable octomap until ROS2 supports it