### PR TITLE
Update COccupancyGridMap2D_insert.cpp

### DIFF
--- a/libs/maps/src/maps/COccupancyGridMap2D_insert.cpp
+++ b/libs/maps/src/maps/COccupancyGridMap2D_insert.cpp
@@ -183,7 +183,7 @@ bool COccupancyGridMap2D::internal_insertObservation(
 
 				for (idx = 0, scanPoint_x = scanPoints_x,
 					scanPoint_y = scanPoints_y;
-					 idx < nRanges; idx += K, scanPoint_x++, scanPoint_y++)
+					 idx < nRanges; idx += K, scanPoint_x += K, scanPoint_y += K)
 				{
 					if (o.getScanRangeValidity(idx))
 					{


### PR DESCRIPTION
When decimation is not 1, scanPoint_x and scanPoint_y should increase K too.

## Changed apps/libraries

* modified-libX
* modified-appY
* ...

## PR Description

* (*REMOVE THIS LINE IF NOT NEEDED*) This PR Closes issue #XXX
* (*REMOVE THIS LINE IF NOT NEEDED*)

---

I acknowledge to have:
* Read the [`CONTRIBUTING`](https://github.com/MRPT/mrpt/blob/master/.github/CONTRIBUTING.md) page
* Updated [`doc/doxygen-pages/changeLog_doc.h`](https://github.com/MRPT/mrpt/blob/master/doc/doxygen-pages/changeLog_doc.h) to describe these changes (if applicable)
* Updated [`AUTHORS`](https://github.com/MRPT/mrpt/blob/master/AUTHORS) (if applicable)

(Notify: @MRPT/owners )
