### PR TITLE
Quaternion singularity fix

### DIFF
--- a/libs/math/include/mrpt/math/CQuaternion.h
+++ b/libs/math/include/mrpt/math/CQuaternion.h
@@ -456,7 +456,7 @@ class CQuaternion : public CVectorFixed<T, 4>
 
 		if (out_dr_dq && resize_out_dr_dq_to3x4) out_dr_dq->setSize(3, 4);
 		const T discr = r() * y() - x() * z();
-		if (fabs(discr) > 0.49999)
+		if (discr > 0.49999)
 		{  // pitch = 90 deg
 			pitch = 0.5 * M_PI;
 			yaw = -2 * atan2(x(), r());


### PR DESCRIPTION
## PR Description

fabs call prevents the handle of the -90 degree degenerate case. This PR fixes it.

---

I acknowledge to have:
* Read the [`CONTRIBUTING`](https://github.com/MRPT/mrpt/blob/master/.github/CONTRIBUTING.md) page
* Updated [`doc/doxygen-pages/changeLog_doc.h`](https://github.com/MRPT/mrpt/blob/master/doc/doxygen-pages/changeLog_doc.h) to describe these changes (if applicable)
* Updated [`AUTHORS`](https://github.com/MRPT/mrpt/blob/master/AUTHORS) (if applicable)

(Notify: @MRPT/owners )
