### PR TITLE
Fix lintian warning in Debian package

### DIFF
--- a/packaging/debian/control.in
+++ b/packaging/debian/control.in
@@ -680,7 +680,6 @@ Recommends: libmrpt-bayes-dev (= ${binary:Version}),
          libmrpt-vision-dev (= ${binary:Version}),
 		 libmrpt-vision-lgpl-dev (= ${binary:Version})
 Description: Mobile Robot Programming Toolkit - Metapackage: all dev packages
- .
  This metapackage install all mrpt -dev packages.
 
 Package: mrpt-common


### PR DESCRIPTION

I acknowledge to have:
* Read the [`CONTRIBUTING`](https://github.com/MRPT/mrpt/blob/master/.github/CONTRIBUTING.md) page
* Updated [`doc/doxygen-pages/changeLog_doc.h`](https://github.com/MRPT/mrpt/blob/master/doc/doxygen-pages/changeLog_doc.h) to describe these changes (if applicable)
* Updated [`AUTHORS`](https://github.com/MRPT/mrpt/blob/master/AUTHORS) (if applicable)

(Notify: @MRPT/owners )
