### PR TITLE
fix big endian (S390X/MIPS) crashes

### DIFF
--- a/libs/maps/src/maps/COccupancyGridMap2D_insert.cpp
+++ b/libs/maps/src/maps/COccupancyGridMap2D_insert.cpp
@@ -183,7 +183,8 @@ bool COccupancyGridMap2D::internal_insertObservation(
 
 				for (idx = 0, scanPoint_x = scanPoints_x,
 					scanPoint_y = scanPoints_y;
-					 idx < nRanges; idx += K, scanPoint_x += K, scanPoint_y += K)
+					 idx < nRanges;
+					 idx += K, scanPoint_x += K, scanPoint_y += K)
 				{
 					if (o.getScanRangeValidity(idx))
 					{


### PR DESCRIPTION
This particular problem was in the 32bit integers in a LUT, using little-endian convention.

(Should...)  Fixes #956 
