### PR TITLE
Update Cyrill Stachniss embedded video link

### DIFF
--- a/doc/source/tutorial-slam-for-beginners-the-basics.rst
+++ b/doc/source/tutorial-slam-for-beginners-the-basics.rst
@@ -22,13 +22,14 @@ recommend the following online resources:
     </div> <br/> <hr><br/>
 
 
-- These `taped seminars <https://www.youtube.com/watch?v=U6vr3iNrwRA&list=PLgnQpQtFTOGQrZ4O5QzbIHgl3b1JHimN_>`_ by Cyrill Stachniss (2012-2013):
+- These `taped seminars <https://www.youtube.com/watch?v=U6vr3iNrwRA&list=PLgnQpQtFTOGQrZ4O5QzbIHgl3b1JHimN_>`_ by Cyrill Stachniss (2013-2014):
 
 .. raw:: html
 
     <div style="position: relative; padding-bottom: 56.25%; height: 0; overflow: hidden; max-width: 100%; height: auto;">
-        <iframe src="https://www.youtube.com/embed/V9qQc5X7O0k" frameborder="0" allowfullscreen style="position: absolute; top: 0; left: 0; width: 100%; height: 100%;"></iframe>
+        <iframe src="https://www.youtube.com/embed/U6vr3iNrwRA?list=PLgnQpQtFTOGQrZ4O5QzbIHgl3b1JHimN_"" frameborder="0" allowfullscreen style="position: absolute; top: 0; left: 0; width: 100%; height: 100%;"></iframe>
     </div> <br/> <hr><br/>
+    
 
 - This course by Dr. Jürgen Sturm (TUM, 2013):
 


### PR DESCRIPTION
The embedded YouTube video for the Cyrill Stachniss course was the previous year's course. I am proposing a change to update this to the newer 2013-2014 course playlist.

## Changed apps/libraries

N/A

## PR Description

Update the Cyrill Stachniss course embedded video link.

---

I acknowledge to have:
* Read the [`CONTRIBUTING`](https://github.com/MRPT/mrpt/blob/master/.github/CONTRIBUTING.md) page
* Updated [`doc/doxygen-pages/changeLog_doc.h`](https://github.com/MRPT/mrpt/blob/master/doc/doxygen-pages/changeLog_doc.h) to describe these changes (if applicable)
* Updated [`AUTHORS`](https://github.com/MRPT/mrpt/blob/master/AUTHORS) (if applicable)

(Notify: @MRPT/owners )
