### PR TITLE
Fix: register classes using namespaces

### DIFF
--- a/apps/ro-localization/CPosePDFParticlesExtended.h
+++ b/apps/ro-localization/CPosePDFParticlesExtended.h
@@ -47,7 +47,7 @@ class CPosePDFParticlesExtended
 		  CPosePDFParticlesExtended,
 		  mrpt::bayes::CParticleFilterData<TExtendedCPose2D>::CParticleList>
 {
-	DEFINE_SERIALIZABLE(CPosePDFParticlesExtended)
+	DEFINE_SERIALIZABLE(CPosePDFParticlesExtended, mrpt::poses)
 
    public:
 	/** The struct for passing extra simulation parameters to the prediction

--- a/doc/doxygen-pages/changeLog_doc.h
+++ b/doc/doxygen-pages/changeLog_doc.h
@@ -52,6 +52,7 @@
   - \ref mrpt_system_grp
     - functions to get timestamp as *local* time were removed, since they don't make sense. All timestamps in MRPT are UTC, and they can be formated as dates in either UTC or local time frames.
   - \ref mrpt_rtti_grp  [NEW IN MRPT 2.0.0]
+	- All classes are now registered (and de/serialized) with their full name including namespaces. A backwards-compatible flag has been added to mrpt::rtti::findRegisteredClass().
     - CLASS_INIT() macro for automatic registration of classes has been removed, since it is not well-defined in which order global objects will be initialized.
       Therefore, manual registration (as already done in registerAllClasses.cpp files) is left as the unique registration system.
       This fixes warning messages "[mrpt::rtti::registerClass] Warning: Invoked with a nullptr".

--- a/libs/detectors/include/mrpt/detectors/CDetectableObject.h
+++ b/libs/detectors/include/mrpt/detectors/CDetectableObject.h
@@ -42,7 +42,7 @@ class CDetectableObject : public mrpt::serialization::CSerializable
 
 class CDetectable2D : public CDetectableObject
 {
-	DEFINE_SERIALIZABLE(CDetectable2D)
+	DEFINE_SERIALIZABLE(CDetectable2D, mrpt::detectors)
 
    public:
 	/** 2D Coordinates of detected object */
@@ -75,7 +75,7 @@ class CDetectable2D : public CDetectableObject
 
 class CDetectable3D : public CDetectable2D
 {
-	DEFINE_SERIALIZABLE(CDetectable3D)
+	DEFINE_SERIALIZABLE(CDetectable3D, mrpt::detectors)
 
    public:
 	CDetectable3D() = default;

--- a/libs/hmtslam/include/mrpt/hmtslam/CHMHMapArc.h
+++ b/libs/hmtslam/include/mrpt/hmtslam/CHMHMapArc.h
@@ -32,7 +32,7 @@ class CHMHMapArc : public mrpt::serialization::CSerializable
 	friend class CHierarchicalMapMHPartition;
 	friend class TArcList;
 
-	DEFINE_SERIALIZABLE(CHMHMapArc)
+	DEFINE_SERIALIZABLE(CHMHMapArc, mrpt::hmtslam)
 
    public:
 	/** The hypothesis IDs under which this arc exists.

--- a/libs/hmtslam/include/mrpt/hmtslam/CHMHMapNode.h
+++ b/libs/hmtslam/include/mrpt/hmtslam/CHMHMapNode.h
@@ -36,7 +36,7 @@ class CHMHMapNode : public mrpt::serialization::CSerializable
 	friend class CHierarchicalMHMapPartition;
 	friend class CHMHMapArc;
 
-	DEFINE_SERIALIZABLE(CHMHMapNode)
+	DEFINE_SERIALIZABLE(CHMHMapNode, mrpt::hmtslam)
 
    public:
 	/** The type of the IDs of nodes.

--- a/libs/hmtslam/include/mrpt/hmtslam/CHMTSLAM.h
+++ b/libs/hmtslam/include/mrpt/hmtslam/CHMTSLAM.h
@@ -72,7 +72,7 @@ class CHMTSLAM : public mrpt::system::COutputLogger,
 	friend class CTopLCDetector_GridMatching;
 	friend class CTopLCDetector_FabMap;
 
-	DEFINE_SERIALIZABLE(CHMTSLAM)
+	DEFINE_SERIALIZABLE(CHMTSLAM, mrpt::hmtslam)
 
    protected:
 	/** @name Inter-thread communication queues:

--- a/libs/hmtslam/include/mrpt/hmtslam/CHierarchicalMHMap.h
+++ b/libs/hmtslam/include/mrpt/hmtslam/CHierarchicalMHMap.h
@@ -29,7 +29,7 @@ class CHierarchicalMHMap : public mrpt::serialization::CSerializable,
 	friend class CHMHMapArc;
 	friend class CHMHMapNode;
 
-	DEFINE_SERIALIZABLE(CHierarchicalMHMap)
+	DEFINE_SERIALIZABLE(CHierarchicalMHMap, mrpt::hmtslam)
    protected:
 	/** Event handler to be called just after a node has being created: it will
 	 * be added to the internal list.

--- a/libs/hmtslam/include/mrpt/hmtslam/CLocalMetricHypothesis.h
+++ b/libs/hmtslam/include/mrpt/hmtslam/CLocalMetricHypothesis.h
@@ -43,7 +43,7 @@ class CLSLAM_RBPF_2DLASER;
  */
 class CLSLAMParticleData : public mrpt::serialization::CSerializable
 {
-	DEFINE_SERIALIZABLE(CLSLAMParticleData)
+	DEFINE_SERIALIZABLE(CLSLAMParticleData, mrpt::hmtslam)
 
    public:
 	CLSLAMParticleData(
@@ -71,7 +71,7 @@ class CLocalMetricHypothesis
 {
 	friend class CLSLAM_RBPF_2DLASER;
 
-	DEFINE_SERIALIZABLE(CLocalMetricHypothesis)
+	DEFINE_SERIALIZABLE(CLocalMetricHypothesis, mrpt::hmtslam)
 
    public:
 	/** Constructor (Default param only used from STL classes)

--- a/libs/hmtslam/include/mrpt/hmtslam/CMHPropertiesValuesList.h
+++ b/libs/hmtslam/include/mrpt/hmtslam/CMHPropertiesValuesList.h
@@ -35,7 +35,7 @@ struct TPropertyValueIDTriplet
  */
 class CMHPropertiesValuesList : public mrpt::serialization::CSerializable
 {
-	DEFINE_SERIALIZABLE(CMHPropertiesValuesList)
+	DEFINE_SERIALIZABLE(CMHPropertiesValuesList, mrpt::hmtslam)
 
    private:
 	std::vector<TPropertyValueIDTriplet> m_properties;

--- a/libs/hmtslam/include/mrpt/hmtslam/CPropertiesValuesList.h
+++ b/libs/hmtslam/include/mrpt/hmtslam/CPropertiesValuesList.h
@@ -20,7 +20,7 @@ namespace mrpt::hmtslam
  */
 class CPropertiesValuesList : public mrpt::serialization::CSerializable
 {
-	DEFINE_SERIALIZABLE(CPropertiesValuesList)
+	DEFINE_SERIALIZABLE(CPropertiesValuesList, mrpt::hmtslam)
    protected:
 	struct TPropertyValuePair
 	{

--- a/libs/hmtslam/include/mrpt/hmtslam/CRobotPosesGraph.h
+++ b/libs/hmtslam/include/mrpt/hmtslam/CRobotPosesGraph.h
@@ -36,7 +36,7 @@ struct TPoseInfo
 class CRobotPosesGraph : public mrpt::serialization::CSerializable,
 						 public std::map<TPoseID, TPoseInfo>
 {
-	DEFINE_SERIALIZABLE(CRobotPosesGraph)
+	DEFINE_SERIALIZABLE(CRobotPosesGraph, mrpt::hmtslam)
    public:
 	/** Insert all the observations in the map (without erasing previous
 	 * contents). */

--- a/libs/hmtslam/include/mrpt/hmtslam/HMT_SLAM_common.h
+++ b/libs/hmtslam/include/mrpt/hmtslam/HMT_SLAM_common.h
@@ -75,7 +75,7 @@ using TPoseIDSet = std::set<TPoseID>;
 class THypothesisIDSet : public mrpt::serialization::CSerializable,
 						 public std::set<THypothesisID>
 {
-	DEFINE_SERIALIZABLE(THypothesisIDSet)
+	DEFINE_SERIALIZABLE(THypothesisIDSet, mrpt::hmtslam)
 
    public:
 	/** Default constructor

--- a/libs/hwdrivers/include/mrpt/hwdrivers/CGenericSensor.h
+++ b/libs/hwdrivers/include/mrpt/hwdrivers/CGenericSensor.h
@@ -205,10 +205,9 @@ class CGenericSensor
 
 	/** Just like createSensor, but returning a smart pointer to the newly
 	 * created sensor object. */
-	static inline CGenericSensor::Ptr createSensorPtr(
-		const std::string& className)
+	static inline Ptr createSensorPtr(const std::string& className)
 	{
-		return CGenericSensor::Ptr(createSensor(className));
+		return Ptr(createSensor(className));
 	}
 
 	/** Constructor */

--- a/libs/img/include/mrpt/img/CImage.h
+++ b/libs/img/include/mrpt/img/CImage.h
@@ -146,7 +146,7 @@ class CExceptionExternalImageNotFound : public std::runtime_error
  */
 class CImage : public mrpt::serialization::CSerializable, public CCanvas
 {
-	DEFINE_SERIALIZABLE(CImage)
+	DEFINE_SERIALIZABLE(CImage, mrpt::img)
 
 	// This must be added for declaration of MEX-related functions
 	DECLARE_MEX_CONVERSION

--- a/libs/img/include/mrpt/img/TCamera.h
+++ b/libs/img/include/mrpt/img/TCamera.h
@@ -24,7 +24,7 @@ namespace mrpt::img
  */
 class TCamera : public mrpt::serialization::CSerializable
 {
-	DEFINE_SERIALIZABLE(TCamera)
+	DEFINE_SERIALIZABLE(TCamera, mrpt::img)
 
 	// This must be added for declaration of MEX-related functions
 	DECLARE_MEX_CONVERSION

--- a/libs/img/include/mrpt/img/TStereoCamera.h
+++ b/libs/img/include/mrpt/img/TStereoCamera.h
@@ -22,7 +22,7 @@ namespace mrpt::img
  */
 class TStereoCamera : public mrpt::serialization::CSerializable
 {
-	DEFINE_SERIALIZABLE(TStereoCamera)
+	DEFINE_SERIALIZABLE(TStereoCamera, mrpt::img)
    public:
 	/** Intrinsic and distortion parameters of the left and right cameras */
 	TCamera leftCamera, rightCamera;

--- a/libs/kinematics/include/mrpt/kinematics/CKinematicChain.h
+++ b/libs/kinematics/include/mrpt/kinematics/CKinematicChain.h
@@ -69,7 +69,7 @@ mrpt::serialization::CArchive& operator<<(
  */
 class CKinematicChain : public mrpt::serialization::CSerializable
 {
-	DEFINE_SERIALIZABLE(CKinematicChain)
+	DEFINE_SERIALIZABLE(CKinematicChain, mrpt::kinematics)
 
    private:
 	/** Smart pointers to the last objects for each link, as returned in

--- a/libs/kinematics/include/mrpt/kinematics/CVehicleVelCmd_DiffDriven.h
+++ b/libs/kinematics/include/mrpt/kinematics/CVehicleVelCmd_DiffDriven.h
@@ -18,7 +18,7 @@ namespace mrpt::kinematics
  */
 class CVehicleVelCmd_DiffDriven : public CVehicleVelCmd
 {
-	DEFINE_SERIALIZABLE(CVehicleVelCmd_DiffDriven)
+	DEFINE_SERIALIZABLE(CVehicleVelCmd_DiffDriven, mrpt::kinematics)
    public:
 	/** Linear velocity (m/s) */
 	double lin_vel{.0};

--- a/libs/kinematics/include/mrpt/kinematics/CVehicleVelCmd_Holo.h
+++ b/libs/kinematics/include/mrpt/kinematics/CVehicleVelCmd_Holo.h
@@ -18,7 +18,7 @@ namespace mrpt::kinematics
  */
 class CVehicleVelCmd_Holo : public CVehicleVelCmd
 {
-	DEFINE_SERIALIZABLE(CVehicleVelCmd_Holo)
+	DEFINE_SERIALIZABLE(CVehicleVelCmd_Holo, mrpt::kinematics)
    public:
 	/** speed(m / s) */
 	double vel{.0};

--- a/libs/maps/include/mrpt/maps/CBeacon.h
+++ b/libs/maps/include/mrpt/maps/CBeacon.h
@@ -34,7 +34,7 @@ class CBeaconMap;
  */
 class CBeacon : public mrpt::poses::CPointPDF
 {
-	DEFINE_SERIALIZABLE(CBeacon)
+	DEFINE_SERIALIZABLE(CBeacon, mrpt::maps)
 
    public:
 	/** The type for the IDs of landmarks.

--- a/libs/maps/include/mrpt/maps/CBeaconMap.h
+++ b/libs/maps/include/mrpt/maps/CBeaconMap.h
@@ -42,7 +42,7 @@ namespace mrpt::maps
  */
 class CBeaconMap : public mrpt::maps::CMetricMap
 {
-	DEFINE_SERIALIZABLE(CBeaconMap)
+	DEFINE_SERIALIZABLE(CBeaconMap, mrpt::maps)
 
    public:
 	using TSequenceBeacons = std::deque<CBeacon>;

--- a/libs/maps/include/mrpt/maps/CColouredOctoMap.h
+++ b/libs/maps/include/mrpt/maps/CColouredOctoMap.h
@@ -37,7 +37,7 @@ class CColouredOctoMap
 	: public COctoMapBase<octomap::ColorOcTree, octomap::ColorOcTreeNode>
 {
 	// This must be added to any CSerializable derived class:
-	DEFINE_SERIALIZABLE(CColouredOctoMap)
+	DEFINE_SERIALIZABLE(CColouredOctoMap, mrpt::maps)
 
    public:
 	CColouredOctoMap(const double resolution = 0.10);  //!< Default constructor

--- a/libs/maps/include/mrpt/maps/CColouredPointsMap.h
+++ b/libs/maps/include/mrpt/maps/CColouredPointsMap.h
@@ -28,7 +28,7 @@ namespace maps
  */
 class CColouredPointsMap : public CPointsMap
 {
-	DEFINE_SERIALIZABLE(CColouredPointsMap)
+	DEFINE_SERIALIZABLE(CColouredPointsMap, mrpt::maps)
 
    public:
 	CColouredPointsMap() = default;

--- a/libs/maps/include/mrpt/maps/CGasConcentrationGridMap2D.h
+++ b/libs/maps/include/mrpt/maps/CGasConcentrationGridMap2D.h
@@ -31,7 +31,7 @@ namespace mrpt::maps
  */
 class CGasConcentrationGridMap2D : public CRandomFieldGridMap2D
 {
-	DEFINE_SERIALIZABLE(CGasConcentrationGridMap2D)
+	DEFINE_SERIALIZABLE(CGasConcentrationGridMap2D, mrpt::maps)
    public:
 	/** Constructor
 	 */

--- a/libs/maps/include/mrpt/maps/CHeightGridMap2D.h
+++ b/libs/maps/include/mrpt/maps/CHeightGridMap2D.h
@@ -64,7 +64,7 @@ class CHeightGridMap2D
 	  public mrpt::containers::CDynamicGrid<THeightGridmapCell>,
 	  public CHeightGridMap2D_Base
 {
-	DEFINE_SERIALIZABLE(CHeightGridMap2D)
+	DEFINE_SERIALIZABLE(CHeightGridMap2D, mrpt::maps)
    public:
 	/** Calls the base CMetricMap::clear
 	 * Declared here to avoid ambiguity between the two clear() in both base

--- a/libs/maps/include/mrpt/maps/CHeightGridMap2D_MRF.h
+++ b/libs/maps/include/mrpt/maps/CHeightGridMap2D_MRF.h
@@ -33,7 +33,7 @@ namespace mrpt::maps
 class CHeightGridMap2D_MRF : public CRandomFieldGridMap2D,
 							 public CHeightGridMap2D_Base
 {
-	DEFINE_SERIALIZABLE(CHeightGridMap2D_MRF)
+	DEFINE_SERIALIZABLE(CHeightGridMap2D_MRF, mrpt::maps)
    public:
 	/** Constructor */
 	CHeightGridMap2D_MRF(

--- a/libs/maps/include/mrpt/maps/CMultiMetricMap.h
+++ b/libs/maps/include/mrpt/maps/CMultiMetricMap.h
@@ -119,7 +119,7 @@ class TSetOfMetricMapInitializers;
  */
 class CMultiMetricMap : public mrpt::maps::CMetricMap
 {
-	DEFINE_SERIALIZABLE(CMultiMetricMap)
+	DEFINE_SERIALIZABLE(CMultiMetricMap, mrpt::maps)
    public:
 	/** @name Access to list of maps
 		@{ */

--- a/libs/maps/include/mrpt/maps/COccupancyGridMap2D.h
+++ b/libs/maps/include/mrpt/maps/COccupancyGridMap2D.h
@@ -54,7 +54,7 @@ class COccupancyGridMap2D
 	: public CMetricMap,
 	  public CLogOddsGridMap2D<OccGridCellTraits::cellType>
 {
-	DEFINE_SERIALIZABLE(COccupancyGridMap2D)
+	DEFINE_SERIALIZABLE(COccupancyGridMap2D, mrpt::maps)
    public:
 	/** The type of the map cells: */
 	using cellType = OccGridCellTraits::cellType;

--- a/libs/maps/include/mrpt/maps/COccupancyGridMap3D.h
+++ b/libs/maps/include/mrpt/maps/COccupancyGridMap3D.h
@@ -34,7 +34,7 @@ class COccupancyGridMap3D
 	: public CMetricMap,
 	  public CLogOddsGridMap3D<OccGridCellTraits::cellType>
 {
-	DEFINE_SERIALIZABLE(COccupancyGridMap3D)
+	DEFINE_SERIALIZABLE(COccupancyGridMap3D, mrpt::maps)
    public:
 	/** The type of the map voxels: */
 	using voxelType = OccGridCellTraits::cellType;

--- a/libs/maps/include/mrpt/maps/COctoMap.h
+++ b/libs/maps/include/mrpt/maps/COctoMap.h
@@ -40,7 +40,7 @@ namespace maps
 class COctoMap : public COctoMapBase<octomap::OcTree, octomap::OcTreeNode>
 {
 	// This must be added to any CSerializable derived class:
-	DEFINE_SERIALIZABLE(COctoMap)
+	DEFINE_SERIALIZABLE(COctoMap, mrpt::maps)
 
    public:
 	COctoMap(const double resolution = 0.10);  //!< Default constructor

--- a/libs/maps/include/mrpt/maps/CPointsMapXYZI.h
+++ b/libs/maps/include/mrpt/maps/CPointsMapXYZI.h
@@ -25,7 +25,7 @@ namespace maps
  */
 class CPointsMapXYZI : public CPointsMap
 {
-	DEFINE_SERIALIZABLE(CPointsMapXYZI)
+	DEFINE_SERIALIZABLE(CPointsMapXYZI, mrpt::maps)
 
    public:
 	CPointsMapXYZI() = default;

--- a/libs/maps/include/mrpt/maps/CRandomFieldGridMap3D.h
+++ b/libs/maps/include/mrpt/maps/CRandomFieldGridMap3D.h
@@ -76,7 +76,7 @@ class CRandomFieldGridMap3D
 {
 	using BASE = mrpt::containers::CDynamicGrid3D<TRandomFieldVoxel>;
 
-	DEFINE_SERIALIZABLE(CRandomFieldGridMap3D)
+	DEFINE_SERIALIZABLE(CRandomFieldGridMap3D, mrpt::maps)
    public:
 	/** [default:false] Enables a profiler to show a performance report at
 	 * application end. */

--- a/libs/maps/include/mrpt/maps/CReflectivityGridMap2D.h
+++ b/libs/maps/include/mrpt/maps/CReflectivityGridMap2D.h
@@ -39,7 +39,7 @@ class CReflectivityGridMap2D : public CMetricMap,
 							   public mrpt::containers::CDynamicGrid<int8_t>,
 							   public CLogOddsGridMap2D<int8_t>
 {
-	DEFINE_SERIALIZABLE(CReflectivityGridMap2D)
+	DEFINE_SERIALIZABLE(CReflectivityGridMap2D, mrpt::maps)
 
    protected:
 	/** Lookup tables for log-odds */

--- a/libs/maps/include/mrpt/maps/CSimplePointsMap.h
+++ b/libs/maps/include/mrpt/maps/CSimplePointsMap.h
@@ -29,7 +29,7 @@ namespace maps
  */
 class CSimplePointsMap : public CPointsMap
 {
-	DEFINE_SERIALIZABLE(CSimplePointsMap)
+	DEFINE_SERIALIZABLE(CSimplePointsMap, mrpt::maps)
 
    public:
 	/** Default constructor */

--- a/libs/maps/include/mrpt/maps/CWeightedPointsMap.h
+++ b/libs/maps/include/mrpt/maps/CWeightedPointsMap.h
@@ -28,7 +28,7 @@ namespace maps
  */
 class CWeightedPointsMap : public CPointsMap
 {
-	DEFINE_SERIALIZABLE(CWeightedPointsMap)
+	DEFINE_SERIALIZABLE(CWeightedPointsMap, mrpt::maps)
 
    public:
 	/** Default constructor */

--- a/libs/maps/include/mrpt/maps/CWirelessPowerGridMap2D.h
+++ b/libs/maps/include/mrpt/maps/CWirelessPowerGridMap2D.h
@@ -31,7 +31,7 @@ namespace mrpt::maps
  */
 class CWirelessPowerGridMap2D : public CRandomFieldGridMap2D
 {
-	DEFINE_SERIALIZABLE(CWirelessPowerGridMap2D)
+	DEFINE_SERIALIZABLE(CWirelessPowerGridMap2D, mrpt::maps)
    public:
 	/** Constructor */
 	CWirelessPowerGridMap2D(

--- a/libs/maps/include/mrpt/obs/CObservationPointCloud.h
+++ b/libs/maps/include/mrpt/obs/CObservationPointCloud.h
@@ -32,7 +32,7 @@ class CObservation3DRangeScan;
  */
 class CObservationPointCloud : public CObservation
 {
-	DEFINE_SERIALIZABLE(CObservationPointCloud)
+	DEFINE_SERIALIZABLE(CObservationPointCloud, mrpt::obs)
 
    public:
 	enum class ExternalStorageFormat : uint8_t

--- a/libs/maps/include/mrpt/obs/CObservationRotatingScan.h
+++ b/libs/maps/include/mrpt/obs/CObservationRotatingScan.h
@@ -59,7 +59,7 @@ class CObservationPointCloud;
  */
 class CObservationRotatingScan : public CObservation
 {
-	DEFINE_SERIALIZABLE(CObservationRotatingScan)
+	DEFINE_SERIALIZABLE(CObservationRotatingScan, mrpt::obs)
 
    public:
 	/** @name Scan range data

--- a/libs/maps/include/mrpt/opengl/CAngularObservationMesh.h
+++ b/libs/maps/include/mrpt/opengl/CAngularObservationMesh.h
@@ -40,7 +40,7 @@ namespace mrpt::opengl
  */
 class CAngularObservationMesh : public CRenderizableDisplayList
 {
-	DEFINE_SERIALIZABLE(CAngularObservationMesh)
+	DEFINE_SERIALIZABLE(CAngularObservationMesh, mrpt::opengl)
    public:
 	/**
 	 * Range specification type, with several uses.

--- a/libs/maps/include/mrpt/opengl/CPlanarLaserScan.h
+++ b/libs/maps/include/mrpt/opengl/CPlanarLaserScan.h
@@ -55,7 +55,7 @@ class CPlanarLaserScan;
  */
 class CPlanarLaserScan : public CRenderizableDisplayList
 {
-	DEFINE_SERIALIZABLE(CPlanarLaserScan)
+	DEFINE_SERIALIZABLE(CPlanarLaserScan, mrpt::opengl)
    protected:
 	mrpt::obs::CObservation2DRangeScan m_scan;
 	mutable mrpt::maps::CSimplePointsMap m_cache_points;

--- a/libs/maps/src/maps/CBeaconMap.cpp
+++ b/libs/maps/src/maps/CBeaconMap.cpp
@@ -40,7 +40,8 @@ using namespace mrpt::tfest;
 using namespace std;
 
 //  =========== Begin of Map definition ============
-MAP_DEFINITION_REGISTER("CBeaconMap,beaconMap", mrpt::maps::CBeaconMap)
+MAP_DEFINITION_REGISTER(
+	"mrpt::maps::CBeaconMap,beaconMap", mrpt::maps::CBeaconMap)
 
 CBeaconMap::TMapDefinition::TMapDefinition() = default;
 void CBeaconMap::TMapDefinition::loadFromConfigFile_map_specific(

--- a/libs/maps/src/maps/CColouredOctoMap.cpp
+++ b/libs/maps/src/maps/CColouredOctoMap.cpp
@@ -42,7 +42,8 @@ using namespace mrpt::math;
 
 //  =========== Begin of Map definition ============
 MAP_DEFINITION_REGISTER(
-	"CColouredOctoMap,colourOctoMap,colorOctoMap", mrpt::maps::CColouredOctoMap)
+	"mrpt::maps::CColouredOctoMap,colourOctoMap,colorOctoMap",
+	mrpt::maps::CColouredOctoMap)
 
 CColouredOctoMap::TMapDefinition::TMapDefinition() = default;
 void CColouredOctoMap::TMapDefinition::loadFromConfigFile_map_specific(

--- a/libs/maps/src/maps/CColouredPointsMap.cpp
+++ b/libs/maps/src/maps/CColouredPointsMap.cpp
@@ -32,7 +32,8 @@ using namespace mrpt::config;
 
 //  =========== Begin of Map definition ============
 MAP_DEFINITION_REGISTER(
-	"CColouredPointsMap,colourPointsMap", mrpt::maps::CColouredPointsMap)
+	"mrpt::maps::CColouredPointsMap,colourPointsMap",
+	mrpt::maps::CColouredPointsMap)
 
 CColouredPointsMap::TMapDefinition::TMapDefinition() = default;
 void CColouredPointsMap::TMapDefinition::loadFromConfigFile_map_specific(

--- a/libs/maps/src/maps/CGasConcentrationGridMap2D.cpp
+++ b/libs/maps/src/maps/CGasConcentrationGridMap2D.cpp
@@ -36,7 +36,7 @@ using namespace mrpt::math;
 
 //  =========== Begin of Map definition ============
 MAP_DEFINITION_REGISTER(
-	"CGasConcentrationGridMap2D,gasGrid",
+	"mrpt::maps::CGasConcentrationGridMap2D,gasGrid",
 	mrpt::maps::CGasConcentrationGridMap2D)
 
 CGasConcentrationGridMap2D::TMapDefinition::TMapDefinition()

--- a/libs/maps/src/maps/CHeightGridMap2D.cpp
+++ b/libs/maps/src/maps/CHeightGridMap2D.cpp
@@ -28,7 +28,7 @@ using namespace std;
 
 //  =========== Begin of Map definition ============
 MAP_DEFINITION_REGISTER(
-	"CHeightGridMap2D,heightMap,dem", mrpt::maps::CHeightGridMap2D)
+	"mrpt::maps::CHeightGridMap2D,heightMap,dem", mrpt::maps::CHeightGridMap2D)
 
 CHeightGridMap2D::TMapDefinition::TMapDefinition()
 

--- a/libs/maps/src/maps/CHeightGridMap2D_MRF.cpp
+++ b/libs/maps/src/maps/CHeightGridMap2D_MRF.cpp
@@ -22,7 +22,8 @@ using namespace mrpt::math;
 
 //  =========== Begin of Map definition ============
 MAP_DEFINITION_REGISTER(
-	"CHeightGridMap2D_MRF,dem_mrf", mrpt::maps::CHeightGridMap2D_MRF)
+	"mrpt::maps::CHeightGridMap2D_MRF,dem_mrf",
+	mrpt::maps::CHeightGridMap2D_MRF)
 
 MRPT_TODO("Improvement: Rewrite to avoid union -> variant");
 

--- a/libs/maps/src/maps/CMultiMetricMap.cpp
+++ b/libs/maps/src/maps/CMultiMetricMap.cpp
@@ -15,6 +15,7 @@
 #include <mrpt/poses/CPoint2D.h>
 #include <mrpt/serialization/CArchive.h>
 #include <mrpt/serialization/metaprogramming_serialization.h>
+#include <mrpt/system/filesystem.h>
 
 using namespace mrpt::maps;
 using namespace mrpt::poses;
@@ -246,7 +247,10 @@ void CMultiMetricMap::saveMetricMapRepresentationToFile(
 		ASSERT_(m);
 		std::string fil = filNamePrefix;
 		fil += format(
-			"_%s_%02u", m->GetRuntimeClass()->className,
+			"_%s_%02u",
+			mrpt::system::fileNameStripInvalidChars(
+				m->GetRuntimeClass()->className)
+				.c_str(),
 			static_cast<unsigned int>(idx));
 		m->saveMetricMapRepresentationToFile(fil);
 	}

--- a/libs/maps/src/maps/COccupancyGridMap2D_common.cpp
+++ b/libs/maps/src/maps/COccupancyGridMap2D_common.cpp
@@ -28,7 +28,8 @@ using namespace std;
 
 //  =========== Begin of Map definition ============
 MAP_DEFINITION_REGISTER(
-	"COccupancyGridMap2D,occupancyGrid", mrpt::maps::COccupancyGridMap2D)
+	"mrpt::maps::COccupancyGridMap2D,occupancyGrid",
+	mrpt::maps::COccupancyGridMap2D)
 
 COccupancyGridMap2D::TMapDefinition::TMapDefinition() = default;
 

--- a/libs/maps/src/maps/COccupancyGridMap3D.cpp
+++ b/libs/maps/src/maps/COccupancyGridMap3D.cpp
@@ -20,7 +20,8 @@ using namespace mrpt;
 using namespace mrpt::maps;
 
 //  =========== Begin of Map definition ============
-MAP_DEFINITION_REGISTER("COccupancyGridMap3D", mrpt::maps::COccupancyGridMap3D)
+MAP_DEFINITION_REGISTER(
+	"mrpt::maps::COccupancyGridMap3D", mrpt::maps::COccupancyGridMap3D)
 
 COccupancyGridMap3D::TMapDefinition::TMapDefinition() = default;
 

--- a/libs/maps/src/maps/COctoMap.cpp
+++ b/libs/maps/src/maps/COctoMap.cpp
@@ -33,7 +33,7 @@ using namespace mrpt::math;
 using namespace mrpt::opengl;
 
 //  =========== Begin of Map definition ============
-MAP_DEFINITION_REGISTER("COctoMap,octoMap", mrpt::maps::COctoMap)
+MAP_DEFINITION_REGISTER("mrpt::maps::COctoMap,octoMap", mrpt::maps::COctoMap)
 
 COctoMap::TMapDefinition::TMapDefinition() = default;
 void COctoMap::TMapDefinition::loadFromConfigFile_map_specific(

--- a/libs/maps/src/maps/CPointsMapXYZI.cpp
+++ b/libs/maps/src/maps/CPointsMapXYZI.cpp
@@ -34,7 +34,8 @@ using namespace mrpt::math;
 using namespace mrpt::config;
 
 //  =========== Begin of Map definition ============
-MAP_DEFINITION_REGISTER("CPointsMapXYZI", mrpt::maps::CPointsMapXYZI)
+MAP_DEFINITION_REGISTER(
+	"mrpt::maps::CPointsMapXYZI", mrpt::maps::CPointsMapXYZI)
 
 CPointsMapXYZI::TMapDefinition::TMapDefinition() = default;
 

--- a/libs/maps/src/maps/CReflectivityGridMap2D.cpp
+++ b/libs/maps/src/maps/CReflectivityGridMap2D.cpp
@@ -29,7 +29,7 @@ using namespace std;
 
 //  =========== Begin of Map definition ============
 MAP_DEFINITION_REGISTER(
-	"CReflectivityGridMap2D,reflectivityMap",
+	"mrpt::maps::CReflectivityGridMap2D,reflectivityMap",
 	mrpt::maps::CReflectivityGridMap2D)
 
 CReflectivityGridMap2D::TMapDefinition::TMapDefinition()

--- a/libs/maps/src/maps/CSimplePointsMap.cpp
+++ b/libs/maps/src/maps/CSimplePointsMap.cpp
@@ -24,7 +24,7 @@ using namespace mrpt::math;
 
 //  =========== Begin of Map definition ============
 MAP_DEFINITION_REGISTER(
-	"CSimplePointsMap,pointsMap", mrpt::maps::CSimplePointsMap)
+	"mrpt::maps::CSimplePointsMap,pointsMap", mrpt::maps::CSimplePointsMap)
 
 CSimplePointsMap::TMapDefinition::TMapDefinition() = default;
 void CSimplePointsMap::TMapDefinition::loadFromConfigFile_map_specific(

--- a/libs/maps/src/maps/CWeightedPointsMap.cpp
+++ b/libs/maps/src/maps/CWeightedPointsMap.cpp
@@ -24,7 +24,8 @@ using namespace mrpt::math;
 
 //  =========== Begin of Map definition ============
 MAP_DEFINITION_REGISTER(
-	"CWeightedPointsMap,weightedPointsMap", mrpt::maps::CWeightedPointsMap)
+	"mrpt::maps::CWeightedPointsMap,weightedPointsMap",
+	mrpt::maps::CWeightedPointsMap)
 
 CWeightedPointsMap::TMapDefinition::TMapDefinition() = default;
 void CWeightedPointsMap::TMapDefinition::loadFromConfigFile_map_specific(

--- a/libs/maps/src/maps/CWirelessPowerGridMap2D.cpp
+++ b/libs/maps/src/maps/CWirelessPowerGridMap2D.cpp
@@ -26,11 +26,10 @@ using namespace std;
 
 //  =========== Begin of Map definition ============
 MAP_DEFINITION_REGISTER(
-	"CWirelessPowerGridMap2D,wifiGrid", mrpt::maps::CWirelessPowerGridMap2D)
+	"mrpt::maps::CWirelessPowerGridMap2D,wifiGrid",
+	mrpt::maps::CWirelessPowerGridMap2D)
 
-CWirelessPowerGridMap2D::TMapDefinition::TMapDefinition()
-
-	= default;
+CWirelessPowerGridMap2D::TMapDefinition::TMapDefinition() = default;
 
 void CWirelessPowerGridMap2D::TMapDefinition::loadFromConfigFile_map_specific(
 	const mrpt::config::CConfigFileBase& source,

--- a/libs/math/include/mrpt/math/CMatrixB.h
+++ b/libs/math/include/mrpt/math/CMatrixB.h
@@ -20,7 +20,7 @@ namespace mrpt::math
  */
 class CMatrixB : public mrpt::serialization::CSerializable, public CMatrixBool
 {
-	DEFINE_SERIALIZABLE(CMatrixB)
+	DEFINE_SERIALIZABLE(CMatrixB, mrpt::math)
    public:
 	/** Constructor */
 	CMatrixB(size_t row = 1, size_t col = 1) : CMatrixBool(row, col) {}

--- a/libs/math/include/mrpt/math/CMatrixD.h
+++ b/libs/math/include/mrpt/math/CMatrixD.h
@@ -23,7 +23,7 @@ namespace mrpt::math
 class CMatrixD : public mrpt::serialization::CSerializable,
 				 public CMatrixDynamic<double>
 {
-	DEFINE_SERIALIZABLE(CMatrixD)
+	DEFINE_SERIALIZABLE(CMatrixD, mrpt::math)
 	DEFINE_SCHEMA_SERIALIZABLE()
    public:
 	using Base = CMatrixDynamic<double>;

--- a/libs/math/include/mrpt/math/CMatrixF.h
+++ b/libs/math/include/mrpt/math/CMatrixF.h
@@ -21,7 +21,7 @@ namespace mrpt::math
  */
 class CMatrixF : public mrpt::serialization::CSerializable, public CMatrixFloat
 {
-	DEFINE_SERIALIZABLE(CMatrixF)
+	DEFINE_SERIALIZABLE(CMatrixF, mrpt::math)
 	DEFINE_SCHEMA_SERIALIZABLE()
 
    public:

--- a/libs/math/include/mrpt/math/CPolygon.h
+++ b/libs/math/include/mrpt/math/CPolygon.h
@@ -19,7 +19,7 @@ namespace mrpt::math
 class CPolygon : public mrpt::serialization::CSerializable,
 				 public mrpt::math::TPolygon2D
 {
-	DEFINE_SERIALIZABLE(CPolygon)
+	DEFINE_SERIALIZABLE(CPolygon, mrpt::math)
 
    public:
 	/** Default constructor (empty polygon, 0 vertices) */

--- a/libs/math/include/mrpt/math/CSplineInterpolator1D.h
+++ b/libs/math/include/mrpt/math/CSplineInterpolator1D.h
@@ -23,7 +23,7 @@ namespace mrpt::math
  */
 class CSplineInterpolator1D : public mrpt::serialization::CSerializable
 {
-	DEFINE_SERIALIZABLE(CSplineInterpolator1D)
+	DEFINE_SERIALIZABLE(CSplineInterpolator1D, mrpt::math)
 
    private:
 	/** The placeholders for the data */

--- a/libs/nav/include/mrpt/nav/holonomic/CHolonomicFullEval.h
+++ b/libs/nav/include/mrpt/nav/holonomic/CHolonomicFullEval.h
@@ -55,7 +55,7 @@ namespace mrpt::nav
  */
 class CHolonomicFullEval : public CAbstractHolonomicReactiveMethod
 {
-	DEFINE_SERIALIZABLE(CHolonomicFullEval)
+	DEFINE_SERIALIZABLE(CHolonomicFullEval, mrpt::nav)
    public:
 	/**  Initialize the parameters of the navigator, from some configuration
 	 * file, or default values if set to nullptr */
@@ -161,7 +161,7 @@ class CHolonomicFullEval : public CAbstractHolonomicReactiveMethod
  */
 class CLogFileRecord_FullEval : public CHolonomicLogFileRecord
 {
-	DEFINE_SERIALIZABLE(CLogFileRecord_FullEval)
+	DEFINE_SERIALIZABLE(CLogFileRecord_FullEval, mrpt::nav)
    public:
 	CLogFileRecord_FullEval();
 

--- a/libs/nav/include/mrpt/nav/holonomic/CHolonomicND.h
+++ b/libs/nav/include/mrpt/nav/holonomic/CHolonomicND.h
@@ -51,7 +51,7 @@ class CLogFileRecord_ND;
  */
 class CHolonomicND : public CAbstractHolonomicReactiveMethod
 {
-	DEFINE_SERIALIZABLE(CHolonomicND)
+	DEFINE_SERIALIZABLE(CHolonomicND, mrpt::nav)
    public:
 	/**  Initialize the parameters of the navigator, from some configuration
 	 * file, or default values if set to nullptr */
@@ -162,7 +162,7 @@ class CHolonomicND : public CAbstractHolonomicReactiveMethod
  */
 class CLogFileRecord_ND : public CHolonomicLogFileRecord
 {
-	DEFINE_SERIALIZABLE(CLogFileRecord_ND)
+	DEFINE_SERIALIZABLE(CLogFileRecord_ND, mrpt::nav)
 
    public:
 	/** Member data.

--- a/libs/nav/include/mrpt/nav/holonomic/CHolonomicVFF.h
+++ b/libs/nav/include/mrpt/nav/holonomic/CHolonomicVFF.h
@@ -24,7 +24,7 @@ namespace mrpt::nav
  */
 class CLogFileRecord_VFF : public CHolonomicLogFileRecord
 {
-	DEFINE_SERIALIZABLE(CLogFileRecord_VFF)
+	DEFINE_SERIALIZABLE(CLogFileRecord_VFF, mrpt::nav)
    public:
 };
 
@@ -46,7 +46,7 @@ class CLogFileRecord_VFF : public CHolonomicLogFileRecord
  */
 class CHolonomicVFF : public CAbstractHolonomicReactiveMethod
 {
-	DEFINE_SERIALIZABLE(CHolonomicVFF)
+	DEFINE_SERIALIZABLE(CHolonomicVFF, mrpt::nav)
    public:
 	/**  Initialize the parameters of the navigator, from some configuration
 	 * file, or default values if set to NULL. */

--- a/libs/nav/include/mrpt/nav/reactive/CLogFileRecord.h
+++ b/libs/nav/include/mrpt/nav/reactive/CLogFileRecord.h
@@ -28,7 +28,7 @@ namespace mrpt::nav
  */
 class CLogFileRecord : public mrpt::serialization::CSerializable
 {
-	DEFINE_SERIALIZABLE(CLogFileRecord)
+	DEFINE_SERIALIZABLE(CLogFileRecord, mrpt::nav)
 
    public:
 	/** Constructor, builds an empty record. */

--- a/libs/nav/include/mrpt/nav/reactive/CMultiObjMotionOpt_Scalarization.h
+++ b/libs/nav/include/mrpt/nav/reactive/CMultiObjMotionOpt_Scalarization.h
@@ -25,7 +25,7 @@ namespace mrpt::nav
 class CMultiObjMotionOpt_Scalarization
 	: public mrpt::nav::CMultiObjectiveMotionOptimizerBase
 {
-	DEFINE_MRPT_OBJECT(CMultiObjMotionOpt_Scalarization)
+	DEFINE_MRPT_OBJECT(CMultiObjMotionOpt_Scalarization, mrpt::nav)
 
    public:
 	CMultiObjMotionOpt_Scalarization();

--- a/libs/nav/include/mrpt/nav/tpspace/CPTG_DiffDrive_C.h
+++ b/libs/nav/include/mrpt/nav/tpspace/CPTG_DiffDrive_C.h
@@ -39,7 +39,7 @@ namespace mrpt::nav
  */
 class CPTG_DiffDrive_C : public CPTG_DiffDrive_CollisionGridBased
 {
-	DEFINE_SERIALIZABLE(CPTG_DiffDrive_C)
+	DEFINE_SERIALIZABLE(CPTG_DiffDrive_C, mrpt::nav)
    public:
 	CPTG_DiffDrive_C() = default;
 	CPTG_DiffDrive_C(

--- a/libs/nav/include/mrpt/nav/tpspace/CPTG_DiffDrive_CC.h
+++ b/libs/nav/include/mrpt/nav/tpspace/CPTG_DiffDrive_CC.h
@@ -24,7 +24,7 @@ namespace mrpt::nav
  */
 class CPTG_DiffDrive_CC : public CPTG_DiffDrive_CollisionGridBased
 {
-	DEFINE_SERIALIZABLE(CPTG_DiffDrive_CC)
+	DEFINE_SERIALIZABLE(CPTG_DiffDrive_CC, mrpt::nav)
    public:
 	CPTG_DiffDrive_CC() = default;
 	CPTG_DiffDrive_CC(

--- a/libs/nav/include/mrpt/nav/tpspace/CPTG_DiffDrive_CCS.h
+++ b/libs/nav/include/mrpt/nav/tpspace/CPTG_DiffDrive_CCS.h
@@ -24,7 +24,7 @@ namespace mrpt::nav
  */
 class CPTG_DiffDrive_CCS : public CPTG_DiffDrive_CollisionGridBased
 {
-	DEFINE_SERIALIZABLE(CPTG_DiffDrive_CCS)
+	DEFINE_SERIALIZABLE(CPTG_DiffDrive_CCS, mrpt::nav)
    public:
 	CPTG_DiffDrive_CCS() = default;
 	CPTG_DiffDrive_CCS(

--- a/libs/nav/include/mrpt/nav/tpspace/CPTG_DiffDrive_CS.h
+++ b/libs/nav/include/mrpt/nav/tpspace/CPTG_DiffDrive_CS.h
@@ -24,7 +24,7 @@ namespace mrpt::nav
  */
 class CPTG_DiffDrive_CS : public CPTG_DiffDrive_CollisionGridBased
 {
-	DEFINE_SERIALIZABLE(CPTG_DiffDrive_CS)
+	DEFINE_SERIALIZABLE(CPTG_DiffDrive_CS, mrpt::nav)
    public:
 	CPTG_DiffDrive_CS() = default;
 	CPTG_DiffDrive_CS(

--- a/libs/nav/include/mrpt/nav/tpspace/CPTG_DiffDrive_alpha.h
+++ b/libs/nav/include/mrpt/nav/tpspace/CPTG_DiffDrive_alpha.h
@@ -34,7 +34,7 @@ namespace mrpt::nav
  */
 class CPTG_DiffDrive_alpha : public CPTG_DiffDrive_CollisionGridBased
 {
-	DEFINE_SERIALIZABLE(CPTG_DiffDrive_alpha)
+	DEFINE_SERIALIZABLE(CPTG_DiffDrive_alpha, mrpt::nav)
    public:
 	CPTG_DiffDrive_alpha() = default;
 	CPTG_DiffDrive_alpha(

--- a/libs/nav/include/mrpt/nav/tpspace/CPTG_Holo_Blend.h
+++ b/libs/nav/include/mrpt/nav/tpspace/CPTG_Holo_Blend.h
@@ -25,7 +25,7 @@ namespace mrpt::nav
  */
 class CPTG_Holo_Blend : public CPTG_RobotShape_Circular
 {
-	DEFINE_SERIALIZABLE(CPTG_Holo_Blend)
+	DEFINE_SERIALIZABLE(CPTG_Holo_Blend, mrpt::nav)
    public:
 	CPTG_Holo_Blend();
 	CPTG_Holo_Blend(

--- a/libs/obs/include/mrpt/maps/CSimpleMap.h
+++ b/libs/obs/include/mrpt/maps/CSimpleMap.h
@@ -31,7 +31,7 @@ namespace mrpt::maps
  */
 class CSimpleMap : public mrpt::serialization::CSerializable
 {
-	DEFINE_SERIALIZABLE(CSimpleMap)
+	DEFINE_SERIALIZABLE(CSimpleMap, mrpt::maps)
    public:
 	/** Default constructor (empty map) */
 	CSimpleMap() = default;

--- a/libs/obs/include/mrpt/maps/metric_map_types.h
+++ b/libs/obs/include/mrpt/maps/metric_map_types.h
@@ -77,7 +77,7 @@ struct TMatchingRatioParams
 class TMapGenericParams : public mrpt::config::CLoadableOptions,
 						  public mrpt::serialization::CSerializable
 {
-	DEFINE_SERIALIZABLE(TMapGenericParams)
+	DEFINE_SERIALIZABLE(TMapGenericParams, mrpt::maps)
    public:
 	/** (Default=true) If false, calling CMetricMap::getAs3DObject() will have
 	 * no effects */

--- a/libs/obs/include/mrpt/obs/CActionCollection.h
+++ b/libs/obs/include/mrpt/obs/CActionCollection.h
@@ -25,7 +25,7 @@ namespace mrpt::obs
  */
 class CActionCollection : public mrpt::serialization::CSerializable
 {
-	DEFINE_SERIALIZABLE(CActionCollection)
+	DEFINE_SERIALIZABLE(CActionCollection, mrpt::obs)
 
    protected:
 	/** The robot "actionss" */

--- a/libs/obs/include/mrpt/obs/CActionRobotMovement2D.h
+++ b/libs/obs/include/mrpt/obs/CActionRobotMovement2D.h
@@ -29,7 +29,7 @@ namespace mrpt::obs
  */
 class CActionRobotMovement2D : public CAction
 {
-	DEFINE_SERIALIZABLE(CActionRobotMovement2D)
+	DEFINE_SERIALIZABLE(CActionRobotMovement2D, mrpt::obs)
 
    public:
 	/** A list of posible ways for estimating the content of a

--- a/libs/obs/include/mrpt/obs/CActionRobotMovement3D.h
+++ b/libs/obs/include/mrpt/obs/CActionRobotMovement3D.h
@@ -25,7 +25,7 @@ namespace mrpt::obs
  */
 class CActionRobotMovement3D : public CAction
 {
-	DEFINE_SERIALIZABLE(CActionRobotMovement3D)
+	DEFINE_SERIALIZABLE(CActionRobotMovement3D, mrpt::obs)
 
    public:
 	/** A list of posible ways for estimating the content of a

--- a/libs/obs/include/mrpt/obs/CObservation2DRangeScan.h
+++ b/libs/obs/include/mrpt/obs/CObservation2DRangeScan.h
@@ -53,7 +53,7 @@ namespace obs
  */
 class CObservation2DRangeScan : public CObservation
 {
-	DEFINE_SERIALIZABLE(CObservation2DRangeScan)
+	DEFINE_SERIALIZABLE(CObservation2DRangeScan, mrpt::obs)
 	// This must be added for declaration of MEX-related functions
 	DECLARE_MEX_CONVERSION
    private:

--- a/libs/obs/include/mrpt/obs/CObservation3DRangeScan.h
+++ b/libs/obs/include/mrpt/obs/CObservation3DRangeScan.h
@@ -222,7 +222,7 @@ void project3DPointsFromDepthImageInto(
  */
 class CObservation3DRangeScan : public CObservation
 {
-	DEFINE_SERIALIZABLE(CObservation3DRangeScan)
+	DEFINE_SERIALIZABLE(CObservation3DRangeScan, mrpt::obs)
 
    protected:
 	/** If set to true, m_points3D_external_file is valid. */

--- a/libs/obs/include/mrpt/obs/CObservation6DFeatures.h
+++ b/libs/obs/include/mrpt/obs/CObservation6DFeatures.h
@@ -24,7 +24,7 @@ namespace mrpt::obs
  */
 class CObservation6DFeatures : public CObservation
 {
-	DEFINE_SERIALIZABLE(CObservation6DFeatures)
+	DEFINE_SERIALIZABLE(CObservation6DFeatures, mrpt::obs)
    public:
 	/** Default ctor */
 	CObservation6DFeatures();

--- a/libs/obs/include/mrpt/obs/CObservationBatteryState.h
+++ b/libs/obs/include/mrpt/obs/CObservationBatteryState.h
@@ -30,7 +30,7 @@ namespace mrpt::obs
  */
 class CObservationBatteryState : public CObservation
 {
-	DEFINE_SERIALIZABLE(CObservationBatteryState)
+	DEFINE_SERIALIZABLE(CObservationBatteryState, mrpt::obs)
 
    public:
 	/** Constructor

--- a/libs/obs/include/mrpt/obs/CObservationBeaconRanges.h
+++ b/libs/obs/include/mrpt/obs/CObservationBeaconRanges.h
@@ -23,7 +23,7 @@ namespace mrpt::obs
  */
 class CObservationBeaconRanges : public CObservation
 {
-	DEFINE_SERIALIZABLE(CObservationBeaconRanges)
+	DEFINE_SERIALIZABLE(CObservationBeaconRanges, mrpt::obs)
 
    public:
 	/** ctor */

--- a/libs/obs/include/mrpt/obs/CObservationBearingRange.h
+++ b/libs/obs/include/mrpt/obs/CObservationBearingRange.h
@@ -27,7 +27,7 @@ namespace mrpt::obs
  */
 class CObservationBearingRange : public CObservation
 {
-	DEFINE_SERIALIZABLE(CObservationBearingRange)
+	DEFINE_SERIALIZABLE(CObservationBearingRange, mrpt::obs)
 
    public:
 	/** Default constructor.

--- a/libs/obs/include/mrpt/obs/CObservationCANBusJ1939.h
+++ b/libs/obs/include/mrpt/obs/CObservationCANBusJ1939.h
@@ -20,7 +20,7 @@ namespace mrpt::obs
  */
 class CObservationCANBusJ1939 : public CObservation
 {
-	DEFINE_SERIALIZABLE(CObservationCANBusJ1939)
+	DEFINE_SERIALIZABLE(CObservationCANBusJ1939, mrpt::obs)
 
    public:
 	/** Constructor.

--- a/libs/obs/include/mrpt/obs/CObservationComment.h
+++ b/libs/obs/include/mrpt/obs/CObservationComment.h
@@ -23,7 +23,7 @@ namespace mrpt::obs
  */
 class CObservationComment : public CObservation
 {
-	DEFINE_SERIALIZABLE(CObservationComment)
+	DEFINE_SERIALIZABLE(CObservationComment, mrpt::obs)
 
    public:
 	/** Constructor.

--- a/libs/obs/include/mrpt/obs/CObservationGPS.h
+++ b/libs/obs/include/mrpt/obs/CObservationGPS.h
@@ -66,7 +66,7 @@ namespace mrpt::obs
  */
 class CObservationGPS : public CObservation
 {
-	DEFINE_SERIALIZABLE(CObservationGPS)
+	DEFINE_SERIALIZABLE(CObservationGPS, mrpt::obs)
 
    public:
 	using message_list_t =

--- a/libs/obs/include/mrpt/obs/CObservationGasSensors.h
+++ b/libs/obs/include/mrpt/obs/CObservationGasSensors.h
@@ -23,7 +23,7 @@ namespace mrpt::obs
  */
 class CObservationGasSensors : public CObservation
 {
-	DEFINE_SERIALIZABLE(CObservationGasSensors)
+	DEFINE_SERIALIZABLE(CObservationGasSensors, mrpt::obs)
 
    public:
 	/** Constructor.

--- a/libs/obs/include/mrpt/obs/CObservationIMU.h
+++ b/libs/obs/include/mrpt/obs/CObservationIMU.h
@@ -110,7 +110,7 @@ enum TIMUDataIndex
  */
 class CObservationIMU : public CObservation
 {
-	DEFINE_SERIALIZABLE(CObservationIMU)
+	DEFINE_SERIALIZABLE(CObservationIMU, mrpt::obs)
 
    public:
 	CObservationIMU() = default;

--- a/libs/obs/include/mrpt/obs/CObservationImage.h
+++ b/libs/obs/include/mrpt/obs/CObservationImage.h
@@ -31,7 +31,7 @@ namespace mrpt::obs
  */
 class CObservationImage : public CObservation
 {
-	DEFINE_SERIALIZABLE(CObservationImage)
+	DEFINE_SERIALIZABLE(CObservationImage, mrpt::obs)
 	// This must be added for declaration of MEX-related functions
 	DECLARE_MEX_CONVERSION
 

--- a/libs/obs/include/mrpt/obs/CObservationOdometry.h
+++ b/libs/obs/include/mrpt/obs/CObservationOdometry.h
@@ -28,7 +28,7 @@ namespace mrpt::obs
  */
 class CObservationOdometry : public CObservation
 {
-	DEFINE_SERIALIZABLE(CObservationOdometry)
+	DEFINE_SERIALIZABLE(CObservationOdometry, mrpt::obs)
 
    public:
 	/** Default ctor */

--- a/libs/obs/include/mrpt/obs/CObservationRFID.h
+++ b/libs/obs/include/mrpt/obs/CObservationRFID.h
@@ -23,7 +23,7 @@ namespace mrpt::obs
  */
 class CObservationRFID : public CObservation
 {
-	DEFINE_SERIALIZABLE(CObservationRFID)
+	DEFINE_SERIALIZABLE(CObservationRFID, mrpt::obs)
 
    public:
 	/** Constructor */

--- a/libs/obs/include/mrpt/obs/CObservationRGBD360.h
+++ b/libs/obs/include/mrpt/obs/CObservationRGBD360.h
@@ -82,7 +82,7 @@ namespace obs
  */
 class CObservationRGBD360 : public CObservation
 {
-	DEFINE_SERIALIZABLE(CObservationRGBD360)
+	DEFINE_SERIALIZABLE(CObservationRGBD360, mrpt::obs)
 
    protected:
 	/** If set to true, m_points3D_external_file is valid. */

--- a/libs/obs/include/mrpt/obs/CObservationRange.h
+++ b/libs/obs/include/mrpt/obs/CObservationRange.h
@@ -26,7 +26,7 @@ namespace mrpt::obs
  */
 class CObservationRange : public CObservation
 {
-	DEFINE_SERIALIZABLE(CObservationRange)
+	DEFINE_SERIALIZABLE(CObservationRange, mrpt::obs)
 
    public:
 	/** Default constructor.

--- a/libs/obs/include/mrpt/obs/CObservationRawDAQ.h
+++ b/libs/obs/include/mrpt/obs/CObservationRawDAQ.h
@@ -28,7 +28,7 @@ namespace mrpt::obs
  */
 class CObservationRawDAQ : public CObservation
 {
-	DEFINE_SERIALIZABLE(CObservationRawDAQ)
+	DEFINE_SERIALIZABLE(CObservationRawDAQ, mrpt::obs)
    public:
 	/** Constructor */
 	inline CObservationRawDAQ() = default;

--- a/libs/obs/include/mrpt/obs/CObservationReflectivity.h
+++ b/libs/obs/include/mrpt/obs/CObservationReflectivity.h
@@ -23,7 +23,7 @@ namespace mrpt::obs
  */
 class CObservationReflectivity : public CObservation
 {
-	DEFINE_SERIALIZABLE(CObservationReflectivity)
+	DEFINE_SERIALIZABLE(CObservationReflectivity, mrpt::obs)
 
    public:
 	/** The read reflectivity level, in the range [0,1] (0=black, 1=white).

--- a/libs/obs/include/mrpt/obs/CObservationRobotPose.h
+++ b/libs/obs/include/mrpt/obs/CObservationRobotPose.h
@@ -20,7 +20,7 @@ namespace mrpt::obs
  */
 class CObservationRobotPose : public CObservation
 {
-	DEFINE_SERIALIZABLE(CObservationRobotPose)
+	DEFINE_SERIALIZABLE(CObservationRobotPose, mrpt::obs)
    public:
 	/** The observed robot pose */
 	mrpt::poses::CPose3DPDFGaussian pose;

--- a/libs/obs/include/mrpt/obs/CObservationSkeleton.h
+++ b/libs/obs/include/mrpt/obs/CObservationSkeleton.h
@@ -24,7 +24,7 @@ namespace mrpt::obs
  */
 class CObservationSkeleton : public CObservation
 {
-	DEFINE_SERIALIZABLE(CObservationSkeleton)
+	DEFINE_SERIALIZABLE(CObservationSkeleton, mrpt::obs)
 
    public:
 	/** Constructor.

--- a/libs/obs/include/mrpt/obs/CObservationStereoImages.h
+++ b/libs/obs/include/mrpt/obs/CObservationStereoImages.h
@@ -37,7 +37,7 @@ namespace mrpt::obs
  */
 class CObservationStereoImages : public mrpt::obs::CObservation
 {
-	DEFINE_SERIALIZABLE(CObservationStereoImages)
+	DEFINE_SERIALIZABLE(CObservationStereoImages, mrpt::obs)
 	// This must be added for declaration of MEX-related functions
 	DECLARE_MEX_CONVERSION
 

--- a/libs/obs/include/mrpt/obs/CObservationStereoImagesFeatures.h
+++ b/libs/obs/include/mrpt/obs/CObservationStereoImagesFeatures.h
@@ -35,7 +35,7 @@ struct TStereoImageFeatures
  */
 class CObservationStereoImagesFeatures : public CObservation
 {
-	DEFINE_SERIALIZABLE(CObservationStereoImagesFeatures)
+	DEFINE_SERIALIZABLE(CObservationStereoImagesFeatures, mrpt::obs)
 
    public:
 	CObservationStereoImagesFeatures() = default;

--- a/libs/obs/include/mrpt/obs/CObservationVelodyneScan.h
+++ b/libs/obs/include/mrpt/obs/CObservationVelodyneScan.h
@@ -79,7 +79,7 @@ namespace obs
  */
 class CObservationVelodyneScan : public CObservation
 {
-	DEFINE_SERIALIZABLE(CObservationVelodyneScan)
+	DEFINE_SERIALIZABLE(CObservationVelodyneScan, mrpt::obs)
 
    public:
 	/** @name Raw scan fixed parameters

--- a/libs/obs/include/mrpt/obs/CObservationWindSensor.h
+++ b/libs/obs/include/mrpt/obs/CObservationWindSensor.h
@@ -27,7 +27,7 @@ namespace mrpt::obs
  */
 class CObservationWindSensor : public CObservation
 {
-	DEFINE_SERIALIZABLE(CObservationWindSensor)
+	DEFINE_SERIALIZABLE(CObservationWindSensor, mrpt::obs)
 
    public:
 	/** @name The data members

--- a/libs/obs/include/mrpt/obs/CObservationWirelessPower.h
+++ b/libs/obs/include/mrpt/obs/CObservationWirelessPower.h
@@ -25,7 +25,7 @@ namespace mrpt::obs
  */
 class CObservationWirelessPower : public CObservation
 {
-	DEFINE_SERIALIZABLE(CObservationWirelessPower)
+	DEFINE_SERIALIZABLE(CObservationWirelessPower, mrpt::obs)
 
    public:
 	/** @name The data members

--- a/libs/obs/include/mrpt/obs/CRawlog.h
+++ b/libs/obs/include/mrpt/obs/CRawlog.h
@@ -64,7 +64,7 @@ using TListTimeAndObservations =
  */
 class CRawlog : public mrpt::serialization::CSerializable
 {
-	DEFINE_SERIALIZABLE(CRawlog)
+	DEFINE_SERIALIZABLE(CRawlog, mrpt::obs)
 
    private:
 	using TListObjects = std::vector<mrpt::serialization::CSerializable::Ptr>;

--- a/libs/obs/include/mrpt/obs/CSensoryFrame.h
+++ b/libs/obs/include/mrpt/obs/CSensoryFrame.h
@@ -50,7 +50,7 @@ namespace mrpt::obs
  */
 class CSensoryFrame : public mrpt::serialization::CSerializable
 {
-	DEFINE_SERIALIZABLE(CSensoryFrame)
+	DEFINE_SERIALIZABLE(CSensoryFrame, mrpt::obs)
 
    public:
 	/** Default constructor

--- a/libs/opengl/include/mrpt/opengl/CArrow.h
+++ b/libs/opengl/include/mrpt/opengl/CArrow.h
@@ -27,7 +27,7 @@ namespace mrpt::opengl
  */
 class CArrow : public CRenderizableDisplayList
 {
-	DEFINE_SERIALIZABLE(CArrow)
+	DEFINE_SERIALIZABLE(CArrow, mrpt::opengl)
 	DEFINE_SCHEMA_SERIALIZABLE()
    protected:
 	mutable float m_x0, m_y0, m_z0;

--- a/libs/opengl/include/mrpt/opengl/CAssimpModel.h
+++ b/libs/opengl/include/mrpt/opengl/CAssimpModel.h
@@ -38,7 +38,7 @@ namespace mrpt::opengl
  */
 class CAssimpModel : public CRenderizableDisplayList
 {
-	DEFINE_SERIALIZABLE(CAssimpModel)
+	DEFINE_SERIALIZABLE(CAssimpModel, mrpt::opengl)
 
    public:
 	/** Render child objects */

--- a/libs/opengl/include/mrpt/opengl/CAxis.h
+++ b/libs/opengl/include/mrpt/opengl/CAxis.h
@@ -28,7 +28,7 @@ namespace mrpt::opengl
  */
 class CAxis : public CRenderizableDisplayList
 {
-	DEFINE_SERIALIZABLE(CAxis)
+	DEFINE_SERIALIZABLE(CAxis, mrpt::opengl)
    protected:
 	float m_xmin, m_ymin, m_zmin;
 	float m_xmax, m_ymax, m_zmax;

--- a/libs/opengl/include/mrpt/opengl/CBox.h
+++ b/libs/opengl/include/mrpt/opengl/CBox.h
@@ -38,7 +38,7 @@ namespace mrpt::opengl
  */
 class CBox : public CRenderizableDisplayList
 {
-	DEFINE_SERIALIZABLE(CBox)
+	DEFINE_SERIALIZABLE(CBox, mrpt::opengl)
 
    protected:
 	/** Corners coordinates */

--- a/libs/opengl/include/mrpt/opengl/CCamera.h
+++ b/libs/opengl/include/mrpt/opengl/CCamera.h
@@ -28,7 +28,7 @@ class CCamera : public CRenderizable
 {
 	friend class COpenGLViewport;
 
-	DEFINE_SERIALIZABLE(CCamera)
+	DEFINE_SERIALIZABLE(CCamera, mrpt::opengl)
    protected:
 	float m_pointingX{0}, m_pointingY{0}, m_pointingZ{0};
 	float m_distanceZoom{10};

--- a/libs/opengl/include/mrpt/opengl/CColorBar.h
+++ b/libs/opengl/include/mrpt/opengl/CColorBar.h
@@ -33,7 +33,7 @@ namespace mrpt::opengl
  */
 class CColorBar : public CRenderizableDisplayList
 {
-	DEFINE_SERIALIZABLE(CColorBar)
+	DEFINE_SERIALIZABLE(CColorBar, mrpt::opengl)
 
    protected:
 	mrpt::img::TColormap m_colormap;

--- a/libs/opengl/include/mrpt/opengl/CCylinder.h
+++ b/libs/opengl/include/mrpt/opengl/CCylinder.h
@@ -28,7 +28,7 @@ class CCylinder;
  */
 class CCylinder : public CRenderizableDisplayList
 {
-	DEFINE_SERIALIZABLE(CCylinder)
+	DEFINE_SERIALIZABLE(CCylinder, mrpt::opengl)
 	DEFINE_SCHEMA_SERIALIZABLE()
    protected:
 	/**

--- a/libs/opengl/include/mrpt/opengl/CDisk.h
+++ b/libs/opengl/include/mrpt/opengl/CDisk.h
@@ -29,7 +29,7 @@ namespace mrpt::opengl
  */
 class CDisk : public CRenderizableDisplayList
 {
-	DEFINE_SERIALIZABLE(CDisk)
+	DEFINE_SERIALIZABLE(CDisk, mrpt::opengl)
 
    protected:
 	float m_radiusIn{0}, m_radiusOut{1};

--- a/libs/opengl/include/mrpt/opengl/CEllipsoid.h
+++ b/libs/opengl/include/mrpt/opengl/CEllipsoid.h
@@ -43,7 +43,7 @@ namespace mrpt::opengl
  */
 class CEllipsoid : public CRenderizableDisplayList
 {
-	DEFINE_SERIALIZABLE(CEllipsoid)
+	DEFINE_SERIALIZABLE(CEllipsoid, mrpt::opengl)
 
    protected:
 	/** Used to store computed values the first time this is rendered, and to

--- a/libs/opengl/include/mrpt/opengl/CEllipsoidInverseDepth2D.h
+++ b/libs/opengl/include/mrpt/opengl/CEllipsoidInverseDepth2D.h
@@ -43,7 +43,7 @@ namespace mrpt::opengl
 class CEllipsoidInverseDepth2D : public CGeneralizedEllipsoidTemplate<2>
 {
 	using BASE = CGeneralizedEllipsoidTemplate<2>;
-	DEFINE_SERIALIZABLE(CEllipsoidInverseDepth2D)
+	DEFINE_SERIALIZABLE(CEllipsoidInverseDepth2D, mrpt::opengl)
 
    public:
 	/** The maximum range to be used as a correction when a point of the

--- a/libs/opengl/include/mrpt/opengl/CEllipsoidInverseDepth3D.h
+++ b/libs/opengl/include/mrpt/opengl/CEllipsoidInverseDepth3D.h
@@ -46,7 +46,7 @@ namespace mrpt::opengl
 class CEllipsoidInverseDepth3D : public CGeneralizedEllipsoidTemplate<3>
 {
 	using BASE = CGeneralizedEllipsoidTemplate<3>;
-	DEFINE_SERIALIZABLE(CEllipsoidInverseDepth3D)
+	DEFINE_SERIALIZABLE(CEllipsoidInverseDepth3D, mrpt::opengl)
 
    public:
 	/** The maximum range to be used as a correction when a point of the

--- a/libs/opengl/include/mrpt/opengl/CEllipsoidRangeBearing2D.h
+++ b/libs/opengl/include/mrpt/opengl/CEllipsoidRangeBearing2D.h
@@ -40,7 +40,7 @@ namespace mrpt::opengl
 class CEllipsoidRangeBearing2D : public CGeneralizedEllipsoidTemplate<2>
 {
 	using BASE = CGeneralizedEllipsoidTemplate<2>;
-	DEFINE_SERIALIZABLE(CEllipsoidRangeBearing2D)
+	DEFINE_SERIALIZABLE(CEllipsoidRangeBearing2D, mrpt::opengl)
    protected:
 	/** To be implemented by derived classes: maps, using some arbitrary space
 	 * transformation, a list of points

--- a/libs/opengl/include/mrpt/opengl/CFrustum.h
+++ b/libs/opengl/include/mrpt/opengl/CFrustum.h
@@ -50,7 +50,7 @@ namespace mrpt::opengl
  */
 class CFrustum : public CRenderizableDisplayList
 {
-	DEFINE_SERIALIZABLE(CFrustum)
+	DEFINE_SERIALIZABLE(CFrustum, mrpt::opengl)
 
    protected:
 	/** Near and far planes */

--- a/libs/opengl/include/mrpt/opengl/CGeneralizedCylinder.h
+++ b/libs/opengl/include/mrpt/opengl/CGeneralizedCylinder.h
@@ -27,7 +27,7 @@ class CGeneralizedCylinder;
  */
 class CGeneralizedCylinder : public CRenderizableDisplayList
 {
-	DEFINE_SERIALIZABLE(CGeneralizedCylinder)
+	DEFINE_SERIALIZABLE(CGeneralizedCylinder, mrpt::opengl)
    public:
 	/**
 	 * Auxiliary struct holding any quadrilateral, represented by foour points.

--- a/libs/opengl/include/mrpt/opengl/CGridPlaneXY.h
+++ b/libs/opengl/include/mrpt/opengl/CGridPlaneXY.h
@@ -28,7 +28,7 @@ namespace mrpt::opengl
  */
 class CGridPlaneXY : public CRenderizableDisplayList
 {
-	DEFINE_SERIALIZABLE(CGridPlaneXY)
+	DEFINE_SERIALIZABLE(CGridPlaneXY, mrpt::opengl)
 
    protected:
 	float m_xMin, m_xMax;

--- a/libs/opengl/include/mrpt/opengl/CGridPlaneXZ.h
+++ b/libs/opengl/include/mrpt/opengl/CGridPlaneXZ.h
@@ -28,7 +28,7 @@ namespace mrpt::opengl
  */
 class CGridPlaneXZ : public CRenderizableDisplayList
 {
-	DEFINE_SERIALIZABLE(CGridPlaneXZ)
+	DEFINE_SERIALIZABLE(CGridPlaneXZ, mrpt::opengl)
 
    protected:
 	float m_xMin, m_xMax;

--- a/libs/opengl/include/mrpt/opengl/CMesh.h
+++ b/libs/opengl/include/mrpt/opengl/CMesh.h
@@ -35,7 +35,7 @@ namespace mrpt::opengl
  */
 class CMesh : public CRenderizableDisplayList
 {
-	DEFINE_SERIALIZABLE(CMesh)
+	DEFINE_SERIALIZABLE(CMesh, mrpt::opengl)
    public:
 	struct TTriangleVertexIndices
 	{

--- a/libs/opengl/include/mrpt/opengl/CMesh3D.h
+++ b/libs/opengl/include/mrpt/opengl/CMesh3D.h
@@ -31,7 +31,7 @@ namespace mrpt::opengl
  */
 class CMesh3D : public CRenderizableDisplayList
 {
-	DEFINE_SERIALIZABLE(CMesh3D)
+	DEFINE_SERIALIZABLE(CMesh3D, mrpt::opengl)
 
 	using f_verts = std::array<int, 4>;
 	using coord3D = mrpt::math::TPoint3Df;

--- a/libs/opengl/include/mrpt/opengl/CMeshFast.h
+++ b/libs/opengl/include/mrpt/opengl/CMeshFast.h
@@ -37,7 +37,7 @@ namespace mrpt::opengl
  */
 class CMeshFast : public CRenderizableDisplayList
 {
-	DEFINE_SERIALIZABLE(CMeshFast)
+	DEFINE_SERIALIZABLE(CMeshFast, mrpt::opengl)
 
    protected:
 	mrpt::img::CImage m_textureImage;

--- a/libs/opengl/include/mrpt/opengl/COctoMapVoxels.h
+++ b/libs/opengl/include/mrpt/opengl/COctoMapVoxels.h
@@ -66,7 +66,7 @@ enum predefined_voxel_sets_t
  */
 class COctoMapVoxels : public CRenderizableDisplayList
 {
-	DEFINE_SERIALIZABLE(COctoMapVoxels)
+	DEFINE_SERIALIZABLE(COctoMapVoxels, mrpt::opengl)
    public:
 	/** The different coloring schemes, which modulate the generic
 	 * mrpt::opengl::CRenderizable object color. Set with setVisualizationMode()

--- a/libs/opengl/include/mrpt/opengl/COpenGLScene.h
+++ b/libs/opengl/include/mrpt/opengl/COpenGLScene.h
@@ -57,7 +57,7 @@ namespace opengl
  */
 class COpenGLScene : public mrpt::serialization::CSerializable
 {
-	DEFINE_SERIALIZABLE(COpenGLScene)
+	DEFINE_SERIALIZABLE(COpenGLScene, mrpt::opengl)
    public:
 	/** Constructor
 	 */

--- a/libs/opengl/include/mrpt/opengl/COpenGLStandardObject.h
+++ b/libs/opengl/include/mrpt/opengl/COpenGLStandardObject.h
@@ -22,7 +22,7 @@ using _GLENUM = uint32_t;
  */
 class COpenGLStandardObject : public CRenderizableDisplayList
 {
-	DEFINE_SERIALIZABLE(COpenGLStandardObject)
+	DEFINE_SERIALIZABLE(COpenGLStandardObject, mrpt::opengl)
    protected:
 	/**
 	 * OpenGL identifier of the object type.

--- a/libs/opengl/include/mrpt/opengl/COpenGLViewport.h
+++ b/libs/opengl/include/mrpt/opengl/COpenGLViewport.h
@@ -59,7 +59,7 @@ namespace opengl
 class COpenGLViewport : public mrpt::serialization::CSerializable,
 						public mrpt::system::CObservable
 {
-	DEFINE_SERIALIZABLE(COpenGLViewport)
+	DEFINE_SERIALIZABLE(COpenGLViewport, mrpt::opengl)
 	friend class COpenGLScene;
 
    public:

--- a/libs/opengl/include/mrpt/opengl/CPointCloud.h
+++ b/libs/opengl/include/mrpt/opengl/CPointCloud.h
@@ -45,7 +45,7 @@ class CPointCloud : public CRenderizable,
 					public mrpt::opengl::PLY_Importer,
 					public mrpt::opengl::PLY_Exporter
 {
-	DEFINE_SERIALIZABLE(CPointCloud)
+	DEFINE_SERIALIZABLE(CPointCloud, mrpt::opengl)
 	DEFINE_SCHEMA_SERIALIZABLE()
    protected:
 	enum Axis

--- a/libs/opengl/include/mrpt/opengl/CPointCloudColoured.h
+++ b/libs/opengl/include/mrpt/opengl/CPointCloudColoured.h
@@ -46,7 +46,7 @@ class CPointCloudColoured : public CRenderizable,
 							public mrpt::opengl::PLY_Importer,
 							public mrpt::opengl::PLY_Exporter
 {
-	DEFINE_SERIALIZABLE(CPointCloudColoured)
+	DEFINE_SERIALIZABLE(CPointCloudColoured, mrpt::opengl)
 
    public:
 	struct TPointColour

--- a/libs/opengl/include/mrpt/opengl/CPolyhedron.h
+++ b/libs/opengl/include/mrpt/opengl/CPolyhedron.h
@@ -42,7 +42,7 @@ class CPolyhedron;
  */
 class CPolyhedron : public CRenderizableDisplayList
 {
-	DEFINE_SERIALIZABLE(CPolyhedron)
+	DEFINE_SERIALIZABLE(CPolyhedron, mrpt::opengl)
    public:
 	/**
 	 * Struct used to store a polyhedron edge. The struct consists only of two

--- a/libs/opengl/include/mrpt/opengl/CSetOfLines.h
+++ b/libs/opengl/include/mrpt/opengl/CSetOfLines.h
@@ -30,7 +30,7 @@ namespace mrpt::opengl
  */
 class CSetOfLines : public CRenderizableDisplayList
 {
-	DEFINE_SERIALIZABLE(CSetOfLines)
+	DEFINE_SERIALIZABLE(CSetOfLines, mrpt::opengl)
    protected:
 	std::vector<mrpt::math::TSegment3D> mSegments;
 	float mLineWidth{1.0};

--- a/libs/opengl/include/mrpt/opengl/CSetOfObjects.h
+++ b/libs/opengl/include/mrpt/opengl/CSetOfObjects.h
@@ -25,7 +25,7 @@ namespace mrpt::opengl
  */
 class CSetOfObjects : public CRenderizable
 {
-	DEFINE_SERIALIZABLE(CSetOfObjects)
+	DEFINE_SERIALIZABLE(CSetOfObjects, mrpt::opengl)
 
    protected:
 	/** The list of child objects.

--- a/libs/opengl/include/mrpt/opengl/CSetOfTexturedTriangles.h
+++ b/libs/opengl/include/mrpt/opengl/CSetOfTexturedTriangles.h
@@ -20,7 +20,7 @@ namespace mrpt::opengl
  */
 class CSetOfTexturedTriangles : public CTexturedObject
 {
-	DEFINE_SERIALIZABLE(CSetOfTexturedTriangles)
+	DEFINE_SERIALIZABLE(CSetOfTexturedTriangles, mrpt::opengl)
 
    public:
 	/** Triangle vertex. This structure encapsulates the vertex coordinates and

--- a/libs/opengl/include/mrpt/opengl/CSetOfTriangles.h
+++ b/libs/opengl/include/mrpt/opengl/CSetOfTriangles.h
@@ -21,7 +21,7 @@ namespace mrpt::opengl
  */
 class CSetOfTriangles : public CRenderizableDisplayList
 {
-	DEFINE_SERIALIZABLE(CSetOfTriangles)
+	DEFINE_SERIALIZABLE(CSetOfTriangles, mrpt::opengl)
    public:
 	/**
 	 * Triangle definition. Each vertex has three spatial coordinates and four

--- a/libs/opengl/include/mrpt/opengl/CSimpleLine.h
+++ b/libs/opengl/include/mrpt/opengl/CSimpleLine.h
@@ -18,7 +18,7 @@ namespace mrpt::opengl
  */
 class CSimpleLine : public CRenderizableDisplayList
 {
-	DEFINE_SERIALIZABLE(CSimpleLine)
+	DEFINE_SERIALIZABLE(CSimpleLine, mrpt::opengl)
 
    protected:
 	float m_x0, m_y0, m_z0;

--- a/libs/opengl/include/mrpt/opengl/CSphere.h
+++ b/libs/opengl/include/mrpt/opengl/CSphere.h
@@ -27,7 +27,7 @@ namespace mrpt::opengl
  */
 class CSphere : public CRenderizableDisplayList
 {
-	DEFINE_SERIALIZABLE(CSphere)
+	DEFINE_SERIALIZABLE(CSphere, mrpt::opengl)
 
    protected:
 	float m_radius;

--- a/libs/opengl/include/mrpt/opengl/CText.h
+++ b/libs/opengl/include/mrpt/opengl/CText.h
@@ -34,7 +34,7 @@ namespace mrpt::opengl
  */
 class CText : public CRenderizable
 {
-	DEFINE_SERIALIZABLE(CText)
+	DEFINE_SERIALIZABLE(CText, mrpt::opengl)
    protected:
 	std::string m_str;
 	std::string m_fontName;

--- a/libs/opengl/include/mrpt/opengl/CText3D.h
+++ b/libs/opengl/include/mrpt/opengl/CText3D.h
@@ -41,7 +41,7 @@ namespace mrpt::opengl
  */
 class CText3D : public CRenderizableDisplayList
 {
-	DEFINE_SERIALIZABLE(CText3D)
+	DEFINE_SERIALIZABLE(CText3D, mrpt::opengl)
    protected:
 	std::string m_str;
 	std::string m_fontName;

--- a/libs/opengl/include/mrpt/opengl/CTexturedPlane.h
+++ b/libs/opengl/include/mrpt/opengl/CTexturedPlane.h
@@ -18,7 +18,7 @@ namespace mrpt::opengl
  */
 class CTexturedPlane : public CTexturedObject
 {
-	DEFINE_SERIALIZABLE(CTexturedPlane)
+	DEFINE_SERIALIZABLE(CTexturedPlane, mrpt::opengl)
    protected:
 	mutable float m_tex_x_min = -1.0f, m_tex_x_max = 1.0f;
 	mutable float m_tex_y_min = -1.0f, m_tex_y_max = 1.0f;

--- a/libs/opengl/include/mrpt/opengl/CVectorField2D.h
+++ b/libs/opengl/include/mrpt/opengl/CVectorField2D.h
@@ -31,7 +31,7 @@ namespace mrpt::opengl
 
 class CVectorField2D : public CRenderizableDisplayList
 {
-	DEFINE_SERIALIZABLE(CVectorField2D)
+	DEFINE_SERIALIZABLE(CVectorField2D, mrpt::opengl)
    protected:
 	/** X component of the vector field */
 	mrpt::math::CMatrixF xcomp;

--- a/libs/opengl/include/mrpt/opengl/CVectorField3D.h
+++ b/libs/opengl/include/mrpt/opengl/CVectorField3D.h
@@ -36,7 +36,7 @@ namespace mrpt::opengl
 
 class CVectorField3D : public CRenderizableDisplayList
 {
-	DEFINE_SERIALIZABLE(CVectorField3D)
+	DEFINE_SERIALIZABLE(CVectorField3D, mrpt::opengl)
    protected:
 	/** X component of the vector field */
 	mrpt::math::CMatrixF x_vf;

--- a/libs/poses/include/mrpt/poses/CPoint2D.h
+++ b/libs/poses/include/mrpt/poses/CPoint2D.h
@@ -32,7 +32,7 @@ class CPose2D;
 class CPoint2D : public CPoint<CPoint2D, 2>,
 				 public mrpt::serialization::CSerializable
 {
-	DEFINE_SERIALIZABLE(CPoint2D)
+	DEFINE_SERIALIZABLE(CPoint2D, mrpt::poses)
 	DEFINE_SCHEMA_SERIALIZABLE()
    public:
 	/** [x,y] */

--- a/libs/poses/include/mrpt/poses/CPoint2DPDFGaussian.h
+++ b/libs/poses/include/mrpt/poses/CPoint2DPDFGaussian.h
@@ -19,7 +19,7 @@ namespace mrpt::poses
  */
 class CPoint2DPDFGaussian : public CPoint2DPDF
 {
-	DEFINE_SERIALIZABLE(CPoint2DPDFGaussian)
+	DEFINE_SERIALIZABLE(CPoint2DPDFGaussian, mrpt::poses)
 	DEFINE_SCHEMA_SERIALIZABLE()
 
    public:

--- a/libs/poses/include/mrpt/poses/CPoint3D.h
+++ b/libs/poses/include/mrpt/poses/CPoint3D.h
@@ -31,7 +31,7 @@ namespace mrpt::poses
 class CPoint3D : public CPoint<CPoint3D, 3>,
 				 public mrpt::serialization::CSerializable
 {
-	DEFINE_SERIALIZABLE(CPoint3D)
+	DEFINE_SERIALIZABLE(CPoint3D, mrpt::poses)
 	DEFINE_SCHEMA_SERIALIZABLE()
    public:
 	/** [x,y,z] */

--- a/libs/poses/include/mrpt/poses/CPointPDFGaussian.h
+++ b/libs/poses/include/mrpt/poses/CPointPDFGaussian.h
@@ -21,7 +21,7 @@ namespace mrpt::poses
  */
 class CPointPDFGaussian : public CPointPDF
 {
-	DEFINE_SERIALIZABLE(CPointPDFGaussian)
+	DEFINE_SERIALIZABLE(CPointPDFGaussian, mrpt::poses)
 	DEFINE_SCHEMA_SERIALIZABLE()
 
    public:

--- a/libs/poses/include/mrpt/poses/CPointPDFParticles.h
+++ b/libs/poses/include/mrpt/poses/CPointPDFParticles.h
@@ -28,7 +28,7 @@ class CPointPDFParticles
 		  CPointPDFParticles, mrpt::bayes::CParticleFilterData<
 								  mrpt::math::TPoint3Df>::CParticleList>
 {
-	DEFINE_SERIALIZABLE(CPointPDFParticles)
+	DEFINE_SERIALIZABLE(CPointPDFParticles, mrpt::poses)
 
    public:
 	/** Default constructor */

--- a/libs/poses/include/mrpt/poses/CPointPDFSOG.h
+++ b/libs/poses/include/mrpt/poses/CPointPDFSOG.h
@@ -32,7 +32,7 @@ namespace mrpt::poses
  */
 class CPointPDFSOG : public CPointPDF
 {
-	DEFINE_SERIALIZABLE(CPointPDFSOG)
+	DEFINE_SERIALIZABLE(CPointPDFSOG, mrpt::poses)
 
    public:
 	/** The struct for each mode:

--- a/libs/poses/include/mrpt/poses/CPose2D.h
+++ b/libs/poses/include/mrpt/poses/CPose2D.h
@@ -40,7 +40,7 @@ class CPose2D : public CPose<CPose2D, 3>,
 				public mrpt::serialization::CSerializable
 {
    public:
-	DEFINE_SERIALIZABLE(CPose2D)
+	DEFINE_SERIALIZABLE(CPose2D, mrpt::poses)
 	DEFINE_SCHEMA_SERIALIZABLE()
 
    public:

--- a/libs/poses/include/mrpt/poses/CPose2DInterpolator.h
+++ b/libs/poses/include/mrpt/poses/CPose2DInterpolator.h
@@ -49,7 +49,7 @@ class CPose2DInterpolator : public mrpt::serialization::CSerializable,
 							public mrpt::poses::CPoseInterpolatorBase<2>
 {
 	// This must be added to any CSerializable derived class:
-	DEFINE_SERIALIZABLE(CPose2DInterpolator)
+	DEFINE_SERIALIZABLE(CPose2DInterpolator, mrpt::poses)
 
 };  // End of class def.
 }  // namespace mrpt::poses

--- a/libs/poses/include/mrpt/poses/CPose3D.h
+++ b/libs/poses/include/mrpt/poses/CPose3D.h
@@ -85,7 +85,7 @@ class CPose3DQuat;
 class CPose3D : public CPose<CPose3D, 6>,
 				public mrpt::serialization::CSerializable
 {
-	DEFINE_SERIALIZABLE(CPose3D)
+	DEFINE_SERIALIZABLE(CPose3D, mrpt::poses)
 	DEFINE_SCHEMA_SERIALIZABLE()
 
 	// This must be added for declaration of MEX-related functions

--- a/libs/poses/include/mrpt/poses/CPose3DInterpolator.h
+++ b/libs/poses/include/mrpt/poses/CPose3DInterpolator.h
@@ -47,6 +47,6 @@ namespace mrpt::poses
 class CPose3DInterpolator : public mrpt::serialization::CSerializable,
 							public mrpt::poses::CPoseInterpolatorBase<3>
 {
-	DEFINE_SERIALIZABLE(CPose3DInterpolator)
+	DEFINE_SERIALIZABLE(CPose3DInterpolator, mrpt::poses)
 };  // End of class def.
 }  // namespace mrpt::poses

--- a/libs/poses/include/mrpt/poses/CPose3DPDFGaussian.h
+++ b/libs/poses/include/mrpt/poses/CPose3DPDFGaussian.h
@@ -38,7 +38,7 @@ class CPose3DQuatPDFGaussian;
  */
 class CPose3DPDFGaussian : public CPose3DPDF
 {
-	DEFINE_SERIALIZABLE(CPose3DPDFGaussian)
+	DEFINE_SERIALIZABLE(CPose3DPDFGaussian, mrpt::poses)
 
    protected:
 	/** Assures the symmetry of the covariance matrix (eventually certain

--- a/libs/poses/include/mrpt/poses/CPose3DPDFGaussianInf.h
+++ b/libs/poses/include/mrpt/poses/CPose3DPDFGaussianInf.h
@@ -39,7 +39,7 @@ class CPose3DQuatPDFGaussian;
 class CPose3DPDFGaussianInf : public CPose3DPDF
 {
 	// This must be added to any CSerializable derived class:
-	DEFINE_SERIALIZABLE(CPose3DPDFGaussianInf)
+	DEFINE_SERIALIZABLE(CPose3DPDFGaussianInf, mrpt::poses)
 	using self_t = CPose3DPDFGaussianInf;
 
    protected:

--- a/libs/poses/include/mrpt/poses/CPose3DPDFGrid.h
+++ b/libs/poses/include/mrpt/poses/CPose3DPDFGrid.h
@@ -24,7 +24,7 @@ namespace mrpt::poses
  */
 class CPose3DPDFGrid : public CPose3DPDF, public CPose3DGridTemplate<double>
 {
-	DEFINE_SERIALIZABLE(CPose3DPDFGrid)
+	DEFINE_SERIALIZABLE(CPose3DPDFGrid, mrpt::poses)
 
    protected:
    public:

--- a/libs/poses/include/mrpt/poses/CPose3DPDFParticles.h
+++ b/libs/poses/include/mrpt/poses/CPose3DPDFParticles.h
@@ -36,7 +36,7 @@ class CPose3DPDFParticles
 			  mrpt::math::TPose3D,
 			  mrpt::bayes::particle_storage_mode::VALUE>::CParticleList>
 {
-	DEFINE_SERIALIZABLE(CPose3DPDFParticles)
+	DEFINE_SERIALIZABLE(CPose3DPDFParticles, mrpt::poses)
 
    public:
 	/** Constructor

--- a/libs/poses/include/mrpt/poses/CPose3DPDFSOG.h
+++ b/libs/poses/include/mrpt/poses/CPose3DPDFSOG.h
@@ -31,7 +31,7 @@ namespace mrpt::poses
  */
 class CPose3DPDFSOG : public CPose3DPDF
 {
-	DEFINE_SERIALIZABLE(CPose3DPDFSOG)
+	DEFINE_SERIALIZABLE(CPose3DPDFSOG, mrpt::poses)
 
    public:
 	/** The struct for each mode:

--- a/libs/poses/include/mrpt/poses/CPose3DQuat.h
+++ b/libs/poses/include/mrpt/poses/CPose3DQuat.h
@@ -45,7 +45,7 @@ namespace mrpt::poses
 class CPose3DQuat : public CPose<CPose3DQuat, 7>,
 					public mrpt::serialization::CSerializable
 {
-	DEFINE_SERIALIZABLE(CPose3DQuat)
+	DEFINE_SERIALIZABLE(CPose3DQuat, mrpt::poses)
 	DEFINE_SCHEMA_SERIALIZABLE()
    public:
 	/** The translation vector [x,y,z] */

--- a/libs/poses/include/mrpt/poses/CPose3DQuatPDFGaussian.h
+++ b/libs/poses/include/mrpt/poses/CPose3DQuatPDFGaussian.h
@@ -42,7 +42,7 @@ class CPose3DPDFGaussian;
  */
 class CPose3DQuatPDFGaussian : public CPose3DQuatPDF
 {
-	DEFINE_SERIALIZABLE(CPose3DQuatPDFGaussian)
+	DEFINE_SERIALIZABLE(CPose3DQuatPDFGaussian, mrpt::poses)
 
    protected:
 	/** Assures the symmetry of the covariance matrix (eventually certain

--- a/libs/poses/include/mrpt/poses/CPose3DQuatPDFGaussianInf.h
+++ b/libs/poses/include/mrpt/poses/CPose3DQuatPDFGaussianInf.h
@@ -42,7 +42,7 @@ class CPose3DPDFGaussian;
 class CPose3DQuatPDFGaussianInf : public CPose3DQuatPDF
 {
 	// This must be added to any CSerializable derived class:
-	DEFINE_SERIALIZABLE(CPose3DQuatPDFGaussianInf)
+	DEFINE_SERIALIZABLE(CPose3DQuatPDFGaussianInf, mrpt::poses)
 	using self_t = CPose3DQuatPDFGaussianInf;
 
    public:

--- a/libs/poses/include/mrpt/poses/CPosePDFGaussian.h
+++ b/libs/poses/include/mrpt/poses/CPosePDFGaussian.h
@@ -27,7 +27,7 @@ class CPoint2DPDFGaussian;
  */
 class CPosePDFGaussian : public CPosePDF
 {
-	DEFINE_SERIALIZABLE(CPosePDFGaussian)
+	DEFINE_SERIALIZABLE(CPosePDFGaussian, mrpt::poses)
 	DEFINE_SCHEMA_SERIALIZABLE()
 
    protected:

--- a/libs/poses/include/mrpt/poses/CPosePDFGaussianInf.h
+++ b/libs/poses/include/mrpt/poses/CPosePDFGaussianInf.h
@@ -33,7 +33,7 @@ class CPose3DPDF;
 class CPosePDFGaussianInf : public CPosePDF
 {
 	// This must be added to any CSerializable derived class:
-	DEFINE_SERIALIZABLE(CPosePDFGaussianInf)
+	DEFINE_SERIALIZABLE(CPosePDFGaussianInf, mrpt::poses)
 	DEFINE_SCHEMA_SERIALIZABLE()
 	using self_t = CPosePDFGaussianInf;
 

--- a/libs/poses/include/mrpt/poses/CPosePDFGrid.h
+++ b/libs/poses/include/mrpt/poses/CPosePDFGrid.h
@@ -23,7 +23,7 @@ namespace mrpt::poses
  */
 class CPosePDFGrid : public CPosePDF, public CPose2DGridTemplate<double>
 {
-	DEFINE_SERIALIZABLE(CPosePDFGrid)
+	DEFINE_SERIALIZABLE(CPosePDFGrid, mrpt::poses)
 
    protected:
    public:

--- a/libs/poses/include/mrpt/poses/CPosePDFParticles.h
+++ b/libs/poses/include/mrpt/poses/CPosePDFParticles.h
@@ -37,7 +37,7 @@ class CPosePDFParticles
 			  mrpt::math::TPose2D,
 			  mrpt::bayes::particle_storage_mode::VALUE>::CParticleList>
 {
-	DEFINE_SERIALIZABLE(CPosePDFParticles)
+	DEFINE_SERIALIZABLE(CPosePDFParticles, mrpt::poses)
 
    public:
 	/** Free all the memory associated to m_particles, and set the number of

--- a/libs/poses/include/mrpt/poses/CPosePDFSOG.h
+++ b/libs/poses/include/mrpt/poses/CPosePDFSOG.h
@@ -33,7 +33,7 @@ namespace mrpt::poses
  */
 class CPosePDFSOG : public CPosePDF
 {
-	DEFINE_SERIALIZABLE(CPosePDFSOG)
+	DEFINE_SERIALIZABLE(CPosePDFSOG, mrpt::poses)
 
    public:
 	/** The struct for each mode:

--- a/libs/poses/include/mrpt/poses/CPoses2DSequence.h
+++ b/libs/poses/include/mrpt/poses/CPoses2DSequence.h
@@ -23,7 +23,7 @@ namespace mrpt::poses
  */
 class CPoses2DSequence : public mrpt::serialization::CSerializable
 {
-	DEFINE_SERIALIZABLE(CPoses2DSequence)
+	DEFINE_SERIALIZABLE(CPoses2DSequence, mrpt::poses)
    public:
 	/** Returns the poses count in the sequence:
 	 */

--- a/libs/poses/include/mrpt/poses/CPoses3DSequence.h
+++ b/libs/poses/include/mrpt/poses/CPoses3DSequence.h
@@ -22,7 +22,7 @@ namespace mrpt::poses
  */
 class CPoses3DSequence : public mrpt::serialization::CSerializable
 {
-	DEFINE_SERIALIZABLE(CPoses3DSequence)
+	DEFINE_SERIALIZABLE(CPoses3DSequence, mrpt::poses)
    public:
 	/** Returns the poses count in the sequence:
 	 */

--- a/libs/rtti/src/rtti_unittest.cpp
+++ b/libs/rtti/src/rtti_unittest.cpp
@@ -20,23 +20,23 @@ class MyDerived1 : public mrpt::rtti::CObject
 
 	MyDerived1() = default;
 	MyDerived1(int v) : m_value(v) {}
-	DEFINE_MRPT_OBJECT(MyDerived1)
+	DEFINE_MRPT_OBJECT(MyDerived1, MyNS)
 };
 
 class MyDerived2 : public mrpt::rtti::CObject
 {
    public:
 	MyDerived2() = default;
-	DEFINE_MRPT_OBJECT(MyDerived2)
+	DEFINE_MRPT_OBJECT(MyDerived2, MyNS)
 };
 
 }  // namespace MyNS
 
-// Register "MyDerived1"
+// Register "MyNS::MyDerived1"
 IMPLEMENTS_MRPT_OBJECT(MyDerived1, mrpt::rtti::CObject, MyNS)
 
 // Register "MyNS::MyDerived2"
-IMPLEMENTS_MRPT_OBJECT_NS_PREFIX(MyDerived2, mrpt::rtti::CObject, MyNS)
+IMPLEMENTS_MRPT_OBJECT(MyDerived2, mrpt::rtti::CObject, MyNS)
 
 void do_register()
 {
@@ -55,7 +55,8 @@ TEST(rtti, MyDerived1_CLASSID)
 {
 	using namespace std;
 	const auto cid_myd1 = CLASS_ID(MyNS::MyDerived1);
-	EXPECT_TRUE(std::string(cid_myd1->className) == std::string("MyDerived1"));
+	EXPECT_TRUE(
+		std::string(cid_myd1->className) == std::string("MyNS::MyDerived1"));
 
 	const auto cid_cobj = CLASS_ID(mrpt::rtti::CObject);
 	EXPECT_TRUE(cid_myd1->getBaseClass() == cid_cobj);
@@ -72,7 +73,8 @@ TEST(rtti, Factory)
 {
 	do_register();
 	{
-		mrpt::rtti::CObject::Ptr p = mrpt::rtti::classFactory("MyDerived1");
+		mrpt::rtti::CObject::Ptr p =
+			mrpt::rtti::classFactory("MyNS::MyDerived1");
 		EXPECT_TRUE(p);
 	}
 	{

--- a/libs/serialization/include/mrpt/serialization/CSerializable.h
+++ b/libs/serialization/include/mrpt/serialization/CSerializable.h
@@ -149,8 +149,8 @@ void OctetVectorToObject(
 
 /** This declaration must be inserted in all CSerializable classes definition,
  * within the class declaration. */
-#define DEFINE_SERIALIZABLE(class_name)                                      \
-	DEFINE_MRPT_OBJECT(class_name)                                           \
+#define DEFINE_SERIALIZABLE(class_name, NS)                                  \
+	DEFINE_MRPT_OBJECT(class_name, NS)                                       \
    protected:                                                                \
 	/*! @name CSerializable virtual methods */                               \
 	/*! @{ */                                                                \
@@ -161,15 +161,7 @@ void OctetVectorToObject(
 /*! @} */
 
 /** To be added to all CSerializable-classes implementation files.
- * This version registers the class name with the NameSpace prefix.
- * \sa IMPLEMENTS_SERIALIZABLE
- */
-#define IMPLEMENTS_SERIALIZABLE_NS_PREFIX(class_name, base, NameSpace) \
-	IMPLEMENTS_MRPT_OBJECT_NS_PREFIX(class_name, base, NameSpace)
-
-/** To be added to all CSerializable-classes implementation files.
- * This version registers the class name with the NameSpace prefix.
- * \sa IMPLEMENTS_SERIALIZABLE_NS_PREFIX
+ * This registers the class name with the NameSpace prefix.
  */
 #define IMPLEMENTS_SERIALIZABLE(class_name, base, NameSpace) \
 	IMPLEMENTS_MRPT_OBJECT(class_name, base, NameSpace)

--- a/libs/serialization/src/CSchemeArchive_unittest.cpp
+++ b/libs/serialization/src/CSchemeArchive_unittest.cpp
@@ -30,7 +30,7 @@ TEST(SchemaSerialization, JSON_archive)
 	arch = pt1;
 	std::stringstream ss;
 	ss << arch;
-	auto pos = ss.str().find("\"datatype\" : \"CPose2D\"");
+	auto pos = ss.str().find("\"datatype\" : \"mrpt::poses::CPose2D\"");
 	EXPECT_TRUE(pos != std::string::npos);
 
 	// test deserializing:
@@ -55,7 +55,7 @@ TEST(SchemaSerialization, JSON_raw)
 	arch = pt1;
 	std::stringstream ss;
 	ss << val;
-	auto pos = ss.str().find("\"datatype\" : \"CPose2D\"");
+	auto pos = ss.str().find("\"datatype\" : \"mrpt::poses::CPose2D\"");
 	EXPECT_TRUE(pos != std::string::npos);
 
 	// test deserializing:

--- a/libs/serialization/src/CSerializable_unittest.cpp
+++ b/libs/serialization/src/CSerializable_unittest.cpp
@@ -18,7 +18,7 @@ namespace MyNS
 {
 class Foo : public CSerializable
 {
-	DEFINE_SERIALIZABLE(Foo)
+	DEFINE_SERIALIZABLE(Foo, MyNS)
    public:
 	int16_t value;
 };

--- a/libs/slam/include/mrpt/maps/CMultiMetricMapPDF.h
+++ b/libs/slam/include/mrpt/maps/CMultiMetricMapPDF.h
@@ -34,7 +34,7 @@ namespace maps
  */
 class CRBPFParticleData : public mrpt::serialization::CSerializable
 {
-	DEFINE_SERIALIZABLE(CRBPFParticleData)
+	DEFINE_SERIALIZABLE(CRBPFParticleData, mrpt::maps)
    public:
 	CRBPFParticleData() = default;
 	CRBPFParticleData(const TSetOfMetricMapInitializers& mapsInit)
@@ -66,7 +66,7 @@ class CMultiMetricMapPDF
 {
 	friend class mrpt::slam::CMetricMapBuilderRBPF;
 
-	DEFINE_SERIALIZABLE(CMultiMetricMapPDF)
+	DEFINE_SERIALIZABLE(CMultiMetricMapPDF, mrpt::maps)
 
    protected:
 	// PF algorithm implementations:

--- a/libs/slam/include/mrpt/slam/CIncrementalMapPartitioner.h
+++ b/libs/slam/include/mrpt/slam/CIncrementalMapPartitioner.h
@@ -55,7 +55,7 @@ class CIncrementalMapPartitioner : public mrpt::system::COutputLogger,
 								   public mrpt::serialization::CSerializable
 {
 	// This must be added to any CSerializable derived class:
-	DEFINE_SERIALIZABLE(CIncrementalMapPartitioner)
+	DEFINE_SERIALIZABLE(CIncrementalMapPartitioner, mrpt::slam)
 
    public:
 	/** ctor */

--- a/libs/slam/src/slam/CMonteCarloLocalization2D_unittest.cpp
+++ b/libs/slam/src/slam/CMonteCarloLocalization2D_unittest.cpp
@@ -263,37 +263,40 @@ void run_test_pf_localization(CPose2D& meanPose, CMatrixDouble33& cov)
 // TEST =================
 TEST(MonteCarlo2D, RunSampleDataset)
 {
-#if MRPT_IS_BIG_ENDIAN
-	MRPT_TODO("Debug this issue in big endian platforms")
-	return;  // Skip this test for now
-#endif
-
-	// Actual ending point:
-	const CPose2D GT_endpose(15.904, -10.010, 4.93_deg);
-
-	// Placeholder for results:
-	CPose2D meanPose;
-	CMatrixDouble33 cov;
-
-	// Invoke test:
-	// Give it 3 opportunities, since it might fail once for bad luck, or even
-	// twice in an extreme bad luck:
-	for (int op = 0; op < 3; op++)
+	try
 	{
-		run_test_pf_localization(meanPose, cov);
+		// Actual ending point:
+		const CPose2D GT_endpose(15.904, -10.010, 4.93_deg);
 
-		const double final_pf_cov_trace = cov.trace();
-		const CPose2D final_pf_pose = meanPose;
+		// Placeholder for results:
+		CPose2D meanPose;
+		CMatrixDouble33 cov;
 
-		bool pass1 = (final_pf_pose - GT_endpose).norm() < 0.10;
-		bool pass2 = final_pf_cov_trace < 0.01;
+		// Invoke test:
+		// Give it 3 opportunities, since it might fail once for bad luck, or
+		// even twice in an extreme bad luck:
+		for (int op = 0; op < 3; op++)
+		{
+			run_test_pf_localization(meanPose, cov);
 
-		if (pass1 && pass2) return;  // OK!
+			const double final_pf_cov_trace = cov.trace();
+			const CPose2D final_pf_pose = meanPose;
 
-		// else: give it another try...
-		cout << "\n*Warning: Test failed. Will give it another chance, since "
-				"after all it's nondeterministic!\n";
+			bool pass1 = (final_pf_pose - GT_endpose).norm() < 0.10;
+			bool pass2 = final_pf_cov_trace < 0.01;
+
+			if (pass1 && pass2) return;  // OK!
+
+			// else: give it another try...
+			cout << "\n*Warning: Test failed. Will give it another chance, "
+					"since "
+					"after all it's nondeterministic!\n";
+		}
+
+		FAIL() << "Failed to converge after 3 opportunities!!" << endl;
 	}
-
-	FAIL() << "Failed to converge after 3 opportunities!!" << endl;
+	catch (const std::exception& e)
+	{
+		FAIL() << mrpt::exception_to_str(e);
+	}
 }

--- a/libs/vision/include/mrpt/maps/CLandmark.h
+++ b/libs/vision/include/mrpt/maps/CLandmark.h
@@ -34,7 +34,7 @@ namespace mrpt::maps
  */
 class CLandmark : public mrpt::serialization::CSerializable
 {
-	DEFINE_SERIALIZABLE(CLandmark)
+	DEFINE_SERIALIZABLE(CLandmark, mrpt::maps)
 
    public:
 	/** The type for the IDs of landmarks. */

--- a/libs/vision/include/mrpt/maps/CLandmarksMap.h
+++ b/libs/vision/include/mrpt/maps/CLandmarksMap.h
@@ -73,7 +73,7 @@ using TSequenceLandmarks = std::vector<CLandmark>;
  */
 class CLandmarksMap : public mrpt::maps::CMetricMap
 {
-	DEFINE_SERIALIZABLE(CLandmarksMap)
+	DEFINE_SERIALIZABLE(CLandmarksMap, mrpt::maps)
 
    private:
 	void internal_clear() override;

--- a/libs/vision/include/mrpt/obs/CObservationVisualLandmarks.h
+++ b/libs/vision/include/mrpt/obs/CObservationVisualLandmarks.h
@@ -24,7 +24,7 @@ namespace mrpt::obs
  */
 class CObservationVisualLandmarks : public CObservation
 {
-	DEFINE_SERIALIZABLE(CObservationVisualLandmarks)
+	DEFINE_SERIALIZABLE(CObservationVisualLandmarks, mrpt::obs)
 
    public:
 	/** Constructor */

--- a/libs/vision/include/mrpt/vision/CFeature.h
+++ b/libs/vision/include/mrpt/vision/CFeature.h
@@ -55,7 +55,7 @@ class CFeature : public mrpt::serialization::CSerializable
 	friend class CFeatureList;
 	friend class CMatchedFeatureList;
 
-	DEFINE_SERIALIZABLE(CFeature)
+	DEFINE_SERIALIZABLE(CFeature, mrpt::vision)
 
    public:
 	CFeature() = default;

--- a/libs/vision/src/maps/CLandmarksMap.cpp
+++ b/libs/vision/src/maps/CLandmarksMap.cpp
@@ -44,7 +44,8 @@ using namespace std;
 using mrpt::maps::internal::TSequenceLandmarks;
 
 //  =========== Begin of Map definition ============
-MAP_DEFINITION_REGISTER("CLandmarksMap,landmarksMap", mrpt::maps::CLandmarksMap)
+MAP_DEFINITION_REGISTER(
+	"mrpt::maps::CLandmarksMap,landmarksMap", mrpt::maps::CLandmarksMap)
 
 CLandmarksMap::TMapDefinition::TMapDefinition() = default;
 void CLandmarksMap::TMapDefinition::loadFromConfigFile_map_specific(

--- a/samples/rtti_example1/test.cpp
+++ b/samples/rtti_example1/test.cpp
@@ -19,7 +19,7 @@ class Foo : public mrpt::rtti::CObject
 {
    public:
 	Foo() {}
-	DEFINE_MRPT_OBJECT(Foo)
+	DEFINE_MRPT_OBJECT(Foo, MyNS)
 
 	void printName() { std::cout << "printName: Foo" << std::endl; }
 };
@@ -37,7 +37,7 @@ class Bar : public BarBase
 {
    public:
 	Bar() {}
-	DEFINE_MRPT_OBJECT(Bar)
+	DEFINE_MRPT_OBJECT(Bar, MyNS)
 
 	void printName() override { std::cout << "class: Bar" << std::endl; }
 	void specificBarMethod()


### PR DESCRIPTION
This addresses an old issue (e.g. reported back in 2012 in #14) regarding the limitation of mrpt to (de)serialize classes with identical names but in different namespaces.

Mechanism are provided to allow backwards compatible deserialization of existing datasets.

