### PR TITLE
Require octomap only for libmaps

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -292,7 +292,9 @@ include(cmakemodules/script_nanogui.cmake REQUIRED)     # Check for nanogui
 include(cmakemodules/script_nanoflann.cmake REQUIRED)   # Check for nanoflann
 include(cmakemodules/script_national_instruments.cmake REQUIRED)  # NI C library
 include(cmakemodules/script_nite2.cmake REQUIRED)       # Check for NITE2 library
-include(cmakemodules/script_octomap.cmake REQUIRED)     # Check for the octomap library
+if(BUILD_mrpt-maps)
+        include(cmakemodules/script_octomap.cmake REQUIRED)     # Check for the octomap library
+endif()
 include(cmakemodules/script_opencv.cmake REQUIRED)      # Check for the OpenCV libraries (via pkg-config, CMake, with different options)
 include(cmakemodules/script_openni2.cmake REQUIRED)     # Check for the OpenNI2 library
 include(cmakemodules/script_pcap.cmake REQUIRED)        # Check for the libpcap library

--- a/doc/source/doxygen-docs/changelog.md
+++ b/doc/source/doxygen-docs/changelog.md
@@ -1,5 +1,8 @@
 \page changelog Change Log
 
+- Bug fixes:
+  - FIX: Don't require liboctomap-dev when not needed.
+
 # Version 2.15.1: Released Oct 29th, 2025
 - Bug fixes:
   - FIX: Avoid throw when viewing and describing as text a PCD with an empty field.


### PR DESCRIPTION
The other parts no longer depend on it and cause unnecessary download of the library sources if the library is not available in the system.

This is related to https://github.com/MRPT/mrpt_ros/pull/5.

---

I acknowledge to have:
* Read the [`CONTRIBUTING`](https://github.com/MRPT/mrpt/blob/master/.github/CONTRIBUTING.md) page
* Updated [`doc/source/doxygen-docs/changelog.md`](https://github.com/MRPT/mrpt/blob/develop/doc/source/doxygen-docs/changelog.md) to describe these changes (if applicable)
* Updated [`AUTHORS`](https://github.com/MRPT/mrpt/blob/master/AUTHORS) (if applicable)

(Notify: @MRPT/owners )
