### PR TITLE
Fix obsolete wxWidgets Connect() function

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,4 @@ graphslam_results/
 
 #visual studio
 .vs/*
+.vscode

--- a/3rdparty/wxThings/src/toggle.cpp
+++ b/3rdparty/wxThings/src/toggle.cpp
@@ -291,7 +291,7 @@ void wxCustomButton::SendEvent()
 	}
 	else
 	{
-		wxCommandEvent eventOut(wxEVT_COMMAND_BUTTON_CLICKED, GetId());
+		wxCommandEvent eventOut(wxEVT_BUTTON, GetId());
 		eventOut.SetInt(0);
 		eventOut.SetExtraLong(m_eventType);
 		eventOut.SetEventObject(this);

--- a/3rdparty/wxThings/wx/things/toggle.h
+++ b/3rdparty/wxThings/wx/things/toggle.h
@@ -24,17 +24,17 @@ There are four styles the button can take.
 
 wxCUSTBUT_BUTTON == wxButton
     Left and Right clicks and double clicks all send
-        wxEVT_COMMAND_BUTTON_CLICKED => EVT_BUTTON(id,fn)
+        wxEVT_BUTTON => EVT_BUTTON(id,fn)
 
 wxCUSTBUT_TOGGLE == wxToggleButton
     Left clicks sends
         wxEVT_COMMAND_TOGGLEBUTTON_CLICKED => EVT_TOGGLEBUTTON(id, fn)
     Left double clicks and Right clicks send
-        wxEVT_COMMAND_BUTTON_CLICKED => EVT_BUTTON(id,fn)
+        wxEVT_BUTTON => EVT_BUTTON(id,fn)
 
 wxCUSTBUT_BUT_DCLICK_TOG
     Left and Right clicks and Right double clicks send
-        wxEVT_COMMAND_BUTTON_CLICKED => EVT_BUTTON(id,fn)
+        wxEVT_BUTTON => EVT_BUTTON(id,fn)
     Left double clicks sends
         wxEVT_COMMAND_TOGGLEBUTTON_CLICKED => EVT_TOGGLEBUTTON(id, fn)
 
@@ -42,13 +42,13 @@ wxCUSTBUT_TOG_DCLICK_BUT
     Left clicks sends
         wxEVT_COMMAND_TOGGLEBUTTON_CLICKED => EVT_TOGGLEBUTTON(id, fn)
     Left and Right double clicks and Right clicks send
-        wxEVT_COMMAND_BUTTON_CLICKED => EVT_BUTTON(id,fn)
+        wxEVT_BUTTON => EVT_BUTTON(id,fn)
 
 The event's wxCommandEvent::GetInt (IsChecked) is true (1) if the button is
     depressed, this is only useful for the wxToggleButton styles
 
 For both types of button when double-clicked it sends this event
-    wxEVT_COMMAND_BUTTON_CLICKED => EVT_BUTTON(id, fn)
+    wxEVT_BUTTON => EVT_BUTTON(id, fn)
     and the button state does not change. Only a single EVT_BUTTON event should
     be sent on double-click and event.GetExtraLong == wxEVT_XXX_DCLICK,
     if not then there's a bug.

--- a/apps/2d-slam-demo/CDlgParams.cpp
+++ b/apps/2d-slam-demo/CDlgParams.cpp
@@ -637,45 +637,36 @@ CDlgParams::CDlgParams(
 	FlexGridSizer1->SetSizeHints(this);
 	Center();
 
-	Connect(
-		ID_RADIOBUTTON1, wxEVT_COMMAND_RADIOBUTTON_SELECTED,
-		(wxObjectEventFunction)&CDlgParams::OnUpdateControlsState);
-	Connect(
-		ID_RADIOBUTTON2, wxEVT_COMMAND_RADIOBUTTON_SELECTED,
-		(wxObjectEventFunction)&CDlgParams::OnUpdateControlsState);
-	Connect(
-		ID_RADIOBUTTON3, wxEVT_COMMAND_RADIOBUTTON_SELECTED,
-		(wxObjectEventFunction)&CDlgParams::OnUpdateControlsState);
-	Connect(
-		ID_RADIOBUTTON4, wxEVT_COMMAND_RADIOBUTTON_SELECTED,
-		(wxObjectEventFunction)&CDlgParams::OnUpdateControlsState);
-	Connect(
-		ID_RADIOBOX3, wxEVT_COMMAND_RADIOBOX_SELECTED,
-		(wxObjectEventFunction)&CDlgParams::OnUpdateControlsState);
-	Connect(
-		ID_RADIOBOX1, wxEVT_COMMAND_RADIOBOX_SELECTED,
-		(wxObjectEventFunction)&CDlgParams::OnUpdateControlsState);
-	Connect(
-		ID_RADIOBUTTON5, wxEVT_COMMAND_RADIOBUTTON_SELECTED,
-		(wxObjectEventFunction)&CDlgParams::OnUpdateControlsState);
-	Connect(
-		ID_RADIOBUTTON6, wxEVT_COMMAND_RADIOBUTTON_SELECTED,
-		(wxObjectEventFunction)&CDlgParams::OnUpdateControlsState);
-	Connect(
-		ID_RADIOBUTTON7, wxEVT_COMMAND_RADIOBUTTON_SELECTED,
-		(wxObjectEventFunction)&CDlgParams::OnUpdateControlsState);
-	Connect(
-		ID_BUTTON3, wxEVT_COMMAND_BUTTON_CLICKED,
-		(wxObjectEventFunction)&CDlgParams::OnbtnBrowseClick);
-	Connect(
-		ID_CHECKBOX1, wxEVT_COMMAND_CHECKBOX_CLICKED,
-		(wxObjectEventFunction)&CDlgParams::OnUpdateControlsState);
-	Connect(
-		ID_BUTTON1, wxEVT_COMMAND_BUTTON_CLICKED,
-		(wxObjectEventFunction)&CDlgParams::OnbtnOkClick);
-	Connect(
-		ID_BUTTON2, wxEVT_COMMAND_BUTTON_CLICKED,
-		(wxObjectEventFunction)&CDlgParams::OnbtnCancelClick);
+	Bind(
+		wxEVT_RADIOBUTTON, &CDlgParams::OnUpdateControlsState, this,
+		ID_RADIOBUTTON1);
+	Bind(
+		wxEVT_RADIOBUTTON, &CDlgParams::OnUpdateControlsState, this,
+		ID_RADIOBUTTON2);
+	Bind(
+		wxEVT_RADIOBUTTON, &CDlgParams::OnUpdateControlsState, this,
+		ID_RADIOBUTTON3);
+	Bind(
+		wxEVT_RADIOBUTTON, &CDlgParams::OnUpdateControlsState, this,
+		ID_RADIOBUTTON4);
+	Bind(
+		wxEVT_RADIOBOX, &CDlgParams::OnUpdateControlsState, this, ID_RADIOBOX3);
+	Bind(
+		wxEVT_RADIOBOX, &CDlgParams::OnUpdateControlsState, this, ID_RADIOBOX1);
+	Bind(
+		wxEVT_RADIOBUTTON, &CDlgParams::OnUpdateControlsState, this,
+		ID_RADIOBUTTON5);
+	Bind(
+		wxEVT_RADIOBUTTON, &CDlgParams::OnUpdateControlsState, this,
+		ID_RADIOBUTTON6);
+	Bind(
+		wxEVT_RADIOBUTTON, &CDlgParams::OnUpdateControlsState, this,
+		ID_RADIOBUTTON7);
+	Bind(wxEVT_BUTTON, &CDlgParams::OnbtnBrowseClick, this, ID_BUTTON3);
+	Bind(
+		wxEVT_CHECKBOX, &CDlgParams::OnUpdateControlsState, this, ID_CHECKBOX1);
+	Bind(wxEVT_BUTTON, &CDlgParams::OnbtnOkClick, this, ID_BUTTON1);
+	Bind(wxEVT_BUTTON, &CDlgParams::OnbtnCancelClick, this, ID_BUTTON2);
 	//*)
 }
 

--- a/apps/2d-slam-demo/CLogView.cpp
+++ b/apps/2d-slam-demo/CLogView.cpp
@@ -63,9 +63,7 @@ CLogView::CLogView(
 	FlexGridSizer1->SetSizeHints(this);
 	Center();
 
-	Connect(
-		ID_BUTTON1, wxEVT_COMMAND_BUTTON_CLICKED,
-		(wxObjectEventFunction)&CLogView::OnbtnOkClick);
+	Bind(wxEVT_BUTTON, &CLogView::OnbtnOkClick, this, ID_BUTTON1);
 	//*)
 }
 

--- a/apps/2d-slam-demo/slamdemoMain.cpp
+++ b/apps/2d-slam-demo/slamdemoMain.cpp
@@ -767,72 +767,37 @@ slamdemoFrame::slamdemoFrame(wxWindow* parent, wxWindowID id)
 	FlexGridSizer1->Fit(this);
 	FlexGridSizer1->SetSizeHints(this);
 
-	Connect(
-		ID_MENUITEM1, wxEVT_COMMAND_MENU_SELECTED,
-		(wxObjectEventFunction)&slamdemoFrame::OnbtnResetClicked);
-	Connect(
-		ID_MENUITEM2, wxEVT_COMMAND_MENU_SELECTED,
-		(wxObjectEventFunction)&slamdemoFrame::OnbtnOneStepClicked);
-	Connect(
-		ID_MENUITEM3, wxEVT_COMMAND_MENU_SELECTED,
-		(wxObjectEventFunction)&slamdemoFrame::OnbtnRunClicked);
-	Connect(
-		ID_MENUITEM6, wxEVT_COMMAND_MENU_SELECTED,
-		(wxObjectEventFunction)&slamdemoFrame::OnbtnStopClicked);
-	Connect(
-		ID_MENUITEM4, wxEVT_COMMAND_MENU_SELECTED,
-		(wxObjectEventFunction)&slamdemoFrame::OnbtnRunBatchClicked);
-	Connect(
-		ID_MENUITEM5, wxEVT_COMMAND_MENU_SELECTED,
-		(wxObjectEventFunction)&slamdemoFrame::OnConfigClicked);
-	Connect(
-		idMenuQuit, wxEVT_COMMAND_MENU_SELECTED,
-		(wxObjectEventFunction)&slamdemoFrame::OnQuit);
-	Connect(
-		ID_MENUITEM8, wxEVT_COMMAND_MENU_SELECTED,
-		(wxObjectEventFunction)&slamdemoFrame::OnMenuSaveFilterState);
-	Connect(
-		ID_MENUITEM11, wxEVT_COMMAND_MENU_SELECTED,
-		(wxObjectEventFunction)&slamdemoFrame::OnmnuSaveLastDASelected);
-	Connect(
-		ID_MENUITEM_SAVE_RAWLOG, wxEVT_COMMAND_MENU_SELECTED,
-		(wxObjectEventFunction)&slamdemoFrame::OnmnuItemSaveRawlogSelected);
-	Connect(
-		ID_MENUITEM9, wxEVT_COMMAND_MENU_SELECTED,
-		(wxObjectEventFunction)&slamdemoFrame::OnMenuProfilerViewStats);
-	Connect(
-		ID_MENUITEM10, wxEVT_COMMAND_MENU_SELECTED,
-		(wxObjectEventFunction)&slamdemoFrame::OnMenuProfilerReset);
-	Connect(
-		idMenuAbout, wxEVT_COMMAND_MENU_SELECTED,
-		(wxObjectEventFunction)&slamdemoFrame::OnAbout);
-	Connect(
-		ID_TOOLBARITEM1, wxEVT_COMMAND_TOOL_CLICKED,
-		(wxObjectEventFunction)&slamdemoFrame::OnbtnResetClicked);
-	Connect(
-		ID_TOOLBARITEM2, wxEVT_COMMAND_TOOL_CLICKED,
-		(wxObjectEventFunction)&slamdemoFrame::OnbtnOneStepClicked);
-	Connect(
-		ID_BTNRUN, wxEVT_COMMAND_TOOL_CLICKED,
-		(wxObjectEventFunction)&slamdemoFrame::OnbtnRunClicked);
-	Connect(
-		ID_BTNSTOP, wxEVT_COMMAND_TOOL_CLICKED,
-		(wxObjectEventFunction)&slamdemoFrame::OnbtnStopClicked);
-	Connect(
-		ID_TOOLBARITEM4, wxEVT_COMMAND_TOOL_CLICKED,
-		(wxObjectEventFunction)&slamdemoFrame::OnbtnRunBatchClicked);
-	Connect(
-		ID_TOOLBARITEM3, wxEVT_COMMAND_TOOL_CLICKED,
-		(wxObjectEventFunction)&slamdemoFrame::OnConfigClicked);
-	Connect(
-		ID_TOOLBARITEM6, wxEVT_COMMAND_TOOL_CLICKED,
-		(wxObjectEventFunction)&slamdemoFrame::OnAbout);
-	Connect(
-		ID_TOOLBARITEM7, wxEVT_COMMAND_TOOL_CLICKED,
-		(wxObjectEventFunction)&slamdemoFrame::OnQuit);
-	Connect(
-		ID_TIMER1, wxEVT_TIMER,
-		(wxObjectEventFunction)&slamdemoFrame::OntimSimulTrigger);
+	Bind(wxEVT_MENU, &slamdemoFrame::OnbtnResetClicked, this, ID_MENUITEM1);
+	Bind(wxEVT_MENU, &slamdemoFrame::OnbtnOneStepClicked, this, ID_MENUITEM2);
+	Bind(wxEVT_MENU, &slamdemoFrame::OnbtnRunClicked, this, ID_MENUITEM3);
+	Bind(wxEVT_MENU, &slamdemoFrame::OnbtnStopClicked, this, ID_MENUITEM6);
+	Bind(wxEVT_MENU, &slamdemoFrame::OnbtnRunBatchClicked, this, ID_MENUITEM4);
+	Bind(wxEVT_MENU, &slamdemoFrame::OnConfigClicked, this, ID_MENUITEM5);
+	Bind(wxEVT_MENU, &slamdemoFrame::OnQuit, this, idMenuQuit);
+	Bind(wxEVT_MENU, &slamdemoFrame::OnMenuSaveFilterState, this, ID_MENUITEM8);
+	Bind(
+		wxEVT_MENU, &slamdemoFrame::OnmnuSaveLastDASelected, this,
+		ID_MENUITEM11);
+	Bind(
+		wxEVT_MENU, &slamdemoFrame::OnmnuItemSaveRawlogSelected, this,
+		ID_MENUITEM_SAVE_RAWLOG);
+	Bind(
+		wxEVT_MENU, &slamdemoFrame::OnMenuProfilerViewStats, this,
+		ID_MENUITEM9);
+	Bind(wxEVT_MENU, &slamdemoFrame::OnMenuProfilerReset, this, ID_MENUITEM10);
+	Bind(wxEVT_MENU, &slamdemoFrame::OnAbout, this, idMenuAbout);
+	Bind(wxEVT_TOOL, &slamdemoFrame::OnbtnResetClicked, this, ID_TOOLBARITEM1);
+	Bind(
+		wxEVT_TOOL, &slamdemoFrame::OnbtnOneStepClicked, this, ID_TOOLBARITEM2);
+	Bind(wxEVT_TOOL, &slamdemoFrame::OnbtnRunClicked, this, ID_BTNRUN);
+	Bind(wxEVT_TOOL, &slamdemoFrame::OnbtnStopClicked, this, ID_BTNSTOP);
+	Bind(
+		wxEVT_TOOL, &slamdemoFrame::OnbtnRunBatchClicked, this,
+		ID_TOOLBARITEM4);
+	Bind(wxEVT_TOOL, &slamdemoFrame::OnConfigClicked, this, ID_TOOLBARITEM3);
+	Bind(wxEVT_TOOL, &slamdemoFrame::OnAbout, this, ID_TOOLBARITEM6);
+	Bind(wxEVT_TOOL, &slamdemoFrame::OnQuit, this, ID_TOOLBARITEM7);
+	Bind(wxEVT_TIMER, &slamdemoFrame::OntimSimulTrigger, this, ID_TIMER1);
 	//*)
 
 	gridDA->SetSelectionMode(wxGrid::wxGridSelectCells);

--- a/apps/GridmapNavSimul/gridmapSimulMain.cpp
+++ b/apps/GridmapNavSimul/gridmapSimulMain.cpp
@@ -679,39 +679,22 @@ gridmapSimulFrame::gridmapSimulFrame(wxWindow* parent, wxWindowID id)
 	FlexGridSizer1->Fit(this);
 	FlexGridSizer1->SetSizeHints(this);
 
-	Connect(
-		ID_BUTTON5, wxEVT_COMMAND_BUTTON_CLICKED,
-		(wxObjectEventFunction)&gridmapSimulFrame::OnbtnSetLaserClick);
-	Connect(
-		ID_BUTTON4, wxEVT_COMMAND_BUTTON_CLICKED,
-		(wxObjectEventFunction)&gridmapSimulFrame::OnbtnResimulateClick);
-	Connect(
-		ID_BUTTON6, wxEVT_COMMAND_BUTTON_CLICKED,
-		(wxObjectEventFunction)&gridmapSimulFrame::OnbtnQuitClick);
-	Connect(
-		ID_BUTTON1, wxEVT_COMMAND_BUTTON_CLICKED,
-		(wxObjectEventFunction)&gridmapSimulFrame::OnbtnStartClick);
-	Connect(
-		ID_BUTTON2, wxEVT_COMMAND_BUTTON_CLICKED,
-		(wxObjectEventFunction)&gridmapSimulFrame::OnbtnEndClick);
-	Connect(
-		ID_BUTTON3, wxEVT_COMMAND_BUTTON_CLICKED,
-		(wxObjectEventFunction)&gridmapSimulFrame::OnbtnExploreClick);
-	Connect(
-		ID_TIMER1, wxEVT_TIMER,
-		(wxObjectEventFunction)&gridmapSimulFrame::OntimRunTrigger);
-	Connect(
-		ID_MENUITEM1, wxEVT_COMMAND_MENU_SELECTED,
-		(wxObjectEventFunction)&gridmapSimulFrame::OnbtnExploreClick);
-	Connect(
-		ID_MENUITEM_LOADMAP, wxEVT_COMMAND_MENU_SELECTED,
-		(wxObjectEventFunction)&gridmapSimulFrame::OnMenuLoadMap);
-	Connect(
-		ID_MENUITEM2, wxEVT_COMMAND_MENU_SELECTED,
-		(wxObjectEventFunction)&gridmapSimulFrame::OnbtnQuitClick);
-	Connect(
-		ID_MENUITEM3, wxEVT_COMMAND_MENU_SELECTED,
-		(wxObjectEventFunction)&gridmapSimulFrame::OnAbout);
+	Bind(
+		wxEVT_BUTTON, &gridmapSimulFrame::OnbtnSetLaserClick, this, ID_BUTTON5);
+	Bind(
+		wxEVT_BUTTON, &gridmapSimulFrame::OnbtnResimulateClick, this,
+		ID_BUTTON4);
+	Bind(wxEVT_BUTTON, &gridmapSimulFrame::OnbtnQuitClick, this, ID_BUTTON6);
+	Bind(wxEVT_BUTTON, &gridmapSimulFrame::OnbtnStartClick, this, ID_BUTTON1);
+	Bind(wxEVT_BUTTON, &gridmapSimulFrame::OnbtnEndClick, this, ID_BUTTON2);
+	Bind(wxEVT_BUTTON, &gridmapSimulFrame::OnbtnExploreClick, this, ID_BUTTON3);
+	Bind(wxEVT_TIMER, &gridmapSimulFrame::OntimRunTrigger, this, ID_TIMER1);
+	Bind(wxEVT_MENU, &gridmapSimulFrame::OnbtnExploreClick, this, ID_MENUITEM1);
+	Bind(
+		wxEVT_MENU, &gridmapSimulFrame::OnMenuLoadMap, this,
+		ID_MENUITEM_LOADMAP);
+	Bind(wxEVT_MENU, &gridmapSimulFrame::OnbtnQuitClick, this, ID_MENUITEM2);
+	Bind(wxEVT_MENU, &gridmapSimulFrame::OnAbout, this, ID_MENUITEM3);
 	//*)
 
 	// Import grid map:
@@ -765,9 +748,7 @@ gridmapSimulFrame::gridmapSimulFrame(wxWindow* parent, wxWindowID id)
 	gl_robot->insert(gl_scan);
 
 	// Redirect all keystrokes in this box to the gl canvas:
-	edInput->Connect(
-		wxEVT_CHAR, (wxObjectEventFunction)&CMyGLCanvas::OnCharCustom, nullptr,
-		m_canvas);
+	edInput->Bind(wxEVT_CHAR, &CMyGLCanvas::OnCharCustom, m_canvas);
 
 	// fix sizes:
 	SplitterWindow1->SetMinSize(wxSize(200, 200));

--- a/apps/RawLogViewer/CFormBatchSensorPose.cpp
+++ b/apps/RawLogViewer/CFormBatchSensorPose.cpp
@@ -130,15 +130,14 @@ CFormBatchSensorPose::CFormBatchSensorPose(wxWindow* parent, wxWindowID id)
 	FlexGridSizer1->SetSizeHints(this);
 	Center();
 
-	Connect(
-		ID_BITMAPBUTTON1, wxEVT_COMMAND_BUTTON_CLICKED,
-		(wxObjectEventFunction)&CFormBatchSensorPose::OnbtnOpenClick);
-	Connect(
-		ID_BUTTON1, wxEVT_COMMAND_BUTTON_CLICKED,
-		(wxObjectEventFunction)&CFormBatchSensorPose::OnbtnApplyClick);
-	Connect(
-		ID_BUTTON2, wxEVT_COMMAND_BUTTON_CLICKED,
-		(wxObjectEventFunction)&CFormBatchSensorPose::OnbtnCancelClick);
+	Bind(
+		wxEVT_BUTTON, &CFormBatchSensorPose::OnbtnOpenClick, this,
+		ID_BITMAPBUTTON1);
+	Bind(
+		wxEVT_BUTTON, &CFormBatchSensorPose::OnbtnApplyClick, this, ID_BUTTON1);
+	Bind(
+		wxEVT_BUTTON, &CFormBatchSensorPose::OnbtnCancelClick, this,
+		ID_BUTTON2);
 	//*)
 }
 

--- a/apps/RawLogViewer/CFormChangeSensorPositions.cpp
+++ b/apps/RawLogViewer/CFormChangeSensorPositions.cpp
@@ -620,43 +620,38 @@ CFormChangeSensorPositions::CFormChangeSensorPositions(
 	FlexGridSizer1->SetSizeHints(this);
 	Center();
 
-	Connect(
-		ID_RADIOBUTTON1, wxEVT_COMMAND_RADIOBUTTON_SELECTED,
-		(wxObjectEventFunction)&CFormChangeSensorPositions::OnrbLoadedSelect);
-	Connect(
-		ID_RADIOBUTTON2, wxEVT_COMMAND_RADIOBUTTON_SELECTED,
-		(wxObjectEventFunction)&CFormChangeSensorPositions::OnrbFileSelect);
-	Connect(
-		ID_BUTTON9, wxEVT_COMMAND_BUTTON_CLICKED,
-		(wxObjectEventFunction)&CFormChangeSensorPositions::
-			OnbtnPickInputClick);
-	Connect(
-		ID_BUTTON11, wxEVT_COMMAND_BUTTON_CLICKED,
-		(wxObjectEventFunction)&CFormChangeSensorPositions::OnbtnPickOutClick);
-	Connect(
-		ID_RADIOBOX1, wxEVT_COMMAND_RADIOBOX_SELECTED,
-		(wxObjectEventFunction)&CFormChangeSensorPositions::OnrbApplySelect);
-	Connect(
-		ID_BUTTON3, wxEVT_COMMAND_BUTTON_CLICKED,
-		(wxObjectEventFunction)&CFormChangeSensorPositions::
-			OnbtnGetCurPoseClick1);
-	Connect(
-		ID_BUTTON1, wxEVT_COMMAND_BUTTON_CLICKED,
-		(wxObjectEventFunction)&CFormChangeSensorPositions::OnbtnOKClick);
-	Connect(
-		ID_BUTTON4, wxEVT_COMMAND_BUTTON_CLICKED,
-		(wxObjectEventFunction)&CFormChangeSensorPositions::
-			OnbtnGetCurCamModelClick);
-	Connect(
-		ID_BUTTON5, wxEVT_COMMAND_BUTTON_CLICKED,
-		(wxObjectEventFunction)&CFormChangeSensorPositions::
-			OnbtnApplyCameraParamsClick);
-	Connect(
-		ID_BUTTON2, wxEVT_COMMAND_BUTTON_CLICKED,
-		(wxObjectEventFunction)&CFormChangeSensorPositions::OnbtnCancelClick);
-	Connect(
-		wxID_ANY, wxEVT_INIT_DIALOG,
-		(wxObjectEventFunction)&CFormChangeSensorPositions::OnInit);
+	Bind(
+		wxEVT_RADIOBUTTON, &CFormChangeSensorPositions::OnrbLoadedSelect, this,
+		ID_RADIOBUTTON1);
+	Bind(
+		wxEVT_RADIOBUTTON, &CFormChangeSensorPositions::OnrbFileSelect, this,
+		ID_RADIOBUTTON2);
+	Bind(
+		wxEVT_BUTTON, &CFormChangeSensorPositions::OnbtnPickInputClick, this,
+		ID_BUTTON9);
+	Bind(
+		wxEVT_BUTTON, &CFormChangeSensorPositions::OnbtnPickOutClick, this,
+		ID_BUTTON11);
+	Bind(
+		wxEVT_RADIOBOX, &CFormChangeSensorPositions::OnrbApplySelect, this,
+		ID_RADIOBOX1);
+	Bind(
+		wxEVT_BUTTON, &CFormChangeSensorPositions::OnbtnGetCurPoseClick1, this,
+		ID_BUTTON3);
+	Bind(
+		wxEVT_BUTTON, &CFormChangeSensorPositions::OnbtnOKClick, this,
+		ID_BUTTON1);
+	Bind(
+		wxEVT_BUTTON, &CFormChangeSensorPositions::OnbtnGetCurCamModelClick,
+		this, ID_BUTTON4);
+	Bind(
+		wxEVT_BUTTON, &CFormChangeSensorPositions::OnbtnApplyCameraParamsClick,
+		this, ID_BUTTON5);
+	Bind(
+		wxEVT_BUTTON, &CFormChangeSensorPositions::OnbtnCancelClick, this,
+		ID_BUTTON2);
+	Bind(
+		wxEVT_INIT_DIALOG, &CFormChangeSensorPositions::OnInit, this, wxID_ANY);
 	//*)
 }
 

--- a/apps/RawLogViewer/CFormEdit.cpp
+++ b/apps/RawLogViewer/CFormEdit.cpp
@@ -475,65 +475,38 @@ CFormEdit::CFormEdit(wxWindow* parent, wxWindowID id)
 	FlexGridSizer1->SetSizeHints(this);
 	Center();
 
-	Connect(
-		ID_RADIOBUTTON1, wxEVT_COMMAND_RADIOBUTTON_SELECTED,
-		(wxObjectEventFunction)&CFormEdit::OnrbLoadedSelect);
-	Connect(
-		ID_RADIOBUTTON2, wxEVT_COMMAND_RADIOBUTTON_SELECTED,
-		(wxObjectEventFunction)&CFormEdit::OnrbFileSelect);
-	Connect(
-		ID_BUTTON9, wxEVT_COMMAND_BUTTON_CLICKED,
-		(wxObjectEventFunction)&CFormEdit::OnbtnPickInputClick);
-	Connect(
-		ID_BUTTON11, wxEVT_COMMAND_BUTTON_CLICKED,
-		(wxObjectEventFunction)&CFormEdit::OnbtnPickOutClick);
-	Connect(
-		ID_SLIDER1, wxEVT_SCROLL_THUMBTRACK,
-		(wxObjectEventFunction)&CFormEdit::OnslFirstCmdScrollChanged);
-	Connect(
-		ID_SLIDER1, wxEVT_SCROLL_CHANGED,
-		(wxObjectEventFunction)&CFormEdit::OnslFirstCmdScrollChanged);
-	Connect(
-		ID_SLIDER2, wxEVT_SCROLL_THUMBTRACK,
-		(wxObjectEventFunction)&CFormEdit::OnslToCmdScrollChanged);
-	Connect(
-		ID_SLIDER2, wxEVT_SCROLL_CHANGED,
-		(wxObjectEventFunction)&CFormEdit::OnslToCmdScrollChanged);
-	Connect(
-		ID_BUTTON1, wxEVT_COMMAND_BUTTON_CLICKED,
-		(wxObjectEventFunction)&CFormEdit::OnbtnKeepClick);
-	Connect(
-		ID_BUTTON2, wxEVT_COMMAND_BUTTON_CLICKED,
-		(wxObjectEventFunction)&CFormEdit::OnbtnDeleteClick);
-	Connect(
-		ID_BUTTON4, wxEVT_COMMAND_BUTTON_CLICKED,
-		(wxObjectEventFunction)&CFormEdit::OnbtnDelObsIndxClick);
-	Connect(
-		ID_BUTTON5, wxEVT_COMMAND_BUTTON_CLICKED,
-		(wxObjectEventFunction)&CFormEdit::OnbtnRemActsIndxClick);
-	Connect(
-		ID_BUTTON7, wxEVT_COMMAND_BUTTON_CLICKED,
-		(wxObjectEventFunction)&CFormEdit::OnbtnRemoveObsClassClick);
-	Connect(
-		ID_BUTTON8, wxEVT_COMMAND_BUTTON_CLICKED,
-		(wxObjectEventFunction)&CFormEdit::OnbtnRemoveAllButByClassClick1);
-	Connect(
-		ID_BUTTON10, wxEVT_COMMAND_BUTTON_CLICKED,
-		(wxObjectEventFunction)&CFormEdit::OnRemoveByLabel);
-	Connect(
-		ID_BUTTON12, wxEVT_COMMAND_BUTTON_CLICKED,
-		(wxObjectEventFunction)&CFormEdit::OnRemoveButLabel);
-	Connect(
-		ID_BUTTON13, wxEVT_COMMAND_BUTTON_CLICKED,
-		(wxObjectEventFunction)&CFormEdit::OnbtnLeaveHorizScansClick);
-	Connect(
-		ID_BUTTON3, wxEVT_COMMAND_BUTTON_CLICKED,
-		(wxObjectEventFunction)&CFormEdit::OnbtnImgSwapClick);
-	Connect(
-		ID_BUTTON6, wxEVT_COMMAND_BUTTON_CLICKED,
-		(wxObjectEventFunction)&CFormEdit::OnbtnCloseClick);
-	Connect(
-		wxID_ANY, wxEVT_INIT_DIALOG, (wxObjectEventFunction)&CFormEdit::OnInit);
+	Bind(
+		wxEVT_RADIOBUTTON, &CFormEdit::OnrbLoadedSelect, this, ID_RADIOBUTTON1);
+	Bind(wxEVT_RADIOBUTTON, &CFormEdit::OnrbFileSelect, this, ID_RADIOBUTTON2);
+	Bind(wxEVT_BUTTON, &CFormEdit::OnbtnPickInputClick, this, ID_BUTTON9);
+	Bind(wxEVT_BUTTON, &CFormEdit::OnbtnPickOutClick, this, ID_BUTTON11);
+	Bind(
+		wxEVT_SCROLL_THUMBTRACK, &CFormEdit::OnslFirstCmdScrollChanged, this,
+		ID_SLIDER1);
+	Bind(
+		wxEVT_SCROLL_CHANGED, &CFormEdit::OnslFirstCmdScrollChanged, this,
+		ID_SLIDER1);
+	Bind(
+		wxEVT_SCROLL_THUMBTRACK, &CFormEdit::OnslToCmdScrollChanged, this,
+		ID_SLIDER2);
+	Bind(
+		wxEVT_SCROLL_CHANGED, &CFormEdit::OnslToCmdScrollChanged, this,
+		ID_SLIDER2);
+	Bind(wxEVT_BUTTON, &CFormEdit::OnbtnKeepClick, this, ID_BUTTON1);
+	Bind(wxEVT_BUTTON, &CFormEdit::OnbtnDeleteClick, this, ID_BUTTON2);
+	Bind(wxEVT_BUTTON, &CFormEdit::OnbtnDelObsIndxClick, this, ID_BUTTON4);
+	Bind(wxEVT_BUTTON, &CFormEdit::OnbtnRemActsIndxClick, this, ID_BUTTON5);
+	Bind(wxEVT_BUTTON, &CFormEdit::OnbtnRemoveObsClassClick, this, ID_BUTTON7);
+	Bind(
+		wxEVT_BUTTON, &CFormEdit::OnbtnRemoveAllButByClassClick1, this,
+		ID_BUTTON8);
+	Bind(wxEVT_BUTTON, &CFormEdit::OnRemoveByLabel, this, ID_BUTTON10);
+	Bind(wxEVT_BUTTON, &CFormEdit::OnRemoveButLabel, this, ID_BUTTON12);
+	Bind(
+		wxEVT_BUTTON, &CFormEdit::OnbtnLeaveHorizScansClick, this, ID_BUTTON13);
+	Bind(wxEVT_BUTTON, &CFormEdit::OnbtnImgSwapClick, this, ID_BUTTON3);
+	Bind(wxEVT_BUTTON, &CFormEdit::OnbtnCloseClick, this, ID_BUTTON6);
+	Bind(wxEVT_INIT_DIALOG, &CFormEdit::OnInit, this, wxID_ANY);
 	//*)
 }
 

--- a/apps/RawLogViewer/CFormMotionModel.cpp
+++ b/apps/RawLogViewer/CFormMotionModel.cpp
@@ -635,51 +635,36 @@ CFormMotionModel::CFormMotionModel(wxWindow* parent, wxWindowID id)
 	SetSizer(FlexGridSizer1);
 	Layout();
 
-	Connect(
-		ID_BUTTON1, wxEVT_COMMAND_BUTTON_CLICKED,
-		(wxObjectEventFunction)&CFormMotionModel::OnbtnOkClick);
-	Connect(
-		ID_BUTTON10, wxEVT_COMMAND_BUTTON_CLICKED,
-		(wxObjectEventFunction)&CFormMotionModel::OnbtnResetGaussClick);
-	Connect(
-		ID_BUTTON2, wxEVT_COMMAND_BUTTON_CLICKED,
-		(wxObjectEventFunction)&CFormMotionModel::OnbtnGaussOKClick);
-	Connect(
-		ID_BUTTON8, wxEVT_COMMAND_BUTTON_CLICKED,
-		(wxObjectEventFunction)&CFormMotionModel::OnbtnSimulateClick);
-	Connect(
-		ID_BUTTON11, wxEVT_COMMAND_BUTTON_CLICKED,
-		(wxObjectEventFunction)&CFormMotionModel::OnbtnResetThrunClick);
-	Connect(
-		ID_BUTTON3, wxEVT_COMMAND_BUTTON_CLICKED,
-		(wxObjectEventFunction)&CFormMotionModel::OnbtnThrunOkClick);
-	Connect(
-		ID_BUTTON9, wxEVT_COMMAND_BUTTON_CLICKED,
-		(wxObjectEventFunction)&CFormMotionModel::OnbtnSimulateThrunClick);
-	Connect(
-		ID_RADIOBUTTON1, wxEVT_COMMAND_RADIOBUTTON_SELECTED,
-		(wxObjectEventFunction)&CFormMotionModel::OnrbLoadedSelect);
-	Connect(
-		ID_BUTTON6, wxEVT_COMMAND_BUTTON_CLICKED,
-		(wxObjectEventFunction)&CFormMotionModel::OnbtnGetFromCurrentClick);
-	Connect(
-		ID_CHECKBOX1, wxEVT_COMMAND_CHECKBOX_CLICKED,
-		(wxObjectEventFunction)&CFormMotionModel::OncbAllClick);
-	Connect(
-		ID_RADIOBUTTON2, wxEVT_COMMAND_RADIOBUTTON_SELECTED,
-		(wxObjectEventFunction)&CFormMotionModel::OnrbFileSelect);
-	Connect(
-		ID_BUTTON4, wxEVT_COMMAND_BUTTON_CLICKED,
-		(wxObjectEventFunction)&CFormMotionModel::OnbtnPickInputClick);
-	Connect(
-		ID_BUTTON7, wxEVT_COMMAND_BUTTON_CLICKED,
-		(wxObjectEventFunction)&CFormMotionModel::OnbtnGetFromFileClick);
-	Connect(
-		ID_BUTTON5, wxEVT_COMMAND_BUTTON_CLICKED,
-		(wxObjectEventFunction)&CFormMotionModel::OnbtnPickOutClick);
-	Connect(
-		wxID_ANY, wxEVT_INIT_DIALOG,
-		(wxObjectEventFunction)&CFormMotionModel::OnInit);
+	Bind(wxEVT_BUTTON, &CFormMotionModel::OnbtnOkClick, this, ID_BUTTON1);
+	Bind(
+		wxEVT_BUTTON, &CFormMotionModel::OnbtnResetGaussClick, this,
+		ID_BUTTON10);
+	Bind(wxEVT_BUTTON, &CFormMotionModel::OnbtnGaussOKClick, this, ID_BUTTON2);
+	Bind(wxEVT_BUTTON, &CFormMotionModel::OnbtnSimulateClick, this, ID_BUTTON8);
+	Bind(
+		wxEVT_BUTTON, &CFormMotionModel::OnbtnResetThrunClick, this,
+		ID_BUTTON11);
+	Bind(wxEVT_BUTTON, &CFormMotionModel::OnbtnThrunOkClick, this, ID_BUTTON3);
+	Bind(
+		wxEVT_BUTTON, &CFormMotionModel::OnbtnSimulateThrunClick, this,
+		ID_BUTTON9);
+	Bind(
+		wxEVT_RADIOBUTTON, &CFormMotionModel::OnrbLoadedSelect, this,
+		ID_RADIOBUTTON1);
+	Bind(
+		wxEVT_BUTTON, &CFormMotionModel::OnbtnGetFromCurrentClick, this,
+		ID_BUTTON6);
+	Bind(wxEVT_CHECKBOX, &CFormMotionModel::OncbAllClick, this, ID_CHECKBOX1);
+	Bind(
+		wxEVT_RADIOBUTTON, &CFormMotionModel::OnrbFileSelect, this,
+		ID_RADIOBUTTON2);
+	Bind(
+		wxEVT_BUTTON, &CFormMotionModel::OnbtnPickInputClick, this, ID_BUTTON4);
+	Bind(
+		wxEVT_BUTTON, &CFormMotionModel::OnbtnGetFromFileClick, this,
+		ID_BUTTON7);
+	Bind(wxEVT_BUTTON, &CFormMotionModel::OnbtnPickOutClick, this, ID_BUTTON5);
+	Bind(wxEVT_INIT_DIALOG, &CFormMotionModel::OnInit, this, wxID_ANY);
 	//*)
 
 	// The graph:

--- a/apps/RawLogViewer/CFormPlayVideo.cpp
+++ b/apps/RawLogViewer/CFormPlayVideo.cpp
@@ -388,45 +388,35 @@ CFormPlayVideo::CFormPlayVideo(wxWindow* parent, wxWindowID id)
 	FlexGridSizer1->SetSizeHints(this);
 	Center();
 
-	Connect(
-		ID_RADIOBUTTON1, wxEVT_COMMAND_RADIOBUTTON_SELECTED,
-		(wxObjectEventFunction)&CFormPlayVideo::OnrbLoadedSelect);
-	Connect(
-		ID_RADIOBUTTON2, wxEVT_COMMAND_RADIOBUTTON_SELECTED,
-		(wxObjectEventFunction)&CFormPlayVideo::OnrbFileSelect);
-	Connect(
-		ID_BUTTON4, wxEVT_COMMAND_BUTTON_CLICKED,
-		(wxObjectEventFunction)&CFormPlayVideo::OnbtnPickClick);
-	Connect(
-		ID_COMBOBOX1, wxEVT_COMMAND_COMBOBOX_SELECTED,
-		(wxObjectEventFunction)&CFormPlayVideo::OncbImageDirsSelect);
-	Connect(
-		ID_BUTTON2, wxEVT_COMMAND_BUTTON_CLICKED,
-		(wxObjectEventFunction)&CFormPlayVideo::OnbtnPlayClick);
-	Connect(
-		ID_BUTTON3, wxEVT_COMMAND_BUTTON_CLICKED,
-		(wxObjectEventFunction)&CFormPlayVideo::OnbtnStopClick);
-	Connect(
-		ID_BUTTON5, wxEVT_COMMAND_BUTTON_CLICKED,
-		(wxObjectEventFunction)&CFormPlayVideo::OnbtnCloseClick);
-	Connect(
-		ID_SLIDER1, wxEVT_SCROLL_THUMBTRACK,
-		(wxObjectEventFunction)&CFormPlayVideo::OnprogressBarCmdScrollChanged);
-	Connect(
-		ID_SLIDER1, wxEVT_SCROLL_CHANGED,
-		(wxObjectEventFunction)&CFormPlayVideo::OnprogressBarCmdScrollChanged);
-	Connect(
-		ID_BITMAPBUTTON1, wxEVT_COMMAND_BUTTON_CLICKED,
-		(wxObjectEventFunction)&CFormPlayVideo::OnbtnSaveCam1Click);
-	Connect(
-		ID_BITMAPBUTTON2, wxEVT_COMMAND_BUTTON_CLICKED,
-		(wxObjectEventFunction)&CFormPlayVideo::OnbtnSaveCam2Click);
-	Connect(
-		ID_BITMAPBUTTON3, wxEVT_COMMAND_BUTTON_CLICKED,
-		(wxObjectEventFunction)&CFormPlayVideo::OnbtnSaveCam3Click);
-	Connect(
-		wxID_ANY, wxEVT_INIT_DIALOG,
-		(wxObjectEventFunction)&CFormPlayVideo::OnInit);
+	Bind(
+		wxEVT_RADIOBUTTON, &CFormPlayVideo::OnrbLoadedSelect, this,
+		ID_RADIOBUTTON1);
+	Bind(
+		wxEVT_RADIOBUTTON, &CFormPlayVideo::OnrbFileSelect, this,
+		ID_RADIOBUTTON2);
+	Bind(wxEVT_BUTTON, &CFormPlayVideo::OnbtnPickClick, this, ID_BUTTON4);
+	Bind(
+		wxEVT_COMBOBOX, &CFormPlayVideo::OncbImageDirsSelect, this,
+		ID_COMBOBOX1);
+	Bind(wxEVT_BUTTON, &CFormPlayVideo::OnbtnPlayClick, this, ID_BUTTON2);
+	Bind(wxEVT_BUTTON, &CFormPlayVideo::OnbtnStopClick, this, ID_BUTTON3);
+	Bind(wxEVT_BUTTON, &CFormPlayVideo::OnbtnCloseClick, this, ID_BUTTON5);
+	Bind(
+		wxEVT_SCROLL_THUMBTRACK, &CFormPlayVideo::OnprogressBarCmdScrollChanged,
+		this, ID_SLIDER1);
+	Bind(
+		wxEVT_SCROLL_CHANGED, &CFormPlayVideo::OnprogressBarCmdScrollChanged,
+		this, ID_SLIDER1);
+	Bind(
+		wxEVT_BUTTON, &CFormPlayVideo::OnbtnSaveCam1Click, this,
+		ID_BITMAPBUTTON1);
+	Bind(
+		wxEVT_BUTTON, &CFormPlayVideo::OnbtnSaveCam2Click, this,
+		ID_BITMAPBUTTON2);
+	Bind(
+		wxEVT_BUTTON, &CFormPlayVideo::OnbtnSaveCam3Click, this,
+		ID_BITMAPBUTTON3);
+	Bind(wxEVT_INIT_DIALOG, &CFormPlayVideo::OnInit, this, wxID_ANY);
 	//*)
 
 	WX_END_TRY

--- a/apps/RawLogViewer/CFormRawMap.cpp
+++ b/apps/RawLogViewer/CFormRawMap.cpp
@@ -392,51 +392,33 @@ CFormRawMap::CFormRawMap(wxWindow* parent, wxWindowID)
 	FlexGridSizer1->SetSizeHints(this);
 	Center();
 
-	Connect(
-		ID_SLIDER1, wxEVT_SCROLL_THUMBTRACK,
-		(wxObjectEventFunction)&CFormRawMap::OnslFromCmdScrollThumbTrack);
-	Connect(
-		ID_SLIDER1, wxEVT_SCROLL_CHANGED,
-		(wxObjectEventFunction)&CFormRawMap::OnslFromCmdScrollThumbTrack);
-	Connect(
-		ID_SLIDER2, wxEVT_SCROLL_THUMBTRACK,
-		(wxObjectEventFunction)&CFormRawMap::OnslToCmdScrollThumbTrack);
-	Connect(
-		ID_SLIDER2, wxEVT_SCROLL_CHANGED,
-		(wxObjectEventFunction)&CFormRawMap::OnslToCmdScrollThumbTrack);
-	Connect(
-		ID_SLIDER3, wxEVT_SCROLL_THUMBTRACK,
-		(wxObjectEventFunction)&CFormRawMap::OnslDecimateCmdScrollThumbTrack);
-	Connect(
-		ID_SLIDER3, wxEVT_SCROLL_CHANGED,
-		(wxObjectEventFunction)&CFormRawMap::OnslDecimateCmdScrollThumbTrack);
-	Connect(
-		ID_BUTTON2, wxEVT_COMMAND_BUTTON_CLICKED,
-		(wxObjectEventFunction)&CFormRawMap::OnbtnGenerateClick);
-	Connect(
-		ID_BUTTON6, wxEVT_COMMAND_BUTTON_CLICKED,
-		(wxObjectEventFunction)&CFormRawMap::OnGenerateFromRTK);
-	Connect(
-		ID_BUTTON5, wxEVT_COMMAND_BUTTON_CLICKED,
-		(wxObjectEventFunction)&CFormRawMap::OnbtnGeneratePathsClick);
-	Connect(
-		ID_BUTTON1, wxEVT_COMMAND_BUTTON_CLICKED,
-		(wxObjectEventFunction)&CFormRawMap::OnbtnSaveTxtClick);
-	Connect(
-		ID_BUTTON3, wxEVT_COMMAND_BUTTON_CLICKED,
-		(wxObjectEventFunction)&CFormRawMap::OnbtnSave3DClick);
-	Connect(
-		ID_BUTTON7, wxEVT_COMMAND_BUTTON_CLICKED,
-		(wxObjectEventFunction)&CFormRawMap::OnbtnSavePathClick);
-	Connect(
-		ID_BUTTON8, wxEVT_COMMAND_BUTTON_CLICKED,
-		(wxObjectEventFunction)&CFormRawMap::OnbtnSaveObsPathClick);
-	Connect(
-		ID_BUTTON9, wxEVT_COMMAND_BUTTON_CLICKED,
-		(wxObjectEventFunction)&CFormRawMap::OnbtnView3DClick);
-	Connect(
-		ID_BUTTON4, wxEVT_COMMAND_BUTTON_CLICKED,
-		(wxObjectEventFunction)&CFormRawMap::OnbtnCloseClick);
+	Bind(
+		wxEVT_SCROLL_THUMBTRACK, &CFormRawMap::OnslFromCmdScrollThumbTrack,
+		this, ID_SLIDER1);
+	Bind(
+		wxEVT_SCROLL_CHANGED, &CFormRawMap::OnslFromCmdScrollThumbTrack, this,
+		ID_SLIDER1);
+	Bind(
+		wxEVT_SCROLL_THUMBTRACK, &CFormRawMap::OnslToCmdScrollThumbTrack, this,
+		ID_SLIDER2);
+	Bind(
+		wxEVT_SCROLL_CHANGED, &CFormRawMap::OnslToCmdScrollThumbTrack, this,
+		ID_SLIDER2);
+	Bind(
+		wxEVT_SCROLL_THUMBTRACK, &CFormRawMap::OnslDecimateCmdScrollThumbTrack,
+		this, ID_SLIDER3);
+	Bind(
+		wxEVT_SCROLL_CHANGED, &CFormRawMap::OnslDecimateCmdScrollThumbTrack,
+		this, ID_SLIDER3);
+	Bind(wxEVT_BUTTON, &CFormRawMap::OnbtnGenerateClick, this, ID_BUTTON2);
+	Bind(wxEVT_BUTTON, &CFormRawMap::OnGenerateFromRTK, this, ID_BUTTON6);
+	Bind(wxEVT_BUTTON, &CFormRawMap::OnbtnGeneratePathsClick, this, ID_BUTTON5);
+	Bind(wxEVT_BUTTON, &CFormRawMap::OnbtnSaveTxtClick, this, ID_BUTTON1);
+	Bind(wxEVT_BUTTON, &CFormRawMap::OnbtnSave3DClick, this, ID_BUTTON3);
+	Bind(wxEVT_BUTTON, &CFormRawMap::OnbtnSavePathClick, this, ID_BUTTON7);
+	Bind(wxEVT_BUTTON, &CFormRawMap::OnbtnSaveObsPathClick, this, ID_BUTTON8);
+	Bind(wxEVT_BUTTON, &CFormRawMap::OnbtnView3DClick, this, ID_BUTTON9);
+	Bind(wxEVT_BUTTON, &CFormRawMap::OnbtnCloseClick, this, ID_BUTTON4);
 	//*)
 
 	Maximize();

--- a/apps/RawLogViewer/CIniEditor.cpp
+++ b/apps/RawLogViewer/CIniEditor.cpp
@@ -74,12 +74,8 @@ CIniEditor::CIniEditor(
 	FlexGridSizer1->SetSizeHints(this);
 	Center();
 
-	Connect(
-		ID_BUTTON1, wxEVT_COMMAND_BUTTON_CLICKED,
-		(wxObjectEventFunction)&CIniEditor::OnbtnOKClick);
-	Connect(
-		ID_BUTTON2, wxEVT_COMMAND_BUTTON_CLICKED,
-		(wxObjectEventFunction)&CIniEditor::OnbtnCancelClick);
+	Bind(wxEVT_BUTTON, &CIniEditor::OnbtnOKClick, this, ID_BUTTON1);
+	Bind(wxEVT_BUTTON, &CIniEditor::OnbtnCancelClick, this, ID_BUTTON2);
 	//*)
 }
 

--- a/apps/RawLogViewer/COdometryParams.cpp
+++ b/apps/RawLogViewer/COdometryParams.cpp
@@ -132,12 +132,8 @@ COdometryParams::COdometryParams(
 	FlexGridSizer1->SetSizeHints(this);
 	Center();
 
-	Connect(
-		ID_BUTTON1, wxEVT_COMMAND_BUTTON_CLICKED,
-		(wxObjectEventFunction)&COdometryParams::OnbtnOkClick);
-	Connect(
-		ID_BUTTON2, wxEVT_COMMAND_BUTTON_CLICKED,
-		(wxObjectEventFunction)&COdometryParams::OnbtnCancelClick);
+	Bind(wxEVT_BUTTON, &COdometryParams::OnbtnOkClick, this, ID_BUTTON1);
+	Bind(wxEVT_BUTTON, &COdometryParams::OnbtnCancelClick, this, ID_BUTTON2);
 	//*)
 }
 

--- a/apps/RawLogViewer/CScanAnimation.cpp
+++ b/apps/RawLogViewer/CScanAnimation.cpp
@@ -257,46 +257,27 @@ CScanAnimation::CScanAnimation(
 	FlexGridSizer1->SetSizeHints(this);
 	Center();
 
-	Connect(
-		ID_RADIOBUTTON1, wxEVT_COMMAND_RADIOBUTTON_SELECTED,
-		(wxObjectEventFunction)&CScanAnimation::OnrbLoadedSelect);
-	Connect(
-		ID_RADIOBUTTON2, wxEVT_COMMAND_RADIOBUTTON_SELECTED,
-		(wxObjectEventFunction)&CScanAnimation::OnrbFile);
-	Connect(
-		ID_BUTTON5, wxEVT_COMMAND_BUTTON_CLICKED,
-		(wxObjectEventFunction)&CScanAnimation::OnbtnPickInputClick);
-	Connect(
-		ID_BUTTON1, wxEVT_COMMAND_BUTTON_CLICKED,
-		(wxObjectEventFunction)&CScanAnimation::OnbtnPlayClick);
-	Connect(
-		ID_BUTTON2, wxEVT_COMMAND_BUTTON_CLICKED,
-		(wxObjectEventFunction)&CScanAnimation::OnbtnStopClick);
-	Connect(
-		ID_CHECKBOX1, wxEVT_COMMAND_CHECKBOX_CLICKED,
-		(wxObjectEventFunction)&CScanAnimation::OncbAllowMixClick);
-	Connect(
-		ID_BUTTON3, wxEVT_COMMAND_BUTTON_CLICKED,
-		(wxObjectEventFunction)&CScanAnimation::OnbtnCloseClick);
-	Connect(
-		ID_SLIDER1,
-		wxEVT_SCROLL_TOP | wxEVT_SCROLL_BOTTOM | wxEVT_SCROLL_LINEUP |
-			wxEVT_SCROLL_LINEDOWN | wxEVT_SCROLL_PAGEUP |
-			wxEVT_SCROLL_PAGEDOWN | wxEVT_SCROLL_THUMBTRACK |
-			wxEVT_SCROLL_THUMBRELEASE | wxEVT_SCROLL_CHANGED,
-		(wxObjectEventFunction)&CScanAnimation::OnslPosCmdScrollChanged);
-	Connect(
-		ID_SLIDER1, wxEVT_SCROLL_THUMBTRACK,
-		(wxObjectEventFunction)&CScanAnimation::OnslPosCmdScrollChanged);
-	Connect(
-		ID_SLIDER1, wxEVT_SCROLL_CHANGED,
-		(wxObjectEventFunction)&CScanAnimation::OnslPosCmdScrollChanged);
-	Connect(
-		ID_BUTTON4, wxEVT_COMMAND_BUTTON_CLICKED,
-		(wxObjectEventFunction)&CScanAnimation::OnbtnJumpClick);
-	Connect(
-		wxID_ANY, wxEVT_INIT_DIALOG,
-		(wxObjectEventFunction)&CScanAnimation::OnInit);
+	Bind(
+		wxEVT_RADIOBUTTON, &CScanAnimation::OnrbLoadedSelect, this,
+		ID_RADIOBUTTON1);
+	Bind(wxEVT_RADIOBUTTON, &CScanAnimation::OnrbFile, this, ID_RADIOBUTTON2);
+	Bind(wxEVT_BUTTON, &CScanAnimation::OnbtnPickInputClick, this, ID_BUTTON5);
+	Bind(wxEVT_BUTTON, &CScanAnimation::OnbtnPlayClick, this, ID_BUTTON1);
+	Bind(wxEVT_BUTTON, &CScanAnimation::OnbtnStopClick, this, ID_BUTTON2);
+	Bind(
+		wxEVT_CHECKBOX, &CScanAnimation::OncbAllowMixClick, this, ID_CHECKBOX1);
+	Bind(wxEVT_BUTTON, &CScanAnimation::OnbtnCloseClick, this, ID_BUTTON3);
+	Bind(
+		wxEVT_SLIDER, &CScanAnimation::OnslPosCmdScrollChanged, this,
+		ID_SLIDER1);
+	Bind(
+		wxEVT_SCROLL_THUMBTRACK, &CScanAnimation::OnslPosCmdScrollChanged, this,
+		ID_SLIDER1);
+	Bind(
+		wxEVT_SCROLL_CHANGED, &CScanAnimation::OnslPosCmdScrollChanged, this,
+		ID_SLIDER1);
+	Bind(wxEVT_BUTTON, &CScanAnimation::OnbtnJumpClick, this, ID_BUTTON4);
+	Bind(wxEVT_INIT_DIALOG, &CScanAnimation::OnInit, this, wxID_ANY);
 	//*)
 
 	// Initialize 3D view:
@@ -626,7 +607,7 @@ void CScanAnimation::OnbtnPlayClick(wxCommandEvent& event)
 
 void CScanAnimation::OnbtnStopClick(wxCommandEvent& event) { m_stop = true; }
 void CScanAnimation::OnbtnCloseClick(wxCommandEvent& event) { Close(); }
-void CScanAnimation::OnslPosCmdScrollChanged(wxScrollEvent& event)
+void CScanAnimation::OnslPosCmdScrollChanged(wxCommandEvent&)
 {
 	edIndex->SetValue(slPos->GetValue());
 	RebuildMaps();

--- a/apps/RawLogViewer/CScanAnimation.h
+++ b/apps/RawLogViewer/CScanAnimation.h
@@ -92,7 +92,7 @@ class CScanAnimation : public wxDialog
 	void OnbtnPlayClick(wxCommandEvent& event);
 	void OnbtnStopClick(wxCommandEvent& event);
 	void OnbtnCloseClick(wxCommandEvent& event);
-	void OnslPosCmdScrollChanged(wxScrollEvent& event);
+	void OnslPosCmdScrollChanged(wxCommandEvent& event);
 	void OnbtnJumpClick(wxCommandEvent& event);
 	void OnslPosCmdScroll(wxScrollEvent& event);
 	void OnbtnPickInputClick(wxCommandEvent& event);

--- a/apps/RawLogViewer/CScanMatching.cpp
+++ b/apps/RawLogViewer/CScanMatching.cpp
@@ -462,27 +462,19 @@ CScanMatching::CScanMatching(wxWindow* parent, wxWindowID)
 	FlexGridSizer1->SetSizeHints(this);
 	Center();
 
-	Connect(
-		ID_BITMAPBUTTON1, wxEVT_COMMAND_BUTTON_CLICKED,
-		(wxObjectEventFunction)&CScanMatching::OnbtnHelpClick);
-	Connect(
-		ID_RADIOBUTTON1, wxEVT_COMMAND_RADIOBUTTON_SELECTED,
-		(wxObjectEventFunction)&CScanMatching::OChangeSelectedMapType);
-	Connect(
-		ID_RADIOBUTTON2, wxEVT_COMMAND_RADIOBUTTON_SELECTED,
-		(wxObjectEventFunction)&CScanMatching::OChangeSelectedMapType);
-	Connect(
-		ID_NOTEBOOK1, wxEVT_COMMAND_NOTEBOOK_PAGE_CHANGING,
-		(wxObjectEventFunction)&CScanMatching::OnNotebook1PageChanging);
-	Connect(
-		ID_BUTTON1, wxEVT_COMMAND_BUTTON_CLICKED,
-		(wxObjectEventFunction)&CScanMatching::OnbtnICPClick);
-	Connect(
-		ID_CHECKBOX1, wxEVT_COMMAND_CHECKBOX_CLICKED,
-		(wxObjectEventFunction)&CScanMatching::OncbAnimateClick);
-	Connect(
-		ID_BUTTON2, wxEVT_COMMAND_BUTTON_CLICKED,
-		(wxObjectEventFunction)&CScanMatching::OnbtnCloseClick);
+	Bind(wxEVT_BUTTON, &CScanMatching::OnbtnHelpClick, this, ID_BITMAPBUTTON1);
+	Bind(
+		wxEVT_RADIOBUTTON, &CScanMatching::OChangeSelectedMapType, this,
+		ID_RADIOBUTTON1);
+	Bind(
+		wxEVT_RADIOBUTTON, &CScanMatching::OChangeSelectedMapType, this,
+		ID_RADIOBUTTON2);
+	Bind(
+		wxEVT_COMMAND_NOTEBOOK_PAGE_CHANGING,
+		&CScanMatching::OnNotebook1PageChanging, this, ID_NOTEBOOK1);
+	Bind(wxEVT_BUTTON, &CScanMatching::OnbtnICPClick, this, ID_BUTTON1);
+	Bind(wxEVT_CHECKBOX, &CScanMatching::OncbAnimateClick, this, ID_CHECKBOX1);
+	Bind(wxEVT_BUTTON, &CScanMatching::OnbtnCloseClick, this, ID_BUTTON2);
 	//*)
 
 	// Initialize 3D view:

--- a/apps/RawLogViewer/xRawLogViewerMain.cpp
+++ b/apps/RawLogViewer/xRawLogViewerMain.cpp
@@ -1434,298 +1434,213 @@ xRawLogViewerFrame::xRawLogViewerFrame(wxWindow* parent, wxWindowID id)
 	timAutoLoad.Start(50, true);
 	FlexGridSizer1->SetSizeHints(this);
 
-	Connect(
-		ID_BUTTON2, wxEVT_COMMAND_BUTTON_CLICKED,
-		(wxObjectEventFunction)&xRawLogViewerFrame::OnFileOpen);
-	Connect(
-		ID_BUTTON3, wxEVT_COMMAND_BUTTON_CLICKED,
-		(wxObjectEventFunction)&xRawLogViewerFrame::OnSaveFile);
-	Connect(
-		ID_BUTTON4, wxEVT_COMMAND_BUTTON_CLICKED,
-		(wxObjectEventFunction)&xRawLogViewerFrame::OnEditRawlog);
-	Connect(
-		ID_BUTTON5, wxEVT_COMMAND_BUTTON_CLICKED,
-		(wxObjectEventFunction)&xRawLogViewerFrame::OnRawMapOdo);
-	Connect(
-		ID_BUTTON6, wxEVT_COMMAND_BUTTON_CLICKED,
-		(wxObjectEventFunction)&xRawLogViewerFrame::OnChangeMotionModel);
-	Connect(
-		ID_BUTTON7, wxEVT_COMMAND_BUTTON_CLICKED,
-		(wxObjectEventFunction)&xRawLogViewerFrame::OnShowICP);
-	Connect(
-		ID_BUTTON8, wxEVT_COMMAND_BUTTON_CLICKED,
-		(wxObjectEventFunction)&xRawLogViewerFrame::OnShowAnimateScans);
-	Connect(
-		ID_BUTTON9, wxEVT_COMMAND_BUTTON_CLICKED,
-		(wxObjectEventFunction)&xRawLogViewerFrame::OnShowImagesAsVideo);
-	Connect(
-		ID_BUTTON10, wxEVT_COMMAND_BUTTON_CLICKED,
-		(wxObjectEventFunction)&xRawLogViewerFrame::OnAbout);
-	Connect(
-		ID_BUTTON11, wxEVT_COMMAND_BUTTON_CLICKED,
-		(wxObjectEventFunction)&xRawLogViewerFrame::OnQuit);
-	Connect(
-		ID_BUTTON1, wxEVT_COMMAND_BUTTON_CLICKED,
-		(wxObjectEventFunction)&xRawLogViewerFrame::OnbtnEditCommentsClick1);
-	Connect(
-		ID_SLIDER1,
-		wxEVT_SCROLL_TOP | wxEVT_SCROLL_BOTTOM | wxEVT_SCROLL_LINEUP |
-			wxEVT_SCROLL_LINEDOWN | wxEVT_SCROLL_PAGEUP |
-			wxEVT_SCROLL_PAGEDOWN | wxEVT_SCROLL_THUMBTRACK |
-			wxEVT_SCROLL_THUMBRELEASE | wxEVT_SCROLL_CHANGED,
-		(wxObjectEventFunction)&xRawLogViewerFrame::
-			Onslid3DcamConfCmdScrollChanged);
-	Connect(
-		ID_SLIDER1, wxEVT_SCROLL_THUMBTRACK,
-		(wxObjectEventFunction)&xRawLogViewerFrame::
-			Onslid3DcamConfCmdScrollChanged);
-	Connect(
-		ID_SLIDER1, wxEVT_SCROLL_CHANGED,
-		(wxObjectEventFunction)&xRawLogViewerFrame::
-			Onslid3DcamConfCmdScrollChanged);
-	Connect(
-		ID_NOTEBOOK1, wxEVT_COMMAND_NOTEBOOK_PAGE_CHANGING,
-		(wxObjectEventFunction)&xRawLogViewerFrame::OnNotebook1PageChanging);
-	Connect(
-		ID_MENUITEM1, wxEVT_COMMAND_MENU_SELECTED,
-		(wxObjectEventFunction)&xRawLogViewerFrame::OnFileOpen);
-	Connect(
-		ID_MENUITEM2, wxEVT_COMMAND_MENU_SELECTED,
-		(wxObjectEventFunction)&xRawLogViewerFrame::OnSaveFile);
-	Connect(
-		ID_MENUITEM76, wxEVT_COMMAND_MENU_SELECTED,
-		(wxObjectEventFunction)&xRawLogViewerFrame::OnMenuRevert);
-	Connect(
-		ID_MENUITEM7, wxEVT_COMMAND_MENU_SELECTED,
-		(wxObjectEventFunction)&xRawLogViewerFrame::OnLoadAPartOnly);
-	Connect(
-		ID_MENUITEM8, wxEVT_COMMAND_MENU_SELECTED,
-		(wxObjectEventFunction)&xRawLogViewerFrame::OnFileCountEntries);
-	Connect(
-		ID_MENUITEM10, wxEVT_COMMAND_MENU_SELECTED,
-		(wxObjectEventFunction)&xRawLogViewerFrame::OnFileSaveImages);
-	Connect(
-		ID_MENUITEM62, wxEVT_COMMAND_MENU_SELECTED,
-		(wxObjectEventFunction)&xRawLogViewerFrame::
-			OnMenuConvertExternallyStored);
-	Connect(
-		ID_MENUITEM64, wxEVT_COMMAND_MENU_SELECTED,
-		(wxObjectEventFunction)&xRawLogViewerFrame::
-			OnMenuConvertObservationOnly);
-	Connect(
-		ID_MENUITEM13, wxEVT_COMMAND_MENU_SELECTED,
-		(wxObjectEventFunction)&xRawLogViewerFrame::
-			OnFileGenVisualLMFromStereoImages);
-	Connect(
-		ID_MENUITEM60, wxEVT_COMMAND_MENU_SELECTED,
-		(wxObjectEventFunction)&xRawLogViewerFrame::OnMenuLossLessDecFILE);
-	Connect(
-		ID_MENUITEM61, wxEVT_COMMAND_MENU_SELECTED,
-		(wxObjectEventFunction)&xRawLogViewerFrame::OnMenCompactFILE);
-	Connect(
-		ID_MENUITEM5, wxEVT_COMMAND_MENU_SELECTED,
-		(wxObjectEventFunction)&xRawLogViewerFrame::OnImportCARMEN);
-	Connect(
-		ID_MENUITEM47, wxEVT_COMMAND_MENU_SELECTED,
-		(wxObjectEventFunction)&xRawLogViewerFrame::OnImportSequenceOfImages);
-	Connect(
-		ID_MENUITEM56, wxEVT_COMMAND_MENU_SELECTED,
-		(wxObjectEventFunction)&xRawLogViewerFrame::OnMenuImportALOG);
-	Connect(
-		ID_MENUITEM63, wxEVT_COMMAND_MENU_SELECTED,
-		(wxObjectEventFunction)&xRawLogViewerFrame::OnImportRTL);
-	Connect(
-		ID_MENUITEM87, wxEVT_COMMAND_MENU_SELECTED,
-		(wxObjectEventFunction)&xRawLogViewerFrame::
-			OnMenuItemImportBremenDLRLog);
-	Connect(
-		ID_MENUITEM58, wxEVT_COMMAND_MENU_SELECTED,
-		(wxObjectEventFunction)&xRawLogViewerFrame::OnGenOdoLaser);
-	Connect(
-		ID_MENUITEM55, wxEVT_COMMAND_MENU_SELECTED,
-		(wxObjectEventFunction)&xRawLogViewerFrame::OnMenuExportALOG);
-	Connect(
-		idMenuQuit, wxEVT_COMMAND_MENU_SELECTED,
-		(wxObjectEventFunction)&xRawLogViewerFrame::OnQuit);
-	Connect(
-		ID_MENUITEM14, wxEVT_COMMAND_MENU_SELECTED,
-		(wxObjectEventFunction)&xRawLogViewerFrame::OnEditRawlog);
-	Connect(
-		ID_MENUITEM51, wxEVT_COMMAND_MENU_SELECTED,
-		(wxObjectEventFunction)&xRawLogViewerFrame::OnMenuInsertComment);
-	Connect(
-		ID_MENUITEM69, wxEVT_COMMAND_MENU_SELECTED,
-		(wxObjectEventFunction)&xRawLogViewerFrame::OnMenuRenameSensor);
-	Connect(
-		ID_MENUITEM91, wxEVT_COMMAND_MENU_SELECTED,
-		(wxObjectEventFunction)&xRawLogViewerFrame::OnMenuRenameSingleObs);
-	Connect(
-		ID_MENUITEM15, wxEVT_COMMAND_MENU_SELECTED,
-		(wxObjectEventFunction)&xRawLogViewerFrame::OnChangeSensorPositions);
-	Connect(
-		ID_MENUITEM70, wxEVT_COMMAND_MENU_SELECTED,
-		(wxObjectEventFunction)&xRawLogViewerFrame::OnMenuChangePosesBatch);
-	Connect(
-		ID_MENUITEM16, wxEVT_COMMAND_MENU_SELECTED,
-		(wxObjectEventFunction)&xRawLogViewerFrame::OnDecimateRecords);
-	Connect(
-		ID_MENUITEM59, wxEVT_COMMAND_MENU_SELECTED,
-		(wxObjectEventFunction)&xRawLogViewerFrame::OnMenuLossLessDecimate);
-	Connect(
-		ID_MENUITEM57, wxEVT_COMMAND_MENU_SELECTED,
-		(wxObjectEventFunction)&xRawLogViewerFrame::OnMenuCompactRawlog);
-	Connect(
-		ID_MENUITEM75, wxEVT_COMMAND_MENU_SELECTED,
-		(wxObjectEventFunction)&xRawLogViewerFrame::OnMenuConvertSF);
-	Connect(
-		ID_MENUITEM67, wxEVT_COMMAND_MENU_SELECTED,
-		(wxObjectEventFunction)&xRawLogViewerFrame::OnMenuResortByTimestamp);
-	Connect(
-		ID_MENUITEM68, wxEVT_COMMAND_MENU_SELECTED,
-		(wxObjectEventFunction)&xRawLogViewerFrame::
-			OnMenuShiftTimestampsByLabel);
-	Connect(
-		ID_MENUITEM82, wxEVT_COMMAND_MENU_SELECTED,
-		(wxObjectEventFunction)&xRawLogViewerFrame::
-			OnMenuRegenerateTimestampBySF);
-	Connect(
-		ID_MENUITEM20, wxEVT_COMMAND_MENU_SELECTED,
-		(wxObjectEventFunction)&xRawLogViewerFrame::OnChangeMotionModel);
-	Connect(
-		ID_MENUITEM22, wxEVT_COMMAND_MENU_SELECTED,
-		(wxObjectEventFunction)&xRawLogViewerFrame::OnRecalculateActionsICP);
-	Connect(
-		ID_MENUITEM53, wxEVT_COMMAND_MENU_SELECTED,
-		(wxObjectEventFunction)&xRawLogViewerFrame::
-			OnMenuModifyICPActionsUncertainty);
-	Connect(
-		ID_MENUITEM23, wxEVT_COMMAND_MENU_SELECTED,
-		(wxObjectEventFunction)&xRawLogViewerFrame::OnRecomputeOdometry);
-	Connect(
-		ID_MENUITEM41, wxEVT_COMMAND_MENU_SELECTED,
-		(wxObjectEventFunction)&xRawLogViewerFrame::OnForceEncodersFalse);
-	Connect(
-		ID_MENUITEM84, wxEVT_COMMAND_MENU_SELECTED,
-		(wxObjectEventFunction)&xRawLogViewerFrame::
-			OnMenuRegenerateOdometryTimes);
-	Connect(
-		ID_MENUITEM17, wxEVT_COMMAND_MENU_SELECTED,
-		(wxObjectEventFunction)&xRawLogViewerFrame::OnShowICP);
-	Connect(
-		ID_MENUITEM44, wxEVT_COMMAND_MENU_SELECTED,
-		(wxObjectEventFunction)&xRawLogViewerFrame::OnShowAnimateScans);
-	Connect(
-		ID_MENUITEM19, wxEVT_COMMAND_MENU_SELECTED,
-		(wxObjectEventFunction)&xRawLogViewerFrame::OnCountBadScans);
-	Connect(
-		ID_MENUITEM25, wxEVT_COMMAND_MENU_SELECTED,
-		(wxObjectEventFunction)&xRawLogViewerFrame::OnFilterErroneousScans);
-	Connect(
-		ID_MENUITEM73, wxEVT_COMMAND_MENU_SELECTED,
-		(wxObjectEventFunction)&xRawLogViewerFrame::OnMenuMarkLaserScanInvalid);
-	Connect(
-		ID_MENUITEM74, wxEVT_COMMAND_MENU_SELECTED,
-		(wxObjectEventFunction)&xRawLogViewerFrame::OnMenuChangeMaxRangeLaser);
-	Connect(
-		ID_MENUITEM77, wxEVT_COMMAND_MENU_SELECTED,
-		(wxObjectEventFunction)&xRawLogViewerFrame::
-			OnMenuBatchLaserExclusionZones);
-	Connect(
-		ID_MENUITEM79, wxEVT_COMMAND_MENU_SELECTED,
-		(wxObjectEventFunction)&xRawLogViewerFrame::OnLaserFilterAngles);
-	Connect(
-		ID_MENUITEM86, wxEVT_COMMAND_MENU_SELECTED,
-		(wxObjectEventFunction)&xRawLogViewerFrame::
-			OnMenuItem3DObsRecoverParams);
-	Connect(
-		ID_MENUITEM29, wxEVT_COMMAND_MENU_SELECTED,
-		(wxObjectEventFunction)&xRawLogViewerFrame::OnGenerateSeqImgs);
-	Connect(
-		ID_MENUITEM9, wxEVT_COMMAND_MENU_SELECTED,
-		(wxObjectEventFunction)&xRawLogViewerFrame::OnShowImagesAsVideo);
-	Connect(
-		ID_MENUITEM71, wxEVT_COMMAND_MENU_SELECTED,
-		(wxObjectEventFunction)&xRawLogViewerFrame::OnMenuMono2Stereo);
-	Connect(
-		ID_MENUITEM72, wxEVT_COMMAND_MENU_SELECTED,
-		(wxObjectEventFunction)&xRawLogViewerFrame::OnMenuRectifyImages);
-	Connect(
-		ID_MENUITEM78, wxEVT_COMMAND_MENU_SELECTED,
-		(wxObjectEventFunction)&xRawLogViewerFrame::OnMenuRenameImageFiles);
-	Connect(
-		ID_MENUITEM83, wxEVT_COMMAND_MENU_SELECTED,
-		(wxObjectEventFunction)&xRawLogViewerFrame::OnmnuCreateAVISelected);
-	Connect(
-		ID_MENUITEM30, wxEVT_COMMAND_MENU_SELECTED,
-		(wxObjectEventFunction)&xRawLogViewerFrame::OnGenGasTxt);
-	Connect(
-		ID_MENUITEM24, wxEVT_COMMAND_MENU_SELECTED,
-		(wxObjectEventFunction)&xRawLogViewerFrame::OnFilterSpureousGas);
-	Connect(
-		ID_MENUITEM31, wxEVT_COMMAND_MENU_SELECTED,
-		(wxObjectEventFunction)&xRawLogViewerFrame::OnGenGPSTxt);
-	Connect(
-		ID_MENUITEM34, wxEVT_COMMAND_MENU_SELECTED,
-		(wxObjectEventFunction)&xRawLogViewerFrame::OnSummaryGPS);
-	Connect(
-		ID_MENUITEM65, wxEVT_COMMAND_MENU_SELECTED,
-		(wxObjectEventFunction)&xRawLogViewerFrame::OnMenuDistanceBtwGPSs);
-	Connect(
-		ID_MENUITEM66, wxEVT_COMMAND_MENU_SELECTED,
-		(wxObjectEventFunction)&xRawLogViewerFrame::
-			OnMenuRegenerateGPSTimestamps);
-	Connect(
-		ID_MENUITEM52, wxEVT_COMMAND_MENU_SELECTED,
-		(wxObjectEventFunction)&xRawLogViewerFrame::OnMenuDrawGPSPath);
-	Connect(
-		ID_MENUITEM80, wxEVT_COMMAND_MENU_SELECTED,
-		(wxObjectEventFunction)&xRawLogViewerFrame::OnMenuGPSDeleteNaN);
-	Connect(
-		ID_MENUITEM33, wxEVT_COMMAND_MENU_SELECTED,
-		(wxObjectEventFunction)&xRawLogViewerFrame::OnMenuGenerateBeaconList);
-	Connect(
-		ID_MENUITEM38, wxEVT_COMMAND_MENU_SELECTED,
-		(wxObjectEventFunction)&xRawLogViewerFrame::OnRemoveSpecificRangeMeas);
-	Connect(
-		ID_MENUITEM40, wxEVT_COMMAND_MENU_SELECTED,
-		(wxObjectEventFunction)&xRawLogViewerFrame::
-			OnGenerateTextFileRangeBearing);
-	Connect(
-		ID_MENUITEM81, wxEVT_COMMAND_MENU_SELECTED,
-		(wxObjectEventFunction)&xRawLogViewerFrame::OnMenuRangeBearFilterIDs);
-	Connect(
-		ID_MENUITEM46, wxEVT_COMMAND_MENU_SELECTED,
-		(wxObjectEventFunction)&xRawLogViewerFrame::OnRangeFinder1DGenTextFile);
-	Connect(
-		ID_MENUITEM43, wxEVT_COMMAND_MENU_SELECTED,
-		(wxObjectEventFunction)&xRawLogViewerFrame::OnGenerateIMUTextFile);
-	Connect(
-		ID_MENUITEM89, wxEVT_COMMAND_MENU_SELECTED,
-		(wxObjectEventFunction)&xRawLogViewerFrame::OnGenWifiTxt);
-	Connect(
-		ID_MENUITEM26, wxEVT_COMMAND_MENU_SELECTED,
-		(wxObjectEventFunction)&xRawLogViewerFrame::OnRawMapOdo);
-	Connect(
-		ID_MENUITEM32, wxEVT_COMMAND_MENU_SELECTED,
-		(wxObjectEventFunction)&xRawLogViewerFrame::OnGenOdoLaser);
-	Connect(
-		ID_MENUITEM27, wxEVT_COMMAND_MENU_SELECTED,
-		(wxObjectEventFunction)&xRawLogViewerFrame::OnMenuShowTips);
-	Connect(
-		idMenuAbout, wxEVT_COMMAND_MENU_SELECTED,
-		(wxObjectEventFunction)&xRawLogViewerFrame::OnAbout);
-	Connect(
-		MNU_1, wxEVT_COMMAND_MENU_SELECTED,
-		(wxObjectEventFunction)&xRawLogViewerFrame::OnMenuItem37Selected);
-	Connect(
-		ID_MENUITEM49, wxEVT_COMMAND_MENU_SELECTED,
-		(wxObjectEventFunction)&xRawLogViewerFrame::OnMenuItem46Selected);
-	Connect(
-		ID_MENUITEM50, wxEVT_COMMAND_MENU_SELECTED,
-		(wxObjectEventFunction)&xRawLogViewerFrame::OnMenuItem47Selected);
-	Connect(
-		ID_TIMER1, wxEVT_TIMER,
-		(wxObjectEventFunction)&xRawLogViewerFrame::OntimAutoLoadTrigger);
+	Bind(wxEVT_BUTTON, &xRawLogViewerFrame::OnFileOpen, this, ID_BUTTON2);
+	Bind(wxEVT_BUTTON, &xRawLogViewerFrame::OnSaveFile, this, ID_BUTTON3);
+	Bind(wxEVT_BUTTON, &xRawLogViewerFrame::OnEditRawlog, this, ID_BUTTON4);
+	Bind(wxEVT_BUTTON, &xRawLogViewerFrame::OnRawMapOdo, this, ID_BUTTON5);
+	Bind(
+		wxEVT_BUTTON, &xRawLogViewerFrame::OnChangeMotionModel, this,
+		ID_BUTTON6);
+	Bind(wxEVT_BUTTON, &xRawLogViewerFrame::OnShowICP, this, ID_BUTTON7);
+	Bind(
+		wxEVT_BUTTON, &xRawLogViewerFrame::OnShowAnimateScans, this,
+		ID_BUTTON8);
+	Bind(
+		wxEVT_BUTTON, &xRawLogViewerFrame::OnShowImagesAsVideo, this,
+		ID_BUTTON9);
+	Bind(wxEVT_BUTTON, &xRawLogViewerFrame::OnAbout, this, ID_BUTTON10);
+	Bind(wxEVT_BUTTON, &xRawLogViewerFrame::OnQuit, this, ID_BUTTON11);
+	Bind(
+		wxEVT_BUTTON, &xRawLogViewerFrame::OnbtnEditCommentsClick1, this,
+		ID_BUTTON1);
+	Bind(
+		wxEVT_SLIDER, &xRawLogViewerFrame::Onslid3DcamConfCmdScrollChanged,
+		this, ID_SLIDER1);
+	Bind(
+		wxEVT_COMMAND_NOTEBOOK_PAGE_CHANGING,
+		&xRawLogViewerFrame::OnNotebook1PageChanging, this, ID_NOTEBOOK1);
+	Bind(wxEVT_MENU, &xRawLogViewerFrame::OnFileOpen, this, ID_MENUITEM1);
+	Bind(wxEVT_MENU, &xRawLogViewerFrame::OnSaveFile, this, ID_MENUITEM2);
+	Bind(wxEVT_MENU, &xRawLogViewerFrame::OnMenuRevert, this, ID_MENUITEM76);
+	Bind(wxEVT_MENU, &xRawLogViewerFrame::OnLoadAPartOnly, this, ID_MENUITEM7);
+	Bind(
+		wxEVT_MENU, &xRawLogViewerFrame::OnFileCountEntries, this,
+		ID_MENUITEM8);
+	Bind(
+		wxEVT_MENU, &xRawLogViewerFrame::OnFileSaveImages, this, ID_MENUITEM10);
+	Bind(
+		wxEVT_MENU, &xRawLogViewerFrame::OnMenuConvertExternallyStored, this,
+		ID_MENUITEM62);
+	Bind(
+		wxEVT_MENU, &xRawLogViewerFrame::OnMenuConvertObservationOnly, this,
+		ID_MENUITEM64);
+	Bind(
+		wxEVT_MENU, &xRawLogViewerFrame::OnFileGenVisualLMFromStereoImages,
+		this, ID_MENUITEM13);
+	Bind(
+		wxEVT_MENU, &xRawLogViewerFrame::OnMenuLossLessDecFILE, this,
+		ID_MENUITEM60);
+	Bind(
+		wxEVT_MENU, &xRawLogViewerFrame::OnMenCompactFILE, this, ID_MENUITEM61);
+	Bind(wxEVT_MENU, &xRawLogViewerFrame::OnImportCARMEN, this, ID_MENUITEM5);
+	Bind(
+		wxEVT_MENU, &xRawLogViewerFrame::OnImportSequenceOfImages, this,
+		ID_MENUITEM47);
+	Bind(
+		wxEVT_MENU, &xRawLogViewerFrame::OnMenuImportALOG, this, ID_MENUITEM56);
+	Bind(wxEVT_MENU, &xRawLogViewerFrame::OnImportRTL, this, ID_MENUITEM63);
+	Bind(
+		wxEVT_MENU, &xRawLogViewerFrame::OnMenuItemImportBremenDLRLog, this,
+		ID_MENUITEM87);
+	Bind(wxEVT_MENU, &xRawLogViewerFrame::OnGenOdoLaser, this, ID_MENUITEM58);
+	Bind(
+		wxEVT_MENU, &xRawLogViewerFrame::OnMenuExportALOG, this, ID_MENUITEM55);
+	Bind(wxEVT_MENU, &xRawLogViewerFrame::OnQuit, this, idMenuQuit);
+	Bind(wxEVT_MENU, &xRawLogViewerFrame::OnEditRawlog, this, ID_MENUITEM14);
+	Bind(
+		wxEVT_MENU, &xRawLogViewerFrame::OnMenuInsertComment, this,
+		ID_MENUITEM51);
+	Bind(
+		wxEVT_MENU, &xRawLogViewerFrame::OnMenuRenameSensor, this,
+		ID_MENUITEM69);
+	Bind(
+		wxEVT_MENU, &xRawLogViewerFrame::OnMenuRenameSingleObs, this,
+		ID_MENUITEM91);
+	Bind(
+		wxEVT_MENU, &xRawLogViewerFrame::OnChangeSensorPositions, this,
+		ID_MENUITEM15);
+	Bind(
+		wxEVT_MENU, &xRawLogViewerFrame::OnMenuChangePosesBatch, this,
+		ID_MENUITEM70);
+	Bind(
+		wxEVT_MENU, &xRawLogViewerFrame::OnDecimateRecords, this,
+		ID_MENUITEM16);
+	Bind(
+		wxEVT_MENU, &xRawLogViewerFrame::OnMenuLossLessDecimate, this,
+		ID_MENUITEM59);
+	Bind(
+		wxEVT_MENU, &xRawLogViewerFrame::OnMenuCompactRawlog, this,
+		ID_MENUITEM57);
+	Bind(wxEVT_MENU, &xRawLogViewerFrame::OnMenuConvertSF, this, ID_MENUITEM75);
+	Bind(
+		wxEVT_MENU, &xRawLogViewerFrame::OnMenuResortByTimestamp, this,
+		ID_MENUITEM67);
+	Bind(
+		wxEVT_MENU, &xRawLogViewerFrame::OnMenuShiftTimestampsByLabel, this,
+		ID_MENUITEM68);
+	Bind(
+		wxEVT_MENU, &xRawLogViewerFrame::OnMenuRegenerateTimestampBySF, this,
+		ID_MENUITEM82);
+	Bind(
+		wxEVT_MENU, &xRawLogViewerFrame::OnChangeMotionModel, this,
+		ID_MENUITEM20);
+	Bind(
+		wxEVT_MENU, &xRawLogViewerFrame::OnRecalculateActionsICP, this,
+		ID_MENUITEM22);
+	Bind(
+		wxEVT_MENU, &xRawLogViewerFrame::OnMenuModifyICPActionsUncertainty,
+		this, ID_MENUITEM53);
+	Bind(
+		wxEVT_MENU, &xRawLogViewerFrame::OnRecomputeOdometry, this,
+		ID_MENUITEM23);
+	Bind(
+		wxEVT_MENU, &xRawLogViewerFrame::OnForceEncodersFalse, this,
+		ID_MENUITEM41);
+	Bind(
+		wxEVT_MENU, &xRawLogViewerFrame::OnMenuRegenerateOdometryTimes, this,
+		ID_MENUITEM84);
+	Bind(wxEVT_MENU, &xRawLogViewerFrame::OnShowICP, this, ID_MENUITEM17);
+	Bind(
+		wxEVT_MENU, &xRawLogViewerFrame::OnShowAnimateScans, this,
+		ID_MENUITEM44);
+	Bind(wxEVT_MENU, &xRawLogViewerFrame::OnCountBadScans, this, ID_MENUITEM19);
+	Bind(
+		wxEVT_MENU, &xRawLogViewerFrame::OnFilterErroneousScans, this,
+		ID_MENUITEM25);
+	Bind(
+		wxEVT_MENU, &xRawLogViewerFrame::OnMenuMarkLaserScanInvalid, this,
+		ID_MENUITEM73);
+	Bind(
+		wxEVT_MENU, &xRawLogViewerFrame::OnMenuChangeMaxRangeLaser, this,
+		ID_MENUITEM74);
+	Bind(
+		wxEVT_MENU, &xRawLogViewerFrame::OnMenuBatchLaserExclusionZones, this,
+		ID_MENUITEM77);
+	Bind(
+		wxEVT_MENU, &xRawLogViewerFrame::OnLaserFilterAngles, this,
+		ID_MENUITEM79);
+	Bind(
+		wxEVT_MENU, &xRawLogViewerFrame::OnMenuItem3DObsRecoverParams, this,
+		ID_MENUITEM86);
+	Bind(
+		wxEVT_MENU, &xRawLogViewerFrame::OnGenerateSeqImgs, this,
+		ID_MENUITEM29);
+	Bind(
+		wxEVT_MENU, &xRawLogViewerFrame::OnShowImagesAsVideo, this,
+		ID_MENUITEM9);
+	Bind(
+		wxEVT_MENU, &xRawLogViewerFrame::OnMenuMono2Stereo, this,
+		ID_MENUITEM71);
+	Bind(
+		wxEVT_MENU, &xRawLogViewerFrame::OnMenuRectifyImages, this,
+		ID_MENUITEM72);
+	Bind(
+		wxEVT_MENU, &xRawLogViewerFrame::OnMenuRenameImageFiles, this,
+		ID_MENUITEM78);
+	Bind(
+		wxEVT_MENU, &xRawLogViewerFrame::OnmnuCreateAVISelected, this,
+		ID_MENUITEM83);
+	Bind(wxEVT_MENU, &xRawLogViewerFrame::OnGenGasTxt, this, ID_MENUITEM30);
+	Bind(
+		wxEVT_MENU, &xRawLogViewerFrame::OnFilterSpureousGas, this,
+		ID_MENUITEM24);
+	Bind(wxEVT_MENU, &xRawLogViewerFrame::OnGenGPSTxt, this, ID_MENUITEM31);
+	Bind(wxEVT_MENU, &xRawLogViewerFrame::OnSummaryGPS, this, ID_MENUITEM34);
+	Bind(
+		wxEVT_MENU, &xRawLogViewerFrame::OnMenuDistanceBtwGPSs, this,
+		ID_MENUITEM65);
+	Bind(
+		wxEVT_MENU, &xRawLogViewerFrame::OnMenuRegenerateGPSTimestamps, this,
+		ID_MENUITEM66);
+	Bind(
+		wxEVT_MENU, &xRawLogViewerFrame::OnMenuDrawGPSPath, this,
+		ID_MENUITEM52);
+	Bind(
+		wxEVT_MENU, &xRawLogViewerFrame::OnMenuGPSDeleteNaN, this,
+		ID_MENUITEM80);
+	Bind(
+		wxEVT_MENU, &xRawLogViewerFrame::OnMenuGenerateBeaconList, this,
+		ID_MENUITEM33);
+	Bind(
+		wxEVT_MENU, &xRawLogViewerFrame::OnRemoveSpecificRangeMeas, this,
+		ID_MENUITEM38);
+	Bind(
+		wxEVT_MENU, &xRawLogViewerFrame::OnGenerateTextFileRangeBearing, this,
+		ID_MENUITEM40);
+	Bind(
+		wxEVT_MENU, &xRawLogViewerFrame::OnMenuRangeBearFilterIDs, this,
+		ID_MENUITEM81);
+	Bind(
+		wxEVT_MENU, &xRawLogViewerFrame::OnRangeFinder1DGenTextFile, this,
+		ID_MENUITEM46);
+	Bind(
+		wxEVT_MENU, &xRawLogViewerFrame::OnGenerateIMUTextFile, this,
+		ID_MENUITEM43);
+	Bind(wxEVT_MENU, &xRawLogViewerFrame::OnGenWifiTxt, this, ID_MENUITEM89);
+	Bind(wxEVT_MENU, &xRawLogViewerFrame::OnRawMapOdo, this, ID_MENUITEM26);
+	Bind(wxEVT_MENU, &xRawLogViewerFrame::OnGenOdoLaser, this, ID_MENUITEM32);
+	Bind(wxEVT_MENU, &xRawLogViewerFrame::OnMenuShowTips, this, ID_MENUITEM27);
+	Bind(wxEVT_MENU, &xRawLogViewerFrame::OnAbout, this, idMenuAbout);
+	Bind(wxEVT_MENU, &xRawLogViewerFrame::OnMenuItem37Selected, this, MNU_1);
+	Bind(
+		wxEVT_MENU, &xRawLogViewerFrame::OnMenuItem46Selected, this,
+		ID_MENUITEM49);
+	Bind(
+		wxEVT_MENU, &xRawLogViewerFrame::OnMenuItem47Selected, this,
+		ID_MENUITEM50);
+	Bind(
+		wxEVT_TIMER, &xRawLogViewerFrame::OntimAutoLoadTrigger, this,
+		ID_TIMER1);
 	//*)
 
 	// "Manually" added code:
@@ -1812,9 +1727,9 @@ xRawLogViewerFrame::xRawLogViewerFrame(wxWindow* parent, wxWindowID id)
 
 	// Image directory selector on the toolbar:
 	// --------------------------------------------
-	Connect(
-		ID_COMBO_IMG_DIRS, wxEVT_COMMAND_COMBOBOX_SELECTED,
-		(wxObjectEventFunction)&xRawLogViewerFrame::OnComboImageDirsChange);
+	Bind(
+		wxEVT_COMBOBOX, &xRawLogViewerFrame::OnComboImageDirsChange, this,
+		ID_COMBO_IMG_DIRS);
 
 	// Construction of "global" dialog variables:
 	// ----------------------------------------------
@@ -6499,7 +6414,7 @@ void xRawLogViewerFrame::OnMenuItem3DObsRecoverParams(wxCommandEvent& event)
 	WX_END_TRY
 }
 
-void xRawLogViewerFrame::Onslid3DcamConfCmdScrollChanged(wxScrollEvent& event)
+void xRawLogViewerFrame::Onslid3DcamConfCmdScrollChanged(wxCommandEvent&)
 {
 	// Refresh:
 	SelectObjectInTreeView(curSelectedObject);

--- a/apps/RawLogViewer/xRawLogViewerMain.h
+++ b/apps/RawLogViewer/xRawLogViewerMain.h
@@ -246,7 +246,7 @@ class xRawLogViewerFrame : public wxFrame
 	void OnmnuCreateAVISelected(wxCommandEvent& event);
 	void OnMenuRegenerateOdometryTimes(wxCommandEvent& event);
 	void OnMenuItem3DObsRecoverParams(wxCommandEvent& event);
-	void Onslid3DcamConfCmdScrollChanged(wxScrollEvent& event);
+	void Onslid3DcamConfCmdScrollChanged(wxCommandEvent&);
 	void OnMenuItemImportBremenDLRLog(wxCommandEvent& event);
 	void OnMenuRenameSingleObs(wxCommandEvent& event);
 	//*)

--- a/apps/ReactiveNavigationDemo/reactive_navigator_demoMain.cpp
+++ b/apps/ReactiveNavigationDemo/reactive_navigator_demoMain.cpp
@@ -813,92 +813,35 @@ reactive_navigator_demoframe::reactive_navigator_demoframe(
 	FlexGridSizer1->SetSizeHints(this);
 	Center();
 
-	Connect(
-		ID_BUTTON4, wxEVT_COMMAND_BUTTON_CLICKED,
-		(wxObjectEventFunction)&reactive_navigator_demoframe::OnbtnStartClick);
-	Connect(
-		ID_BUTTON5, wxEVT_COMMAND_BUTTON_CLICKED,
-		(wxObjectEventFunction)&reactive_navigator_demoframe::OnbtnStopClick);
-	Connect(
-		ID_BUTTON7, wxEVT_COMMAND_BUTTON_CLICKED,
-		(wxObjectEventFunction)&reactive_navigator_demoframe::
-			OnbtnPlaceTargetClick);
-	Connect(
-		ID_BUTTON12, wxEVT_COMMAND_BUTTON_CLICKED,
-		(wxObjectEventFunction)&reactive_navigator_demoframe::
-			OnbtnSetWaypointSeqClick);
-	Connect(
-		ID_BUTTON6, wxEVT_COMMAND_BUTTON_CLICKED,
-		(wxObjectEventFunction)&reactive_navigator_demoframe::
-			OnbtnPlaceRobotClick);
-	Connect(
-		ID_BUTTON8, wxEVT_COMMAND_BUTTON_CLICKED,
-		(wxObjectEventFunction)&reactive_navigator_demoframe::
-			OnbtnDrawMapObsClick);
-	Connect(
-		ID_BUTTON11, wxEVT_COMMAND_BUTTON_CLICKED,
-		(wxObjectEventFunction)&reactive_navigator_demoframe::
-			OnbtnDrawEmptyClick);
-	Connect(
-		ID_BUTTON1, wxEVT_COMMAND_BUTTON_CLICKED,
-		(wxObjectEventFunction)&reactive_navigator_demoframe::
-			OnbtnLoadMapClick);
-	Connect(
-		ID_BUTTON9, wxEVT_COMMAND_BUTTON_CLICKED,
-		(wxObjectEventFunction)&reactive_navigator_demoframe::
-			OnbtnEmptyMapClick);
-	Connect(
-		ID_BUTTON10, wxEVT_COMMAND_BUTTON_CLICKED,
-		(wxObjectEventFunction)&reactive_navigator_demoframe::
-			OnbtnSaveMapClick);
-	Connect(
-		ID_BUTTON2, wxEVT_COMMAND_BUTTON_CLICKED,
-		(wxObjectEventFunction)&reactive_navigator_demoframe::OnAbout);
-	Connect(
-		ID_BUTTON3, wxEVT_COMMAND_BUTTON_CLICKED,
-		(wxObjectEventFunction)&reactive_navigator_demoframe::OnbtnQuitClick);
-	Connect(
-		ID_RADIOBOX1, wxEVT_COMMAND_RADIOBOX_SELECTED,
-		(wxObjectEventFunction)&reactive_navigator_demoframe::
-			OnrbKinTypeSelect);
-	Connect(
-		ID_BUTTON13, wxEVT_COMMAND_BUTTON_CLICKED,
-		(wxObjectEventFunction)&reactive_navigator_demoframe::
-			OnbtnGenerateTemplateClick);
-	Connect(
-		ID_TEXTCTRL3, wxEVT_COMMAND_TEXT_UPDATED,
-		(wxObjectEventFunction)&reactive_navigator_demoframe::
-			OnedManualKinRampsText);
-	Connect(
-		ID_NOTEBOOK1, wxEVT_COMMAND_NOTEBOOK_PAGE_CHANGED,
-		(wxObjectEventFunction)&reactive_navigator_demoframe::
-			OnNotebook1PageChanged1);
-	Connect(
-		ID_MENUITEM4, wxEVT_COMMAND_MENU_SELECTED,
-		(wxObjectEventFunction)&reactive_navigator_demoframe::
-			OnbtnLoadMapClick);
-	Connect(
-		idMenuQuit, wxEVT_COMMAND_MENU_SELECTED,
-		(wxObjectEventFunction)&reactive_navigator_demoframe::OnQuit);
-	Connect(
-		ID_MENUITEM1, wxEVT_COMMAND_MENU_SELECTED,
-		(wxObjectEventFunction)&reactive_navigator_demoframe::
-			OnMenuItemChangeVisibleStuff);
-	Connect(
-		ID_MENUITEM2, wxEVT_COMMAND_MENU_SELECTED,
-		(wxObjectEventFunction)&reactive_navigator_demoframe::
-			OnMenuItemChangeVisibleStuff);
-	Connect(
-		ID_MENUITEM3, wxEVT_COMMAND_MENU_SELECTED,
-		(wxObjectEventFunction)&reactive_navigator_demoframe::
-			OnMenuItemClearRobotPath);
-	Connect(
-		idMenuAbout, wxEVT_COMMAND_MENU_SELECTED,
-		(wxObjectEventFunction)&reactive_navigator_demoframe::OnAbout);
-	Connect(
-		ID_TIMER1, wxEVT_TIMER,
-		(wxObjectEventFunction)&reactive_navigator_demoframe::
-			OntimRunSimulTrigger);
+	using rndf = reactive_navigator_demoframe;
+
+	Bind(wxEVT_BUTTON, &rndf::OnbtnStartClick, this, ID_BUTTON4);
+	Bind(wxEVT_BUTTON, &rndf::OnbtnStopClick, this, ID_BUTTON5);
+	Bind(wxEVT_BUTTON, &rndf::OnbtnPlaceTargetClick, this, ID_BUTTON7);
+	Bind(wxEVT_BUTTON, &rndf::OnbtnSetWaypointSeqClick, this, ID_BUTTON12);
+	Bind(wxEVT_BUTTON, &rndf::OnbtnPlaceRobotClick, this, ID_BUTTON6);
+	Bind(wxEVT_BUTTON, &rndf::OnbtnDrawMapObsClick, this, ID_BUTTON8);
+	Bind(wxEVT_BUTTON, &rndf::OnbtnDrawEmptyClick, this, ID_BUTTON11);
+	Bind(wxEVT_BUTTON, &rndf::OnbtnLoadMapClick, this, ID_BUTTON1);
+	Bind(wxEVT_BUTTON, &rndf::OnbtnEmptyMapClick, this, ID_BUTTON9);
+	Bind(wxEVT_BUTTON, &rndf::OnbtnSaveMapClick, this, ID_BUTTON10);
+	Bind(wxEVT_BUTTON, &rndf::OnAbout, this, ID_BUTTON2);
+	Bind(wxEVT_BUTTON, &rndf::OnbtnQuitClick, this, ID_BUTTON3);
+	Bind(wxEVT_RADIOBOX, &rndf::OnrbKinTypeSelect, this, ID_RADIOBOX1);
+	Bind(wxEVT_BUTTON, &rndf::OnbtnGenerateTemplateClick, this, ID_BUTTON13);
+	Bind(
+		wxEVT_COMMAND_TEXT_UPDATED, &rndf::OnedManualKinRampsText, this,
+		ID_TEXTCTRL3);
+	Bind(
+		wxEVT_COMMAND_NOTEBOOK_PAGE_CHANGED, &rndf::OnNotebook1PageChanged1,
+		this, ID_NOTEBOOK1);
+	Bind(wxEVT_MENU, &rndf::OnbtnLoadMapClick, this, ID_MENUITEM4);
+	Bind(wxEVT_MENU, &rndf::OnQuit, this, idMenuQuit);
+	Bind(wxEVT_MENU, &rndf::OnMenuItemChangeVisibleStuff, this, ID_MENUITEM1);
+	Bind(wxEVT_MENU, &rndf::OnMenuItemChangeVisibleStuff, this, ID_MENUITEM2);
+	Bind(wxEVT_MENU, &rndf::OnMenuItemClearRobotPath, this, ID_MENUITEM3);
+	Bind(wxEVT_MENU, &rndf::OnAbout, this, idMenuAbout);
+	Bind(wxEVT_TIMER, &rndf::OntimRunSimulTrigger, this, ID_TIMER1);
 	//*)
 
 	// Load updated cfg file:
@@ -925,20 +868,14 @@ reactive_navigator_demoframe::reactive_navigator_demoframe(
 	SplitterWindow1->SetSashPosition(200);
 	SplitterWindow2->SetSashPosition(90);
 
-	m_plot3D->Connect(
-		wxEVT_MOTION,
-		(wxObjectEventFunction)&reactive_navigator_demoframe::Onplot3DMouseMove,
-		nullptr, this);
-	m_plot3D->Connect(
-		wxEVT_LEFT_DOWN,
-		(wxObjectEventFunction)&reactive_navigator_demoframe::
-			Onplot3DMouseClick,
-		nullptr, this);
-	m_plot3D->Connect(
-		wxEVT_RIGHT_DOWN,
-		(wxObjectEventFunction)&reactive_navigator_demoframe::
-			Onplot3DMouseClick,
-		nullptr, this);
+	m_plot3D->Bind(
+		wxEVT_MOTION, &reactive_navigator_demoframe::Onplot3DMouseMove, this);
+	m_plot3D->Bind(
+		wxEVT_LEFT_DOWN, &reactive_navigator_demoframe::Onplot3DMouseClick,
+		this);
+	m_plot3D->Bind(
+		wxEVT_RIGHT_DOWN, &reactive_navigator_demoframe::Onplot3DMouseClick,
+		this);
 
 	mnuViewMaxRange->Check(true);
 	mnuViewRobotPath->Check(true);

--- a/apps/SceneViewer3D/CAboutBox.cpp
+++ b/apps/SceneViewer3D/CAboutBox.cpp
@@ -159,11 +159,10 @@ CAboutBox::CAboutBox(wxWindow* parent, wxWindowID id)
 	FlexGridSizer1->SetSizeHints(this);
 	Center();
 
-	Connect(
-		ID_BUTTON1, wxEVT_COMMAND_BUTTON_CLICKED,
-		(wxObjectEventFunction)&CAboutBox::OnButton1Click);
-	Connect(
-		wxID_ANY, wxEVT_INIT_DIALOG, (wxObjectEventFunction)&CAboutBox::OnInit);
+	Bind(
+		wxEVT_COMMAND_BUTTON_CLICKED, &CAboutBox::OnButton1Click, this,
+		ID_BUTTON1);
+	Bind(wxEVT_INIT_DIALOG, &CAboutBox::OnInit, this, wxID_ANY);
 	//*)
 	lbLicense->SetValue(mrpt::system::getMRPTLicense().c_str());
 }

--- a/apps/SceneViewer3D/CDialogOptions.cpp
+++ b/apps/SceneViewer3D/CDialogOptions.cpp
@@ -289,12 +289,8 @@ CDialogOptions::CDialogOptions(
 	FlexGridSizer1->SetSizeHints(this);
 	Center();
 
-	Connect(
-		ID_BUTTON1, wxEVT_COMMAND_BUTTON_CLICKED,
-		(wxObjectEventFunction)&CDialogOptions::OnbtnOkClick);
-	Connect(
-		ID_BUTTON2, wxEVT_COMMAND_BUTTON_CLICKED,
-		(wxObjectEventFunction)&CDialogOptions::OnbtnCancelClick);
+	Bind(wxEVT_BUTTON, &CDialogOptions::OnbtnOkClick, this, ID_BUTTON1);
+	Bind(wxEVT_BUTTON, &CDialogOptions::OnbtnCancelClick, this, ID_BUTTON2);
 	//*)
 }
 

--- a/apps/SceneViewer3D/CDlgCamTracking.cpp
+++ b/apps/SceneViewer3D/CDlgCamTracking.cpp
@@ -122,27 +122,13 @@ CDlgCamTracking::CDlgCamTracking(
 	FlexGridSizer1->Fit(this);
 	FlexGridSizer1->SetSizeHints(this);
 
-	Connect(
-		ID_BUTTON2, wxEVT_COMMAND_BUTTON_CLICKED,
-		(wxObjectEventFunction)&CDlgCamTracking::OnbtnLoadClick);
-	Connect(
-		ID_BUTTON3, wxEVT_COMMAND_BUTTON_CLICKED,
-		(wxObjectEventFunction)&CDlgCamTracking::OnbtnSaveClick);
-	Connect(
-		ID_BUTTON4, wxEVT_COMMAND_BUTTON_CLICKED,
-		(wxObjectEventFunction)&CDlgCamTracking::OnbtnGrabClick);
-	Connect(
-		ID_BUTTON6, wxEVT_COMMAND_BUTTON_CLICKED,
-		(wxObjectEventFunction)&CDlgCamTracking::OnbtnStartClick);
-	Connect(
-		ID_BUTTON5, wxEVT_COMMAND_BUTTON_CLICKED,
-		(wxObjectEventFunction)&CDlgCamTracking::OnbtnStopClick);
-	Connect(
-		ID_BUTTON1, wxEVT_COMMAND_BUTTON_CLICKED,
-		(wxObjectEventFunction)&CDlgCamTracking::OnbtnCloseClick);
-	Connect(
-		ID_MENUITEM1, wxEVT_COMMAND_MENU_SELECTED,
-		(wxObjectEventFunction)&CDlgCamTracking::OnMenuItemDelete);
+	Bind(wxEVT_BUTTON, &CDlgCamTracking::OnbtnLoadClick, this, ID_BUTTON2);
+	Bind(wxEVT_BUTTON, &CDlgCamTracking::OnbtnSaveClick, this, ID_BUTTON3);
+	Bind(wxEVT_BUTTON, &CDlgCamTracking::OnbtnGrabClick, this, ID_BUTTON4);
+	Bind(wxEVT_BUTTON, &CDlgCamTracking::OnbtnStartClick, this, ID_BUTTON6);
+	Bind(wxEVT_BUTTON, &CDlgCamTracking::OnbtnStopClick, this, ID_BUTTON5);
+	Bind(wxEVT_BUTTON, &CDlgCamTracking::OnbtnCloseClick, this, ID_BUTTON1);
+	Bind(wxEVT_MENU, &CDlgCamTracking::OnMenuItemDelete, this, ID_MENUITEM1);
 	//*)
 }
 

--- a/apps/SceneViewer3D/CDlgPLYOptions.cpp
+++ b/apps/SceneViewer3D/CDlgPLYOptions.cpp
@@ -187,15 +187,9 @@ CDlgPLYOptions::CDlgPLYOptions(wxWindow* parent, wxWindowID id)
 	FlexGridSizer1->SetSizeHints(this);
 	Center();
 
-	Connect(
-		ID_RADIOBOX2, wxEVT_COMMAND_RADIOBOX_SELECTED,
-		(wxObjectEventFunction)&CDlgPLYOptions::OnrbClassSelect);
-	Connect(
-		ID_BUTTON1, wxEVT_COMMAND_BUTTON_CLICKED,
-		(wxObjectEventFunction)&CDlgPLYOptions::OnbtnCancelClick);
-	Connect(
-		ID_BUTTON2, wxEVT_COMMAND_BUTTON_CLICKED,
-		(wxObjectEventFunction)&CDlgPLYOptions::OnbtnOKClick);
+	Bind(wxEVT_RADIOBOX, &CDlgPLYOptions::OnrbClassSelect, this, ID_RADIOBOX2);
+	Bind(wxEVT_BUTTON, &CDlgPLYOptions::OnbtnCancelClick, this, ID_BUTTON1);
+	Bind(wxEVT_BUTTON, &CDlgPLYOptions::OnbtnOKClick, this, ID_BUTTON2);
 	//*)
 
 	wxCommandEvent ev;

--- a/apps/SceneViewer3D/_DSceneViewerMain.cpp
+++ b/apps/SceneViewer3D/_DSceneViewerMain.cpp
@@ -712,139 +712,61 @@ _DSceneViewerFrame::_DSceneViewerFrame(wxWindow* parent, wxWindowID id)
 	FlexGridSizer1->SetSizeHints(this);
 	Center();
 
-	Connect(
-		ID_BUTTON1, wxEVT_COMMAND_BUTTON_CLICKED,
-		(wxObjectEventFunction)&_DSceneViewerFrame::OnNewScene);
-	Connect(
-		ID_BUTTON2, wxEVT_COMMAND_BUTTON_CLICKED,
-		(wxObjectEventFunction)&_DSceneViewerFrame::OnOpenFile);
-	Connect(
-		ID_BUTTON3, wxEVT_COMMAND_BUTTON_CLICKED,
-		(wxObjectEventFunction)&_DSceneViewerFrame::OnPrevious);
-	Connect(
-		ID_BUTTON4, wxEVT_COMMAND_BUTTON_CLICKED,
-		(wxObjectEventFunction)&_DSceneViewerFrame::OnNext);
-	Connect(
-		ID_BUTTON5, wxEVT_COMMAND_BUTTON_CLICKED,
-		(wxObjectEventFunction)&_DSceneViewerFrame::OnReload);
-	Connect(
-		ID_BUTTON6, wxEVT_COMMAND_BUTTON_CLICKED,
-		(wxObjectEventFunction)&_DSceneViewerFrame::OnMenuOptions);
-	Connect(
-		ID_BUTTON7, wxEVT_COMMAND_TOGGLEBUTTON_CLICKED,
-		(wxObjectEventFunction)&_DSceneViewerFrame::OnbtnOrthoClicked);
-	Connect(
-		ID_BUTTON8, wxEVT_COMMAND_TOGGLEBUTTON_CLICKED,
-		(wxObjectEventFunction)&_DSceneViewerFrame::OnbtnAutoplayClicked);
-	Connect(
-		ID_BUTTON9, wxEVT_COMMAND_TOGGLEBUTTON_CLICKED,
-		(wxObjectEventFunction)&_DSceneViewerFrame::OnBtnRecordClicked);
-	Connect(
-		ID_BUTTON10, wxEVT_COMMAND_BUTTON_CLICKED,
-		(wxObjectEventFunction)&_DSceneViewerFrame::OnAbout);
-	Connect(
-		ID_BUTTON11, wxEVT_COMMAND_BUTTON_CLICKED,
-		(wxObjectEventFunction)&_DSceneViewerFrame::OnQuit);
-	Connect(
-		ID_MENUITEM1, wxEVT_COMMAND_MENU_SELECTED,
-		(wxObjectEventFunction)&_DSceneViewerFrame::OnNewScene);
-	Connect(
-		ID_MENUITEM2, wxEVT_COMMAND_MENU_SELECTED,
-		(wxObjectEventFunction)&_DSceneViewerFrame::OnOpenFile);
-	Connect(
-		ID_MENUITEM5, wxEVT_COMMAND_MENU_SELECTED,
-		(wxObjectEventFunction)&_DSceneViewerFrame::OnReload);
-	Connect(
-		ID_MENUITEM7, wxEVT_COMMAND_MENU_SELECTED,
-		(wxObjectEventFunction)&_DSceneViewerFrame::OnMenuSave);
-	Connect(
-		ID_MENUITEM6, wxEVT_COMMAND_MENU_SELECTED,
-		(wxObjectEventFunction)&_DSceneViewerFrame::OnInsert3DS);
-	Connect(
-		ID_MENUITEM20, wxEVT_COMMAND_MENU_SELECTED,
-		(wxObjectEventFunction)&_DSceneViewerFrame::
-			OnMenuItemImportPLYPointCloud);
-	Connect(
-		ID_MENUITEM25, wxEVT_COMMAND_MENU_SELECTED,
-		(wxObjectEventFunction)&_DSceneViewerFrame::OnmnuImportLASSelected);
-	Connect(
-		ID_MENUITEM22, wxEVT_COMMAND_MENU_SELECTED,
-		(wxObjectEventFunction)&_DSceneViewerFrame::OnMenuItemExportPointsPLY);
-	Connect(
-		ID_MENUITEM29, wxEVT_COMMAND_MENU_SELECTED,
-		(wxObjectEventFunction)&_DSceneViewerFrame::OnPrevious);
-	Connect(
-		ID_MENUITEM30, wxEVT_COMMAND_MENU_SELECTED,
-		(wxObjectEventFunction)&_DSceneViewerFrame::OnNext);
-	Connect(
-		ID_MENUITEM12, wxEVT_COMMAND_MENU_SELECTED,
-		(wxObjectEventFunction)&_DSceneViewerFrame::OnMenuItem14Selected);
-	Connect(
-		ID_MENUITEM23, wxEVT_COMMAND_MENU_SELECTED,
-		(wxObjectEventFunction)&_DSceneViewerFrame::OnMenuItemHighResRender);
-	Connect(
-		ID_MENUITEM18, wxEVT_COMMAND_MENU_SELECTED,
-		(wxObjectEventFunction)&_DSceneViewerFrame::OnmnuSceneStatsSelected);
-	Connect(
-		idMenuQuit, wxEVT_COMMAND_MENU_SELECTED,
-		(wxObjectEventFunction)&_DSceneViewerFrame::OnQuit);
-	Connect(
-		ID_MENUITEM24, wxEVT_COMMAND_MENU_SELECTED,
-		(wxObjectEventFunction)&_DSceneViewerFrame::OnmnuSelectNoneSelected);
-	Connect(
-		ID_MENUITEM26, wxEVT_COMMAND_MENU_SELECTED,
-		(wxObjectEventFunction)&_DSceneViewerFrame::OnmnuSelectByClassSelected);
-	Connect(
-		ID_MENUITEM27, wxEVT_COMMAND_MENU_SELECTED,
-		(wxObjectEventFunction)&_DSceneViewerFrame::
-			OnmnuSelectionScaleSelected);
-	Connect(
-		ID_MENUITEM28, wxEVT_COMMAND_MENU_SELECTED,
-		(wxObjectEventFunction)&_DSceneViewerFrame::
-			OnmnuSelectionDeleteSelected);
-	Connect(
-		ID_MENUITEM4, wxEVT_COMMAND_MENU_SELECTED,
-		(wxObjectEventFunction)&_DSceneViewerFrame::OnMenuBackColor);
-	Connect(
-		ID_MENUITEM3, wxEVT_COMMAND_MENU_SELECTED,
-		(wxObjectEventFunction)&_DSceneViewerFrame::OnMenuOptions);
-	Connect(
-		ID_MENUITEM15, wxEVT_COMMAND_MENU_SELECTED,
-		(wxObjectEventFunction)&_DSceneViewerFrame::
-			OnmnuItemShowCloudOctreesSelected);
-	Connect(
-		ID_MENUITEM17, wxEVT_COMMAND_MENU_SELECTED,
-		(wxObjectEventFunction)&_DSceneViewerFrame::
-			OnmnuItemChangeMaxPointsPerOctreeNodeSelected);
-	Connect(
-		ID_MENUITEM11, wxEVT_COMMAND_MENU_SELECTED,
-		(wxObjectEventFunction)&_DSceneViewerFrame::OnMenuDeleteAll);
-	Connect(
-		ID_MENUITEM9, wxEVT_COMMAND_MENU_SELECTED,
-		(wxObjectEventFunction)&_DSceneViewerFrame::OnMenuAddSICK);
-	Connect(
-		ID_MENUITEM10, wxEVT_COMMAND_MENU_SELECTED,
-		(wxObjectEventFunction)&_DSceneViewerFrame::OnStartCameraTravelling);
-	Connect(
-		idMenuAbout, wxEVT_COMMAND_MENU_SELECTED,
-		(wxObjectEventFunction)&_DSceneViewerFrame::OnAbout);
-	Connect(
-		ID_TIMER1, wxEVT_TIMER,
-		(wxObjectEventFunction)&_DSceneViewerFrame::
-			OntimLoadFileCmdLineTrigger);
+	using svf = _DSceneViewerFrame;
+
+	Bind(wxEVT_BUTTON, &svf::OnNewScene, this, ID_BUTTON1);
+	Bind(wxEVT_BUTTON, &svf::OnOpenFile, this, ID_BUTTON2);
+	Bind(wxEVT_BUTTON, &svf::OnPrevious, this, ID_BUTTON3);
+	Bind(wxEVT_BUTTON, &svf::OnNext, this, ID_BUTTON4);
+	Bind(wxEVT_BUTTON, &svf::OnReload, this, ID_BUTTON5);
+	Bind(wxEVT_BUTTON, &svf::OnMenuOptions, this, ID_BUTTON6);
+	Bind(
+		wxEVT_COMMAND_TOGGLEBUTTON_CLICKED, &svf::OnbtnOrthoClicked, this,
+		ID_BUTTON7);
+	Bind(
+		wxEVT_COMMAND_TOGGLEBUTTON_CLICKED, &svf::OnbtnAutoplayClicked, this,
+		ID_BUTTON8);
+	Bind(
+		wxEVT_COMMAND_TOGGLEBUTTON_CLICKED, &svf::OnBtnRecordClicked, this,
+		ID_BUTTON9);
+	Bind(wxEVT_BUTTON, &svf::OnAbout, this, ID_BUTTON10);
+	Bind(wxEVT_BUTTON, &svf::OnQuit, this, ID_BUTTON11);
+	Bind(wxEVT_MENU, &svf::OnNewScene, this, ID_MENUITEM1);
+	Bind(wxEVT_MENU, &svf::OnOpenFile, this, ID_MENUITEM2);
+	Bind(wxEVT_MENU, &svf::OnReload, this, ID_MENUITEM5);
+	Bind(wxEVT_MENU, &svf::OnMenuSave, this, ID_MENUITEM7);
+	Bind(wxEVT_MENU, &svf::OnInsert3DS, this, ID_MENUITEM6);
+	Bind(wxEVT_MENU, &svf::OnMenuItemImportPLYPointCloud, this, ID_MENUITEM20);
+	Bind(wxEVT_MENU, &svf::OnmnuImportLASSelected, this, ID_MENUITEM25);
+	Bind(wxEVT_MENU, &svf::OnMenuItemExportPointsPLY, this, ID_MENUITEM22);
+	Bind(wxEVT_MENU, &svf::OnPrevious, this, ID_MENUITEM29);
+	Bind(wxEVT_MENU, &svf::OnNext, this, ID_MENUITEM30);
+	Bind(wxEVT_MENU, &svf::OnMenuItem14Selected, this, ID_MENUITEM12);
+	Bind(wxEVT_MENU, &svf::OnMenuItemHighResRender, this, ID_MENUITEM23);
+	Bind(wxEVT_MENU, &svf::OnmnuSceneStatsSelected, this, ID_MENUITEM18);
+	Bind(wxEVT_MENU, &svf::OnQuit, this, idMenuQuit);
+	Bind(wxEVT_MENU, &svf::OnmnuSelectNoneSelected, this, ID_MENUITEM24);
+	Bind(wxEVT_MENU, &svf::OnmnuSelectByClassSelected, this, ID_MENUITEM26);
+	Bind(wxEVT_MENU, &svf::OnmnuSelectionScaleSelected, this, ID_MENUITEM27);
+	Bind(wxEVT_MENU, &svf::OnmnuSelectionDeleteSelected, this, ID_MENUITEM28);
+	Bind(wxEVT_MENU, &svf::OnMenuBackColor, this, ID_MENUITEM4);
+	Bind(wxEVT_MENU, &svf::OnMenuOptions, this, ID_MENUITEM3);
+	Bind(
+		wxEVT_MENU, &svf::OnmnuItemShowCloudOctreesSelected, this,
+		ID_MENUITEM15);
+	Bind(
+		wxEVT_MENU, &svf::OnmnuItemChangeMaxPointsPerOctreeNodeSelected, this,
+		ID_MENUITEM17);
+	Bind(wxEVT_MENU, &svf::OnMenuDeleteAll, this, ID_MENUITEM11);
+	Bind(wxEVT_MENU, &svf::OnMenuAddSICK, this, ID_MENUITEM9);
+	Bind(wxEVT_MENU, &svf::OnStartCameraTravelling, this, ID_MENUITEM10);
+	Bind(wxEVT_MENU, &svf::OnAbout, this, idMenuAbout);
+	Bind(wxEVT_TIMER, &svf::OntimLoadFileCmdLineTrigger, this, ID_TIMER1);
 	//*)
 
-	Connect(
-		ID_MENUITEM14, wxEVT_COMMAND_MENU_SELECTED,
-		(wxObjectEventFunction)&_DSceneViewerFrame::
-			OnMenuCameraTrackingArbitrary);
-
-	Connect(
-		ID_TIMER_AUTOPLAY, wxEVT_TIMER,
-		(wxObjectEventFunction)&_DSceneViewerFrame::OntimAutoplay);
-	Connect(
-		ID_TRAVELLING_TIMER, wxEVT_TIMER,
-		(wxObjectEventFunction)&_DSceneViewerFrame::OnTravellingTrigger);
+	Bind(wxEVT_MENU, &svf::OnMenuCameraTrackingArbitrary, this, ID_MENUITEM14);
+	Bind(wxEVT_TIMER, &svf::OntimAutoplay, this, ID_TIMER_AUTOPLAY);
+	Bind(wxEVT_TIMER, &svf::OnTravellingTrigger, this, ID_TRAVELLING_TIMER);
 
 	// Create the wxCanvas object:
 	m_canvas =

--- a/apps/camera-calib/CDlgCalibWizardOnline.cpp
+++ b/apps/camera-calib/CDlgCalibWizardOnline.cpp
@@ -270,18 +270,17 @@ CDlgCalibWizardOnline::CDlgCalibWizardOnline(
 	FlexGridSizer1->SetSizeHints(this);
 	Center();
 
-	Connect(
-		ID_BUTTON1, wxEVT_COMMAND_BUTTON_CLICKED,
-		(wxObjectEventFunction)&CDlgCalibWizardOnline::OnbtnStartClick);
-	Connect(
-		ID_BUTTON2, wxEVT_COMMAND_BUTTON_CLICKED,
-		(wxObjectEventFunction)&CDlgCalibWizardOnline::OnbtnStopClick);
-	Connect(
-		ID_BUTTON3, wxEVT_COMMAND_BUTTON_CLICKED,
-		(wxObjectEventFunction)&CDlgCalibWizardOnline::OnbtnCloseClick);
-	Connect(
-		ID_TIMER1, wxEVT_TIMER,
-		(wxObjectEventFunction)&CDlgCalibWizardOnline::OntimCaptureTrigger);
+	Bind(
+		wxEVT_BUTTON, &CDlgCalibWizardOnline::OnbtnStartClick, this,
+		ID_BUTTON1);
+	Bind(
+		wxEVT_BUTTON, &CDlgCalibWizardOnline::OnbtnStopClick, this, ID_BUTTON2);
+	Bind(
+		wxEVT_BUTTON, &CDlgCalibWizardOnline::OnbtnCloseClick, this,
+		ID_BUTTON3);
+	Bind(
+		wxEVT_TIMER, &CDlgCalibWizardOnline::OntimCaptureTrigger, this,
+		ID_TIMER1);
 	//*)
 
 	redire = new CMyRedirector(txtLog, true, 10);

--- a/apps/camera-calib/CDlgPoseEst.cpp
+++ b/apps/camera-calib/CDlgPoseEst.cpp
@@ -281,18 +281,10 @@ CDlgPoseEst::CDlgPoseEst(
 	FlexGridSizer1->SetSizeHints(this);
 	Center();
 
-	Connect(
-		ID_BUTTON1, wxEVT_COMMAND_BUTTON_CLICKED,
-		(wxObjectEventFunction)&CDlgPoseEst::OnbtnStartClick);
-	Connect(
-		ID_BUTTON2, wxEVT_COMMAND_BUTTON_CLICKED,
-		(wxObjectEventFunction)&CDlgPoseEst::OnbtnStopClick);
-	Connect(
-		ID_BUTTON3, wxEVT_COMMAND_BUTTON_CLICKED,
-		(wxObjectEventFunction)&CDlgPoseEst::OnbtnCloseClick);
-	Connect(
-		ID_TIMER1, wxEVT_TIMER,
-		(wxObjectEventFunction)&CDlgPoseEst::OntimCaptureTrigger);
+	Bind(wxEVT_BUTTON, &CDlgPoseEst::OnbtnStartClick, this, ID_BUTTON1);
+	Bind(wxEVT_BUTTON, &CDlgPoseEst::OnbtnStopClick, this, ID_BUTTON2);
+	Bind(wxEVT_BUTTON, &CDlgPoseEst::OnbtnCloseClick, this, ID_BUTTON3);
+	Bind(wxEVT_TIMER, &CDlgPoseEst::OntimCaptureTrigger, this, ID_TIMER1);
 	cam_intrinsic = Eigen::MatrixXd::Zero(3, 3);
 	I3 = Eigen::MatrixXd::Identity(3, 3);
 	pose_mat = Eigen::MatrixXd::Zero(6, 1);

--- a/apps/camera-calib/camera_calib_guiMain.cpp
+++ b/apps/camera-calib/camera_calib_guiMain.cpp
@@ -478,43 +478,38 @@ camera_calib_guiDialog::camera_calib_guiDialog(wxWindow* parent, wxWindowID id)
 	FlexGridSizer1->Fit(this);
 	FlexGridSizer1->SetSizeHints(this);
 
-	Connect(
-		ID_BUTTON8, wxEVT_COMMAND_BUTTON_CLICKED,
-		(wxObjectEventFunction)&camera_calib_guiDialog::OnbtnCaptureNowClick);
-	Connect(
-		ID_BUTTON1, wxEVT_COMMAND_BUTTON_CLICKED,
-		(wxObjectEventFunction)&camera_calib_guiDialog::OnAddImage);
-	Connect(
-		ID_BUTTON2, wxEVT_COMMAND_BUTTON_CLICKED,
-		(wxObjectEventFunction)&camera_calib_guiDialog::OnListClear);
-	Connect(
-		ID_BUTTON9, wxEVT_COMMAND_BUTTON_CLICKED,
-		(wxObjectEventFunction)&camera_calib_guiDialog::OnbtnSaveImagesClick);
-	Connect(
-		ID_LISTBOX1, wxEVT_COMMAND_LISTBOX_SELECTED,
-		(wxObjectEventFunction)&camera_calib_guiDialog::OnlbFilesSelect);
-	Connect(
-		ID_CHOICE1, wxEVT_COMMAND_CHOICE_SELECTED,
-		(wxObjectEventFunction)&camera_calib_guiDialog::OncbZoomSelect);
-	Connect(
-		ID_BUTTON3, wxEVT_COMMAND_BUTTON_CLICKED,
-		(wxObjectEventFunction)&camera_calib_guiDialog::OnbtnRunCalibClick);
-	Connect(
-		ID_BUTTON6, wxEVT_COMMAND_BUTTON_CLICKED,
-		(wxObjectEventFunction)&camera_calib_guiDialog::OnbtnSaveClick);
-	Connect(
-		ID_BUTTON7, wxEVT_COMMAND_BUTTON_CLICKED,
-		(wxObjectEventFunction)&camera_calib_guiDialog::OnbtnManualRectClick);
-	Connect(
-		ID_BUTTON5, wxEVT_COMMAND_BUTTON_CLICKED,
-		(wxObjectEventFunction)&camera_calib_guiDialog::OnbtnAboutClick);
-	Connect(
-		ID_BUTTON4, wxEVT_COMMAND_BUTTON_CLICKED,
-		(wxObjectEventFunction)&camera_calib_guiDialog::OnbtnCloseClick);
-	Connect(
-		ID_BUTTON10, wxEVT_COMMAND_BUTTON_CLICKED,
-		(wxObjectEventFunction)&camera_calib_guiDialog::
-			OnbtnPoseEstimateNowClick);
+	Bind(
+		wxEVT_BUTTON, &camera_calib_guiDialog::OnbtnCaptureNowClick, this,
+		ID_BUTTON8);
+	Bind(wxEVT_BUTTON, &camera_calib_guiDialog::OnAddImage, this, ID_BUTTON1);
+	Bind(wxEVT_BUTTON, &camera_calib_guiDialog::OnListClear, this, ID_BUTTON2);
+	Bind(
+		wxEVT_BUTTON, &camera_calib_guiDialog::OnbtnSaveImagesClick, this,
+		ID_BUTTON9);
+	Bind(
+		wxEVT_LISTBOX, &camera_calib_guiDialog::OnlbFilesSelect, this,
+		ID_LISTBOX1);
+	Bind(
+		wxEVT_CHOICE, &camera_calib_guiDialog::OncbZoomSelect, this,
+		ID_CHOICE1);
+	Bind(
+		wxEVT_BUTTON, &camera_calib_guiDialog::OnbtnRunCalibClick, this,
+		ID_BUTTON3);
+	Bind(
+		wxEVT_BUTTON, &camera_calib_guiDialog::OnbtnSaveClick, this,
+		ID_BUTTON6);
+	Bind(
+		wxEVT_BUTTON, &camera_calib_guiDialog::OnbtnManualRectClick, this,
+		ID_BUTTON7);
+	Bind(
+		wxEVT_BUTTON, &camera_calib_guiDialog::OnbtnAboutClick, this,
+		ID_BUTTON5);
+	Bind(
+		wxEVT_BUTTON, &camera_calib_guiDialog::OnbtnCloseClick, this,
+		ID_BUTTON4);
+	Bind(
+		wxEVT_BUTTON, &camera_calib_guiDialog::OnbtnPoseEstimateNowClick, this,
+		ID_BUTTON10);
 	//*)
 
 	camera_params.intrinsicParams(0, 0) = 0;  // Indicate calib didn't run yet.

--- a/apps/hmt-slam-gui/CDlgLog.cpp
+++ b/apps/hmt-slam-gui/CDlgLog.cpp
@@ -84,11 +84,8 @@ CDlgLog::CDlgLog(
 	timDumpLog.Start(250, false);
 	FlexGridSizer1->SetSizeHints(this);
 
-	Connect(
-		ID_TIMER1, wxEVT_TIMER,
-		(wxObjectEventFunction)&CDlgLog::OntimDumpLogTrigger);
-	Connect(
-		wxID_ANY, wxEVT_CLOSE_WINDOW, (wxObjectEventFunction)&CDlgLog::OnClose);
+	Bind(wxEVT_TIMER, &CDlgLog::OntimDumpLogTrigger, this, ID_TIMER1);
+	Bind(wxEVT_CLOSE_WINDOW, &CDlgLog::OnClose, this, wxID_ANY);
 	//*)
 
 	m_redirector = std::make_unique<CMyRedirector>(

--- a/apps/hmt-slam-gui/hmt_slam_guiMain.cpp
+++ b/apps/hmt-slam-gui/hmt_slam_guiMain.cpp
@@ -780,60 +780,32 @@ hmt_slam_guiFrame::hmt_slam_guiFrame(wxWindow* parent, wxWindowID id)
 	SetStatusBar(StatusBar1);
 	FlexGridSizer1->SetSizeHints(this);
 
-	Connect(
-		ID_BUTTON1, wxEVT_COMMAND_BUTTON_CLICKED,
-		(wxObjectEventFunction)&hmt_slam_guiFrame::OnbtnResetClick);
-	Connect(
-		ID_BUTTON2, wxEVT_COMMAND_BUTTON_CLICKED,
-		(wxObjectEventFunction)&hmt_slam_guiFrame::OnbtnLoadClick);
-	Connect(
-		ID_BUTTON3, wxEVT_COMMAND_BUTTON_CLICKED,
-		(wxObjectEventFunction)&hmt_slam_guiFrame::OnbtnSaveClick);
-	Connect(
-		ID_BUTTON4, wxEVT_COMMAND_BUTTON_CLICKED,
-		(wxObjectEventFunction)&hmt_slam_guiFrame::OnbtnStartClick);
-	Connect(
-		ID_BUTTON6, wxEVT_COMMAND_BUTTON_CLICKED,
-		(wxObjectEventFunction)&hmt_slam_guiFrame::OnbtnPauseClick);
-	Connect(
-		ID_BUTTON12, wxEVT_COMMAND_BUTTON_CLICKED,
-		(wxObjectEventFunction)&hmt_slam_guiFrame::OnbtnShowLogWinClick);
-	Connect(
-		ID_BUTTON10, wxEVT_COMMAND_BUTTON_CLICKED,
-		(wxObjectEventFunction)&hmt_slam_guiFrame::OnAbout);
-	Connect(
-		ID_BUTTON5, wxEVT_COMMAND_BUTTON_CLICKED,
-		(wxObjectEventFunction)&hmt_slam_guiFrame::OnQuit);
-	Connect(
-		ID_BUTTON11, wxEVT_COMMAND_BUTTON_CLICKED,
-		(wxObjectEventFunction)&hmt_slam_guiFrame::OnbtnPickRawlogClick);
-	Connect(
-		ID_NOTEBOOK2, wxEVT_COMMAND_NOTEBOOK_PAGE_CHANGED,
-		(wxObjectEventFunction)&hmt_slam_guiFrame::OnNotebook2PageChanged);
-	Connect(
-		ID_MENUITEM1, wxEVT_COMMAND_MENU_SELECTED,
-		(wxObjectEventFunction)&hmt_slam_guiFrame::OnbtnResetClick);
-	Connect(
-		ID_MENUITEM2, wxEVT_COMMAND_MENU_SELECTED,
-		(wxObjectEventFunction)&hmt_slam_guiFrame::OnbtnLoadClick);
-	Connect(
-		ID_MENUITEM3, wxEVT_COMMAND_MENU_SELECTED,
-		(wxObjectEventFunction)&hmt_slam_guiFrame::OnbtnSaveClick);
-	Connect(
-		idMenuQuit, wxEVT_COMMAND_MENU_SELECTED,
-		(wxObjectEventFunction)&hmt_slam_guiFrame::OnQuit);
-	Connect(
-		ID_MENUITEM6, wxEVT_COMMAND_MENU_SELECTED,
-		(wxObjectEventFunction)&hmt_slam_guiFrame::OnMenuSetSLAMParameter);
-	Connect(
-		ID_MENUITEM4, wxEVT_COMMAND_MENU_SELECTED,
-		(wxObjectEventFunction)&hmt_slam_guiFrame::OnbtnStartClick);
-	Connect(
-		ID_MENUITEM5, wxEVT_COMMAND_MENU_SELECTED,
-		(wxObjectEventFunction)&hmt_slam_guiFrame::OnbtnPauseClick);
-	Connect(
-		idMenuAbout, wxEVT_COMMAND_MENU_SELECTED,
-		(wxObjectEventFunction)&hmt_slam_guiFrame::OnAbout);
+	Bind(wxEVT_BUTTON, &hmt_slam_guiFrame::OnbtnResetClick, this, ID_BUTTON1);
+	Bind(wxEVT_BUTTON, &hmt_slam_guiFrame::OnbtnLoadClick, this, ID_BUTTON2);
+	Bind(wxEVT_BUTTON, &hmt_slam_guiFrame::OnbtnSaveClick, this, ID_BUTTON3);
+	Bind(wxEVT_BUTTON, &hmt_slam_guiFrame::OnbtnStartClick, this, ID_BUTTON4);
+	Bind(wxEVT_BUTTON, &hmt_slam_guiFrame::OnbtnPauseClick, this, ID_BUTTON6);
+	Bind(
+		wxEVT_BUTTON, &hmt_slam_guiFrame::OnbtnShowLogWinClick, this,
+		ID_BUTTON12);
+	Bind(wxEVT_BUTTON, &hmt_slam_guiFrame::OnAbout, this, ID_BUTTON10);
+	Bind(wxEVT_BUTTON, &hmt_slam_guiFrame::OnQuit, this, ID_BUTTON5);
+	Bind(
+		wxEVT_BUTTON, &hmt_slam_guiFrame::OnbtnPickRawlogClick, this,
+		ID_BUTTON11);
+	Bind(
+		wxEVT_COMMAND_NOTEBOOK_PAGE_CHANGED,
+		&hmt_slam_guiFrame::OnNotebook2PageChanged, this, ID_NOTEBOOK2);
+	Bind(wxEVT_MENU, &hmt_slam_guiFrame::OnbtnResetClick, this, ID_MENUITEM1);
+	Bind(wxEVT_MENU, &hmt_slam_guiFrame::OnbtnLoadClick, this, ID_MENUITEM2);
+	Bind(wxEVT_MENU, &hmt_slam_guiFrame::OnbtnSaveClick, this, ID_MENUITEM3);
+	Bind(wxEVT_MENU, &hmt_slam_guiFrame::OnQuit, this, idMenuQuit);
+	Bind(
+		wxEVT_MENU, &hmt_slam_guiFrame::OnMenuSetSLAMParameter, this,
+		ID_MENUITEM6);
+	Bind(wxEVT_MENU, &hmt_slam_guiFrame::OnbtnStartClick, this, ID_MENUITEM4);
+	Bind(wxEVT_MENU, &hmt_slam_guiFrame::OnbtnPauseClick, this, ID_MENUITEM5);
+	Bind(wxEVT_MENU, &hmt_slam_guiFrame::OnAbout, this, idMenuAbout);
 	//*)
 
 	// Initialize data ========================================================

--- a/apps/hmtMapViewer/hmtMapViewerMain.cpp
+++ b/apps/hmtMapViewer/hmtMapViewerMain.cpp
@@ -461,40 +461,27 @@ hmtMapViewerFrame::hmtMapViewerFrame(wxWindow* parent, wxWindowID id)
 	SetToolBar(ToolBar1);
 	Center();
 
-	Connect(
-		ID_TREECTRL1, wxEVT_COMMAND_TREE_SEL_CHANGED,
-		(wxObjectEventFunction)&hmtMapViewerFrame::OntreeViewSelectionChanged);
-	Connect(
-		ID_MENUITEM1, wxEVT_COMMAND_MENU_SELECTED,
-		(wxObjectEventFunction)&hmtMapViewerFrame::OnMenuLoad);
-	Connect(
-		ID_MENUITEM4, wxEVT_COMMAND_MENU_SELECTED,
-		(wxObjectEventFunction)&hmtMapViewerFrame::
-			OnmenuExportLocalMapsSelected);
-	Connect(
-		idMenuQuit, wxEVT_COMMAND_MENU_SELECTED,
-		(wxObjectEventFunction)&hmtMapViewerFrame::OnQuit);
-	Connect(
-		ID_MENUITEM2, wxEVT_COMMAND_MENU_SELECTED,
-		(wxObjectEventFunction)&hmtMapViewerFrame::OnMenuTranslationBtw2);
-	Connect(
-		ID_MENUITEM3, wxEVT_COMMAND_MENU_SELECTED,
-		(wxObjectEventFunction)&hmtMapViewerFrame::OnMenuOverlapBtw2);
-	Connect(
-		ID_MENUITEM6, wxEVT_COMMAND_MENU_SELECTED,
-		(wxObjectEventFunction)&hmtMapViewerFrame::OnTopologicalModel_Gridmap);
-	Connect(
-		ID_MENUITEM7, wxEVT_COMMAND_MENU_SELECTED,
-		(wxObjectEventFunction)&hmtMapViewerFrame::OnTopologicalModel_Fabmap);
-	Connect(
-		idMenuAbout, wxEVT_COMMAND_MENU_SELECTED,
-		(wxObjectEventFunction)&hmtMapViewerFrame::OnAbout);
-	Connect(
-		ID_TOOLBARITEM1, wxEVT_COMMAND_TOOL_CLICKED,
-		(wxObjectEventFunction)&hmtMapViewerFrame::OnMenuLoad);
-	Connect(
-		ID_TOOLBARITEM2, wxEVT_COMMAND_TOOL_CLICKED,
-		(wxObjectEventFunction)&hmtMapViewerFrame::OnQuit);
+	Bind(
+		wxEVT_COMMAND_TREE_SEL_CHANGED,
+		&hmtMapViewerFrame::OntreeViewSelectionChanged, this, ID_TREECTRL1);
+	Bind(wxEVT_MENU, &hmtMapViewerFrame::OnMenuLoad, this, ID_MENUITEM1);
+	Bind(
+		wxEVT_MENU, &hmtMapViewerFrame::OnmenuExportLocalMapsSelected, this,
+		ID_MENUITEM4);
+	Bind(wxEVT_MENU, &hmtMapViewerFrame::OnQuit, this, idMenuQuit);
+	Bind(
+		wxEVT_MENU, &hmtMapViewerFrame::OnMenuTranslationBtw2, this,
+		ID_MENUITEM2);
+	Bind(wxEVT_MENU, &hmtMapViewerFrame::OnMenuOverlapBtw2, this, ID_MENUITEM3);
+	Bind(
+		wxEVT_MENU, &hmtMapViewerFrame::OnTopologicalModel_Gridmap, this,
+		ID_MENUITEM6);
+	Bind(
+		wxEVT_MENU, &hmtMapViewerFrame::OnTopologicalModel_Fabmap, this,
+		ID_MENUITEM7);
+	Bind(wxEVT_MENU, &hmtMapViewerFrame::OnAbout, this, idMenuAbout);
+	Bind(wxEVT_TOOL, &hmtMapViewerFrame::OnMenuLoad, this, ID_TOOLBARITEM1);
+	Bind(wxEVT_TOOL, &hmtMapViewerFrame::OnQuit, this, ID_TOOLBARITEM2);
 	//*)
 
 	// Fix sizes:
@@ -542,9 +529,9 @@ hmtMapViewerFrame::hmtMapViewerFrame(wxWindow* parent, wxWindowID id)
 	timAutoLoad.SetOwner(this, ID_TIMER1);
 	if (!global_fileToOpen.empty())
 	{
-		Connect(
-			ID_TIMER1, wxEVT_TIMER,
-			(wxObjectEventFunction)&hmtMapViewerFrame::OntimAutoLoadTrigger);
+		Bind(
+			wxEVT_TIMER, &hmtMapViewerFrame::OntimAutoLoadTrigger, this,
+			ID_TIMER1);
 		timAutoLoad.Start(250, true);
 	}
 }

--- a/apps/holonomic-navigator-demo/holonomic_navigator_demoMain.cpp
+++ b/apps/holonomic-navigator-demo/holonomic_navigator_demoMain.cpp
@@ -371,68 +371,26 @@ holonomic_navigator_demoFrame::holonomic_navigator_demoFrame(
 	FlexGridSizer1->SetSizeHints(this);
 	Center();
 
-	Connect(
-		ID_BUTTON1, wxEVT_COMMAND_BUTTON_CLICKED,
-		(wxObjectEventFunction)&holonomic_navigator_demoFrame::
-			OnbtnLoadMapClick);
-	Connect(
-		ID_BUTTON2, wxEVT_COMMAND_BUTTON_CLICKED,
-		(wxObjectEventFunction)&holonomic_navigator_demoFrame::OnAbout);
-	Connect(
-		ID_BUTTON3, wxEVT_COMMAND_BUTTON_CLICKED,
-		(wxObjectEventFunction)&holonomic_navigator_demoFrame::OnQuit);
-	Connect(
-		ID_BUTTON6, wxEVT_COMMAND_BUTTON_CLICKED,
-		(wxObjectEventFunction)&holonomic_navigator_demoFrame::
-			OnbtnPlaceRobotClick);
-	Connect(
-		ID_BUTTON7, wxEVT_COMMAND_BUTTON_CLICKED,
-		(wxObjectEventFunction)&holonomic_navigator_demoFrame::
-			OnbtnPlaceTargetClick);
-	Connect(
-		ID_BUTTON4, wxEVT_COMMAND_BUTTON_CLICKED,
-		(wxObjectEventFunction)&holonomic_navigator_demoFrame::OnbtnStartClick);
-	Connect(
-		ID_BUTTON5, wxEVT_COMMAND_BUTTON_CLICKED,
-		(wxObjectEventFunction)&holonomic_navigator_demoFrame::OnbtnStopClick);
-	Connect(
-		ID_MENUITEM4, wxEVT_COMMAND_MENU_SELECTED,
-		(wxObjectEventFunction)&holonomic_navigator_demoFrame::
-			OnbtnLoadMapClick);
-	Connect(
-		idMenuQuit, wxEVT_COMMAND_MENU_SELECTED,
-		(wxObjectEventFunction)&holonomic_navigator_demoFrame::OnQuit);
-	Connect(
-		ID_MENUITEM1, wxEVT_COMMAND_MENU_SELECTED,
-		(wxObjectEventFunction)&holonomic_navigator_demoFrame::
-			OnMenuItemChangeVisibleStuff);
-	Connect(
-		ID_MENUITEM2, wxEVT_COMMAND_MENU_SELECTED,
-		(wxObjectEventFunction)&holonomic_navigator_demoFrame::
-			OnMenuItemChangeVisibleStuff);
-	Connect(
-		ID_MENUITEM3, wxEVT_COMMAND_MENU_SELECTED,
-		(wxObjectEventFunction)&holonomic_navigator_demoFrame::
-			OnMenuItemClearRobotPath);
-	Connect(
-		idMenuAbout, wxEVT_COMMAND_MENU_SELECTED,
-		(wxObjectEventFunction)&holonomic_navigator_demoFrame::OnAbout);
-	Connect(
-		ID_TIMER1, wxEVT_TIMER,
-		(wxObjectEventFunction)&holonomic_navigator_demoFrame::
-			OntimRunSimulTrigger);
+	using hndf = holonomic_navigator_demoFrame;
+
+	Bind(wxEVT_BUTTON, &hndf::OnbtnLoadMapClick, this, ID_BUTTON1);
+	Bind(wxEVT_BUTTON, &hndf::OnAbout, this, ID_BUTTON2);
+	Bind(wxEVT_BUTTON, &hndf::OnQuit, this, ID_BUTTON3);
+	Bind(wxEVT_BUTTON, &hndf::OnbtnPlaceRobotClick, this, ID_BUTTON6);
+	Bind(wxEVT_BUTTON, &hndf::OnbtnPlaceTargetClick, this, ID_BUTTON7);
+	Bind(wxEVT_BUTTON, &hndf::OnbtnStartClick, this, ID_BUTTON4);
+	Bind(wxEVT_BUTTON, &hndf::OnbtnStopClick, this, ID_BUTTON5);
+	Bind(wxEVT_MENU, &hndf::OnbtnLoadMapClick, this, ID_MENUITEM4);
+	Bind(wxEVT_MENU, &hndf::OnQuit, this, idMenuQuit);
+	Bind(wxEVT_MENU, &hndf::OnMenuItemChangeVisibleStuff, this, ID_MENUITEM1);
+	Bind(wxEVT_MENU, &hndf::OnMenuItemChangeVisibleStuff, this, ID_MENUITEM2);
+	Bind(wxEVT_MENU, &hndf::OnMenuItemClearRobotPath, this, ID_MENUITEM3);
+	Bind(wxEVT_MENU, &hndf::OnAbout, this, idMenuAbout);
+	Bind(wxEVT_TIMER, &hndf::OntimRunSimulTrigger, this, ID_TIMER1);
 	//*)
 
-	m_plot3D->Connect(
-		wxEVT_MOTION,
-		(wxObjectEventFunction)&holonomic_navigator_demoFrame::
-			Onplot3DMouseMove,
-		nullptr, this);
-	m_plot3D->Connect(
-		wxEVT_LEFT_DOWN,
-		(wxObjectEventFunction)&holonomic_navigator_demoFrame::
-			Onplot3DMouseClick,
-		nullptr, this);
+	m_plot3D->Bind(wxEVT_MOTION, &hndf::Onplot3DMouseMove, this);
+	m_plot3D->Bind(wxEVT_LEFT_DOWN, &hndf::Onplot3DMouseClick, this);
 
 	mnuViewMaxRange->Check(true);
 	mnuViewRobotPath->Check(true);

--- a/apps/kinect-stereo-calib/kinect_calibrate_guiMain.cpp
+++ b/apps/kinect-stereo-calib/kinect_calibrate_guiMain.cpp
@@ -184,7 +184,7 @@ END_EVENT_TABLE()
 
 kinect_calibrate_guiDialog::kinect_calibrate_guiDialog(
 	wxWindow* parent, wxWindowID id)
-	: m_config(_("kinect-stereo-calib")), m_my_redirector(nullptr)
+	: m_config(_("kinect-stereo-calib"))
 {
 	m_grabstate = gsIdle;
 
@@ -1151,157 +1151,71 @@ kinect_calibrate_guiDialog::kinect_calibrate_guiDialog(
 	FlexGridSizer1->SetSizeHints(this);
 	Center();
 
-	Connect(
-		ID_BUTTON15, wxEVT_COMMAND_BUTTON_CLICKED,
-		(wxObjectEventFunction)&kinect_calibrate_guiDialog::
-			OnbtnOpCalibKinectClick);
-	Connect(
-		ID_BUTTON16, wxEVT_COMMAND_BUTTON_CLICKED,
-		(wxObjectEventFunction)&kinect_calibrate_guiDialog::
-			OnbtnOpCalibStereoGenericClick);
-	Connect(
-		ID_BUTTON17, wxEVT_COMMAND_BUTTON_CLICKED,
-		(wxObjectEventFunction)&kinect_calibrate_guiDialog::
-			OnbtnOpTestKinectClick);
-	Connect(
-		ID_BUTTON3, wxEVT_COMMAND_BUTTON_CLICKED,
-		(wxObjectEventFunction)&kinect_calibrate_guiDialog::OnbtnNext1Click);
-	Connect(
-		ID_BUTTON5, wxEVT_COMMAND_BUTTON_CLICKED,
-		(wxObjectEventFunction)&kinect_calibrate_guiDialog::OnbtnConnectClick);
-	Connect(
-		ID_BUTTON4, wxEVT_COMMAND_BUTTON_CLICKED,
-		(wxObjectEventFunction)&kinect_calibrate_guiDialog::OnbtnNext1Click);
-	Connect(
-		ID_BUTTON8, wxEVT_COMMAND_BUTTON_CLICKED,
-		(wxObjectEventFunction)&kinect_calibrate_guiDialog::
-			OnbtnDisconnectClick);
-	Connect(
-		ID_RADIOBOX1, wxEVT_COMMAND_RADIOBOX_SELECTED,
-		(wxObjectEventFunction)&kinect_calibrate_guiDialog::
-			OnrbChannelSwitchSelect);
-	Connect(
-		ID_SPINCTRL7, wxEVT_COMMAND_SPINCTRL_UPDATED,
-		(wxObjectEventFunction)&kinect_calibrate_guiDialog::OnedTiltChange);
-	Connect(
-		ID_BUTTON6, wxEVT_COMMAND_BUTTON_CLICKED,
-		(wxObjectEventFunction)&kinect_calibrate_guiDialog::OnbtnCaptureClick);
-	Connect(
-		ID_BUTTON7, wxEVT_COMMAND_BUTTON_CLICKED,
-		(wxObjectEventFunction)&kinect_calibrate_guiDialog::
-			OnbtnNextCalibClick);
-	Connect(
-		ID_LISTBOX1, wxEVT_COMMAND_LISTBOX_SELECTED,
-		(wxObjectEventFunction)&kinect_calibrate_guiDialog::
-			OnlbImagePairsSelect);
-	Connect(
-		ID_BUTTON9, wxEVT_COMMAND_BUTTON_CLICKED,
-		(wxObjectEventFunction)&kinect_calibrate_guiDialog::
-			OnbtnListRemoveSelectedClick);
-	Connect(
-		ID_BUTTON10, wxEVT_COMMAND_BUTTON_CLICKED,
-		(wxObjectEventFunction)&kinect_calibrate_guiDialog::OnbtnListLoadClick);
-	Connect(
-		ID_BUTTON11, wxEVT_COMMAND_BUTTON_CLICKED,
-		(wxObjectEventFunction)&kinect_calibrate_guiDialog::
-			OnbtnLoadImageListClick);
-	Connect(
-		ID_BUTTON12, wxEVT_COMMAND_BUTTON_CLICKED,
-		(wxObjectEventFunction)&kinect_calibrate_guiDialog::OnbtnListSaveClick);
-	Connect(
-		ID_RADIOBOX2, wxEVT_COMMAND_RADIOBOX_SELECTED,
-		(wxObjectEventFunction)&kinect_calibrate_guiDialog::
-			OnrbShowImagesSelect);
-	Connect(
-		ID_SPINCTRL3, wxEVT_COMMAND_SPINCTRL_UPDATED,
-		(wxObjectEventFunction)&kinect_calibrate_guiDialog::
-			OnNeedsToUpdate6DCamPlot);
-	Connect(
-		ID_SPINCTRL4, wxEVT_COMMAND_SPINCTRL_UPDATED,
-		(wxObjectEventFunction)&kinect_calibrate_guiDialog::
-			OnNeedsToUpdate6DCamPlot);
-	Connect(
-		ID_TEXTCTRL6, wxEVT_COMMAND_TEXT_UPDATED,
-		(wxObjectEventFunction)&kinect_calibrate_guiDialog::OnedCalibSizeXText);
-	Connect(
-		ID_TEXTCTRL7, wxEVT_COMMAND_TEXT_UPDATED,
-		(wxObjectEventFunction)&kinect_calibrate_guiDialog::OnedCalibSizeXText);
-	Connect(
-		ID_CHECKBOX3, wxEVT_COMMAND_CHECKBOX_CLICKED,
-		(wxObjectEventFunction)&kinect_calibrate_guiDialog::
-			OncbCalibNormalizeClick);
-	Connect(
-		ID_CHECKBOX2, wxEVT_COMMAND_CHECKBOX_CLICKED,
-		(wxObjectEventFunction)&kinect_calibrate_guiDialog::
-			OncbCalibNormalizeClick);
-	Connect(
-		ID_BUTTON14, wxEVT_COMMAND_BUTTON_CLICKED,
-		(wxObjectEventFunction)&kinect_calibrate_guiDialog::OnbtnRunCalibClick);
-	Connect(
-		ID_BUTTON13, wxEVT_COMMAND_BUTTON_CLICKED,
-		(wxObjectEventFunction)&kinect_calibrate_guiDialog::
-			OnbtnSaveCalibClick);
-	Connect(
-		ID_BUTTON18, wxEVT_COMMAND_BUTTON_CLICKED,
-		(wxObjectEventFunction)&kinect_calibrate_guiDialog::
-			OnbtnConnectLive3DClick);
-	Connect(
-		ID_BUTTON20, wxEVT_COMMAND_BUTTON_CLICKED,
-		(wxObjectEventFunction)&kinect_calibrate_guiDialog::
-			OnbtnDisconnectLiveClick);
-	Connect(
-		ID_BUTTON19, wxEVT_COMMAND_BUTTON_CLICKED,
-		(wxObjectEventFunction)&kinect_calibrate_guiDialog::
-			OnbtnLoadCalibClick);
-	Connect(
-		ID_BUTTON21, wxEVT_COMMAND_BUTTON_CLICKED,
-		(wxObjectEventFunction)&kinect_calibrate_guiDialog::
-			OnbtnSaveCalibLiveClick);
-	Connect(
-		ID_BITMAPBUTTON1, wxEVT_COMMAND_BUTTON_CLICKED,
-		(wxObjectEventFunction)&kinect_calibrate_guiDialog::
-			OnbtnHelpLiveCalibClick);
-	Panel5->Connect(
-		wxEVT_SET_FOCUS,
-		(wxObjectEventFunction)&kinect_calibrate_guiDialog::OnPanel5SetFocus,
-		nullptr, this);
-	Connect(
-		ID_NOTEBOOK1, wxEVT_COMMAND_NOTEBOOK_PAGE_CHANGING,
-		(wxObjectEventFunction)&kinect_calibrate_guiDialog::
-			OnNotebook1PageChanging);
-	Connect(
-		ID_BUTTON1, wxEVT_COMMAND_BUTTON_CLICKED,
-		(wxObjectEventFunction)&kinect_calibrate_guiDialog::OnAbout);
-	Connect(
-		ID_BUTTON2, wxEVT_COMMAND_BUTTON_CLICKED,
-		(wxObjectEventFunction)&kinect_calibrate_guiDialog::OnbtnQuitClick);
-	Connect(
-		ID_TIMER1, wxEVT_TIMER,
-		(wxObjectEventFunction)&kinect_calibrate_guiDialog::
-			OntimConsoleDumpTrigger);
-	Connect(
-		ID_TIMER2, wxEVT_TIMER,
-		(wxObjectEventFunction)&kinect_calibrate_guiDialog::OntimMiscTrigger);
-	Connect(
-		wxID_ANY, wxEVT_CLOSE_WINDOW,
-		(wxObjectEventFunction)&kinect_calibrate_guiDialog::OnClose);
-	Connect(
-		wxEVT_SIZE,
-		(wxObjectEventFunction)&kinect_calibrate_guiDialog::OnResize);
+	using kcgd = kinect_calibrate_guiDialog;
+
+	Bind(wxEVT_BUTTON, &kcgd::OnbtnOpCalibKinectClick, this, ID_BUTTON15);
+	Bind(
+		wxEVT_BUTTON, &kcgd::OnbtnOpCalibStereoGenericClick, this, ID_BUTTON16);
+	Bind(wxEVT_BUTTON, &kcgd::OnbtnOpTestKinectClick, this, ID_BUTTON17);
+	Bind(wxEVT_BUTTON, &kcgd::OnbtnNext1Click, this, ID_BUTTON3);
+	Bind(wxEVT_BUTTON, &kcgd::OnbtnConnectClick, this, ID_BUTTON5);
+	Bind(wxEVT_BUTTON, &kcgd::OnbtnNext1Click, this, ID_BUTTON4);
+	Bind(wxEVT_BUTTON, &kcgd::OnbtnDisconnectClick, this, ID_BUTTON8);
+	Bind(wxEVT_RADIOBOX, &kcgd::OnrbChannelSwitchSelect, this, ID_RADIOBOX1);
+	Bind(
+		wxEVT_COMMAND_SPINCTRL_UPDATED, &kcgd::OnedTiltChange, this,
+		ID_SPINCTRL7);
+	Bind(wxEVT_BUTTON, &kcgd::OnbtnCaptureClick, this, ID_BUTTON6);
+	Bind(wxEVT_BUTTON, &kcgd::OnbtnNextCalibClick, this, ID_BUTTON7);
+	Bind(wxEVT_LISTBOX, &kcgd::OnlbImagePairsSelect, this, ID_LISTBOX1);
+	Bind(wxEVT_BUTTON, &kcgd::OnbtnListRemoveSelectedClick, this, ID_BUTTON9);
+	Bind(wxEVT_BUTTON, &kcgd::OnbtnListLoadClick, this, ID_BUTTON10);
+	Bind(wxEVT_BUTTON, &kcgd::OnbtnLoadImageListClick, this, ID_BUTTON11);
+	Bind(wxEVT_BUTTON, &kcgd::OnbtnListSaveClick, this, ID_BUTTON12);
+	Bind(wxEVT_RADIOBOX, &kcgd::OnrbShowImagesSelect, this, ID_RADIOBOX2);
+	Bind(
+		wxEVT_COMMAND_SPINCTRL_UPDATED, &kcgd::OnNeedsToUpdate6DCamPlot, this,
+		ID_SPINCTRL3);
+	Bind(
+		wxEVT_COMMAND_SPINCTRL_UPDATED, &kcgd::OnNeedsToUpdate6DCamPlot, this,
+		ID_SPINCTRL4);
+	Bind(
+		wxEVT_COMMAND_TEXT_UPDATED, &kcgd::OnedCalibSizeXText, this,
+		ID_TEXTCTRL6);
+	Bind(
+		wxEVT_COMMAND_TEXT_UPDATED, &kcgd::OnedCalibSizeXText, this,
+		ID_TEXTCTRL7);
+	Bind(wxEVT_CHECKBOX, &kcgd::OncbCalibNormalizeClick, this, ID_CHECKBOX3);
+	Bind(wxEVT_CHECKBOX, &kcgd::OncbCalibNormalizeClick, this, ID_CHECKBOX2);
+	Bind(wxEVT_BUTTON, &kcgd::OnbtnRunCalibClick, this, ID_BUTTON14);
+	Bind(wxEVT_BUTTON, &kcgd::OnbtnSaveCalibClick, this, ID_BUTTON13);
+	Bind(wxEVT_BUTTON, &kcgd::OnbtnConnectLive3DClick, this, ID_BUTTON18);
+	Bind(wxEVT_BUTTON, &kcgd::OnbtnDisconnectLiveClick, this, ID_BUTTON20);
+	Bind(wxEVT_BUTTON, &kcgd::OnbtnLoadCalibClick, this, ID_BUTTON19);
+	Bind(wxEVT_BUTTON, &kcgd::OnbtnSaveCalibLiveClick, this, ID_BUTTON21);
+	Bind(wxEVT_BUTTON, &kcgd::OnbtnHelpLiveCalibClick, this, ID_BITMAPBUTTON1);
+	Panel5->Bind(wxEVT_SET_FOCUS, &kcgd::OnPanel5SetFocus, this);
+	Bind(
+		wxEVT_NOTEBOOK_PAGE_CHANGING, &kcgd::OnNotebook1PageChanging, this,
+		ID_NOTEBOOK1);
+	Bind(wxEVT_BUTTON, &kcgd::OnAbout, this, ID_BUTTON1);
+	Bind(wxEVT_BUTTON, &kcgd::OnbtnQuitClick, this, ID_BUTTON2);
+	Bind(wxEVT_TIMER, &kcgd::OntimConsoleDumpTrigger, this, ID_TIMER1);
+	Bind(wxEVT_TIMER, &kcgd::OntimMiscTrigger, this, ID_TIMER2);
+	Bind(wxEVT_CLOSE_WINDOW, &kcgd::OnClose, this, wxID_ANY);
+	Bind(wxEVT_SIZE, &kcgd::OnResize, this);
 	//*)
 
-	Connect(
-		ID_GRID1,
+	Bind(
 #if wxCHECK_VERSION(3, 1, 0)
 		wxEVT_GRID_CELL_CHANGED,
 #else
 		wxEVT_GRID_CELL_CHANGE,
 #endif
-		(wxObjectEventFunction)&kinect_calibrate_guiDialog::
-			Onm_grid_live_calibCellChange);
+		&kcgd::Onm_grid_live_calibCellChange, this, ID_GRID1);
 
 	// Set std::cout/cerr out:
-	m_my_redirector = new CMyRedirector(
+	m_my_redirector = std::make_unique<CMyRedirector>(
 		edLogTest,
 		false,  // yieldApplication
 		0,  // bufferSize
@@ -1364,9 +1278,6 @@ kinect_calibrate_guiDialog::kinect_calibrate_guiDialog(
 
 kinect_calibrate_guiDialog::~kinect_calibrate_guiDialog()
 {
-	delete m_my_redirector;
-	m_my_redirector = nullptr;
-
 	//(*Destroy(kinect_calibrate_guiDialog)
 	//*)
 }

--- a/apps/kinect-stereo-calib/kinect_calibrate_guiMain.h
+++ b/apps/kinect-stereo-calib/kinect_calibrate_guiMain.h
@@ -104,7 +104,7 @@ class kinect_calibrate_guiDialog : public wxDialog
    private:
 	wxConfig m_config;
 
-	CMyRedirector* m_my_redirector;
+	std::unique_ptr<CMyRedirector> m_my_redirector;
 
 	std::thread m_cap_thread;
 	TThreadParam m_cap_thread_data;

--- a/apps/navlog-viewer/navlog_viewer_GUI_designMain.cpp
+++ b/apps/navlog-viewer/navlog_viewer_GUI_designMain.cpp
@@ -380,36 +380,23 @@ navlog_viewer_GUI_designDialog::navlog_viewer_GUI_designDialog(
 
 	using me = navlog_viewer_GUI_designDialog;
 
-	Bind(wxEVT_COMMAND_BUTTON_CLICKED, &me::OnbtnLoadClick, this, ID_BUTTON1);
-	Bind(wxEVT_COMMAND_BUTTON_CLICKED, &me::OnbtnHelpClick, this, ID_BUTTON2);
-	Bind(wxEVT_COMMAND_BUTTON_CLICKED, &me::OnbtnQuitClick, this, ID_BUTTON3);
-	Bind(
-		wxEVT_COMMAND_RADIOBOX_SELECTED, &me::OnrbPerPTGPlotsSelect, this,
-		ID_RADIOBOX1);
-	Bind(
-		wxEVT_COMMAND_CHECKLISTBOX_TOGGLED, &me::OncbGlobalFrameClick, this,
-		ID_CHECKLISTBOX1);
+	Bind(wxEVT_BUTTON, &me::OnbtnLoadClick, this, ID_BUTTON1);
+	Bind(wxEVT_BUTTON, &me::OnbtnHelpClick, this, ID_BUTTON2);
+	Bind(wxEVT_BUTTON, &me::OnbtnQuitClick, this, ID_BUTTON3);
+	Bind(wxEVT_RADIOBOX, &me::OnrbPerPTGPlotsSelect, this, ID_RADIOBOX1);
+	Bind(wxEVT_CHECKLISTBOX, &me::OncbGlobalFrameClick, this, ID_CHECKLISTBOX1);
 	Bind(wxEVT_SCROLL_THUMBTRACK, &me::OnslidLogCmdScroll, this, ID_SLIDER1);
 	Bind(wxEVT_SCROLL_CHANGED, &me::OnslidLogCmdScroll, this, ID_SLIDER1);
-	Bind(
-		wxEVT_COMMAND_BUTTON_CLICKED, &me::OnbtnMoreOpsClick, this, ID_BUTTON6);
-	Bind(wxEVT_COMMAND_BUTTON_CLICKED, &me::OnbtnPlayClick, this, ID_BUTTON4);
-	Bind(wxEVT_COMMAND_BUTTON_CLICKED, &me::OnbtnStopClick, this, ID_BUTTON5);
+	Bind(wxEVT_BUTTON, &me::OnbtnMoreOpsClick, this, ID_BUTTON6);
+	Bind(wxEVT_BUTTON, &me::OnbtnPlayClick, this, ID_BUTTON4);
+	Bind(wxEVT_BUTTON, &me::OnbtnStopClick, this, ID_BUTTON5);
 	Bind(wxEVT_TIMER, &me::OntimPlayTrigger, this, ID_TIMER1);
 	Bind(wxEVT_TIMER, &me::OntimAutoloadTrigger, this, ID_TIMER2);
-	Bind(
-		wxEVT_COMMAND_MENU_SELECTED, &me::OnmnuSeePTGParamsSelected, this,
-		ID_MENUITEM2);
-	Bind(
-		wxEVT_COMMAND_MENU_SELECTED, &me::OnmnuMatlabPlotsSelected, this,
-		ID_MENUITEM1);
-	Bind(
-		wxEVT_COMMAND_MENU_SELECTED, &me::OnmnuSaveScoreMatrixSelected, this,
-		ID_MENUITEM3);
+	Bind(wxEVT_MENU, &me::OnmnuSeePTGParamsSelected, this, ID_MENUITEM2);
+	Bind(wxEVT_MENU, &me::OnmnuMatlabPlotsSelected, this, ID_MENUITEM1);
+	Bind(wxEVT_MENU, &me::OnmnuSaveScoreMatrixSelected, this, ID_MENUITEM3);
 	//*)
-	Bind(
-		wxEVT_COMMAND_MENU_SELECTED, &me::OnmnuSaveCurrentObstacles, this,
-		ID_MENUITEM100);
+	Bind(wxEVT_MENU, &me::OnmnuSaveCurrentObstacles, this, ID_MENUITEM100);
 
 	{
 		wxMenuItem* mnuMatlabExportPaths;
@@ -418,7 +405,7 @@ navlog_viewer_GUI_designDialog::navlog_viewer_GUI_designDialog(
 			_("Export paths info to MATLAB..."), wxEmptyString, wxITEM_NORMAL);
 		mnuMoreOps.Append(mnuMatlabExportPaths);
 		Bind(
-			wxEVT_COMMAND_MENU_SELECTED, &me::OnmnuMatlabExportPaths, this,
+			wxEVT_MENU, &me::OnmnuMatlabExportPaths, this,
 			ID_MENUITEM_SAVE_MATLAB_PATH);
 	}
 

--- a/apps/ptg-configurator/ptgConfiguratorMain.cpp
+++ b/apps/ptg-configurator/ptgConfiguratorMain.cpp
@@ -625,86 +625,34 @@ ptgConfiguratorframe::ptgConfiguratorframe(wxWindow* parent, wxWindowID id)
 	FlexGridSizer1->SetSizeHints(this);
 	Center();
 
-	Connect(
-		ID_CHOICE1, wxEVT_COMMAND_CHOICE_SELECTED,
-		(wxObjectEventFunction)&ptgConfiguratorframe::OncbPTGClassSelect);
-	Connect(
-		ID_BUTTON1, wxEVT_COMMAND_BUTTON_CLICKED,
-		(wxObjectEventFunction)&ptgConfiguratorframe::OnbtnReloadParamsClick);
-	Connect(
-		ID_SPINCTRL1, wxEVT_COMMAND_SPINCTRL_UPDATED,
-		(wxObjectEventFunction)&ptgConfiguratorframe::OnedPTGIndexChange);
-	Connect(
-		ID_CHECKBOX1, wxEVT_COMMAND_CHECKBOX_CLICKED,
-		(wxObjectEventFunction)&ptgConfiguratorframe::OncbDrawShapePathClick);
-	Connect(
-		ID_BUTTON5, wxEVT_COMMAND_BUTTON_CLICKED,
-		(wxObjectEventFunction)&ptgConfiguratorframe::OnButton1Click);
-	Connect(
-		ID_CHECKBOX3, wxEVT_COMMAND_CHECKBOX_CLICKED,
-		(wxObjectEventFunction)&ptgConfiguratorframe::
-			OncbHighlightOnePathClick);
-	Connect(
-		ID_SLIDER1,
-		wxEVT_SCROLL_TOP | wxEVT_SCROLL_BOTTOM | wxEVT_SCROLL_LINEUP |
-			wxEVT_SCROLL_LINEDOWN | wxEVT_SCROLL_PAGEUP |
-			wxEVT_SCROLL_PAGEDOWN | wxEVT_SCROLL_THUMBTRACK |
-			wxEVT_SCROLL_THUMBRELEASE | wxEVT_SCROLL_CHANGED,
-		(wxObjectEventFunction)&ptgConfiguratorframe::
-			OnslidPathHighlightCmdScroll);
-	Connect(
-		ID_SLIDER1, wxEVT_SCROLL_THUMBTRACK,
-		(wxObjectEventFunction)&ptgConfiguratorframe::
-			OnslidPathHighlightCmdScroll);
-	Connect(
-		ID_SLIDER1, wxEVT_SCROLL_CHANGED,
-		(wxObjectEventFunction)&ptgConfiguratorframe::
-			OnslidPathHighlightCmdScroll);
-	Connect(
-		ID_SPINCTRL2, wxEVT_COMMAND_SPINCTRL_UPDATED,
-		(wxObjectEventFunction)&ptgConfiguratorframe::
-			OnedIndexHighlightPathChange);
-	Connect(
-		ID_CHECKBOX4, wxEVT_COMMAND_CHECKBOX_CLICKED,
-		(wxObjectEventFunction)&ptgConfiguratorframe::
-			OncbHighlightOnePathClick);
-	Connect(
-		ID_CHECKBOX2, wxEVT_COMMAND_CHECKBOX_CLICKED,
-		(wxObjectEventFunction)&ptgConfiguratorframe::OncbBuildTPObsClick);
-	Connect(
-		ID_BUTTON3, wxEVT_COMMAND_BUTTON_CLICKED,
-		(wxObjectEventFunction)&ptgConfiguratorframe::OnbtnPlaceObsClick);
-	Connect(
-		ID_BUTTON2, wxEVT_COMMAND_BUTTON_CLICKED,
-		(wxObjectEventFunction)&ptgConfiguratorframe::OnbtnRebuildTPObsClick);
-	Connect(
-		ID_BUTTON4, wxEVT_COMMAND_BUTTON_CLICKED,
-		(wxObjectEventFunction)&ptgConfiguratorframe::OnbtnPlaceTargetClick);
-	Connect(
-		ID_CHECKBOX5, wxEVT_COMMAND_CHECKBOX_CLICKED,
-		(wxObjectEventFunction)&ptgConfiguratorframe::OnrbShowTPSelectSelect);
-	Connect(
-		ID_CHECKBOX6, wxEVT_COMMAND_CHECKBOX_CLICKED,
-		(wxObjectEventFunction)&ptgConfiguratorframe::OnrbShowTPSelectSelect);
-	Connect(
-		ID_CHECKBOX7, wxEVT_COMMAND_CHECKBOX_CLICKED,
-		(wxObjectEventFunction)&ptgConfiguratorframe::OnrbShowTPSelectSelect);
-	Connect(
-		idMenuQuit, wxEVT_COMMAND_MENU_SELECTED,
-		(wxObjectEventFunction)&ptgConfiguratorframe::OnQuit);
-	Connect(
-		idMenuAbout, wxEVT_COMMAND_MENU_SELECTED,
-		(wxObjectEventFunction)&ptgConfiguratorframe::OnAbout);
+	using pcf = ptgConfiguratorframe;
+
+	Bind(wxEVT_CHOICE, &pcf::OncbPTGClassSelect, this, ID_CHOICE1);
+	Bind(wxEVT_BUTTON, &pcf::OnbtnReloadParamsClick, this, ID_BUTTON1);
+	Bind(
+		wxEVT_COMMAND_SPINCTRL_UPDATED, &pcf::OnedPTGIndexChange, this,
+		ID_SPINCTRL1);
+	Bind(wxEVT_CHECKBOX, &pcf::OncbDrawShapePathClick, this, ID_CHECKBOX1);
+	Bind(wxEVT_BUTTON, &pcf::OnButton1Click, this, ID_BUTTON5);
+	Bind(wxEVT_CHECKBOX, &pcf::OncbHighlightOnePathClick, this, ID_CHECKBOX3);
+	Bind(wxEVT_SLIDER, &pcf::OnslidPathHighlightCmdScroll, this, ID_SLIDER1);
+	Bind(
+		wxEVT_COMMAND_SPINCTRL_UPDATED, &pcf::OnedIndexHighlightPathChange,
+		this, ID_SPINCTRL2);
+	Bind(wxEVT_CHECKBOX, &pcf::OncbHighlightOnePathClick, this, ID_CHECKBOX4);
+	Bind(wxEVT_CHECKBOX, &pcf::OncbBuildTPObsClick, this, ID_CHECKBOX2);
+	Bind(wxEVT_BUTTON, &pcf::OnbtnPlaceObsClick, this, ID_BUTTON3);
+	Bind(wxEVT_BUTTON, &pcf::OnbtnRebuildTPObsClick, this, ID_BUTTON2);
+	Bind(wxEVT_BUTTON, &pcf::OnbtnPlaceTargetClick, this, ID_BUTTON4);
+	Bind(wxEVT_CHECKBOX, &pcf::OnrbShowTPSelectSelect, this, ID_CHECKBOX5);
+	Bind(wxEVT_CHECKBOX, &pcf::OnrbShowTPSelectSelect, this, ID_CHECKBOX6);
+	Bind(wxEVT_CHECKBOX, &pcf::OnrbShowTPSelectSelect, this, ID_CHECKBOX7);
+	Bind(wxEVT_MENU, &pcf::OnQuit, this, idMenuQuit);
+	Bind(wxEVT_MENU, &pcf::OnAbout, this, idMenuAbout);
 	//*)
 
-	m_plot->Connect(
-		wxEVT_MOTION,
-		(wxObjectEventFunction)&ptgConfiguratorframe::Onplot3DMouseMove,
-		nullptr, this);
-	m_plot->Connect(
-		wxEVT_LEFT_DOWN,
-		(wxObjectEventFunction)&ptgConfiguratorframe::Onplot3DMouseClick,
-		nullptr, this);
+	m_plot->Bind(wxEVT_MOTION, &pcf::Onplot3DMouseMove, this);
+	m_plot->Bind(wxEVT_LEFT_DOWN, &pcf::Onplot3DMouseClick, this);
 
 	// Redirect all output to control:
 	m_myRedirector = new CMyRedirector(edLog, false, 100, true, false, true);
@@ -1434,7 +1382,7 @@ void ptgConfiguratorframe::OnbtnPlaceTargetClick(wxCommandEvent& event)
 	m_cursorPickState = cpsPickTarget;
 }
 
-void ptgConfiguratorframe::OnslidPathHighlightCmdScroll(wxScrollEvent& event)
+void ptgConfiguratorframe::OnslidPathHighlightCmdScroll(wxCommandEvent&)
 {
 	edIndexHighlightPath->SetValue(slidPathHighlight->GetValue());
 	wxSpinEvent dm;

--- a/apps/ptg-configurator/ptgConfiguratorMain.h
+++ b/apps/ptg-configurator/ptgConfiguratorMain.h
@@ -70,7 +70,7 @@ class ptgConfiguratorframe : public wxFrame
 	void OnbtnRebuildTPObsClick(wxCommandEvent& event);
 	void OnbtnPlaceObsClick(wxCommandEvent& event);
 	void OnbtnPlaceTargetClick(wxCommandEvent& event);
-	void OnslidPathHighlightCmdScroll(wxScrollEvent& event);
+	void OnslidPathHighlightCmdScroll(wxCommandEvent&);
 	void OncbHighlightOnePathClick(wxCommandEvent& event);
 	void OnedIndexHighlightPathChange(wxSpinEvent& event);
 	void OnedCfgText(wxCommandEvent& event);

--- a/apps/robotic-arm-kinematics/CAboutBox.cpp
+++ b/apps/robotic-arm-kinematics/CAboutBox.cpp
@@ -139,11 +139,8 @@ CAboutBox::CAboutBox(wxWindow* parent, wxWindowID id)
 	FlexGridSizer1->SetSizeHints(this);
 	Center();
 
-	Connect(
-		ID_BUTTON1, wxEVT_COMMAND_BUTTON_CLICKED,
-		(wxObjectEventFunction)&CAboutBox::OnButton1Click);
-	Connect(
-		wxID_ANY, wxEVT_INIT_DIALOG, (wxObjectEventFunction)&CAboutBox::OnInit);
+	Bind(wxEVT_BUTTON, &CAboutBox::OnButton1Click, this, ID_BUTTON1);
+	Bind(wxEVT_INIT_DIALOG, &CAboutBox::OnInit, this, wxID_ANY);
 	//*)
 
 	lbLicense->SetValue(mrpt::system::getMRPTLicense().c_str());

--- a/apps/robotic-arm-kinematics/PanelDOF.cpp
+++ b/apps/robotic-arm-kinematics/PanelDOF.cpp
@@ -66,19 +66,21 @@ PanelDOF::PanelDOF(wxWindow* parent, wxWindowID id)
 	FlexGridSizer1->SetSizeHints(this);
 	//*)
 
-	Connect(
-		ID_SLIDER1,
-		wxEVT_SCROLL_TOP | wxEVT_SCROLL_BOTTOM | wxEVT_SCROLL_LINEUP |
-			wxEVT_SCROLL_LINEDOWN | wxEVT_SCROLL_PAGEUP |
-			wxEVT_SCROLL_PAGEDOWN | wxEVT_SCROLL_THUMBTRACK |
-			wxEVT_SCROLL_THUMBRELEASE | wxEVT_SCROLL_CHANGED,
-		(wxObjectEventFunction)&robotic_arm_kinematicsFrame::OnSliderDOFScroll,
-		nullptr, the_win);
-	Connect(
-		ID_SLIDER1, wxEVT_COMMAND_SLIDER_UPDATED,
-		(wxObjectEventFunction)&robotic_arm_kinematicsFrame::OnSliderDOFScroll,
-		nullptr, the_win);
-	// Connect(ID_SLIDER1,wxEVT_SCROLL_CHANGED,(wxObjectEventFunction)&robotic_arm_kinematicsFrame::OnSliderScroll);
+	using rakf = robotic_arm_kinematicsFrame;
+
+	Bind(wxEVT_SCROLL_TOP, &rakf::OnSliderDOFScroll, the_win, ID_SLIDER1);
+	Bind(wxEVT_SCROLL_BOTTOM, &rakf::OnSliderDOFScroll, the_win, ID_SLIDER1);
+	Bind(wxEVT_SCROLL_LINEUP, &rakf::OnSliderDOFScroll, the_win, ID_SLIDER1);
+	Bind(wxEVT_SCROLL_LINEDOWN, &rakf::OnSliderDOFScroll, the_win, ID_SLIDER1);
+	Bind(wxEVT_SCROLL_PAGEUP, &rakf::OnSliderDOFScroll, the_win, ID_SLIDER1);
+	Bind(wxEVT_SCROLL_PAGEDOWN, &rakf::OnSliderDOFScroll, the_win, ID_SLIDER1);
+	Bind(
+		wxEVT_SCROLL_THUMBTRACK, &rakf::OnSliderDOFScroll, the_win, ID_SLIDER1);
+	Bind(
+		wxEVT_SCROLL_THUMBRELEASE, &rakf::OnSliderDOFScroll, the_win,
+		ID_SLIDER1);
+	Bind(wxEVT_SCROLL_CHANGED, &rakf::OnSliderDOFScroll, the_win, ID_SLIDER1);
+	Bind(wxEVT_SLIDER, &rakf::OnSliderDOFScrollBis, the_win, ID_SLIDER1);
 }
 
 PanelDOF::~PanelDOF()

--- a/apps/robotic-arm-kinematics/robotic_arm_kinematicsMain.cpp
+++ b/apps/robotic-arm-kinematics/robotic_arm_kinematicsMain.cpp
@@ -569,110 +569,39 @@ robotic_arm_kinematicsFrame::robotic_arm_kinematicsFrame(
 	FlexGridSizer1->SetSizeHints(this);
 	Center();
 
-	Connect(
-		ID_RADIOBOX2, wxEVT_COMMAND_RADIOBOX_SELECTED,
-		(wxObjectEventFunction)&robotic_arm_kinematicsFrame::On1stXYZSelect);
-	Connect(
-		ID_SIMPLEHTMLLISTBOX1, wxEVT_COMMAND_LISTBOX_SELECTED,
-		(wxObjectEventFunction)&robotic_arm_kinematicsFrame::OnlistLinksSelect);
-	Connect(
-		ID_BUTTON5, wxEVT_COMMAND_BUTTON_CLICKED,
-		(wxObjectEventFunction)&robotic_arm_kinematicsFrame::OnbtnAddLinkClick);
-	Connect(
-		ID_BUTTON6, wxEVT_COMMAND_BUTTON_CLICKED,
-		(wxObjectEventFunction)&robotic_arm_kinematicsFrame::OnbtnClearClick);
-	Connect(
-		ID_BUTTON7, wxEVT_COMMAND_BUTTON_CLICKED,
-		(wxObjectEventFunction)&robotic_arm_kinematicsFrame::OnbtnDeleteClick);
-	Connect(
-		ID_RADIOBOX1, wxEVT_COMMAND_RADIOBOX_SELECTED,
-		(wxObjectEventFunction)&robotic_arm_kinematicsFrame::OnrbTypeSelect);
-	Connect(
-		ID_BUTTON1, wxEVT_COMMAND_BUTTON_CLICKED,
-		(wxObjectEventFunction)&robotic_arm_kinematicsFrame::
-			OnButtonSaveFromEdit);
-	Connect(
-		ID_SLIDER1,
-		wxEVT_SCROLL_TOP | wxEVT_SCROLL_BOTTOM | wxEVT_SCROLL_LINEUP |
-			wxEVT_SCROLL_LINEDOWN | wxEVT_SCROLL_PAGEUP |
-			wxEVT_SCROLL_PAGEDOWN | wxEVT_SCROLL_THUMBTRACK |
-			wxEVT_SCROLL_THUMBRELEASE | wxEVT_SCROLL_CHANGED,
-		(wxObjectEventFunction)&robotic_arm_kinematicsFrame::OnSliderScroll);
-	Connect(
-		ID_SLIDER1, wxEVT_SCROLL_CHANGED,
-		(wxObjectEventFunction)&robotic_arm_kinematicsFrame::OnSliderScroll);
-	Connect(
-		ID_SLIDER1, wxEVT_COMMAND_SLIDER_UPDATED,
-		(wxObjectEventFunction)&robotic_arm_kinematicsFrame::OnSliderScroll);
-	Connect(
-		ID_BUTTON2, wxEVT_COMMAND_BUTTON_CLICKED,
-		(wxObjectEventFunction)&robotic_arm_kinematicsFrame::
-			OnButtonSaveFromEdit);
-	Connect(
-		ID_SLIDER2,
-		wxEVT_SCROLL_TOP | wxEVT_SCROLL_BOTTOM | wxEVT_SCROLL_LINEUP |
-			wxEVT_SCROLL_LINEDOWN | wxEVT_SCROLL_PAGEUP |
-			wxEVT_SCROLL_PAGEDOWN | wxEVT_SCROLL_THUMBTRACK |
-			wxEVT_SCROLL_THUMBRELEASE | wxEVT_SCROLL_CHANGED,
-		(wxObjectEventFunction)&robotic_arm_kinematicsFrame::OnSliderScroll);
-	Connect(
-		ID_SLIDER2, wxEVT_SCROLL_CHANGED,
-		(wxObjectEventFunction)&robotic_arm_kinematicsFrame::OnSliderScroll);
-	Connect(
-		ID_SLIDER2, wxEVT_COMMAND_SLIDER_UPDATED,
-		(wxObjectEventFunction)&robotic_arm_kinematicsFrame::OnSliderScroll);
-	Connect(
-		ID_BUTTON3, wxEVT_COMMAND_BUTTON_CLICKED,
-		(wxObjectEventFunction)&robotic_arm_kinematicsFrame::
-			OnButtonSaveFromEdit);
-	Connect(
-		ID_SLIDER3,
-		wxEVT_SCROLL_TOP | wxEVT_SCROLL_BOTTOM | wxEVT_SCROLL_LINEUP |
-			wxEVT_SCROLL_LINEDOWN | wxEVT_SCROLL_PAGEUP |
-			wxEVT_SCROLL_PAGEDOWN | wxEVT_SCROLL_THUMBTRACK |
-			wxEVT_SCROLL_THUMBRELEASE | wxEVT_SCROLL_CHANGED,
-		(wxObjectEventFunction)&robotic_arm_kinematicsFrame::OnSliderScroll);
-	Connect(
-		ID_SLIDER3, wxEVT_SCROLL_CHANGED,
-		(wxObjectEventFunction)&robotic_arm_kinematicsFrame::OnSliderScroll);
-	Connect(
-		ID_SLIDER3, wxEVT_COMMAND_SLIDER_UPDATED,
-		(wxObjectEventFunction)&robotic_arm_kinematicsFrame::OnSliderScroll);
-	Connect(
-		ID_BUTTON4, wxEVT_COMMAND_BUTTON_CLICKED,
-		(wxObjectEventFunction)&robotic_arm_kinematicsFrame::
-			OnButtonSaveFromEdit);
-	Connect(
-		ID_SLIDER4,
-		wxEVT_SCROLL_TOP | wxEVT_SCROLL_BOTTOM | wxEVT_SCROLL_LINEUP |
-			wxEVT_SCROLL_LINEDOWN | wxEVT_SCROLL_PAGEUP |
-			wxEVT_SCROLL_PAGEDOWN | wxEVT_SCROLL_THUMBTRACK |
-			wxEVT_SCROLL_THUMBRELEASE | wxEVT_SCROLL_CHANGED,
-		(wxObjectEventFunction)&robotic_arm_kinematicsFrame::OnSliderScroll);
-	Connect(
-		ID_SLIDER4, wxEVT_SCROLL_CHANGED,
-		(wxObjectEventFunction)&robotic_arm_kinematicsFrame::OnSliderScroll);
-	Connect(
-		ID_SLIDER4, wxEVT_COMMAND_SLIDER_UPDATED,
-		(wxObjectEventFunction)&robotic_arm_kinematicsFrame::OnSliderScroll);
-	Connect(
-		ID_LISTBOX1, wxEVT_COMMAND_LISTBOX_SELECTED,
-		(wxObjectEventFunction)&robotic_arm_kinematicsFrame::OnlbXYZsSelect);
-	Connect(
-		ID_MENUITEM3, wxEVT_COMMAND_MENU_SELECTED,
-		(wxObjectEventFunction)&robotic_arm_kinematicsFrame::OnbtnClearClick);
-	Connect(
-		ID_MENUITEM1, wxEVT_COMMAND_MENU_SELECTED,
-		(wxObjectEventFunction)&robotic_arm_kinematicsFrame::OnLoadBinary);
-	Connect(
-		ID_MENUITEM2, wxEVT_COMMAND_MENU_SELECTED,
-		(wxObjectEventFunction)&robotic_arm_kinematicsFrame::OnSaveBinary);
-	Connect(
-		idMenuQuit, wxEVT_COMMAND_MENU_SELECTED,
-		(wxObjectEventFunction)&robotic_arm_kinematicsFrame::OnQuit);
-	Connect(
-		idMenuAbout, wxEVT_COMMAND_MENU_SELECTED,
-		(wxObjectEventFunction)&robotic_arm_kinematicsFrame::OnAbout);
+	using rakf = robotic_arm_kinematicsFrame;
+
+	Bind(wxEVT_RADIOBOX, &rakf::On1stXYZSelect, this, ID_RADIOBOX2);
+	Bind(wxEVT_LISTBOX, &rakf::OnlistLinksSelect, this, ID_SIMPLEHTMLLISTBOX1);
+	Bind(wxEVT_BUTTON, &rakf::OnbtnAddLinkClick, this, ID_BUTTON5);
+	Bind(wxEVT_BUTTON, &rakf::OnbtnClearClick, this, ID_BUTTON6);
+	Bind(wxEVT_BUTTON, &rakf::OnbtnDeleteClick, this, ID_BUTTON7);
+	Bind(wxEVT_RADIOBOX, &rakf::OnrbTypeSelect, this, ID_RADIOBOX1);
+	Bind(wxEVT_BUTTON, &rakf::OnButtonSaveFromEdit, this, ID_BUTTON1);
+	Bind(wxEVT_SLIDER, &rakf::OnSliderScroll, this, ID_SLIDER1);
+	Bind(wxEVT_BUTTON, &rakf::OnButtonSaveFromEdit, this, ID_BUTTON2);
+	Bind(wxEVT_SCROLL_TOP, &rakf::OnSliderScroll, this, ID_SLIDER2);
+	Bind(wxEVT_SCROLL_BOTTOM, &rakf::OnSliderScroll, this, ID_SLIDER2);
+	Bind(wxEVT_SCROLL_LINEUP, &rakf::OnSliderScroll, this, ID_SLIDER2);
+	Bind(wxEVT_SCROLL_LINEDOWN, &rakf::OnSliderScroll, this, ID_SLIDER2);
+	Bind(wxEVT_SCROLL_PAGEUP, &rakf::OnSliderScroll, this, ID_SLIDER2);
+	Bind(wxEVT_SCROLL_PAGEDOWN, &rakf::OnSliderScroll, this, ID_SLIDER2);
+	Bind(wxEVT_SCROLL_THUMBTRACK, &rakf::OnSliderScroll, this, ID_SLIDER2);
+	Bind(wxEVT_SCROLL_THUMBRELEASE, &rakf::OnSliderScroll, this, ID_SLIDER2);
+	Bind(wxEVT_SCROLL_CHANGED, &rakf::OnSliderScroll, this, ID_SLIDER2);
+	Bind(wxEVT_SLIDER, &rakf::OnSliderScroll, this, ID_SLIDER2);
+	Bind(wxEVT_BUTTON, &rakf::OnButtonSaveFromEdit, this, ID_BUTTON3);
+	Bind(wxEVT_SLIDER, &rakf::OnSliderScroll, this, ID_SLIDER3);
+	Bind(wxEVT_SLIDER, &rakf::OnSliderScroll, this, ID_SLIDER3);
+	Bind(wxEVT_BUTTON, &rakf::OnButtonSaveFromEdit, this, ID_BUTTON4);
+	Bind(wxEVT_SLIDER, &rakf::OnSliderScroll, this, ID_SLIDER4);
+	Bind(wxEVT_SLIDER, &rakf::OnSliderScroll, this, ID_SLIDER4);
+	Bind(wxEVT_LISTBOX, &rakf::OnlbXYZsSelect, this, ID_LISTBOX1);
+	Bind(wxEVT_MENU, &rakf::OnbtnClearClick, this, ID_MENUITEM3);
+	Bind(wxEVT_MENU, &rakf::OnLoadBinary, this, ID_MENUITEM1);
+	Bind(wxEVT_MENU, &rakf::OnSaveBinary, this, ID_MENUITEM2);
+	Bind(wxEVT_MENU, &rakf::OnQuit, this, idMenuQuit);
+	Bind(wxEVT_MENU, &rakf::OnAbout, this, idMenuAbout);
 	//*)
 
 	// maximize:
@@ -914,7 +843,7 @@ void robotic_arm_kinematicsFrame::OnlistLinksSelect(wxCommandEvent& event)
 }
 
 // Sliders of the DOFs bottom panels:
-void robotic_arm_kinematicsFrame::OnSliderDOFScroll(wxScrollEvent& event)
+void robotic_arm_kinematicsFrame::OnSliderDOFScroll(wxScrollEvent&)
 {
 	for (size_t i = 0; i < m_dof_panels.size(); i++)
 	{
@@ -934,7 +863,7 @@ void robotic_arm_kinematicsFrame::OnSliderDOFScroll(wxScrollEvent& event)
 }
 
 // Sliders of the left panel:
-void robotic_arm_kinematicsFrame::OnSliderScroll(wxScrollEvent& event)
+void robotic_arm_kinematicsFrame::OnSliderScroll(wxCommandEvent&)
 {
 	UpdateMatrixView();
 

--- a/apps/robotic-arm-kinematics/robotic_arm_kinematicsMain.h
+++ b/apps/robotic-arm-kinematics/robotic_arm_kinematicsMain.h
@@ -37,14 +37,19 @@ class robotic_arm_kinematicsFrame : public wxFrame
 	robotic_arm_kinematicsFrame(wxWindow* parent, wxWindowID id = -1);
 	~robotic_arm_kinematicsFrame() override;
 
-	void OnSliderDOFScroll(wxScrollEvent& event);
+	void OnSliderDOFScroll(wxScrollEvent&);
+	void OnSliderDOFScrollBis(wxCommandEvent&)
+	{
+		wxScrollEvent e;
+		OnSliderDOFScroll(e);
+	}
 
    private:
 	//(*Handlers(robotic_arm_kinematicsFrame)
 	void OnQuit(wxCommandEvent& event);
 	void OnAbout(wxCommandEvent& event);
 	void OnlistLinksSelect(wxCommandEvent& event);
-	void OnSliderScroll(wxScrollEvent& event);
+	void OnSliderScroll(wxCommandEvent& event);
 	void OnButtonSaveFromEdit(wxCommandEvent& event);
 	void OnbtnClearClick(wxCommandEvent& event);
 	void OnbtnAddLinkClick(wxCommandEvent& event);

--- a/apps/wx-common/CPanelCameraSelection.cpp
+++ b/apps/wx-common/CPanelCameraSelection.cpp
@@ -425,12 +425,12 @@ CPanelCameraSelection::CPanelCameraSelection(wxWindow* parent, wxWindowID id)
 	FlexGridSizer1->Fit(this);
 	FlexGridSizer1->SetSizeHints(this);
 
-	Connect(
-		ID_BUTTON7, wxEVT_COMMAND_BUTTON_CLICKED,
-		(wxObjectEventFunction)&CPanelCameraSelection::OnbtnBrowseVideoClick);
-	Connect(
-		ID_BUTTON8, wxEVT_COMMAND_BUTTON_CLICKED,
-		(wxObjectEventFunction)&CPanelCameraSelection::OnbtnBrowseRawlogClick);
+	Bind(
+		wxEVT_COMMAND_BUTTON_CLICKED,
+		&CPanelCameraSelection::OnbtnBrowseVideoClick, this, ID_BUTTON7);
+	Bind(
+		wxEVT_COMMAND_BUTTON_CLICKED,
+		&CPanelCameraSelection::OnbtnBrowseRawlogClick, this, ID_BUTTON8);
 	Connect(
 		ID_BUTTON9, wxEVT_COMMAND_BUTTON_CLICKED,
 		(wxObjectEventFunction)&CPanelCameraSelection::

--- a/libs/gui/src/CAboutBox_wx.cpp
+++ b/libs/gui/src/CAboutBox_wx.cpp
@@ -146,12 +146,8 @@ CAboutBox::CAboutBox(
 	FlexGridSizer1->SetSizeHints(this);
 	Center();
 
-	Connect(
-		ID_BUTTON1, wxEVT_COMMAND_BUTTON_CLICKED,
-		wxCommandEventHandler(CAboutBox::OnButton1Click));
-	Connect(
-		wxID_ANY, wxEVT_INIT_DIALOG,
-		wxInitDialogEventHandler(CAboutBox::OnInit));
+	Bind(wxEVT_BUTTON, &CAboutBox::OnButton1Click, this, ID_BUTTON1);
+	Bind(wxEVT_INIT_DIALOG, &CAboutBox::OnInit, this);
 	//*)
 
 	lbLicense->SetValue(license().c_str());

--- a/libs/gui/src/CDisplayWindow.cpp
+++ b/libs/gui/src/CDisplayWindow.cpp
@@ -41,25 +41,14 @@ CWindowDialog::wxMRPTImageControl::wxMRPTImageControl(
 {
 	this->Create(parent, winID, wxPoint(x, y), wxSize(width, height));
 
-	Connect(
-		wxEVT_PAINT,
-		wxPaintEventHandler(CWindowDialog::wxMRPTImageControl::OnPaint));
-	Connect(
-		wxEVT_MOTION,
-		wxMouseEventHandler(CWindowDialog::wxMRPTImageControl::OnMouseMove));
-	Connect(
-		wxID_ANY, wxEVT_LEFT_DOWN,
-		wxMouseEventHandler(CWindowDialog::wxMRPTImageControl::OnMouseClick));
-
-	Connect(
-		wxID_ANY, wxEVT_CHAR,
-		(wxObjectEventFunction)&CWindowDialog::wxMRPTImageControl::OnChar);
-	Connect(
-		wxEVT_CHAR,
-		(wxObjectEventFunction)&CWindowDialog::wxMRPTImageControl::OnChar);
-
-	//	Connect(wxID_ANY,wxEVT_CHAR,(wxObjectEventFunction)&CWindowDialog::wxMRPTImageControl::OnChar);
-	//	Connect(wxID_ANY,wxEVT_KEY_DOWN,(wxObjectEventFunction)&CWindowDialog::wxMRPTImageControl::OnChar);
+	Bind(wxEVT_PAINT, &CWindowDialog::wxMRPTImageControl::OnPaint, this);
+	Bind(wxEVT_MOTION, &CWindowDialog::wxMRPTImageControl::OnMouseMove, this);
+	Bind(
+		wxEVT_LEFT_DOWN, &CWindowDialog::wxMRPTImageControl::OnMouseClick,
+		this);
+	Bind(
+		wxEVT_CHAR, &CWindowDialog::wxMRPTImageControl::OnChar, this, wxID_ANY);
+	Bind(wxEVT_CHAR, &CWindowDialog::wxMRPTImageControl::OnChar, this);
 }
 
 CWindowDialog::wxMRPTImageControl::~wxMRPTImageControl()
@@ -160,42 +149,20 @@ CWindowDialog::CWindowDialog(
 	SetMenuBar(MenuBar1);
 
 	// Events:
-	Connect(
-		wxID_ANY, wxEVT_CLOSE_WINDOW,
-		(wxObjectEventFunction)&CWindowDialog::OnClose);
-	Connect(
-		ID_MENUITEM1, wxEVT_COMMAND_MENU_SELECTED,
-		(wxObjectEventFunction)&CWindowDialog::OnMenuClose);
-	Connect(
-		ID_MENUITEM2, wxEVT_COMMAND_MENU_SELECTED,
-		(wxObjectEventFunction)&CWindowDialog::OnMenuAbout);
-	Connect(
-		ID_MENUITEM3, wxEVT_COMMAND_MENU_SELECTED,
-		(wxObjectEventFunction)&CWindowDialog::OnMenuSave);
+	Bind(wxEVT_CLOSE_WINDOW, &CWindowDialog::OnClose, this, wxID_ANY);
+	Bind(wxEVT_MENU, &CWindowDialog::OnMenuClose, this, ID_MENUITEM1);
+	Bind(wxEVT_MENU, &CWindowDialog::OnMenuAbout, this, ID_MENUITEM2);
+	Bind(wxEVT_MENU, &CWindowDialog::OnMenuSave, this, ID_MENUITEM3);
 
-	//	Connect(wxID_ANY,wxEVT_CHAR,(wxObjectEventFunction)&CWindowDialog::OnChar);
-	Connect(
-		wxID_ANY, wxEVT_KEY_DOWN,
-		(wxObjectEventFunction)&CWindowDialog::OnChar);
-	// Connect(wxID_ANY,wxEVT_CHAR,(wxObjectEventFunction)&CWindowDialog::OnChar);
-	Connect(wxEVT_CHAR, (wxObjectEventFunction)&CWindowDialog::OnChar);
+	Bind(wxEVT_KEY_DOWN, &CWindowDialog::OnChar, this, wxID_ANY);
+	Bind(wxEVT_CHAR, &CWindowDialog::OnChar, this, wxID_ANY);
 
-	m_image->Connect(
-		wxID_ANY, wxEVT_KEY_DOWN, (wxObjectEventFunction)&CWindowDialog::OnChar,
-		nullptr, this);
-	m_image->Connect(
-		wxEVT_SIZE, (wxObjectEventFunction)&CWindowDialog::OnResize, nullptr,
-		this);
+	m_image->Bind(wxEVT_KEY_DOWN, &CWindowDialog::OnChar, this);
+	m_image->Bind(wxEVT_SIZE, &CWindowDialog::OnResize, this);
 
-	m_image->Connect(
-		wxEVT_LEFT_DOWN, (wxObjectEventFunction)&CWindowDialog::OnMouseDown,
-		nullptr, this);
-	m_image->Connect(
-		wxEVT_RIGHT_DOWN, (wxObjectEventFunction)&CWindowDialog::OnMouseDown,
-		nullptr, this);
-	m_image->Connect(
-		wxEVT_MOTION, (wxObjectEventFunction)&CWindowDialog::OnMouseMove,
-		nullptr, this);
+	m_image->Bind(wxEVT_LEFT_DOWN, &CWindowDialog::OnMouseDown, this);
+	m_image->Bind(wxEVT_RIGHT_DOWN, &CWindowDialog::OnMouseDown, this);
+	m_image->Bind(wxEVT_MOTION, &CWindowDialog::OnMouseMove, this);
 
 	// Increment number of windows:
 	// int winCount =

--- a/libs/gui/src/CDisplayWindow3D.cpp
+++ b/libs/gui/src/CDisplayWindow3D.cpp
@@ -300,12 +300,8 @@ C3DWindowDialog::C3DWindowDialog(
 
 	// Events:
 	this->Bind(wxEVT_CLOSE_WINDOW, &C3DWindowDialog::OnClose, this);
-	this->Bind(
-		wxEVT_COMMAND_MENU_SELECTED, &C3DWindowDialog::OnMenuClose, this,
-		ID_MENUITEM1);
-	this->Bind(
-		wxEVT_COMMAND_MENU_SELECTED, &C3DWindowDialog::OnMenuAbout, this,
-		ID_MENUITEM2);
+	this->Bind(wxEVT_MENU, &C3DWindowDialog::OnMenuClose, this, ID_MENUITEM1);
+	this->Bind(wxEVT_MENU, &C3DWindowDialog::OnMenuAbout, this, ID_MENUITEM2);
 	this->Bind(wxEVT_CHAR, &C3DWindowDialog::OnChar, this);
 	this->Bind(wxEVT_SIZE, &C3DWindowDialog::OnResize, this);
 

--- a/libs/gui/src/CDisplayWindowPlots.cpp
+++ b/libs/gui/src/CDisplayWindowPlots.cpp
@@ -83,46 +83,23 @@ CWindowDialogPlots::CWindowDialogPlots(
 	SetMenuBar(MenuBar1);
 
 	// Events:
-	Connect(
-		wxID_ANY, wxEVT_CLOSE_WINDOW,
-		(wxObjectEventFunction)&CWindowDialogPlots::OnClose);
-	Connect(
-		ID_MENUITEM1, wxEVT_COMMAND_MENU_SELECTED,
-		(wxObjectEventFunction)&CWindowDialogPlots::OnMenuClose);
-	Connect(
-		ID_MENU_PRINT, wxEVT_COMMAND_MENU_SELECTED,
-		(wxObjectEventFunction)&CWindowDialogPlots::OnMenuPrint);
-	Connect(
-		ID_MENUITEM2, wxEVT_COMMAND_MENU_SELECTED,
-		(wxObjectEventFunction)&CWindowDialogPlots::OnMenuAbout);
+	Bind(wxEVT_CLOSE_WINDOW, &CWindowDialogPlots::OnClose, this, wxID_ANY);
+	Bind(wxEVT_MENU, &CWindowDialogPlots::OnMenuClose, this, ID_MENUITEM1);
+	Bind(wxEVT_MENU, &CWindowDialogPlots::OnMenuPrint, this, ID_MENU_PRINT);
+	Bind(wxEVT_MENU, &CWindowDialogPlots::OnMenuAbout, this, ID_MENUITEM2);
 
-	Connect(
-		wxID_ANY, wxEVT_SIZE,
-		(wxObjectEventFunction)&CWindowDialogPlots::OnResize);
+	Bind(wxEVT_SIZE, &CWindowDialogPlots::OnResize, this, wxID_ANY);
 
-	Connect(
-		wxID_ANY, wxEVT_CHAR,
-		(wxObjectEventFunction)&CWindowDialogPlots::OnChar);
-	m_plot->Connect(
-		wxEVT_CHAR, (wxObjectEventFunction)&CWindowDialogPlots::OnChar, nullptr,
-		this);
-	m_plot->Connect(
-		wxEVT_MOTION, (wxObjectEventFunction)&CWindowDialogPlots::OnMouseMove,
-		nullptr, this);
+	Bind(wxEVT_CHAR, &CWindowDialogPlots::OnChar, this, wxID_ANY);
+	m_plot->Bind(wxEVT_CHAR, &CWindowDialogPlots::OnChar, this);
+	m_plot->Bind(wxEVT_MOTION, &CWindowDialogPlots::OnMouseMove, this);
 
-	m_plot->Connect(
-		wxEVT_LEFT_DOWN,
-		(wxObjectEventFunction)&CWindowDialogPlots::OnMouseDown, nullptr, this);
-	m_plot->Connect(
-		wxEVT_RIGHT_DOWN,
-		(wxObjectEventFunction)&CWindowDialogPlots::OnMouseDown, nullptr, this);
+	m_plot->Bind(wxEVT_LEFT_DOWN, &CWindowDialogPlots::OnMouseDown, this);
+	m_plot->Bind(wxEVT_RIGHT_DOWN, &CWindowDialogPlots::OnMouseDown, this);
 
 	// Increment number of windows:
 	// int winCount =
 	WxSubsystem::CWXMainFrame::notifyWindowCreation();
-	// cout << "[CWindowDialogPlots] Notifying new window: " << winCount <<
-	// endl;
-
 	// this->Iconize(false);
 
 #if 0

--- a/libs/gui/src/WxSubsystem.cpp
+++ b/libs/gui/src/WxSubsystem.cpp
@@ -124,12 +124,10 @@ class CDialogAskUserForCamera : public wxDialog
 			btnCancel, 1, wxALL | wxALIGN_BOTTOM | wxALIGN_CENTER_HORIZONTAL,
 			5);
 
-		Connect(
-			ID_BTN_OK, wxEVT_COMMAND_BUTTON_CLICKED,
-			(wxObjectEventFunction)&CDialogAskUserForCamera::OnBtnOk);
-		Connect(
-			ID_BTN_CANCEL, wxEVT_COMMAND_BUTTON_CLICKED,
-			(wxObjectEventFunction)&CDialogAskUserForCamera::OnBtnCancel);
+		Bind(wxEVT_BUTTON, &CDialogAskUserForCamera::OnBtnOk, this, ID_BTN_OK);
+		Bind(
+			wxEVT_BUTTON, &CDialogAskUserForCamera::OnBtnCancel, this,
+			ID_BTN_CANCEL);
 
 		SetSizer(f1);
 		Fit();
@@ -173,9 +171,9 @@ WxSubsystem::CWXMainFrame::CWXMainFrame(wxWindow* parent, wxWindowID id)
 	// Create a timer so requests from the main application thread can be
 	// processed regularly:
 	// ------------------------------------------------------------------------------------------
-	Connect(
-		ID_TIMER_WX_PROCESS_REQUESTS, wxEVT_TIMER,
-		(wxObjectEventFunction)&CWXMainFrame::OnTimerProcessRequests);
+	Bind(
+		wxEVT_TIMER, &CWXMainFrame::OnTimerProcessRequests, this,
+		ID_TIMER_WX_PROCESS_REQUESTS);
 	m_theTimer = new wxTimer(this, ID_TIMER_WX_PROCESS_REQUESTS);
 
 	m_theTimer->Start(10, true);  // One-shot
@@ -700,10 +698,9 @@ void WxSubsystem::CWXMainFrame::OnTimerProcessRequests(wxTimerEvent& event)
 								wxEmptyString, wxITEM_NORMAL);
 							popupMnu->Insert(0, mnuTarget);
 
-							wnd->Connect(
-								MENUITEM_ID, wxEVT_COMMAND_MENU_SELECTED,
-								(wxObjectEventFunction)&CWindowDialogPlots::
-									OnMenuSelected);
+							wnd->Bind(
+								wxEVT_MENU, &CWindowDialogPlots::OnMenuSelected,
+								wnd, MENUITEM_ID);
 						}
 					}
 					break;

--- a/libs/gui/src/WxUtils.cpp
+++ b/libs/gui/src/WxUtils.cpp
@@ -116,13 +116,9 @@ wxMRPTImageControl::wxMRPTImageControl(
 {
 	this->Create(parent, winID, wxPoint(x, y), wxSize(width, height));
 
-	Connect(wxEVT_PAINT, wxPaintEventHandler(wxMRPTImageControl::OnPaint));
-	Connect(wxEVT_MOTION, wxMouseEventHandler(wxMRPTImageControl::OnMouseMove));
-	Connect(
-		wxID_ANY, wxEVT_LEFT_DOWN,
-		wxMouseEventHandler(wxMRPTImageControl::OnMouseClick));
-
-	// Connect(wxID_ANY,wxEVT_CHAR,(wxObjectEventFunction)&wxMRPTImageControl::OnChar);
+	Bind(wxEVT_PAINT, &wxMRPTImageControl::OnPaint, this);
+	Bind(wxEVT_MOTION, &wxMRPTImageControl::OnMouseMove, this);
+	Bind(wxEVT_LEFT_DOWN, &wxMRPTImageControl::OnMouseClick, this);
 }
 
 wxMRPTImageControl::~wxMRPTImageControl()
@@ -608,16 +604,15 @@ CPanelCameraSelection::CPanelCameraSelection(wxWindow* parent, wxWindowID id)
 	FlexGridSizer1->Fit(this);
 	FlexGridSizer1->SetSizeHints(this);
 
-	Connect(
-		ID_BUTTON7, wxEVT_COMMAND_BUTTON_CLICKED,
-		(wxObjectEventFunction)&CPanelCameraSelection::OnbtnBrowseVideoClick);
-	Connect(
-		ID_BUTTON8, wxEVT_COMMAND_BUTTON_CLICKED,
-		(wxObjectEventFunction)&CPanelCameraSelection::OnbtnBrowseRawlogClick);
-	Connect(
-		ID_BUTTON9, wxEVT_COMMAND_BUTTON_CLICKED,
-		(wxObjectEventFunction)&CPanelCameraSelection::
-			OnbtnBrowseRawlogDirClick);
+	Bind(
+		wxEVT_BUTTON, &CPanelCameraSelection::OnbtnBrowseVideoClick, this,
+		ID_BUTTON7);
+	Bind(
+		wxEVT_BUTTON, &CPanelCameraSelection::OnbtnBrowseRawlogClick, this,
+		ID_BUTTON8);
+	Bind(
+		wxEVT_BUTTON, &CPanelCameraSelection::OnbtnBrowseRawlogDirClick, this,
+		ID_BUTTON9);
 	//*)
 
 	// end of automatically-generated code above:


### PR DESCRIPTION
- Replaced by Bind(), without unsafe function typecasting. 
- Replace old event names with new (shorter) ones.