### PR TITLE
Small vector optimization

### DIFF
--- a/apps/mrpt-performance/perf-matrix1.cpp
+++ b/apps/mrpt-performance/perf-matrix1.cpp
@@ -152,6 +152,22 @@ double matrix_test_det_fix(int a1, int a2)
 	return tictac.Tac() / N;
 }
 
+template <typename MAT, size_t DIM>
+double matrix_test_vector_resize(int VECTOR_LEN, int a2)
+{
+	using vec_t = std::vector<MAT>;
+
+	const long N = 10000;
+	CTicTac tictac;
+	for (long i = 0; i < N; i++)
+	{
+		vec_t v;
+		v.resize(VECTOR_LEN);
+		for (auto& m : v) m.resize(DIM, DIM);
+	}
+	return tictac.Tac() / N;
+}
+
 // ------------------------------------------------------
 // register_tests_matrices: Part 1
 // ------------------------------------------------------
@@ -238,4 +254,23 @@ void register_tests_matrices1()
 		"matrix: det, dyn[double] 20x20", matrix_test_det_dyn<double, 20>);
 	lstTests.emplace_back(
 		"matrix: det, dyn[double] 40x40", matrix_test_det_dyn<double, 40>);
+
+	// clang-format off
+	lstTests.emplace_back("matrix: vector of, resize(10) dyn[double] 4x4",    matrix_test_vector_resize<CMatrixDynamic<double>, 4>, 10);
+	lstTests.emplace_back("matrix: vector of, resize(100) dyn[double] 4x4",   matrix_test_vector_resize<CMatrixDynamic<double>, 4>, 100);
+	lstTests.emplace_back("matrix: vector of, resize(1000) dyn[double] 4x4",  matrix_test_vector_resize<CMatrixDynamic<double>, 4>, 1000);
+
+	lstTests.emplace_back("matrix: vector of, resize(10) dyn[double] 5x5",    matrix_test_vector_resize<CMatrixDynamic<double>, 5>, 10);
+	lstTests.emplace_back("matrix: vector of, resize(100) dyn[double] 5x5",   matrix_test_vector_resize<CMatrixDynamic<double>, 5>, 100);
+	lstTests.emplace_back("matrix: vector of, resize(1000) dyn[double] 5x5",  matrix_test_vector_resize<CMatrixDynamic<double>, 5>, 1000);
+
+	lstTests.emplace_back("matrix: vector of, resize(10) fix[double] 4x4",    matrix_test_vector_resize<CMatrixDouble44, 4>, 10);
+	lstTests.emplace_back("matrix: vector of, resize(100) fix[double] 4x4",   matrix_test_vector_resize<CMatrixDouble44, 4>, 100);
+	lstTests.emplace_back("matrix: vector of, resize(1000) fix[double] 4x4",  matrix_test_vector_resize<CMatrixDouble44, 4>, 1000);
+
+	lstTests.emplace_back("matrix: vector of, resize(10) fix[double] 5x5",    matrix_test_vector_resize<CMatrixFixed<double,5,5>, 5>, 10);
+	lstTests.emplace_back("matrix: vector of, resize(100) fix[double] 5x5",   matrix_test_vector_resize<CMatrixFixed<double,5,5>, 5>, 100);
+	lstTests.emplace_back("matrix: vector of, resize(1000) fix[double] 5x5",  matrix_test_vector_resize<CMatrixFixed<double,5,5>, 5>, 1000);
+
+	// clang-format on
 }

--- a/libs/containers/include/mrpt/containers/vector_with_small_size_optimization.h
+++ b/libs/containers/include/mrpt/containers/vector_with_small_size_optimization.h
@@ -161,15 +161,14 @@ class vector_with_small_size_optimization
 
 	const_reference back() const
 	{
-		return m_is_small ? m_a.back() : m_v.back();
+		return m_is_small ? m_a[m_size - 1] : m_v.back();
 	}
-	reference back() { return m_is_small ? m_a.back() : m_v.back(); }
+	reference back() { return m_is_small ? m_a[m_size - 1] : m_v.back(); }
 
 	const_reference front() const
 	{
 		return m_is_small ? m_a.front() : m_v.front();
 	}
-
 	reference front() { return m_is_small ? m_a.front() : m_v.front(); }
 
 	void swap(vector& x)

--- a/libs/containers/include/mrpt/containers/vector_with_small_size_optimization.h
+++ b/libs/containers/include/mrpt/containers/vector_with_small_size_optimization.h
@@ -30,7 +30,7 @@ struct UnspecializedBool
  * \note In `#include <mrpt/containers/vector_with_small_size_optimization.h>`
  * \ingroup mrpt_containers_grp
  */
-template <typename VAL, size_t small_size, size_t alignment>
+template <typename VAL, size_t small_size, size_t alignment = 16>
 class vector_with_small_size_optimization
 {
    private:
@@ -69,6 +69,7 @@ class vector_with_small_size_optimization
 		using pointer = POINTER;
 		using iterator_category = std::random_access_iterator_tag;
 		using difference_type = typename large_vec::difference_type;
+		iteratorImpl() = default;
 		iteratorImpl(STORAGE ptr) : m_ptr(ptr) {}
 		self operator++()
 		{
@@ -121,7 +122,7 @@ class vector_with_small_size_optimization
 		bool operator!=(const self& o) { return m_ptr != o.m_ptr; }
 
 	   private:
-		STORAGE m_ptr;
+		STORAGE m_ptr{nullptr};
 	};
 
 	using iterator = iteratorImpl<VAL, VAL*, VAL&>;
@@ -135,18 +136,21 @@ class vector_with_small_size_optimization
 			{
 				m_v.assign(m_a.begin(), m_a.begin() + m_size);
 			}
-			else if (!m_is_small && n < small_size)
+			else if (!m_is_small && n <= small_size)
 			{
 				std::copy(m_v.begin(), m_v.begin() + n, m_a.begin());
 			}
 		}
 		m_size = n;
-		m_is_small = n < small_size;
+		m_is_small = (n <= small_size);
 		if (!m_is_small)
 		{
 			m_v.resize(m_size);
 		}
 	}
+
+	size_t size() const { return m_size; }
+	bool empty() const { return m_size == 0; }
 
 	reference operator[](size_type n) { return m_is_small ? m_a[n] : m_v[n]; }
 
@@ -154,6 +158,19 @@ class vector_with_small_size_optimization
 	{
 		return m_is_small ? m_a[n] : m_v[n];
 	}
+
+	const_reference back() const
+	{
+		return m_is_small ? m_a.back() : m_v.back();
+	}
+	reference back() { return m_is_small ? m_a.back() : m_v.back(); }
+
+	const_reference front() const
+	{
+		return m_is_small ? m_a.front() : m_v.front();
+	}
+
+	reference front() { return m_is_small ? m_a.front() : m_v.front(); }
 
 	void swap(vector& x)
 	{

--- a/libs/containers/include/mrpt/containers/vector_with_small_size_optimization.h
+++ b/libs/containers/include/mrpt/containers/vector_with_small_size_optimization.h
@@ -1,0 +1,198 @@
+/* +------------------------------------------------------------------------+
+   |                     Mobile Robot Programming Toolkit (MRPT)            |
+   |                          https://www.mrpt.org/                         |
+   |                                                                        |
+   | Copyright (c) 2005-2019, Individual contributors, see AUTHORS file     |
+   | See: https://www.mrpt.org/Authors - All rights reserved.               |
+   | Released under BSD License. See: https://www.mrpt.org/License          |
+   +------------------------------------------------------------------------+ */
+#pragma once
+
+#include <mrpt/core/aligned_allocator.h>  // aligned_allocator_cpp11
+#include <array>
+#include <cstddef>  // size_t
+#include <type_traits>  // conditional_t, ...
+#include <vector>
+
+namespace mrpt::containers
+{
+struct UnspecializedBool
+{
+	operator const bool&() const { return b; }
+	operator bool&() { return b; }
+
+	bool b;
+};
+
+/** Container that transparently and dynamically switches between a std::array
+ * and std::vector. Used to avoid heap allocations with small vectors.
+ *
+ * \note In `#include <mrpt/containers/vector_with_small_size_optimization.h>`
+ * \ingroup mrpt_containers_grp
+ */
+template <typename VAL, size_t small_size, size_t alignment>
+class vector_with_small_size_optimization
+{
+   private:
+	using T =
+		std::conditional_t<std::is_same_v<VAL, bool>, UnspecializedBool, VAL>;
+	using ALLOC = mrpt::aligned_allocator_cpp11<T>;
+	using vector =
+		vector_with_small_size_optimization<VAL, small_size, alignment>;
+	using large_vec = std::vector<T, ALLOC>;
+	using small_array = std::array<T, small_size>;
+
+	large_vec m_v;
+	alignas(alignment) small_array m_a;
+	bool m_is_small = true;
+	size_t m_size = 0;
+
+   public:
+	using value_type = T;
+	using reference = T&;
+	using const_reference = const T&;
+	using difference_type = typename large_vec::difference_type;
+	using size_type = typename large_vec::size_type;
+	template <typename TYPE, typename POINTER, typename REFERENCE>
+	class iteratorImpl
+	{
+		using STORAGE = std::conditional_t<
+			std::is_same_v<POINTER, bool*>, UnspecializedBool*,
+			std::conditional_t<
+				std::is_same_v<POINTER, const bool*>, const UnspecializedBool*,
+				POINTER>>;
+		using self = iteratorImpl<TYPE, POINTER, REFERENCE>;
+
+	   public:
+		using value_type = TYPE;
+		using reference = REFERENCE;
+		using pointer = POINTER;
+		using iterator_category = std::random_access_iterator_tag;
+		using difference_type = typename large_vec::difference_type;
+		iteratorImpl(STORAGE ptr) : m_ptr(ptr) {}
+		self operator++()
+		{
+			self i = *this;
+			m_ptr++;
+			return i;
+		}
+		self operator--()
+		{
+			self i = *this;
+			m_ptr--;
+			return i;
+		}
+		self operator++(int)
+		{
+			m_ptr++;
+			return *this;
+		}
+		self operator--(int)
+		{
+			m_ptr--;
+			return *this;
+		}
+		self operator+(difference_type n)
+		{
+			self i = *this;
+			i.m_ptr += n;
+			return i;
+		}
+		self operator-(difference_type n)
+		{
+			self i = *this;
+			i.m_ptr -= n;
+			return i;
+		}
+		self operator+=(difference_type n)
+		{
+			m_ptr += n;
+			return *this;
+		}
+		self operator-=(difference_type n)
+		{
+			m_ptr -= n;
+			return *this;
+		}
+		difference_type operator-(const self& o) { return m_ptr - o.m_ptr; }
+		REFERENCE operator*() { return *m_ptr; }
+		POINTER operator->() { return m_ptr; }
+		bool operator==(const self& o) { return m_ptr == o.m_ptr; }
+		bool operator!=(const self& o) { return m_ptr != o.m_ptr; }
+
+	   private:
+		STORAGE m_ptr;
+	};
+
+	using iterator = iteratorImpl<VAL, VAL*, VAL&>;
+	using const_iterator = iteratorImpl<VAL, const VAL*, const VAL&>;
+
+	void resize(size_type n)
+	{
+		if (m_size)
+		{
+			if (m_is_small && n > small_size)
+			{
+				m_v.assign(m_a.begin(), m_a.begin() + m_size);
+			}
+			else if (!m_is_small && n < small_size)
+			{
+				std::copy(m_v.begin(), m_v.begin() + n, m_a.begin());
+			}
+		}
+		m_size = n;
+		m_is_small = n < small_size;
+		if (!m_is_small)
+		{
+			m_v.resize(m_size);
+		}
+	}
+
+	reference operator[](size_type n) { return m_is_small ? m_a[n] : m_v[n]; }
+
+	const_reference operator[](size_type n) const
+	{
+		return m_is_small ? m_a[n] : m_v[n];
+	}
+
+	void swap(vector& x)
+	{
+		if (m_is_small & x.m_is_small)
+		{
+			m_a.swap(x.m_a);
+		}
+		else if (!m_is_small && !x.m_is_small)
+		{
+			m_v.swap(x.m_v);
+		}
+		else if (!m_is_small && x.m_is_small)
+		{
+			std::copy(x.m_a.begin(), x.m_a.begin() + x.m_size, m_a.begin());
+			x.m_v.swap(m_v);
+		}
+		else
+		{
+			m_v.swap(x.m_v);
+			std::copy(m_a.begin(), m_a.begin() + m_size, x.m_a.begin());
+		}
+		std::swap(m_size, x.m_size);
+		std::swap(m_is_small, x.m_is_small);
+	}
+
+	iterator begin() noexcept { return m_is_small ? m_a.data() : m_v.data(); }
+	const_iterator begin() const noexcept
+	{
+		return m_is_small ? m_a.data() : m_v.data();
+	}
+
+	iterator end() noexcept
+	{
+		return m_is_small ? m_a.data() + m_size : m_v.data() + m_size;
+	}
+	const_iterator end() const noexcept
+	{
+		return m_is_small ? m_a.data() + m_size : m_v.data() + m_size;
+	}
+};
+
+}  // namespace mrpt::containers

--- a/libs/containers/src/vector_with_small_size_optimization_unittest.cpp
+++ b/libs/containers/src/vector_with_small_size_optimization_unittest.cpp
@@ -1,0 +1,143 @@
+/* +------------------------------------------------------------------------+
+   |                     Mobile Robot Programming Toolkit (MRPT)            |
+   |                          https://www.mrpt.org/                         |
+   |                                                                        |
+   | Copyright (c) 2005-2019, Individual contributors, see AUTHORS file     |
+   | See: https://www.mrpt.org/Authors - All rights reserved.               |
+   | Released under BSD License. See: https://www.mrpt.org/License          |
+   +------------------------------------------------------------------------+ */
+
+#include <CTraitsTest.h>
+#include <gtest/gtest.h>
+#include <mrpt/containers/vector_with_small_size_optimization.h>
+#include <mrpt/core/common.h>
+
+using data_t = unsigned int;
+constexpr size_t SMALL_LEN = 16;
+
+using vwsso_t =
+	mrpt::containers::vector_with_small_size_optimization<data_t, SMALL_LEN>;
+
+template class mrpt::CTraitsTest<vwsso_t>;
+
+TEST(vector_with_small_size_optimization, Empty)
+{
+	vwsso_t v;
+
+	EXPECT_TRUE(v.empty());
+	EXPECT_TRUE(v.size() == 0);
+}
+
+TEST(vector_with_small_size_optimization, ResizeSize)
+{
+	// New one each time:
+	for (size_t n = 1; n < SMALL_LEN * 2; n++)
+	{
+		vwsso_t v;
+		v.resize(n);
+		EXPECT_FALSE(v.empty());
+		EXPECT_EQ(v.size(), n);
+	}
+
+	// Reusing object:
+	vwsso_t v;
+	for (size_t n = 1; n < SMALL_LEN * 2; n++)
+	{
+		v.resize(n);
+		EXPECT_FALSE(v.empty());
+		EXPECT_EQ(v.size(), n);
+	}
+}
+
+TEST(vector_with_small_size_optimization, ResizeWriteRead)
+{
+	// New one each time:
+	for (size_t n = 1; n < SMALL_LEN * 2; n++)
+	{
+		vwsso_t v;
+		v.resize(n);
+
+		for (size_t i = 0; i < n; i++) v[i] = i;
+		for (size_t i = 0; i < n; i++) EXPECT_EQ(v[i], i);
+	}
+
+	// Reusing object:
+	vwsso_t v;
+	for (size_t n = 1; n < SMALL_LEN * 2; n++)
+	{
+		v.resize(n);
+		for (size_t i = 0; i < n; i++) v[i] = i;
+		for (size_t i = 0; i < n; i++) EXPECT_EQ(v[i], i);
+	}
+}
+
+TEST(vector_with_small_size_optimization, ResizeWriteReadIterators)
+{
+	// New one each time:
+	for (size_t n = 1; n < SMALL_LEN * 2; n++)
+	{
+		vwsso_t v;
+		v.resize(n);
+
+		for (size_t i = 0; i < n; i++) v[i] = i;
+
+		size_t i = 0;
+		for (const auto& val : v)
+		{
+			EXPECT_EQ(val, i);
+			i++;
+		}
+	}
+
+	// Reusing object:
+	vwsso_t v;
+	for (size_t n = 1; n < SMALL_LEN * 2; n++)
+	{
+		v.resize(n);
+		for (size_t i = 0; i < n; i++) v[i] = i;
+		size_t i = 0;
+		for (const auto& val : v)
+		{
+			EXPECT_EQ(val, i);
+			i++;
+		}
+	}
+}
+
+TEST(vector_with_small_size_optimization, GrowCheckContents)
+{
+	vwsso_t v;
+	for (size_t n = 1; n < SMALL_LEN * 2; n++)
+	{
+		v.resize(n);
+		v[n - 1] = n - 1;
+
+		for (size_t i = 0; i < n; i++) EXPECT_EQ(v[i], i) << "n=" << n;
+	}
+}
+
+TEST(vector_with_small_size_optimization, ShrinkCheckContents)
+{
+	vwsso_t v;
+	v.resize(SMALL_LEN * 2);
+	for (size_t i = 0; i < v.size(); i++) v[i] = i;
+
+	while (!v.empty())
+	{
+		v.resize(v.size() - 1);
+
+		for (size_t i = 0; i < v.size(); i++)
+			EXPECT_EQ(v[i], i) << "size()=" << v.size();
+	}
+}
+
+TEST(vector_with_small_size_optimization, GrowCheckFrontBack)
+{
+	vwsso_t v;
+	for (size_t n = 1; n < SMALL_LEN * 2; n++)
+	{
+		v.resize(n);
+		EXPECT_EQ(&v[0], &v.front()) << "n=" << n;
+		EXPECT_EQ(&v[n - 1], &v.back()) << "n=" << n;
+	}
+}

--- a/libs/math/include/mrpt/math/CMatrixDynamic.h
+++ b/libs/math/include/mrpt/math/CMatrixDynamic.h
@@ -152,12 +152,12 @@ public:
 			m_v.swap(x.m_v);
 		}
 		else if (!m_is_small && x.m_is_small) {
-			m_a = x.m_a;
+			std::copy(x.m_a.begin(), x.m_a.begin() + x.m_size, m_a.begin());
 			x.m_v.swap(m_v);
 		}
 		else {
 			m_v.swap(x.m_v);
-			x.m_a = x.m_a;
+			std::copy(m_a.begin(), m_a.begin() + m_size, x.m_a.begin());
 		}
 		std::swap(m_size, x.m_size);
 		std::swap(m_is_small, x.m_is_small);

--- a/libs/math/include/mrpt/math/CMatrixDynamic.h
+++ b/libs/math/include/mrpt/math/CMatrixDynamic.h
@@ -65,12 +65,12 @@ public:
 		iteratorImpl(STORAGE ptr) : m_ptr(ptr) { }
 		self operator++() {
 			self i = *this;
-			i.m_ptr++;
+			m_ptr++;
 			return i;
 		}
 		self operator--() {
 			self i = *this;
-			i.m_ptr--;
+			m_ptr--;
 			return i;
 		}
 		self operator++(int) {

--- a/libs/math/include/mrpt/math/CMatrixDynamic.h
+++ b/libs/math/include/mrpt/math/CMatrixDynamic.h
@@ -22,6 +22,162 @@
 
 namespace mrpt::math
 {
+struct UnspecializedBool
+{
+	operator const bool&() const { return b; }
+	operator bool&() { return b; }
+
+	bool b;
+};
+
+template <typename VAL, size_t small_size, size_t alignment>
+class vector_with_small_size_optimization {
+private:
+	using T = std::conditional_t<std::is_same_v<VAL,bool>, UnspecializedBool, VAL>;
+	using ALLOC =  mrpt::aligned_allocator_cpp11<T>;
+	using vector = vector_with_small_size_optimization<VAL, small_size, alignment>;
+	using large_vec = std::vector<T, ALLOC>;
+	using small_array = std::array<T,small_size>;
+
+	large_vec m_v;
+	alignas(alignment) small_array m_a;
+	bool m_is_small = true;
+	size_t m_size = 0;
+public:
+	using value_type = T;
+	using reference = T&;
+	using const_reference = const T&;
+	using difference_type = typename large_vec::difference_type;
+	using size_type = typename large_vec::size_type;
+	template <typename TYPE, typename POINTER, typename REFERENCE>
+	class iteratorImpl
+	{
+		using STORAGE = std::conditional_t<std::is_same_v<POINTER, bool *>,UnspecializedBool *,
+		      std::conditional_t<std::is_same_v<POINTER, const bool *>, const UnspecializedBool *,POINTER>
+		>;
+		using self = iteratorImpl<TYPE, POINTER,REFERENCE>;
+		public:
+		using value_type = TYPE;
+		using reference = REFERENCE;
+		using pointer = POINTER;
+		using iterator_category = std::random_access_iterator_tag;
+		using difference_type = typename large_vec::difference_type;
+		iteratorImpl(STORAGE ptr) : m_ptr(ptr) { }
+		self operator++() {
+			self i = *this;
+			i.m_ptr++;
+			return i;
+		}
+		self operator--() {
+			self i = *this;
+			i.m_ptr--;
+			return i;
+		}
+		self operator++(int) {
+			m_ptr++;
+			return *this;
+		}
+		self operator--(int) {
+			m_ptr--;
+			return *this;
+		}
+		self operator+(difference_type n) {
+			self i = *this;
+			i.m_ptr += n;
+			return i;
+		}
+		self operator-(difference_type n) {
+			self i = *this;
+			i.m_ptr -= n;
+			return i;
+		}
+		self operator+=(difference_type n) {
+			m_ptr += n;
+			return *this;
+		}
+		self operator-=(difference_type n) {
+			m_ptr -= n;
+			return *this;
+		}
+		difference_type operator-(const self &o)
+		{
+			return m_ptr - o.m_ptr;
+		}
+		REFERENCE operator*() { return *m_ptr; }
+		POINTER operator->() { return m_ptr; }
+		bool operator==(const self& o) {
+			return m_ptr == o.m_ptr;
+		}
+		bool operator!=(const self& o) {
+			return m_ptr != o.m_ptr;
+		}
+	    private:
+		STORAGE m_ptr;
+	};
+
+	using iterator = iteratorImpl<VAL, VAL *, VAL &>;
+	using const_iterator = iteratorImpl<VAL, const VAL *, const VAL &>;
+
+	void resize (size_type n) {
+		if(m_size) {
+			if(m_is_small && n > small_size) {
+				m_v.assign(m_a.begin(), m_a.begin() + m_size);
+			}
+			else if(!m_is_small && n < small_size)
+			{
+				std::copy (m_v.begin(), m_v.begin()+n, m_a.begin() );
+			}
+		}
+		m_size = n;
+		m_is_small = n < small_size;
+		if(!m_is_small){
+			m_v.resize(m_size);
+		}
+	}
+
+	reference operator[] (size_type n) {
+		return m_is_small ? m_a[n] : m_v[n];
+	}
+
+	const_reference operator[] (size_type n) const {
+		return m_is_small ? m_a[n] : m_v[n];
+	}
+
+	void swap (vector& x)
+	{
+		if (m_is_small & x.m_is_small){
+			m_a.swap(x.m_a);
+		}
+		else if (!m_is_small && !x.m_is_small) {
+			m_v.swap(x.m_v);
+		}
+		else if (!m_is_small && x.m_is_small) {
+			m_a = x.m_a;
+			x.m_v.swap(m_v);
+		}
+		else {
+			m_v.swap(x.m_v);
+			x.m_a = x.m_a;
+		}
+		std::swap(m_size, x.m_size);
+		std::swap(m_is_small, x.m_is_small);
+	}
+
+	iterator begin() noexcept {
+		return m_is_small ? m_a.data() : m_v.data();
+	}
+	const_iterator begin() const noexcept {
+		return m_is_small ? m_a.data() : m_v.data();
+	}
+
+	iterator end() noexcept {
+		return m_is_small ? m_a.data() + m_size : m_v.data() + m_size;
+	}
+	const_iterator end() const noexcept {
+		return m_is_small ? m_a.data() + m_size : m_v.data() + m_size;
+	}
+};
+
 /**  This template class provides the basic functionality for a general 2D
  *any-size, resizable container of numerical or non-numerical elements.
  * NOTES:
@@ -40,7 +196,8 @@ template <class T>
 class CMatrixDynamic : public MatrixBase<T, CMatrixDynamic<T>>
 {
    private:
-	using vec_t = mrpt::aligned_std_basicstring<T>;
+	static constexpr size_t small_size = 16;
+	using vec_t = vector_with_small_size_optimization<T, small_size,MRPT_MAX_STATIC_ALIGN_BYTES>;
 
 	/** RowMajor matrix data */
 	vec_t m_data;

--- a/libs/math/include/mrpt/math/CMatrixDynamic.h
+++ b/libs/math/include/mrpt/math/CMatrixDynamic.h
@@ -8,7 +8,7 @@
    +------------------------------------------------------------------------+ */
 #pragma once
 
-#include <mrpt/core/aligned_std_basicstring.h>
+#include <mrpt/containers/vector_with_small_size_optimization.h>
 #include <mrpt/core/exceptions.h>  // ASSERT_()
 #include <mrpt/core/format.h>
 #include <mrpt/math/MatrixBase.h>
@@ -16,168 +16,11 @@
 #include <mrpt/math/matrix_size_t.h>
 #include <mrpt/typemeta/TTypeName.h>
 #include <algorithm>  // swap()
-#include <array>
 #include <cstring>  // memset()
 #include <type_traits>
 
 namespace mrpt::math
 {
-struct UnspecializedBool
-{
-	operator const bool&() const { return b; }
-	operator bool&() { return b; }
-
-	bool b;
-};
-
-template <typename VAL, size_t small_size, size_t alignment>
-class vector_with_small_size_optimization {
-private:
-	using T = std::conditional_t<std::is_same_v<VAL,bool>, UnspecializedBool, VAL>;
-	using ALLOC =  mrpt::aligned_allocator_cpp11<T>;
-	using vector = vector_with_small_size_optimization<VAL, small_size, alignment>;
-	using large_vec = std::vector<T, ALLOC>;
-	using small_array = std::array<T,small_size>;
-
-	large_vec m_v;
-	alignas(alignment) small_array m_a;
-	bool m_is_small = true;
-	size_t m_size = 0;
-public:
-	using value_type = T;
-	using reference = T&;
-	using const_reference = const T&;
-	using difference_type = typename large_vec::difference_type;
-	using size_type = typename large_vec::size_type;
-	template <typename TYPE, typename POINTER, typename REFERENCE>
-	class iteratorImpl
-	{
-		using STORAGE = std::conditional_t<std::is_same_v<POINTER, bool *>,UnspecializedBool *,
-		      std::conditional_t<std::is_same_v<POINTER, const bool *>, const UnspecializedBool *,POINTER>
-		>;
-		using self = iteratorImpl<TYPE, POINTER,REFERENCE>;
-		public:
-		using value_type = TYPE;
-		using reference = REFERENCE;
-		using pointer = POINTER;
-		using iterator_category = std::random_access_iterator_tag;
-		using difference_type = typename large_vec::difference_type;
-		iteratorImpl(STORAGE ptr) : m_ptr(ptr) { }
-		self operator++() {
-			self i = *this;
-			m_ptr++;
-			return i;
-		}
-		self operator--() {
-			self i = *this;
-			m_ptr--;
-			return i;
-		}
-		self operator++(int) {
-			m_ptr++;
-			return *this;
-		}
-		self operator--(int) {
-			m_ptr--;
-			return *this;
-		}
-		self operator+(difference_type n) {
-			self i = *this;
-			i.m_ptr += n;
-			return i;
-		}
-		self operator-(difference_type n) {
-			self i = *this;
-			i.m_ptr -= n;
-			return i;
-		}
-		self operator+=(difference_type n) {
-			m_ptr += n;
-			return *this;
-		}
-		self operator-=(difference_type n) {
-			m_ptr -= n;
-			return *this;
-		}
-		difference_type operator-(const self &o)
-		{
-			return m_ptr - o.m_ptr;
-		}
-		REFERENCE operator*() { return *m_ptr; }
-		POINTER operator->() { return m_ptr; }
-		bool operator==(const self& o) {
-			return m_ptr == o.m_ptr;
-		}
-		bool operator!=(const self& o) {
-			return m_ptr != o.m_ptr;
-		}
-	    private:
-		STORAGE m_ptr;
-	};
-
-	using iterator = iteratorImpl<VAL, VAL *, VAL &>;
-	using const_iterator = iteratorImpl<VAL, const VAL *, const VAL &>;
-
-	void resize (size_type n) {
-		if(m_size) {
-			if(m_is_small && n > small_size) {
-				m_v.assign(m_a.begin(), m_a.begin() + m_size);
-			}
-			else if(!m_is_small && n < small_size)
-			{
-				std::copy (m_v.begin(), m_v.begin()+n, m_a.begin() );
-			}
-		}
-		m_size = n;
-		m_is_small = n < small_size;
-		if(!m_is_small){
-			m_v.resize(m_size);
-		}
-	}
-
-	reference operator[] (size_type n) {
-		return m_is_small ? m_a[n] : m_v[n];
-	}
-
-	const_reference operator[] (size_type n) const {
-		return m_is_small ? m_a[n] : m_v[n];
-	}
-
-	void swap (vector& x)
-	{
-		if (m_is_small & x.m_is_small){
-			m_a.swap(x.m_a);
-		}
-		else if (!m_is_small && !x.m_is_small) {
-			m_v.swap(x.m_v);
-		}
-		else if (!m_is_small && x.m_is_small) {
-			std::copy(x.m_a.begin(), x.m_a.begin() + x.m_size, m_a.begin());
-			x.m_v.swap(m_v);
-		}
-		else {
-			m_v.swap(x.m_v);
-			std::copy(m_a.begin(), m_a.begin() + m_size, x.m_a.begin());
-		}
-		std::swap(m_size, x.m_size);
-		std::swap(m_is_small, x.m_is_small);
-	}
-
-	iterator begin() noexcept {
-		return m_is_small ? m_a.data() : m_v.data();
-	}
-	const_iterator begin() const noexcept {
-		return m_is_small ? m_a.data() : m_v.data();
-	}
-
-	iterator end() noexcept {
-		return m_is_small ? m_a.data() + m_size : m_v.data() + m_size;
-	}
-	const_iterator end() const noexcept {
-		return m_is_small ? m_a.data() + m_size : m_v.data() + m_size;
-	}
-};
-
 /**  This template class provides the basic functionality for a general 2D
  *any-size, resizable container of numerical or non-numerical elements.
  * NOTES:
@@ -197,7 +40,8 @@ class CMatrixDynamic : public MatrixBase<T, CMatrixDynamic<T>>
 {
    private:
 	static constexpr size_t small_size = 16;
-	using vec_t = vector_with_small_size_optimization<T, small_size,MRPT_MAX_STATIC_ALIGN_BYTES>;
+	using vec_t = mrpt::containers::vector_with_small_size_optimization<
+		T, small_size, MRPT_MAX_STATIC_ALIGN_BYTES>;
 
 	/** RowMajor matrix data */
 	vec_t m_data;

--- a/libs/math/include/mrpt/math/CVectorDynamic.h
+++ b/libs/math/include/mrpt/math/CVectorDynamic.h
@@ -33,7 +33,7 @@ class CVectorDynamic : public MatrixVectorBase<T, CVectorDynamic<T>>
    protected:
 	static constexpr size_t small_size = 16;
 	using vec_t = mrpt::containers::vector_with_small_size_optimization<
-	    T, small_size, MRPT_MAX_STATIC_ALIGN_BYTES>;
+		T, small_size, MRPT_MAX_STATIC_ALIGN_BYTES>;
 
 	vec_t m_data;
 

--- a/libs/math/include/mrpt/math/CVectorDynamic.h
+++ b/libs/math/include/mrpt/math/CVectorDynamic.h
@@ -8,14 +8,13 @@
    +------------------------------------------------------------------------+ */
 #pragma once
 
-#include <mrpt/core/aligned_std_basicstring.h>
+#include <mrpt/containers/vector_with_small_size_optimization.h>
 #include <mrpt/core/exceptions.h>  // ASSERT_()
 #include <mrpt/math/MatrixVectorBase.h>
 #include <mrpt/math/math_frwds.h>
 #include <mrpt/math/matrix_size_t.h>
 #include <mrpt/serialization/serialization_frwds.h>
 #include <mrpt/typemeta/TTypeName.h>
-#include <array>
 #include <cstring>  // memset()
 #include <type_traits>
 
@@ -32,7 +31,10 @@ template <class T>
 class CVectorDynamic : public MatrixVectorBase<T, CVectorDynamic<T>>
 {
    protected:
-	using vec_t = mrpt::aligned_std_basicstring<T>;
+	static constexpr size_t small_size = 16;
+	using vec_t = mrpt::containers::vector_with_small_size_optimization<
+	    T, small_size, MRPT_MAX_STATIC_ALIGN_BYTES>;
+
 	vec_t m_data;
 
    public:

--- a/libs/math/src/container_ops_unittest.cpp
+++ b/libs/math/src/container_ops_unittest.cpp
@@ -48,9 +48,6 @@ TEST(CVectorDouble, resize)
 			v.push_back(double(i));
 			EXPECT_TRUE(v.size() == (i + 1));
 		}
-		for (int i = 0; i < 10; i++)
-		{
-			EXPECT_TRUE(v[i] == i);
-		}
+		for (int i = 0; i < 10; i++) EXPECT_NEAR(v[i], i, 1e-10);
 	}
 }


### PR DESCRIPTION
Add SVO to matrix classes directly, instead of using the vendor-dependant std::basic_string.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mrpt/mrpt/934)
<!-- Reviewable:end -->
