### PR TITLE
Fix missing lock guard

### DIFF
--- a/libs/hmtslam/src/CLocalMetricHypothesis.cpp
+++ b/libs/hmtslam/src/CLocalMetricHypothesis.cpp
@@ -793,7 +793,7 @@ void CLocalMetricHypothesis::updateAreaFromLMH(
 
 	CHMHMapNode::Ptr node;
 	{
-		std::lock_guard<std::mutex>(m_parent->m_map_cs);
+		std::lock_guard<std::mutex> lock(m_parent->m_map_cs);
 		node = m_parent->m_map.getNodeByID(areaID);
 		ASSERT_(node);
 		ASSERT_(node->m_hypotheses.has(m_ID));


### PR DESCRIPTION
This commit fixes a bug where the lock guard (for concurrently accessing
the same scope from different threads) had basically no effect, due to
being bound to a temporary only.
