### PR TITLE
Re-enable the octomap dependency.

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -65,7 +65,7 @@
   <!-- Deps for ros1bridge/ros2bridge -->
   <depend>cv_bridge</depend>
   <depend>libopencv-dev</depend>
-  <!-- <depend>octomap</depend> -->  <!-- Temporarily removed 2024 March due to FTBFS octomap in u24.04 -->
+  <depend>liboctomap-dev</depend>
   <!--<depend>pcl_conversions</depend> WAS: To run unit tests only -->
 
   <depend condition="$ROS_VERSION == 1">rosbag_storage</depend>


### PR DESCRIPTION
## Changed apps/libraries

This should now work by enabling the system dependency on octomap, rather than the one built-in to ROS 2 (which we'll be removing).

This is now possible because https://github.com/ros/rosdistro/pull/41623 has been merged in.

If this is accepted, this should be backported to the branches supporting ROS 2 Jazzy, Iron, and Humble.

## PR Description

---

I acknowledge to have:
* Read the [`CONTRIBUTING`](https://github.com/MRPT/mrpt/blob/master/.github/CONTRIBUTING.md) page
* Updated [`doc/source/doxygen-docs/changelog.md`](https://github.com/MRPT/mrpt/blob/develop/doc/source/doxygen-docs/changelog.md) to describe these changes (if applicable)
* Updated [`AUTHORS`](https://github.com/MRPT/mrpt/blob/master/AUTHORS) (if applicable)

(Notify: @MRPT/owners )
