### PR TITLE
Fix CObservationIMU get function name.

### DIFF
--- a/libs/obs/include/mrpt/obs/CObservationIMU.h
+++ b/libs/obs/include/mrpt/obs/CObservationIMU.h
@@ -141,7 +141,7 @@ class CObservationIMU : public CObservation
 	}
 
 	/** Gets a given data type, throws if not set. \sa has(), get() */
-	double set(TIMUDataIndex idx) const
+	double get(TIMUDataIndex idx) const
 	{
 		ASSERTMSG_(dataIsPresent.at(idx), "Trying to access non-set value");
 		return rawMeasurements.at(idx);


### PR DESCRIPTION
## PR Description

CObservationIMU class get function name is erroneously spelt. This PR fixes its name.

---

I acknowledge to have:
* Read the [`CONTRIBUTING`](https://github.com/MRPT/mrpt/blob/master/.github/CONTRIBUTING.md) page
* Updated [`doc/doxygen-pages/changeLog_doc.h`](https://github.com/MRPT/mrpt/blob/master/doc/doxygen-pages/changeLog_doc.h) to describe these changes (if applicable)
* Updated [`AUTHORS`](https://github.com/MRPT/mrpt/blob/master/AUTHORS) (if applicable)

(Notify: @MRPT/owners )
