### PR TITLE
ros: Add missing dependencies

### DIFF
--- a/doc/source/doxygen-docs/changelog.md
+++ b/doc/source/doxygen-docs/changelog.md
@@ -8,6 +8,8 @@
 - BUG FIXES:
   - Fix CSparse "C" linkage build error (OSX Clang). PR [#1280](https://github.com/MRPT/mrpt/pull/1280)
   - Fix missing Python wrapping of poses PDF (poses with uncertainty) composition (\oplus and \ominus) operators. (Closes [#1281](https://github.com/MRPT/mrpt/issues/1281)). PR [#1283](https://github.com/MRPT/mrpt/pull/1283)
+- Build system:
+  - ROS: fix missing deps in package.xml needed for build via Nix.
 
 # Version 2.10.1: Released August 10th, 2023
 - Build system:

--- a/package.xml
+++ b/package.xml
@@ -26,6 +26,7 @@
   <depend>libxrandr</depend>
   <depend>libxxf86vm</depend>
   <depend>nav_msgs</depend>
+  <depend>opengl</depend>
   <depend>sensor_msgs</depend>
   <depend>std_msgs</depend>
   <depend>stereo_msgs</depend>
@@ -40,12 +41,14 @@
   <build_depend>assimp-dev</build_depend>
   <build_depend>ffmpeg</build_depend>
   <build_depend>libfreenect-dev</build_depend>
+  <build_depend>libfyaml-dev</build_depend>
   <build_depend>libjpeg</build_depend>
   <build_depend>libjsoncpp-dev</build_depend>
   <build_depend>libopenni2-dev</build_depend>
   <build_depend>libpcap</build_depend>
   <build_depend>libudev-dev</build_depend>
   <build_depend>libusb-1.0-dev</build_depend>
+  <build_depend>pkg-config</build_depend>
   <build_depend>pybind11-dev</build_depend>
   <build_depend>python3-pip</build_depend>
   <build_depend>tinyxml2</build_depend>


### PR DESCRIPTION
Without these, the package cannot be built on NixOS.

Before merging this, please wait for this [rosdep PR](https://github.com/ros/rosdistro/pull/38406).

---

I acknowledge to have:
* Read the [`CONTRIBUTING`](https://github.com/MRPT/mrpt/blob/master/.github/CONTRIBUTING.md) page
* Updated [`doc/source/doxygen-docs/changelog.md`](https://github.com/MRPT/mrpt/blob/develop/doc/source/doxygen-docs/changelog.md) to describe these changes (if applicable)
* Updated [`AUTHORS`](https://github.com/MRPT/mrpt/blob/master/AUTHORS) (if applicable)

(Notify: @MRPT/owners )
