### PR TITLE
Request CMake to find OpenCV 2

### DIFF
--- a/cmakemodules/script_opencv.cmake
+++ b/cmakemodules/script_opencv.cmake
@@ -25,7 +25,7 @@ endif()
 
 # 1st option: Try to find OpenCV config file (NO_MODULE: Don't find a module, but OpenCVConfig.cmake):
 if(NOT CMAKE_MRPT_HAS_OPENCV)
-	find_package(OpenCV QUIET NO_MODULE)
+	find_package(OpenCV 2 QUIET NO_MODULE)
 	if(OpenCV_FOUND)
 		set(MRPT_OPENCV_VERSION ${OpenCV_VERSION})
 		set(OpenCV_LIBRARIES ${OpenCV_LIBS})


### PR DESCRIPTION
## Changed apps/libraries

- `cmakemodules/script_opencv.cmake`

## PR Description

This patch encourages CMake to find OpenCV 2 by default. Since I have multiple OpenCV installed. Especially Arch Linux allows installing `opencv` (>=4) and `opencv2-opt` in the mean time. The change makes sure build script will not find the wrong version.