### PR TITLE
CWaypointsNavigator: stop aligning after wp is reached

### DIFF
--- a/doc/source/doxygen-docs/changelog.md
+++ b/doc/source/doxygen-docs/changelog.md
@@ -10,6 +10,8 @@
   - This main MRPT repository is no longer directly built as a ROS package. Please, use the wrappers for better modularity:
     - https://github.com/MRPT/mrpt_ros
     - https://github.com/MRPT/python_mrpt_ros
+- BUG FIXES:
+  - CWaypointsNavigator::waypoints_navigationStep() stops aligning with target after the waypoint is considered as reached.
 
 # Version 2.13.4: Released July 24th, 2024
 - Fix docs typos.

--- a/libs/nav/src/reactive/CWaypointsNavigator.cpp
+++ b/libs/nav/src/reactive/CWaypointsNavigator.cpp
@@ -239,6 +239,8 @@ void CWaypointsNavigator::waypoints_navigationStep()
                    " segment-to-target dist: "
                 << dist2target << ", allowed_dist: " << wp.allowed_distance);
 
+            m_is_aligning = false;
+
             wp.reached = true;
             wp.skipped = false;
             wp.timestamp_reach = mrpt::Clock::now();


### PR DESCRIPTION
## Changed apps/libraries

libs/nav/reactive/CWaypointsNavigator

## PR Description

Fixed situation where robot tries to align with target even after the waypoint is considered as reached. For robots that do not support in-place alignment, this meant being stuck in place with an empty cmd_vel after stopping.

---

I acknowledge to have:
* Read the [`CONTRIBUTING`](https://github.com/MRPT/mrpt/blob/master/.github/CONTRIBUTING.md) page
* Updated [`doc/source/doxygen-docs/changelog.md`](https://github.com/MRPT/mrpt/blob/develop/doc/source/doxygen-docs/changelog.md) to describe these changes (if applicable)
* Updated [`AUTHORS`](https://github.com/MRPT/mrpt/blob/master/AUTHORS) (if applicable)

(Notify: @MRPT/owners )
