### PR TITLE
debian: Remove Breaks/Replaces from libmrpt-dev

### DIFF
--- a/packaging/debian/control.in
+++ b/packaging/debian/control.in
@@ -717,8 +717,6 @@ Description: Mobile Robot Programming Toolkit - common development files
 Package: libmrpt-dev
 Section: libdevel
 Architecture: any
-Breaks: libmrpt-dev (<< 1:2)
-Replaces: libmrpt-dev (<< 1:2)
 Depends: ${misc:Depends},
 Recommends: libmrpt-bayes-dev (= ${binary:Version}),
          libmrpt-comms-dev (= ${binary:Version}),


### PR DESCRIPTION
I acknowledge to have:
* Read the [`CONTRIBUTING`](https://github.com/MRPT/mrpt/blob/master/.github/CONTRIBUTING.md) page
* Updated [`doc/doxygen-pages/changeLog_doc.h`](https://github.com/MRPT/mrpt/blob/master/doc/doxygen-pages/changeLog_doc.h) to describe these changes (if applicable)
* Updated [`AUTHORS`](https://github.com/MRPT/mrpt/blob/master/AUTHORS) (if applicable)

(Notify: @MRPT/owners )
