### PR TITLE
add std designator before an endl

### DIFF
--- a/libs/graphslam/include/mrpt/graphslam/misc/TNodeProps.h
+++ b/libs/graphslam/include/mrpt/graphslam/misc/TNodeProps.h
@@ -50,7 +50,7 @@ struct TNodeProps
 
 	friend std::ostream& operator<<(std::ostream& o, const TNodeProps& obj)
 	{
-		o << obj.getAsString() << endl;
+		o << obj.getAsString() << std::endl;
 		return o;
 	}
 };


### PR DESCRIPTION
## Changed apps/libraries

* graphslam

## PR Description

Small fix to add `std::` in front of an `endl` in a header file.

(Notify: @MRPT/owners )

Does changelog need to be updated?