### PR TITLE
Make MRPT_EXCEPTIONS_WITH_CALL_STACK public

### DIFF
--- a/libs/core/CMakeLists.txt
+++ b/libs/core/CMakeLists.txt
@@ -36,7 +36,7 @@ if(BUILD_mrpt-core)
 
 	target_compile_definitions(core PRIVATE MRPT_EXCEPTIONS_CALL_STACK_MAX_DEPTH=${MRPT_EXCEPTIONS_CALL_STACK_MAX_DEPTH})
 	if (MRPT_EXCEPTIONS_WITH_CALL_STACK)
-		target_compile_definitions(core PRIVATE MRPT_EXCEPTIONS_WITH_CALL_STACK)
+		target_compile_definitions(core PUBLIC MRPT_EXCEPTIONS_WITH_CALL_STACK)
 	endif()
 
 endif()

--- a/libs/core/include/mrpt/core/exceptions.h
+++ b/libs/core/include/mrpt/core/exceptions.h
@@ -105,6 +105,7 @@ struct ExceptionWithCallBack : public BASE_EXCEPTION,
 	throw mrpt::ExceptionWithCallBack<exceptionClass>(                         \
 		exceptionClass(mrpt::internal::exception_line_msg(                     \
 			msg, __FILE__, __LINE__, __CURRENT_FUNCTION_NAME__)))
+
 /** \def THROW_EXCEPTION(msg);
  * \param msg This can be a char*, a std::string, or a literal string.
  * Defines a unified way of reporting exceptions

--- a/libs/core/include/mrpt/core/exceptions.h
+++ b/libs/core/include/mrpt/core/exceptions.h
@@ -105,7 +105,6 @@ struct ExceptionWithCallBack : public BASE_EXCEPTION,
 	throw mrpt::ExceptionWithCallBack<exceptionClass>(                         \
 		exceptionClass(mrpt::internal::exception_line_msg(                     \
 			msg, __FILE__, __LINE__, __CURRENT_FUNCTION_NAME__)))
-
 /** \def THROW_EXCEPTION(msg);
  * \param msg This can be a char*, a std::string, or a literal string.
  * Defines a unified way of reporting exceptions

--- a/libs/core/src/exception_unittest.cpp
+++ b/libs/core/src/exception_unittest.cpp
@@ -51,13 +51,16 @@ TEST(exception, stackedExceptionComplex)
 	catch (const std::exception& e)
 	{
 		const auto sExc = mrpt::exception_to_str(e);
+
+#if !defined(MRPT_EXCEPTIONS_WITH_CALL_STACK)
+		EXPECT_TRUE(sExc.find("Aw!") != std::string::npos) << sExc;
+#else
 		const auto num_lines = std::count(sExc.begin(), sExc.end(), '\n');
 		EXPECT_GT(num_lines, 10) << sExc;
-
 		EXPECT_TRUE(sExc.find("Message:  Aw!") != std::string::npos) << sExc;
-
+#endif
 // This test doesn't pass in Windows if building w/o debug symbols:
-#if !defined(_WIN32) || defined(_DEBUG)
+#if defined(MRPT_EXCEPTIONS_WITH_CALL_STACK) && (!defined(_WIN32) || defined(_DEBUG))
 		EXPECT_TRUE(sExc.find("test_except_toplevel") != std::string::npos)
 			<< sExc;
 #endif

--- a/libs/core/src/exception_unittest.cpp
+++ b/libs/core/src/exception_unittest.cpp
@@ -60,7 +60,8 @@ TEST(exception, stackedExceptionComplex)
 		EXPECT_TRUE(sExc.find("Message:  Aw!") != std::string::npos) << sExc;
 #endif
 // This test doesn't pass in Windows if building w/o debug symbols:
-#if defined(MRPT_EXCEPTIONS_WITH_CALL_STACK) && (!defined(_WIN32) || defined(_DEBUG))
+#if defined(MRPT_EXCEPTIONS_WITH_CALL_STACK) &&                                \
+	(!defined(_WIN32) || defined(_DEBUG))
 		EXPECT_TRUE(sExc.find("test_except_toplevel") != std::string::npos)
 			<< sExc;
 #endif


### PR DESCRIPTION
MRPT_EXCEPTIONS_WITH_CALL_STACK was not public,
so it wasn't being defined in unit tests or apps.

Any define used in a public header file should be
a PUBLIC define.

---

I acknowledge to have:
* Read the [`CONTRIBUTING`](https://github.com/MRPT/mrpt/blob/master/.github/CONTRIBUTING.md) page
* Updated [`doc/doxygen-pages/changeLog_doc.h`](https://github.com/MRPT/mrpt/blob/master/doc/doxygen-pages/changeLog_doc.h) to describe these changes (if applicable)
* Updated [`AUTHORS`](https://github.com/MRPT/mrpt/blob/master/AUTHORS) (if applicable)

(Notify: @MRPT/owners )
