### PR TITLE
debian: Avoid running out of memory when building on mipsel

### DIFF
--- a/packaging/debian/rules
+++ b/packaging/debian/rules
@@ -2,6 +2,8 @@
 # -*- makefile -*-
 # Makefile for MRPT Debian package.
 
+include /usr/share/dpkg/architecture.mk
+
 export DEB_BUILD_MAINT_OPTIONS=hardening=+all,+fortify
 
 # default: dont build expensive caller graphs with dot in the documentation pkg
@@ -22,6 +24,11 @@ endif
 # Unit tests can be run with target "test_legacy", or "test_gdb", which shows stack
 # traces on failure:
 MRPT_TEST_TARGET = test_legacy
+
+# Avoid running out of memory on mipsel
+ifneq (,$(filter $(DEB_HOST_ARCH), mipsel))
+  export DEB_CXXFLAGS_MAINT_APPEND += -g1
+endif
 
 CMAKE_FLAGS = \
 	-DCMAKE_INSTALL_PREFIX="$(CURDIR)/debian/usr/" \


### PR DESCRIPTION
mipsel architecture is limited to 2GB address space.  This change reduces
the amount of debug generated and thus allows the build to succeed there.

I acknowledge to have:
* Read the [`CONTRIBUTING`](https://github.com/MRPT/mrpt/blob/master/.github/CONTRIBUTING.md) page
* Updated [`doc/doxygen-pages/changeLog_doc.h`](https://github.com/MRPT/mrpt/blob/master/doc/doxygen-pages/changeLog_doc.h) to describe these changes (if applicable)
* Updated [`AUTHORS`](https://github.com/MRPT/mrpt/blob/master/AUTHORS) (if applicable)

(Notify: @MRPT/owners )
