### PR TITLE
Fix build error against libjsoncpp 1.9.4

### DIFF
--- a/doc/source/doxygen-docs/changelog.md
+++ b/doc/source/doxygen-docs/changelog.md
@@ -15,6 +15,7 @@
 - BUG FIXES:
   - Fix error rendering an opengl scene with mrpt::opengl::CCamera objects in it.
   - rawlog-edit silently ignored when more than one operation was requested.
+  - Fix FTBFS against libjsoncpp 1.9.4 (Closes [#1118](https://github.com/MRPT/mrpt/issues/1118))
 
 ------
 # Version 2.1.4: Released Nov 8th, 2020

--- a/libs/serialization/include/mrpt/serialization/CSchemeArchive.h
+++ b/libs/serialization/include/mrpt/serialization/CSchemeArchive.h
@@ -71,12 +71,6 @@ class CSchemeArchive : public mrpt::serialization::CSchemeArchiveBase_impl
 		return *m_parent;
 	}
 	mrpt::serialization::CSchemeArchiveBase& operator=(
-		const std::nullptr_t val) override
-	{
-		m_val = val;
-		return *m_parent;
-	}
-	mrpt::serialization::CSchemeArchiveBase& operator=(
 		const std::string val) override
 	{
 		m_val = val;

--- a/libs/serialization/include/mrpt/serialization/CSchemeArchiveBase.h
+++ b/libs/serialization/include/mrpt/serialization/CSchemeArchiveBase.h
@@ -32,7 +32,6 @@ class CSchemeArchiveBase_impl
 	virtual CSchemeArchiveBase& operator=(const uint64_t) = 0;
 	virtual CSchemeArchiveBase& operator=(const float) = 0;
 	virtual CSchemeArchiveBase& operator=(const double) = 0;
-	virtual CSchemeArchiveBase& operator=(const std::nullptr_t) = 0;
 	virtual CSchemeArchiveBase& operator=(const std::string) = 0;
 	virtual CSchemeArchiveBase& operator=(bool) = 0;
 


### PR DESCRIPTION
## Changed apps/libraries

* mrpt-serialization

## PR Description

Remove possibility of assigning a scheme value from a `nullptr`. It was removed in libjsoncpp.

Perhaps it might be needed to add an alternative method to set a given json/yaml/... node as "null", but apparently no code was using this feature, so it was just removed. Add if needed in the future.

Closes #1118 