### PR TITLE
GraphPartitioner: move implementation to cpp

### DIFF
--- a/libs/bayes/include/mrpt/bayes/CKalmanFilterCapable.h
+++ b/libs/bayes/include/mrpt/bayes/CKalmanFilterCapable.h
@@ -277,7 +277,7 @@ class CKalmanFilterCapable : public mrpt::system::COutputLogger
 	 */
 	inline void getLandmarkCov(size_t idx, KFMatrix_FxF& feat_cov) const
 	{
-		feat_cov = m_pkk.block<FEAT_SIZE, FEAT_SIZE>(
+		feat_cov = m_pkk.blockCopy<FEAT_SIZE, FEAT_SIZE>(
 			VEH_SIZE + idx * FEAT_SIZE, VEH_SIZE + idx * FEAT_SIZE);
 	}
 

--- a/libs/graphs/include/mrpt/graphs/CGraphPartitioner.h
+++ b/libs/graphs/include/mrpt/graphs/CGraphPartitioner.h
@@ -8,9 +8,8 @@
    +------------------------------------------------------------------------+ */
 #pragma once
 
-#include <mrpt/math/CMatrixF.h>
-#include <mrpt/math/ops_matrices.h>
-#include <mrpt/system/COutputLogger.h>
+#include <mrpt/math/CMatrixDynamic.h>
+#include <vector>
 
 namespace mrpt
 {
@@ -19,39 +18,36 @@ namespace mrpt
  */
 namespace graphs
 {
-/** Algorithms for finding the min-normalized-cut of a weighted undirected
- * graph.
- *    Two methods are provided, one for bisection and the other for
- *      iterative N-parts partition.
- *  It is an implementation of the Shi-Malik method proposed in:<br><br>
- *  <code>J. Shi and J. Malik, "Normalized Cuts and Image Segmentation,"IEEE
- * Transactions on Pattern Analysis and Machine Intelligence, vol.22, no.8, pp.
- * 888-905, Aug. 2000.</code><br>
+/** Finds the min-normalized-cut of a weighted undirected graph.
+ * Two methods are provided:
+ *  - SpectralBisection(): Bisection.
+ *  - RecursiveSpectralPartition(): Iterative N-parts partition.
+ *
+ *  This is an implementation of the Shi-Malik method proposed in:
+ *  - J. Shi and J. Malik, "Normalized Cuts and Image Segmentation",
+ *    IEEE Transactions on Pattern Analysis and Machine Intelligence,
+ *    vol.22, no.8, pp. 888-905, Aug. 2000.
  *
  * \tparam GRAPH_MATRIX The type of square matrices used to represent the
- * connectivity in a graph (e.g. mrpt::math::CMatrixF)
- * \tparam num_t The type of matrix elements, thresholds, etc. (typ: float or
- * double). Defaults to the type of matrix elements.
+ * connectivity in a graph. Supported types are: mrpt::math::CMatrixDouble,
+ * mrpt::math::CMatrixD, mrpt::math::CMatrixFloat, mrpt::math::CMatrixF
  *
- * \note Prior to MRPT 1.0.0 this class wasn't a template and provided static
- * variables for debugging, which were removed since that version.
+ * \tparam num_t The type of matrix elements, thresholds, etc. (double or
+ * float). Defaults to the type of matrix elements.
  */
 template <class GRAPH_MATRIX, typename num_t = typename GRAPH_MATRIX::Scalar>
-class CGraphPartitioner : public mrpt::system::COutputLogger
+class CGraphPartitioner
 {
    public:
 	/** Performs the spectral recursive partition into K-parts for a given
 	 * graph.
-	 *   The default threshold for the N-cut is 1, which correspond to a cut
-	 * equal
-	 *   of the geometric mean of self-associations of each pair of groups.
+	 * The default threshold for the N-cut is 1, which correspond to a cut
+	 * equal of the geometric mean of self-associations of each pair of groups.
 	 *
-	 * \param in_A			 [IN] The weights matrix for the graph. It must be a
-	 * square
+	 * \param in_A  [IN] The weights matrix for the graph. It must be a square
 	 * matrix, where element W<sub>ij</sub> is the "likelihood" between nodes
 	 * "i" and "j", and typically W<sub>ii</sub> = 1.
-	 * \param out_parts		 [OUT] An array of partitions, where each partition
-	 * is
+	 * \param out_parts [OUT] An array of partitions, where each partition is
 	 * represented as a vector of indexs for nodes.
 	 * \param threshold_Ncut [IN] If it is desired to use other than the default
 	 * threshold, it can be passed here.
@@ -67,7 +63,7 @@ class CGraphPartitioner : public mrpt::system::COutputLogger
 	 * \param minSizeClusters [IN] Default=1, Minimum size of partitions to be
 	 * accepted.
 	 *
-	 * \sa mrpt::math::CMatrixF, SpectralBisection
+	 * \sa SpectralBisection
 	 *
 	 * \exception Throws a std::logic_error if an invalid matrix is passed.
 	 */
@@ -146,7 +142,3 @@ class CGraphPartitioner : public mrpt::system::COutputLogger
 
 }  // namespace graphs
 }  // namespace mrpt
-
-// Template implementation:
-#define CGRAPHPARTITIONER_H
-#include "CGraphPartitioner_impl.h"

--- a/libs/graphs/src/CGraphPartitioner.cpp
+++ b/libs/graphs/src/CGraphPartitioner.cpp
@@ -364,4 +364,4 @@ template class CGraphPartitioner<mrpt::math::CMatrixDouble, double>;
 template class CGraphPartitioner<mrpt::math::CMatrixFloat, float>;
 template class CGraphPartitioner<mrpt::math::CMatrixD, double>;
 template class CGraphPartitioner<mrpt::math::CMatrixF, float>;
-}  // namespace mrpt::poses
+}  // namespace mrpt::graphs

--- a/libs/graphs/src/CGraphPartitioner.cpp
+++ b/libs/graphs/src/CGraphPartitioner.cpp
@@ -7,20 +7,21 @@
    | Released under BSD License. See: https://www.mrpt.org/License          |
    +------------------------------------------------------------------------+ */
 
-#pragma once
+#include "graphs-precomp.h"  // Precompiled headers
 
-#if !defined(CGRAPHPARTITIONER_H)
-#error "This file can't be included from outside of CGraphPartitioner.h"
-#endif
-
+#include <mrpt/graphs/CGraphPartitioner.h>
+#include <mrpt/math/CMatrixD.h>
+#include <mrpt/math/CMatrixF.h>
 #include <mrpt/math/ops_matrices.h>  // laplacian()
 #include <iostream>  // cout
 
-namespace mrpt::graphs
-{
+using namespace mrpt;
+using namespace mrpt::graphs;
+using namespace std;
+
 /*---------------------------------------------------------------
-					SpectralPartition
-  ---------------------------------------------------------------*/
+SpectralPartition
+---------------------------------------------------------------*/
 template <class GRAPH_MATRIX, typename num_t>
 void CGraphPartitioner<GRAPH_MATRIX, num_t>::SpectralBisection(
 	GRAPH_MATRIX& in_A, std::vector<uint32_t>& out_part1,
@@ -96,8 +97,8 @@ void CGraphPartitioner<GRAPH_MATRIX, num_t>::SpectralBisection(
 }
 
 /*---------------------------------------------------------------
-					RecursiveSpectralPartition
-  ---------------------------------------------------------------*/
+RecursiveSpectralPartition
+---------------------------------------------------------------*/
 template <class GRAPH_MATRIX, typename num_t>
 void CGraphPartitioner<GRAPH_MATRIX, num_t>::RecursiveSpectralPartition(
 	GRAPH_MATRIX& in_A, std::vector<std::vector<uint32_t>>& out_parts,
@@ -223,8 +224,8 @@ void CGraphPartitioner<GRAPH_MATRIX, num_t>::RecursiveSpectralPartition(
 }
 
 /*---------------------------------------------------------------
-						nCut
-  ---------------------------------------------------------------*/
+nCut
+---------------------------------------------------------------*/
 template <class GRAPH_MATRIX, typename num_t>
 num_t CGraphPartitioner<GRAPH_MATRIX, num_t>::nCut(
 	const GRAPH_MATRIX& in_A, const std::vector<uint32_t>& in_part1,
@@ -260,8 +261,8 @@ num_t CGraphPartitioner<GRAPH_MATRIX, num_t>::nCut(
 }
 
 /*---------------------------------------------------------------
-					exactBisection
-  ---------------------------------------------------------------*/
+exactBisection
+---------------------------------------------------------------*/
 template <class GRAPH_MATRIX, typename num_t>
 void CGraphPartitioner<GRAPH_MATRIX, num_t>::exactBisection(
 	GRAPH_MATRIX& in_A, std::vector<uint32_t>& out_part1,
@@ -355,4 +356,12 @@ void CGraphPartitioner<GRAPH_MATRIX, num_t>::exactBisection(
 	}
 }
 
-}  // namespace mrpt::graphs
+// Explicit instantiations:
+namespace mrpt::graphs
+{
+// Explicit instantiations:
+template class CGraphPartitioner<mrpt::math::CMatrixDouble, double>;
+template class CGraphPartitioner<mrpt::math::CMatrixFloat, float>;
+template class CGraphPartitioner<mrpt::math::CMatrixD, double>;
+template class CGraphPartitioner<mrpt::math::CMatrixF, float>;
+}  // namespace mrpt::poses

--- a/libs/math/include/mrpt/math/MatrixVectorBase.h
+++ b/libs/math/include/mrpt/math/MatrixVectorBase.h
@@ -72,27 +72,27 @@ class MatrixVectorBase
 		std::fill(mvbDerived().begin(), mvbDerived().end(), val);
 	}
 
-	inline void setZero() { fill(0); }
-	inline void setZero(size_t nrows, size_t ncols)
+	inline void setConstant(const Scalar value) { fill(value); }
+	inline void setConstant(size_t nrows, size_t ncols, const Scalar value)
 	{
 		mvbDerived().resize(nrows, ncols);
-		fill(0);
+		fill(value);
 	}
 
-	static Derived Zero()
+	static Derived Constant(const Scalar value)
 	{
 		ASSERTMSG_(
 			Derived::RowsAtCompileTime > 0 && Derived::ColsAtCompileTime > 0,
-			"Zero() without arguments can be used only for fixed-size "
+			"Constant() without arguments can be used only for fixed-size "
 			"matrices/vectors");
 		Derived m;
-		m.setZero();
+		m.fill(value);
 		return m;
 	}
-	static Derived Zero(size_t nrows, size_t ncols)
+	static Derived Constant(size_t nrows, size_t ncols, const Scalar value)
 	{
 		Derived m;
-		m.setZero(nrows, ncols);
+		m.setConstant(nrows, ncols, value);
 		return m;
 	}
 
@@ -101,6 +101,19 @@ class MatrixVectorBase
 		mvbDerived().resize(N);
 		fill(value);
 	}
+
+	inline void setZero() { fill(0); }
+	inline void setZero(size_t nrows, size_t ncols)
+	{
+		setConstant(nrows, ncols, 0);
+	}
+
+	static Derived Zero() { return Constant(0); }
+	static Derived Zero(size_t nrows, size_t ncols)
+	{
+		return Constant(nrows, ncols, 0);
+	}
+
 	/** @} */
 
 	/** @name Operations that DO require `#include <Eigen/Dense>` in user code

--- a/libs/math/include/mrpt/math/MatrixVectorBase.h
+++ b/libs/math/include/mrpt/math/MatrixVectorBase.h
@@ -78,6 +78,13 @@ class MatrixVectorBase
 		mvbDerived().resize(nrows, ncols);
 		fill(value);
 	}
+	inline void setConstant(size_t nrows, const Scalar value)
+	{
+		ASSERTMSG_(
+			Derived::ColsAtCompileTime == 1,
+			"setConstant(n) can be used only for vectors, not matrices");
+		setConstant(nrows, 1, value);
+	}
 
 	static Derived Constant(const Scalar value)
 	{
@@ -106,6 +113,13 @@ class MatrixVectorBase
 	inline void setZero(size_t nrows, size_t ncols)
 	{
 		setConstant(nrows, ncols, 0);
+	}
+	inline void setZero(size_t nrows)
+	{
+		ASSERTMSG_(
+			Derived::ColsAtCompileTime == 1,
+			"setZero(n) can be used only for vectors, not matrices");
+		setConstant(nrows, 1, 0);
 	}
 
 	static Derived Zero() { return Constant(0); }

--- a/libs/math/include/mrpt/math/ops_matrices.h
+++ b/libs/math/include/mrpt/math/ops_matrices.h
@@ -208,7 +208,8 @@ void laplacian(const MATIN& g, MATOUT& ret)
 	if (g.rows() != g.cols())
 		throw std::runtime_error("laplacian: Defined for square matrixes only");
 	const auto N = g.rows();
-	ret = -g;
+	ret = g;
+	ret *= -1;
 	for (typename MATIN::Index i = 0; i < N; i++)
 	{
 		typename MATIN::Scalar deg = 0;

--- a/libs/pbmap/include/mrpt/pbmap/SemanticClustering.h
+++ b/libs/pbmap/include/mrpt/pbmap/SemanticClustering.h
@@ -19,7 +19,7 @@
 #if MRPT_HAS_PCL
 
 #include <mrpt/graphs/CGraphPartitioner.h>
-
+#include <mrpt/math/CMatrixF.h>
 #include <mrpt/pbmap/PbMap.h>
 #include <mrpt/pbmap/Plane.h>
 #include <map>


### PR DESCRIPTION
## Changed apps/libraries

* modified-graphs

Fixes build in user apps including mrpt-graphs, introduced after the last matrices refactoring.