### PR TITLE
Fix: clang-OSX errors and warnings

### DIFF
--- a/doc/source/doxygen-docs/changelog.md
+++ b/doc/source/doxygen-docs/changelog.md
@@ -2,6 +2,8 @@
 
 # Version 2.4.2: UNRELEASED
 - Changes in libraries:
+  - \ref mrpt_containers_grp
+    - mrpt::container::yaml::operator(size_t) added, conditionally to `size_t` being a different type than `uint64_t` and such (Fixes build errors on OSX).
   - \ref mrpt_gui_grp
     - GUI windows can now have custom icons via mrpt::gui::CDisplayWindowGUI::setIcon() or mrpt::gui::CDisplayWindowGUI::setIconFromData()
   - \ref mrpt_img_grp

--- a/doc/source/doxygen-docs/changelog.md
+++ b/doc/source/doxygen-docs/changelog.md
@@ -4,6 +4,8 @@
 - Changes in libraries:
   - \ref mrpt_containers_grp
     - mrpt::container::yaml::operator(size_t) added, conditionally to `size_t` being a different type than `uint64_t` and such (Fixes build errors on OSX).
+  - \ref mrpt_core_grp
+    - mrpt::callStackBackTrace() (and exception backtraces) now only use BFD to solve for line numbers in DEBUG builds, to avoid the large delay in processing each exception.
   - \ref mrpt_gui_grp
     - GUI windows can now have custom icons via mrpt::gui::CDisplayWindowGUI::setIcon() or mrpt::gui::CDisplayWindowGUI::setIconFromData()
   - \ref mrpt_img_grp

--- a/libs/containers/include/mrpt/containers/yaml.h
+++ b/libs/containers/include/mrpt/containers/yaml.h
@@ -600,6 +600,21 @@ class yaml
 	yaml& operator=(int64_t v);
 	yaml& operator=(uint64_t v);
 
+	// Additional operator for "size_t", in systems/compilers where
+	// size_t != all other types above
+	// (e.g. OSX with clang, see https://stackoverflow.com/a/11603907/1631514 )
+	template <
+		typename = std::enable_if<
+			!std::is_same_v<std::size_t, uint64_t> &&
+			!std::is_same_v<std::size_t, int64_t> &&
+			!std::is_same_v<std::size_t, uint32_t> &&
+			!std::is_same_v<std::size_t, int32_t>>	//
+		>
+	yaml& operator=(std::size_t v)
+	{
+		return operator=(static_cast<uint64_t>(v));
+	}
+
 	yaml& operator=(const std::string& v);
 	inline yaml& operator=(const char* v) { return operator=(std::string(v)); }
 	inline yaml& operator=(const std::string_view& v)

--- a/libs/containers/src/yaml_unittest.cpp
+++ b/libs/containers/src/yaml_unittest.cpp
@@ -38,6 +38,7 @@ MRPT_TEST(yaml, assignments)
 	p["enabled"] = true;
 	p["visible"] = false;
 	p["hidden"] = "true";
+	p["val_of_size_t"] = size_t(10);
 	auto nHidden1 = p["hidden"];
 
 	EXPECT_FALSE(p.empty());
@@ -54,6 +55,8 @@ MRPT_TEST(yaml, assignments)
 	EXPECT_TRUE(p["enabled"]);
 	EXPECT_FALSE(p["visible"]);
 	EXPECT_TRUE(p["hidden"]);
+
+	EXPECT_EQ(p["val_of_size_t"].as<size_t>(), size_t(10));
 
 	EXPECT_EQ(p["K"].scalarType(), typeid(double));
 	EXPECT_EQ(p["K"].as<double>(), 2.0);

--- a/libs/core/src/backtrace.cpp
+++ b/libs/core/src/backtrace.cpp
@@ -38,7 +38,7 @@
 #include <string>
 #endif
 
-#if MRPT_HAS_BFD
+#if MRPT_HAS_BFD && defined(_DEBUG)
 // Partially based on code from:
 // https://webcache.googleusercontent.com/search?q=cache:MXn9tpmIK5QJ:https://oroboro.com/printing-stack-traces-file-line/+&cd=2&hl=es&ct=clnk&gl=es
 
@@ -140,8 +140,8 @@ class FileLineDesc
 	void findAddressInSection(bfd* abfd, asection* section) noexcept;
 
 	bfd_vma mPc;
-	char* mFilename;
-	char* mFunctionname;
+	char* mFilename = nullptr;
+	char* mFunctionname = nullptr;
 	unsigned int mLine;
 	bool mFound = false;
 	asymbol** mSyms;
@@ -389,7 +389,8 @@ void mrpt::callStackBackTrace(
 	int nFrames = ::backtrace(callstack.data(), nMaxFrames);
 	char** symbols = ::backtrace_symbols(callstack.data(), nFrames);
 
-#if MRPT_HAS_BFD
+// Detailed callback stack traces with debug symbols: only in debug builds:
+#if MRPT_HAS_BFD && defined(_DEBUG)
 	static const bool MRPT_BACKTRACE_DISABLE_BFD =
 		mrpt::get_env<bool>("MRPT_BACKTRACE_DISABLE_BFD", false);
 	const bool use_bfd = !MRPT_BACKTRACE_DISABLE_BFD;
@@ -404,7 +405,7 @@ void mrpt::callStackBackTrace(
 		for (int i = (int)framesToSkip; i < nFrames; i++)
 			addrs.push_back(callstack[i]);
 
-#if MRPT_HAS_BFD
+#if MRPT_HAS_BFD && defined(_DEBUG)
 		// It seems BFD crashes if it is invoked from several threads in
 		// parallel!
 		static std::mutex bfdMtx;

--- a/libs/opengl/include/mrpt/opengl/CPointCloud.h
+++ b/libs/opengl/include/mrpt/opengl/CPointCloud.h
@@ -276,7 +276,7 @@ class CPointCloud : public CRenderizableShaderPoints,
 	 */
 	~CPointCloud() override = default;
 
-	void toYAMLMap(mrpt::containers::yaml& propertiesMap) const;
+	void toYAMLMap(mrpt::containers::yaml& propertiesMap) const override;
 
    private:
 	/** Buffer for min/max coords when m_colorFromDepth is true. */

--- a/libs/opengl/include/mrpt/opengl/CPointCloudColoured.h
+++ b/libs/opengl/include/mrpt/opengl/CPointCloudColoured.h
@@ -196,7 +196,7 @@ class CPointCloudColoured : public CRenderizableShaderPoints,
 		const bool all, const std::vector<size_t>& idxs,
 		const float render_area_sqpixels) const;
 
-	void toYAMLMap(mrpt::containers::yaml& propertiesMap) const;
+	void toYAMLMap(mrpt::containers::yaml& propertiesMap) const override;
 
    protected:
 	/** @name PLY Import virtual methods to implement in base classes

--- a/libs/opengl/include/mrpt/opengl/CText.h
+++ b/libs/opengl/include/mrpt/opengl/CText.h
@@ -70,7 +70,7 @@ class CText : public CRenderizableShaderText
 
 	virtual ~CText() override;
 
-	void toYAMLMap(mrpt::containers::yaml& propertiesMap) const;
+	void toYAMLMap(mrpt::containers::yaml& propertiesMap) const override;
 };
 
 }  // namespace mrpt::opengl


### PR DESCRIPTION
## Changed apps/libraries

* mrpt-containers
* mrpt-core
