### PR TITLE
FIX: safer multithread handling of string_views in CGenericPointsMap

### DIFF
--- a/libs/maps/include/mrpt/maps/CGenericPointsMap.h
+++ b/libs/maps/include/mrpt/maps/CGenericPointsMap.h
@@ -14,7 +14,9 @@
 #include <mrpt/opengl/pointcloud_adapters.h>
 #include <mrpt/serialization/CSerializable.h>
 
-#include <unordered_map>
+#include <map>
+#include <string>
+#include <vector>
 
 namespace mrpt::maps
 {
@@ -65,36 +67,33 @@ class CGenericPointsMap : public CPointsMap
     @{ */
 
   // see docs in parent class
-  bool registerField_float(const std::string_view& fieldName) override;
-  bool registerField_double(const std::string_view& fieldName) override;
-  bool registerField_uint16(const std::string_view& fieldName) override;
-  bool registerField_uint8(const std::string_view& fieldName) override;
+  bool registerField_float(const std::string& fieldName) override;
+  bool registerField_double(const std::string& fieldName) override;
+  bool registerField_uint16(const std::string& fieldName) override;
+  bool registerField_uint8(const std::string& fieldName) override;
 
   /** Removes a data channel.
    * \return True if the field existed and was removed, false otherwise.
    */
-  bool unregisterField(const std::string_view& fieldName);
+  bool unregisterField(const std::string& fieldName);
 
   /** Returns the map of float fields: map<field_name, vector_of_data> */
-  const std::unordered_map<std::string_view, mrpt::aligned_std_vector<float>>& float_fields() const
+  const std::map<std::string, mrpt::aligned_std_vector<float>>& float_fields() const
   {
     return m_float_fields;
   }
   /** Returns the map of double fields: map<field_name, vector_of_data> */
-  const std::unordered_map<std::string_view, mrpt::aligned_std_vector<double>>& double_fields()
-      const
+  const std::map<std::string, mrpt::aligned_std_vector<double>>& double_fields() const
   {
     return m_double_fields;
   }
   /** Returns the map of uint16_t fields: map<field_name, vector_of_data> */
-  const std::unordered_map<std::string_view, mrpt::aligned_std_vector<uint16_t>>& uint16_fields()
-      const
+  const std::map<std::string, mrpt::aligned_std_vector<uint16_t>>& uint16_fields() const
   {
     return m_uint16_fields;
   }
   /** Returns the map of uint8_t fields: map<field_name, vector_of_data> */
-  const std::unordered_map<std::string_view, mrpt::aligned_std_vector<uint8_t>>& uint8_fields()
-      const
+  const std::map<std::string, mrpt::aligned_std_vector<uint8_t>>& uint8_fields() const
   {
     return m_uint8_fields;
   }
@@ -122,62 +121,61 @@ class CGenericPointsMap : public CPointsMap
 
   /** @name String-keyed field access virtual interface implementation
     @{ */
-  bool hasPointField(const std::string_view& fieldName) const override;
-  std::vector<std::string_view> getPointFieldNames_float() const override;
-  std::vector<std::string_view> getPointFieldNames_double() const override;
-  std::vector<std::string_view> getPointFieldNames_uint16() const override;
-  std::vector<std::string_view> getPointFieldNames_uint8() const override;
+  bool hasPointField(const std::string& fieldName) const override;
+  std::vector<std::string> getPointFieldNames_float() const override;
+  std::vector<std::string> getPointFieldNames_double() const override;
+  std::vector<std::string> getPointFieldNames_uint16() const override;
+  std::vector<std::string> getPointFieldNames_uint8() const override;
 
-  float getPointField_float(size_t index, const std::string_view& fieldName) const override;
-  double getPointField_double(size_t index, const std::string_view& fieldName) const override;
-  uint16_t getPointField_uint16(size_t index, const std::string_view& fieldName) const override;
-  uint8_t getPointField_uint8(size_t index, const std::string_view& fieldName) const override;
+  float getPointField_float(size_t index, const std::string& fieldName) const override;
+  double getPointField_double(size_t index, const std::string& fieldName) const override;
+  uint16_t getPointField_uint16(size_t index, const std::string& fieldName) const override;
+  uint8_t getPointField_uint8(size_t index, const std::string& fieldName) const override;
 
-  void setPointField_float(size_t index, const std::string_view& fieldName, float value) override;
-  void setPointField_double(size_t index, const std::string_view& fieldName, double value) override;
-  void setPointField_uint16(
-      size_t index, const std::string_view& fieldName, uint16_t value) override;
-  void setPointField_uint8(size_t index, const std::string_view& fieldName, uint8_t value) override;
-
-  /** Appends a value to the given field.
-   * The field must be registered.
-   * Asserts that the field vector's size is exactly `this->size() - 1`
-   * (i.e. you just called `insertPointFast()`).
-   */
-  void insertPointField_float(const std::string_view& fieldName, float value) override;
+  void setPointField_float(size_t index, const std::string& fieldName, float value) override;
+  void setPointField_double(size_t index, const std::string& fieldName, double value) override;
+  void setPointField_uint16(size_t index, const std::string& fieldName, uint16_t value) override;
+  void setPointField_uint8(size_t index, const std::string& fieldName, uint8_t value) override;
 
   /** Appends a value to the given field.
    * The field must be registered.
    * Asserts that the field vector's size is exactly `this->size() - 1`
    * (i.e. you just called `insertPointFast()`).
    */
-  void insertPointField_double(const std::string_view& fieldName, double value) override;
+  void insertPointField_float(const std::string& fieldName, float value) override;
 
   /** Appends a value to the given field.
    * The field must be registered.
    * Asserts that the field vector's size is exactly `this->size() - 1`
    * (i.e. you just called `insertPointFast()`).
    */
-  void insertPointField_uint16(const std::string_view& fieldName, uint16_t value) override;
+  void insertPointField_double(const std::string& fieldName, double value) override;
 
   /** Appends a value to the given field.
    * The field must be registered.
    * Asserts that the field vector's size is exactly `this->size() - 1`
    * (i.e. you just called `insertPointFast()`).
    */
-  void insertPointField_uint8(const std::string_view& fieldName, uint8_t value) override;
+  void insertPointField_uint16(const std::string& fieldName, uint16_t value) override;
 
-  void reserveField_float(const std::string_view& fieldName, size_t n) override;
-  void reserveField_double(const std::string_view& fieldName, size_t n) override;
-  void reserveField_uint16(const std::string_view& fieldName, size_t n) override;
-  void reserveField_uint8(const std::string_view& fieldName, size_t n) override;
+  /** Appends a value to the given field.
+   * The field must be registered.
+   * Asserts that the field vector's size is exactly `this->size() - 1`
+   * (i.e. you just called `insertPointFast()`).
+   */
+  void insertPointField_uint8(const std::string& fieldName, uint8_t value) override;
 
-  void resizeField_float(const std::string_view& fieldName, size_t n) override;
-  void resizeField_double(const std::string_view& fieldName, size_t n) override;
-  void resizeField_uint16(const std::string_view& fieldName, size_t n) override;
-  void resizeField_uint8(const std::string_view& fieldName, size_t n) override;
+  void reserveField_float(const std::string& fieldName, size_t n) override;
+  void reserveField_double(const std::string& fieldName, size_t n) override;
+  void reserveField_uint16(const std::string& fieldName, size_t n) override;
+  void reserveField_uint8(const std::string& fieldName, size_t n) override;
 
-  auto getPointsBufferRef_float_field(const std::string_view& fieldName) const
+  void resizeField_float(const std::string& fieldName, size_t n) override;
+  void resizeField_double(const std::string& fieldName, size_t n) override;
+  void resizeField_uint16(const std::string& fieldName, size_t n) override;
+  void resizeField_uint8(const std::string& fieldName, size_t n) override;
+
+  auto getPointsBufferRef_float_field(const std::string& fieldName) const
       -> const mrpt::aligned_std_vector<float>* override
   {
     if (auto* f = CPointsMap::getPointsBufferRef_float_field(fieldName); f)
@@ -190,7 +188,7 @@ class CGenericPointsMap : public CPointsMap
     }
     return nullptr;
   }
-  auto getPointsBufferRef_double_field(const std::string_view& fieldName) const
+  auto getPointsBufferRef_double_field(const std::string& fieldName) const
       -> const mrpt::aligned_std_vector<double>* override
   {
     if (auto it = m_double_fields.find(fieldName); it != m_double_fields.end())
@@ -199,7 +197,7 @@ class CGenericPointsMap : public CPointsMap
     }
     return nullptr;
   }
-  auto getPointsBufferRef_uint16_field(const std::string_view& fieldName) const
+  auto getPointsBufferRef_uint16_field(const std::string& fieldName) const
       -> const mrpt::aligned_std_vector<uint16_t>* override
   {
     if (auto it = m_uint16_fields.find(fieldName); it != m_uint16_fields.end())
@@ -208,7 +206,7 @@ class CGenericPointsMap : public CPointsMap
     }
     return nullptr;
   }
-  auto getPointsBufferRef_uint8_field(const std::string_view& fieldName) const
+  auto getPointsBufferRef_uint8_field(const std::string& fieldName) const
       -> const mrpt::aligned_std_vector<uint8_t>* override
   {
     if (auto it = m_uint8_fields.find(fieldName); it != m_uint8_fields.end())
@@ -218,7 +216,7 @@ class CGenericPointsMap : public CPointsMap
     return nullptr;
   }
 
-  auto getPointsBufferRef_float_field(const std::string_view& fieldName)
+  auto getPointsBufferRef_float_field(const std::string& fieldName)
       -> mrpt::aligned_std_vector<float>* override
   {
     if (auto* f = CPointsMap::getPointsBufferRef_float_field(fieldName); f)
@@ -231,7 +229,7 @@ class CGenericPointsMap : public CPointsMap
     }
     return nullptr;
   }
-  auto getPointsBufferRef_double_field(const std::string_view& fieldName)
+  auto getPointsBufferRef_double_field(const std::string& fieldName)
       -> mrpt::aligned_std_vector<double>* override
   {
     if (auto it = m_double_fields.find(fieldName); it != m_double_fields.end())
@@ -240,7 +238,7 @@ class CGenericPointsMap : public CPointsMap
     }
     return nullptr;
   }
-  auto getPointsBufferRef_uint16_field(const std::string_view& fieldName)
+  auto getPointsBufferRef_uint16_field(const std::string& fieldName)
       -> mrpt::aligned_std_vector<uint16_t>* override
   {
     if (auto it = m_uint16_fields.find(fieldName); it != m_uint16_fields.end())
@@ -249,7 +247,7 @@ class CGenericPointsMap : public CPointsMap
     }
     return nullptr;
   }
-  auto getPointsBufferRef_uint8_field(const std::string_view& fieldName)
+  auto getPointsBufferRef_uint8_field(const std::string& fieldName)
       -> mrpt::aligned_std_vector<uint8_t>* override
   {
     if (auto it = m_uint8_fields.find(fieldName); it != m_uint8_fields.end())
@@ -262,11 +260,12 @@ class CGenericPointsMap : public CPointsMap
   /** @} */
 
  protected:
-  std::unordered_map<std::string_view, mrpt::aligned_std_vector<float>> m_float_fields;
-  std::unordered_map<std::string_view, mrpt::aligned_std_vector<double>> m_double_fields;
-  std::unordered_map<std::string_view, mrpt::aligned_std_vector<uint16_t>> m_uint16_fields;
-  std::unordered_map<std::string_view, mrpt::aligned_std_vector<uint8_t>> m_uint8_fields;
+  std::map<std::string, mrpt::aligned_std_vector<float>> m_float_fields;
+  std::map<std::string, mrpt::aligned_std_vector<double>> m_double_fields;
+  std::map<std::string, mrpt::aligned_std_vector<uint16_t>> m_uint16_fields;
+  std::map<std::string, mrpt::aligned_std_vector<uint8_t>> m_uint8_fields;
 
+ private:
   /** Clear the map, erasing all the points and all fields */
   void internal_clear() override;
 

--- a/libs/maps/include/mrpt/maps/CPointsMap.h
+++ b/libs/maps/include/mrpt/maps/CPointsMap.h
@@ -377,15 +377,15 @@ class CPointsMap :
   /** @name Register/unregister custom data fields
     @{ */
 
-  constexpr static std::string_view POINT_FIELD_INTENSITY = "intensity";
-  constexpr static std::string_view POINT_FIELD_RING_ID = "ring";
-  constexpr static std::string_view POINT_FIELD_TIMESTAMP = "t";
-  constexpr static std::string_view POINT_FIELD_COLOR_Ru8 = "color_r";  //!< uint8_t RGB.r
-  constexpr static std::string_view POINT_FIELD_COLOR_Gu8 = "color_g";  //!< uint8_t RGB.g
-  constexpr static std::string_view POINT_FIELD_COLOR_Bu8 = "color_b";  //!< uint8_t RGB.b
-  constexpr static std::string_view POINT_FIELD_COLOR_Rf = "color_rf";  //!< float RGB.r
-  constexpr static std::string_view POINT_FIELD_COLOR_Gf = "color_gf";  //!< float RGB.g
-  constexpr static std::string_view POINT_FIELD_COLOR_Bf = "color_bf";  //!< float RGB.b
+  constexpr static const char* POINT_FIELD_INTENSITY = "intensity";
+  constexpr static const char* POINT_FIELD_RING_ID = "ring";
+  constexpr static const char* POINT_FIELD_TIMESTAMP = "t";
+  constexpr static const char* POINT_FIELD_COLOR_Ru8 = "color_r";  //!< uint8_t RGB.r
+  constexpr static const char* POINT_FIELD_COLOR_Gu8 = "color_g";  //!< uint8_t RGB.g
+  constexpr static const char* POINT_FIELD_COLOR_Bu8 = "color_b";  //!< uint8_t RGB.b
+  constexpr static const char* POINT_FIELD_COLOR_Rf = "color_rf";  //!< float RGB.r
+  constexpr static const char* POINT_FIELD_COLOR_Gf = "color_gf";  //!< float RGB.g
+  constexpr static const char* POINT_FIELD_COLOR_Bf = "color_bf";  //!< float RGB.b
 
   /** Registers a new data channel of type `float`.
    * If the map is not empty, the new channel is filled with default values (0)
@@ -393,7 +393,7 @@ class CPointsMap :
    * \return true if the field could effectively be added to the underlying point map class.
    * \sa hasPointField(), getPointFieldNames_float()
    */
-  virtual bool registerField_float(const std::string_view& fieldName)
+  virtual bool registerField_float(const std::string& fieldName)
   {
     return fieldName == "x" || fieldName == "y" || fieldName == "z";
   }
@@ -404,7 +404,7 @@ class CPointsMap :
    * \return true if the field could effectively be added to the underlying point map class.
    * \sa hasPointField(), getPointFieldNames_uint16()
    */
-  virtual bool registerField_uint16(const std::string_view& fieldName) { return false; }
+  virtual bool registerField_uint16(const std::string& fieldName) { return false; }
 
   /** Registers a new data channel of type `uint8_t`.
    * If the map is not empty, the new channel is filled with default values (0)
@@ -412,7 +412,7 @@ class CPointsMap :
    * \return true if the field could effectively be added to the underlying point map class.
    * \sa hasPointField(), getPointFieldNames_uint8()
    */
-  virtual bool registerField_uint8(const std::string_view& fieldName) { return false; }
+  virtual bool registerField_uint8(const std::string& fieldName) { return false; }
 
   /** Registers a new data channel of type `double`.
    * If the map is not empty, the new channel is filled with default values (0)
@@ -420,7 +420,7 @@ class CPointsMap :
    * \return true if the field could effectively be added to the underlying point map class.
    * \sa hasPointField(), getPointFieldNames_double()
    */
-  virtual bool registerField_double(const std::string_view& fieldName) { return false; }
+  virtual bool registerField_double(const std::string& fieldName) { return false; }
 
   /** @} */
 
@@ -594,29 +594,29 @@ class CPointsMap :
   /** Returns true if the map has a data channel with the given name.
    * \sa getPointField_float, getPointField_double, getPointField_uint16
    */
-  virtual bool hasPointField(const std::string_view& fieldName) const
+  virtual bool hasPointField(const std::string& fieldName) const
   {
     return (fieldName == "x") || (fieldName == "y") || (fieldName == "z");
   }
 
   /** Get list of all float channel names */
-  virtual std::vector<std::string_view> getPointFieldNames_float() const { return {"x", "y", "z"}; }
+  virtual std::vector<std::string> getPointFieldNames_float() const { return {"x", "y", "z"}; }
   /** Get list of all double channel names */
-  virtual std::vector<std::string_view> getPointFieldNames_double() const { return {}; }
+  virtual std::vector<std::string> getPointFieldNames_double() const { return {}; }
   /** Get list of all uint16_t channel names */
-  virtual std::vector<std::string_view> getPointFieldNames_uint16() const { return {}; }
+  virtual std::vector<std::string> getPointFieldNames_uint16() const { return {}; }
   /** Get list of all uint8_t channel names */
-  virtual std::vector<std::string_view> getPointFieldNames_uint8() const { return {}; }
+  virtual std::vector<std::string> getPointFieldNames_uint8() const { return {}; }
 
   /** Get list of all float channel names, except x,y,z */
-  std::vector<std::string_view> getPointFieldNames_float_except_xyz() const;
+  std::vector<std::string> getPointFieldNames_float_except_xyz() const;
 
   /** Read the value of a float channel for a given point.
    * Returns 0 if field does not exist.
    * \exception std::exception on index out of bounds or if field exists but
    * is not float.
    */
-  virtual float getPointField_float(size_t index, const std::string_view& fieldName) const
+  virtual float getPointField_float(size_t index, const std::string& fieldName) const
   {
     if (fieldName == "x") return m_x.at(index);
     if (fieldName == "y") return m_y.at(index);
@@ -629,7 +629,7 @@ class CPointsMap :
    * \exception std::exception on index out of bounds or if field exists but
    * is not double.
    */
-  virtual double getPointField_double(size_t index, const std::string_view& fieldName) const
+  virtual double getPointField_double(size_t index, const std::string& fieldName) const
   {
     return 0;
   }
@@ -639,7 +639,7 @@ class CPointsMap :
    * \exception std::exception on index out of bounds or if field exists but
    * is not uint16_t.
    */
-  virtual uint16_t getPointField_uint16(size_t index, const std::string_view& fieldName) const
+  virtual uint16_t getPointField_uint16(size_t index, const std::string& fieldName) const
   {
     return 0;
   }
@@ -649,7 +649,7 @@ class CPointsMap :
    * \exception std::exception on index out of bounds or if field exists but
    * is not uint16_t.
    */
-  virtual uint8_t getPointField_uint8(size_t index, const std::string_view& fieldName) const
+  virtual uint8_t getPointField_uint8(size_t index, const std::string& fieldName) const
   {
     return 0;
   }
@@ -658,7 +658,7 @@ class CPointsMap :
    * \exception std::exception on index out of bounds or if field does not
    * exist or is not float.
    */
-  virtual void setPointField_float(size_t index, const std::string_view& fieldName, float value)
+  virtual void setPointField_float(size_t index, const std::string& fieldName, float value)
   {
     if (fieldName == "x")
       m_x.at(index) = value;
@@ -671,46 +671,40 @@ class CPointsMap :
    * \exception std::exception on index out of bounds or if field does not
    * exist or is not double.
    */
-  virtual void setPointField_double(size_t index, const std::string_view& fieldName, double value)
-  {
-  }
+  virtual void setPointField_double(size_t index, const std::string& fieldName, double value) {}
 
   /** Sets the value of a uint16_t channel for a given point.
    * \exception std::exception on index out of bounds or if field does not
    * exist or is not uint16_t.
    */
-  virtual void setPointField_uint16(size_t index, const std::string_view& fieldName, uint16_t value)
-  {
-  }
+  virtual void setPointField_uint16(size_t index, const std::string& fieldName, uint16_t value) {}
 
   /** Sets the value of a uint8_t channel for a given point.
    * \exception std::exception on index out of bounds or if field does not
    * exist or is not uint8_t.
    */
-  virtual void setPointField_uint8(size_t index, const std::string_view& fieldName, uint8_t value)
-  {
-  }
+  virtual void setPointField_uint8(size_t index, const std::string& fieldName, uint8_t value) {}
 
   /** Appends a value to a float channel (for use after insertPointFast()) */
-  virtual void insertPointField_float(const std::string_view& fieldName, float value) {}
+  virtual void insertPointField_float(const std::string& fieldName, float value) {}
   /** Appends a value to a double channel (for use after insertPointFast()) */
-  virtual void insertPointField_double(const std::string_view& fieldName, double value) {}
+  virtual void insertPointField_double(const std::string& fieldName, double value) {}
   /** Appends a value to a uint16_t channel (for use after insertPointFast()) */
-  virtual void insertPointField_uint16(const std::string_view& fieldName, uint16_t value) {}
+  virtual void insertPointField_uint16(const std::string& fieldName, uint16_t value) {}
   /** Appends a value to a uint8_t channel (for use after insertPointFast()) */
-  virtual void insertPointField_uint8(const std::string_view& fieldName, uint8_t value) {}
+  virtual void insertPointField_uint8(const std::string& fieldName, uint8_t value) {}
 
-  virtual void reserveField_float(const std::string_view& fieldName, size_t n) {}
-  virtual void reserveField_double(const std::string_view& fieldName, size_t n) {}
-  virtual void reserveField_uint16(const std::string_view& fieldName, size_t n) {}
-  virtual void reserveField_uint8(const std::string_view& fieldName, size_t n) {}
+  virtual void reserveField_float(const std::string& fieldName, size_t n) {}
+  virtual void reserveField_double(const std::string& fieldName, size_t n) {}
+  virtual void reserveField_uint16(const std::string& fieldName, size_t n) {}
+  virtual void reserveField_uint8(const std::string& fieldName, size_t n) {}
 
-  virtual void resizeField_float(const std::string_view& fieldName, size_t n) {}
-  virtual void resizeField_double(const std::string_view& fieldName, size_t n) {}
-  virtual void resizeField_uint16(const std::string_view& fieldName, size_t n) {}
-  virtual void resizeField_uint8(const std::string_view& fieldName, size_t n) {}
+  virtual void resizeField_float(const std::string& fieldName, size_t n) {}
+  virtual void resizeField_double(const std::string& fieldName, size_t n) {}
+  virtual void resizeField_uint16(const std::string& fieldName, size_t n) {}
+  virtual void resizeField_uint8(const std::string& fieldName, size_t n) {}
 
-  virtual auto getPointsBufferRef_float_field(const std::string_view& fieldName) const
+  virtual auto getPointsBufferRef_float_field(const std::string& fieldName) const
       -> const mrpt::aligned_std_vector<float>*
   {
     if (fieldName == "x") return &m_x;
@@ -718,23 +712,23 @@ class CPointsMap :
     if (fieldName == "z") return &m_z;
     return nullptr;
   }
-  virtual auto getPointsBufferRef_double_field([[maybe_unused]] const std::string_view& fieldName)
-      const -> const mrpt::aligned_std_vector<double>*
+  virtual auto getPointsBufferRef_double_field([[maybe_unused]] const std::string& fieldName) const
+      -> const mrpt::aligned_std_vector<double>*
   {
     return nullptr;
   }
-  virtual auto getPointsBufferRef_uint16_field([[maybe_unused]] const std::string_view& fieldName)
-      const -> const mrpt::aligned_std_vector<uint16_t>*
+  virtual auto getPointsBufferRef_uint16_field([[maybe_unused]] const std::string& fieldName) const
+      -> const mrpt::aligned_std_vector<uint16_t>*
   {
     return nullptr;
   }
-  virtual auto getPointsBufferRef_uint8_field([[maybe_unused]] const std::string_view& fieldName)
-      const -> const mrpt::aligned_std_vector<uint8_t>*
+  virtual auto getPointsBufferRef_uint8_field([[maybe_unused]] const std::string& fieldName) const
+      -> const mrpt::aligned_std_vector<uint8_t>*
   {
     return nullptr;
   }
 
-  virtual auto getPointsBufferRef_float_field(const std::string_view& fieldName)
+  virtual auto getPointsBufferRef_float_field(const std::string& fieldName)
       -> mrpt::aligned_std_vector<float>*
   {
     if (fieldName == "x") return &m_x;
@@ -742,17 +736,17 @@ class CPointsMap :
     if (fieldName == "z") return &m_z;
     return nullptr;
   }
-  virtual auto getPointsBufferRef_double_field([[maybe_unused]] const std::string_view& fieldName)
+  virtual auto getPointsBufferRef_double_field([[maybe_unused]] const std::string& fieldName)
       -> mrpt::aligned_std_vector<double>*
   {
     return nullptr;
   }
-  virtual auto getPointsBufferRef_uint16_field([[maybe_unused]] const std::string_view& fieldName)
+  virtual auto getPointsBufferRef_uint16_field([[maybe_unused]] const std::string& fieldName)
       -> mrpt::aligned_std_vector<uint16_t>*
   {
     return nullptr;
   }
-  virtual auto getPointsBufferRef_uint8_field([[maybe_unused]] const std::string_view& fieldName)
+  virtual auto getPointsBufferRef_uint8_field([[maybe_unused]] const std::string& fieldName)
       -> mrpt::aligned_std_vector<uint8_t>*
   {
     return nullptr;

--- a/libs/maps/include/mrpt/maps/CPointsMapXYZI.h
+++ b/libs/maps/include/mrpt/maps/CPointsMapXYZI.h
@@ -138,17 +138,17 @@ class [[deprecated("Use mrpt::maps::CGenericPointsMap")]] CPointsMapXYZI : publi
   /** @name String-keyed field access virtual interface implementation
       @{ */
 
-  bool hasPointField(const std::string_view& fieldName) const override;
-  std::vector<std::string_view> getPointFieldNames_float() const override;
+  bool hasPointField(const std::string& fieldName) const override;
+  std::vector<std::string> getPointFieldNames_float() const override;
 
-  float getPointField_float(size_t index, const std::string_view& fieldName) const override;
-  void setPointField_float(size_t index, const std::string_view& fieldName, float value) override;
+  float getPointField_float(size_t index, const std::string& fieldName) const override;
+  void setPointField_float(size_t index, const std::string& fieldName, float value) override;
 
-  void insertPointField_float(const std::string_view& fieldName, float value) override;
-  void reserveField_float(const std::string_view& fieldName, size_t n) override;
-  void resizeField_float(const std::string_view& fieldName, size_t n) override;
+  void insertPointField_float(const std::string& fieldName, float value) override;
+  void reserveField_float(const std::string& fieldName, size_t n) override;
+  void resizeField_float(const std::string& fieldName, size_t n) override;
 
-  auto getPointsBufferRef_float_field(const std::string_view& fieldName)
+  auto getPointsBufferRef_float_field(const std::string& fieldName)
       const->const mrpt::aligned_std_vector<float>* override
   {
     if (auto* f = CPointsMap::getPointsBufferRef_float_field(fieldName); f)
@@ -158,7 +158,7 @@ class [[deprecated("Use mrpt::maps::CGenericPointsMap")]] CPointsMapXYZI : publi
     if (fieldName == POINT_FIELD_INTENSITY) return &m_intensity;
     return nullptr;
   }
-  auto getPointsBufferRef_float_field(const std::string_view& fieldName)
+  auto getPointsBufferRef_float_field(const std::string& fieldName)
       ->mrpt::aligned_std_vector<float>* override
   {
     if (auto* f = CPointsMap::getPointsBufferRef_float_field(fieldName); f)

--- a/libs/maps/include/mrpt/maps/CPointsMapXYZIRT.h
+++ b/libs/maps/include/mrpt/maps/CPointsMapXYZIRT.h
@@ -189,26 +189,25 @@ class [[deprecated("Use CGenericPointsMap instead")]] CPointsMapXYZIRT : public 
 
   /** @name String-keyed field access virtual interface implementation
       @{ */
-  bool hasPointField(const std::string_view& fieldName) const override;
-  std::vector<std::string_view> getPointFieldNames_float() const override;
-  std::vector<std::string_view> getPointFieldNames_uint16() const override;
+  bool hasPointField(const std::string& fieldName) const override;
+  std::vector<std::string> getPointFieldNames_float() const override;
+  std::vector<std::string> getPointFieldNames_uint16() const override;
 
-  float getPointField_float(size_t index, const std::string_view& fieldName) const override;
-  uint16_t getPointField_uint16(size_t index, const std::string_view& fieldName) const override;
+  float getPointField_float(size_t index, const std::string& fieldName) const override;
+  uint16_t getPointField_uint16(size_t index, const std::string& fieldName) const override;
 
-  void setPointField_float(size_t index, const std::string_view& fieldName, float value) override;
-  void setPointField_uint16(size_t index, const std::string_view& fieldName, uint16_t value)
-      override;
+  void setPointField_float(size_t index, const std::string& fieldName, float value) override;
+  void setPointField_uint16(size_t index, const std::string& fieldName, uint16_t value) override;
 
-  void insertPointField_float(const std::string_view& fieldName, float value) override;
-  void insertPointField_uint16(const std::string_view& fieldName, uint16_t value) override;
+  void insertPointField_float(const std::string& fieldName, float value) override;
+  void insertPointField_uint16(const std::string& fieldName, uint16_t value) override;
 
-  void reserveField_float(const std::string_view& fieldName, size_t n) override;
-  void reserveField_uint16(const std::string_view& fieldName, size_t n) override;
-  void resizeField_float(const std::string_view& fieldName, size_t n) override;
-  void resizeField_uint16(const std::string_view& fieldName, size_t n) override;
+  void reserveField_float(const std::string& fieldName, size_t n) override;
+  void reserveField_uint16(const std::string& fieldName, size_t n) override;
+  void resizeField_float(const std::string& fieldName, size_t n) override;
+  void resizeField_uint16(const std::string& fieldName, size_t n) override;
 
-  auto getPointsBufferRef_float_field(const std::string_view& fieldName)
+  auto getPointsBufferRef_float_field(const std::string& fieldName)
       const->const mrpt::aligned_std_vector<float>* override
   {
     if (auto* f = CPointsMap::getPointsBufferRef_float_field(fieldName); f)
@@ -219,14 +218,14 @@ class [[deprecated("Use CGenericPointsMap instead")]] CPointsMapXYZIRT : public 
     if (fieldName == POINT_FIELD_TIMESTAMP) return &m_time;
     return nullptr;
   }
-  auto getPointsBufferRef_uint16_field(const std::string_view& fieldName)
+  auto getPointsBufferRef_uint16_field(const std::string& fieldName)
       const->const mrpt::aligned_std_vector<uint16_t>* override
   {
     if (fieldName == POINT_FIELD_RING_ID) return &m_ring;
     return nullptr;
   }
 
-  auto getPointsBufferRef_float_field(const std::string_view& fieldName)
+  auto getPointsBufferRef_float_field(const std::string& fieldName)
       ->mrpt::aligned_std_vector<float>* override
   {
     if (auto* f = CPointsMap::getPointsBufferRef_float_field(fieldName); f)
@@ -237,7 +236,7 @@ class [[deprecated("Use CGenericPointsMap instead")]] CPointsMapXYZIRT : public 
     if (fieldName == POINT_FIELD_TIMESTAMP) return &m_time;
     return nullptr;
   }
-  auto getPointsBufferRef_uint16_field(const std::string_view& fieldName)
+  auto getPointsBufferRef_uint16_field(const std::string& fieldName)
       ->mrpt::aligned_std_vector<uint16_t>* override
   {
     if (fieldName == POINT_FIELD_RING_ID) return &m_ring;

--- a/libs/maps/src/maps/CGenericPointsMap.cpp
+++ b/libs/maps/src/maps/CGenericPointsMap.cpp
@@ -9,6 +9,8 @@
 
 #include "maps-precomp.h"  // Precomp header
 //
+#include <algorithm>
+//
 #include <mrpt/maps/CGenericPointsMap.h>
 #include <mrpt/obs/CObservation2DRangeScan.h>
 #include <mrpt/obs/CObservation3DRangeScan.h>
@@ -26,13 +28,6 @@ using namespace mrpt::img;
 using namespace mrpt::poses;
 using namespace mrpt::math;
 using namespace mrpt::config;
-
-namespace
-{
-/// using string_view requires using a permanent storage somewhere in a place that outlives all
-/// possible accesses.
-thread_local std::set<std::string> fieldNamesCache;
-}  // namespace
 
 //  =========== Begin of Map definition ============
 MAP_DEFINITION_REGISTER("mrpt::maps::CGenericPointsMap", mrpt::maps::CGenericPointsMap)
@@ -131,48 +126,36 @@ void CGenericPointsMap::serializeTo(mrpt::serialization::CArchive& out) const
   out.WriteAs<uint32_t>(m_float_fields.size());
   for (const auto& [name, v] : m_float_fields)
   {
-    out << std::string(name);
+    out << name;
     out.WriteAs<uint32_t>(v.size());
-    if (!v.empty())
-    {
-      out.WriteBufferFixEndianness(v.data(), v.size());
-    }
+    if (!v.empty()) out.WriteBufferFixEndianness(v.data(), v.size());
   }
 
   // Double fields (v1)
   out.WriteAs<uint32_t>(m_double_fields.size());
   for (const auto& [name, v] : m_double_fields)
   {
-    out << std::string(name);
+    out << name;
     out.WriteAs<uint32_t>(v.size());
-    if (!v.empty())
-    {
-      out.WriteBufferFixEndianness(v.data(), v.size());
-    }
+    if (!v.empty()) out.WriteBufferFixEndianness(v.data(), v.size());
   }
 
   // Uint16 fields
   out.WriteAs<uint32_t>(m_uint16_fields.size());
   for (const auto& [name, v] : m_uint16_fields)
   {
-    out << std::string(name);
+    out << name;
     out.WriteAs<uint32_t>(v.size());
-    if (!v.empty())
-    {
-      out.WriteBufferFixEndianness(v.data(), v.size());
-    }
+    if (!v.empty()) out.WriteBufferFixEndianness(v.data(), v.size());
   }
 
   // uint8 fields (v2)
   out.WriteAs<uint32_t>(m_uint8_fields.size());
   for (const auto& [name, v] : m_uint8_fields)
   {
-    out << std::string(name);
-    out.WriteAs<uint32_t>(v.size());  // v3
-    if (!v.empty())
-    {
-      out.WriteBufferFixEndianness(v.data(), v.size());  // v3
-    }
+    out << name;
+    out.WriteAs<uint32_t>(v.size());                                   // v3
+    if (!v.empty()) out.WriteBufferFixEndianness(v.data(), v.size());  // v3
   }
 
   insertionOptions.writeToStream(out);
@@ -230,7 +213,9 @@ void CGenericPointsMap::serializeFrom(mrpt::serialization::CArchive& in, uint8_t
           std::string name;
           in >> name;
           this->registerField_float(name);
-          lambdaReadVector(m_float_fields[name]);
+          auto itF = m_float_fields.find(name);
+          ASSERT_(itF != m_float_fields.end());
+          lambdaReadVector(itF->second);
         }
       }
       // double fields
@@ -242,7 +227,9 @@ void CGenericPointsMap::serializeFrom(mrpt::serialization::CArchive& in, uint8_t
           std::string name;
           in >> name;
           this->registerField_double(name);
-          lambdaReadVector(m_double_fields[name]);
+          auto itD = m_double_fields.find(name);
+          ASSERT_(itD != m_double_fields.end());
+          lambdaReadVector(itD->second);
         }
       }
       // Uint16 fields
@@ -253,7 +240,9 @@ void CGenericPointsMap::serializeFrom(mrpt::serialization::CArchive& in, uint8_t
           std::string name;
           in >> name;
           this->registerField_uint16(name);
-          lambdaReadVector(m_uint16_fields[name]);
+          auto itU16 = m_uint16_fields.find(name);
+          ASSERT_(itU16 != m_uint16_fields.end());
+          lambdaReadVector(itU16->second);
         }
       }
       // u8 fields
@@ -265,7 +254,9 @@ void CGenericPointsMap::serializeFrom(mrpt::serialization::CArchive& in, uint8_t
           std::string name;
           in >> name;
           this->registerField_uint8(name);
-          lambdaReadVector(m_uint8_fields[name]);
+          auto itU8 = m_uint8_fields.find(name);
+          ASSERT_(itU8 != m_uint8_fields.end());
+          lambdaReadVector(itU8->second);
         }
       }
 
@@ -290,55 +281,47 @@ void CGenericPointsMap::internal_clear()
   mark_as_modified();
 }
 
-bool CGenericPointsMap::registerField_float(const std::string_view& fieldName)
+bool CGenericPointsMap::registerField_float(const std::string& fieldName)
 {
   if (hasPointField(fieldName))
   {
-    THROW_EXCEPTION_FMT(
-        "Field '%.*s' already exists.", static_cast<int>(fieldName.size()), fieldName.data());
+    THROW_EXCEPTION_FMT("Field '%s' already exists.", fieldName.c_str());
   }
-  const auto [itPermanentFieldName, _] = fieldNamesCache.insert(std::string(fieldName));
-  m_float_fields[*itPermanentFieldName].resize(size(), 0);
+  m_float_fields[fieldName].resize(size(), 0);
   return true;
 }
 
-bool CGenericPointsMap::registerField_double(const std::string_view& fieldName)
+bool CGenericPointsMap::registerField_double(const std::string& fieldName)
 {
   if (hasPointField(fieldName))
   {
-    THROW_EXCEPTION_FMT(
-        "Field '%.*s' already exists.", static_cast<int>(fieldName.size()), fieldName.data());
+    THROW_EXCEPTION_FMT("Field '%s' already exists.", fieldName.c_str());
   }
-  const auto [itPermanentFieldName, _] = fieldNamesCache.insert(std::string(fieldName));
-  m_double_fields[*itPermanentFieldName].resize(size(), 0);
+  m_double_fields[fieldName].resize(size(), 0);
   return true;
 }
 
-bool CGenericPointsMap::registerField_uint16(const std::string_view& fieldName)
+bool CGenericPointsMap::registerField_uint16(const std::string& fieldName)
 {
   if (hasPointField(fieldName))
   {
-    THROW_EXCEPTION_FMT(
-        "Field '%.*s' already exists.", static_cast<int>(fieldName.size()), fieldName.data());
+    THROW_EXCEPTION_FMT("Field '%s' already exists.", fieldName.c_str());
   }
-  const auto [itPermanentFieldName, _] = fieldNamesCache.insert(std::string(fieldName));
-  m_uint16_fields[*itPermanentFieldName].resize(size(), 0);
+  m_uint16_fields[fieldName].resize(size(), 0);
   return true;
 }
 
-bool CGenericPointsMap::registerField_uint8(const std::string_view& fieldName)
+bool CGenericPointsMap::registerField_uint8(const std::string& fieldName)
 {
   if (hasPointField(fieldName))
   {
-    THROW_EXCEPTION_FMT(
-        "Field '%.*s' already exists.", static_cast<int>(fieldName.size()), fieldName.data());
+    THROW_EXCEPTION_FMT("Field '%s' already exists.", fieldName.c_str());
   }
-  const auto [itPermanentFieldName, _] = fieldNamesCache.insert(std::string(fieldName));
-  m_uint8_fields[*itPermanentFieldName].resize(size(), 0);
+  m_uint8_fields[fieldName].resize(size(), 0);
   return true;
 }
 
-bool CGenericPointsMap::unregisterField(const std::string_view& fieldName)
+bool CGenericPointsMap::unregisterField(const std::string& fieldName)
 {
   if (m_float_fields.erase(fieldName) > 0) return true;
   if (m_double_fields.erase(fieldName) > 0) return true;
@@ -349,37 +332,37 @@ bool CGenericPointsMap::unregisterField(const std::string_view& fieldName)
 
 void CGenericPointsMap::getPointAllFieldsFast(size_t index, std::vector<float>& point_data) const
 {
-  const size_t nFields = 3 + m_float_fields.size() + m_uint16_fields.size() +
-                         m_double_fields.size() + m_uint8_fields.size();
+  const size_t nFields = 3 + m_float_fields.size() + m_double_fields.size() +
+                         m_uint16_fields.size() + m_uint8_fields.size();
   point_data.resize(nFields);
   point_data[0] = m_x[index];
   point_data[1] = m_y[index];
   point_data[2] = m_z[index];
 
   size_t i = 3;
-  for (const auto& field : m_float_fields) point_data[i++] = field.second[index];
-  for (const auto& field : m_double_fields) point_data[i++] = field.second[index];
-  for (const auto& field : m_uint16_fields) point_data[i++] = field.second[index];
-  for (const auto& field : m_uint8_fields) point_data[i++] = field.second[index];
+  for (const auto& [name, vec] : m_float_fields) point_data[i++] = vec[index];
+  for (const auto& [name, vec] : m_double_fields) point_data[i++] = static_cast<float>(vec[index]);
+  for (const auto& [name, vec] : m_uint16_fields) point_data[i++] = static_cast<float>(vec[index]);
+  for (const auto& [name, vec] : m_uint8_fields) point_data[i++] = static_cast<float>(vec[index]);
 }
 
 void CGenericPointsMap::setPointAllFieldsFast(size_t index, const std::vector<float>& point_data)
 {
-  const size_t nFields = 3 + m_float_fields.size() + m_uint16_fields.size() +
-                         m_double_fields.size() + m_uint8_fields.size();
+  const size_t nFields = 3 + m_float_fields.size() + m_double_fields.size() +
+                         m_uint16_fields.size() + m_uint8_fields.size();
   ASSERT_EQUAL_(point_data.size(), nFields);
   m_x[index] = point_data[0];
   m_y[index] = point_data[1];
   m_z[index] = point_data[2];
 
   size_t i = 3;
-  for (auto& field : m_float_fields) field.second[index] = point_data[i++];
-  for (auto& field : m_double_fields) field.second[index] = point_data[i++];
-  for (auto& field : m_uint16_fields) field.second[index] = static_cast<uint16_t>(point_data[i++]);
-  for (auto& field : m_uint8_fields) field.second[index] = static_cast<uint8_t>(point_data[i++]);
+  for (auto& [name, vec] : m_float_fields) vec[index] = point_data[i++];
+  for (auto& [name, vec] : m_double_fields) vec[index] = static_cast<double>(point_data[i++]);
+  for (auto& [name, vec] : m_uint16_fields) vec[index] = static_cast<uint16_t>(point_data[i++]);
+  for (auto& [name, vec] : m_uint8_fields) vec[index] = static_cast<uint8_t>(point_data[i++]);
 }
 
-bool CGenericPointsMap::hasPointField(const std::string_view& fieldName) const
+bool CGenericPointsMap::hasPointField(const std::string& fieldName) const
 {
   return CPointsMap::hasPointField(fieldName) ||  //
          m_float_fields.count(fieldName) ||       //
@@ -388,32 +371,32 @@ bool CGenericPointsMap::hasPointField(const std::string_view& fieldName) const
          m_uint8_fields.count(fieldName);
 }
 
-std::vector<std::string_view> CGenericPointsMap::getPointFieldNames_float() const
+std::vector<std::string> CGenericPointsMap::getPointFieldNames_float() const
 {
-  std::vector<std::string_view> names = CPointsMap::getPointFieldNames_float();
-  for (const auto& f : m_float_fields) names.push_back(f.first);
+  std::vector<std::string> names = CPointsMap::getPointFieldNames_float();
+  for (const auto& [name, _] : m_float_fields) names.push_back(name);
   return names;
 }
-std::vector<std::string_view> CGenericPointsMap::getPointFieldNames_double() const
+std::vector<std::string> CGenericPointsMap::getPointFieldNames_double() const
 {
-  std::vector<std::string_view> names = CPointsMap::getPointFieldNames_double();
-  for (const auto& f : m_double_fields) names.push_back(f.first);
+  std::vector<std::string> names = CPointsMap::getPointFieldNames_double();
+  for (const auto& [name, _] : m_double_fields) names.push_back(name);
   return names;
 }
-std::vector<std::string_view> CGenericPointsMap::getPointFieldNames_uint16() const
+std::vector<std::string> CGenericPointsMap::getPointFieldNames_uint16() const
 {
-  std::vector<std::string_view> names = CPointsMap::getPointFieldNames_uint16();
-  for (const auto& f : m_uint16_fields) names.push_back(f.first);
+  std::vector<std::string> names = CPointsMap::getPointFieldNames_uint16();
+  for (const auto& [name, _] : m_uint16_fields) names.push_back(name);
   return names;
 }
-std::vector<std::string_view> CGenericPointsMap::getPointFieldNames_uint8() const
+std::vector<std::string> CGenericPointsMap::getPointFieldNames_uint8() const
 {
-  std::vector<std::string_view> names = CPointsMap::getPointFieldNames_uint8();
-  for (const auto& f : m_uint8_fields) names.push_back(f.first);
+  std::vector<std::string> names = CPointsMap::getPointFieldNames_uint8();
+  for (const auto& [name, _] : m_uint8_fields) names.push_back(name);
   return names;
 }
 
-float CGenericPointsMap::getPointField_float(size_t index, const std::string_view& fieldName) const
+float CGenericPointsMap::getPointField_float(size_t index, const std::string& fieldName) const
 {
   auto it = m_float_fields.find(fieldName);
   if (it == m_float_fields.end())
@@ -424,8 +407,7 @@ float CGenericPointsMap::getPointField_float(size_t index, const std::string_vie
   return it->second[index];
 }
 
-double CGenericPointsMap::getPointField_double(
-    size_t index, const std::string_view& fieldName) const
+double CGenericPointsMap::getPointField_double(size_t index, const std::string& fieldName) const
 {
   auto it = m_double_fields.find(fieldName);
   if (it == m_double_fields.end())
@@ -436,8 +418,7 @@ double CGenericPointsMap::getPointField_double(
   return it->second[index];
 }
 
-uint16_t CGenericPointsMap::getPointField_uint16(
-    size_t index, const std::string_view& fieldName) const
+uint16_t CGenericPointsMap::getPointField_uint16(size_t index, const std::string& fieldName) const
 {
   auto it = m_uint16_fields.find(fieldName);
   if (it == m_uint16_fields.end())
@@ -448,8 +429,7 @@ uint16_t CGenericPointsMap::getPointField_uint16(
   return it->second[index];
 }
 
-uint8_t CGenericPointsMap::getPointField_uint8(
-    size_t index, const std::string_view& fieldName) const
+uint8_t CGenericPointsMap::getPointField_uint8(size_t index, const std::string& fieldName) const
 {
   auto it = m_uint8_fields.find(fieldName);
   if (it == m_uint8_fields.end())
@@ -460,63 +440,57 @@ uint8_t CGenericPointsMap::getPointField_uint8(
   return it->second[index];
 }
 
-void CGenericPointsMap::setPointField_float(
-    size_t index, const std::string_view& fieldName, float value)
+void CGenericPointsMap::setPointField_float(size_t index, const std::string& fieldName, float value)
 {
   auto it = m_float_fields.find(fieldName);
   if (it == m_float_fields.end())
   {
-    THROW_EXCEPTION_FMT(
-        "Field '%.*s' is not registered.", static_cast<int>(fieldName.size()), fieldName.data());
+    THROW_EXCEPTION_FMT("Field '%s' is not registered.", fieldName.c_str());
   }
   ASSERT_LT_(index, it->second.size());
   it->second[index] = value;
 }
 void CGenericPointsMap::setPointField_double(
-    size_t index, const std::string_view& fieldName, double value)
+    size_t index, const std::string& fieldName, double value)
 {
   auto it = m_double_fields.find(fieldName);
   if (it == m_double_fields.end())
   {
-    THROW_EXCEPTION_FMT(
-        "Field '%.*s' is not registered.", static_cast<int>(fieldName.size()), fieldName.data());
+    THROW_EXCEPTION_FMT("Field '%s' is not registered.", fieldName.c_str());
   }
   ASSERT_LT_(index, it->second.size());
   it->second[index] = value;
 }
 
 void CGenericPointsMap::setPointField_uint16(
-    size_t index, const std::string_view& fieldName, uint16_t value)
+    size_t index, const std::string& fieldName, uint16_t value)
 {
   auto it = m_uint16_fields.find(fieldName);
   if (it == m_uint16_fields.end())
   {
-    THROW_EXCEPTION_FMT(
-        "Field '%.*s' is not registered.", static_cast<int>(fieldName.size()), fieldName.data());
+    THROW_EXCEPTION_FMT("Field '%s' is not registered.", fieldName.c_str());
   }
   ASSERT_LT_(index, it->second.size());
   it->second[index] = value;
 }
 void CGenericPointsMap::setPointField_uint8(
-    size_t index, const std::string_view& fieldName, uint8_t value)
+    size_t index, const std::string& fieldName, uint8_t value)
 {
   auto it = m_uint8_fields.find(fieldName);
   if (it == m_uint8_fields.end())
   {
-    THROW_EXCEPTION_FMT(
-        "Field '%.*s' is not registered.", static_cast<int>(fieldName.size()), fieldName.data());
+    THROW_EXCEPTION_FMT("Field '%s' is not registered.", fieldName.c_str());
   }
   ASSERT_LT_(index, it->second.size());
   it->second[index] = value;
 }
 
-void CGenericPointsMap::insertPointField_float(const std::string_view& fieldName, float value)
+void CGenericPointsMap::insertPointField_float(const std::string& fieldName, float value)
 {
   auto it = m_float_fields.find(fieldName);
   if (it == m_float_fields.end())
   {
-    THROW_EXCEPTION_FMT(
-        "Field '%.*s' is not registered.", static_cast<int>(fieldName.size()), fieldName.data());
+    THROW_EXCEPTION_FMT("Field '%s' is not registered.", fieldName.c_str());
   }
   auto& vec = it->second;
   if (vec.size() < m_x.size() - 1) vec.resize(m_x.size() - 1, 0);  // Pad
@@ -524,13 +498,12 @@ void CGenericPointsMap::insertPointField_float(const std::string_view& fieldName
   vec.push_back(value);
 }
 
-void CGenericPointsMap::insertPointField_double(const std::string_view& fieldName, double value)
+void CGenericPointsMap::insertPointField_double(const std::string& fieldName, double value)
 {
   auto it = m_double_fields.find(fieldName);
   if (it == m_double_fields.end())
   {
-    THROW_EXCEPTION_FMT(
-        "Field '%.*s' is not registered.", static_cast<int>(fieldName.size()), fieldName.data());
+    THROW_EXCEPTION_FMT("Field '%s' is not registered.", fieldName.c_str());
   }
   auto& vec = it->second;
   if (vec.size() < m_x.size() - 1) vec.resize(m_x.size() - 1, 0);  // Pad
@@ -538,13 +511,12 @@ void CGenericPointsMap::insertPointField_double(const std::string_view& fieldNam
   vec.push_back(value);
 }
 
-void CGenericPointsMap::insertPointField_uint16(const std::string_view& fieldName, uint16_t value)
+void CGenericPointsMap::insertPointField_uint16(const std::string& fieldName, uint16_t value)
 {
   auto it = m_uint16_fields.find(fieldName);
   if (it == m_uint16_fields.end())
   {
-    THROW_EXCEPTION_FMT(
-        "Field '%.*s' is not registered.", static_cast<int>(fieldName.size()), fieldName.data());
+    THROW_EXCEPTION_FMT("Field '%s' is not registered.", fieldName.c_str());
   }
   auto& vec = it->second;
   if (vec.size() < m_x.size() - 1) vec.resize(m_x.size() - 1, 0);  // Pad
@@ -552,13 +524,12 @@ void CGenericPointsMap::insertPointField_uint16(const std::string_view& fieldNam
   vec.push_back(value);
 }
 
-void CGenericPointsMap::insertPointField_uint8(const std::string_view& fieldName, uint8_t value)
+void CGenericPointsMap::insertPointField_uint8(const std::string& fieldName, uint8_t value)
 {
   auto it = m_uint8_fields.find(fieldName);
   if (it == m_uint8_fields.end())
   {
-    THROW_EXCEPTION_FMT(
-        "Field '%.*s' is not registered.", static_cast<int>(fieldName.size()), fieldName.data());
+    THROW_EXCEPTION_FMT("Field '%s' is not registered.", fieldName.c_str());
   }
   auto& vec = it->second;
   if (vec.size() < m_x.size() - 1) vec.resize(m_x.size() - 1, 0);  // Pad
@@ -566,38 +537,54 @@ void CGenericPointsMap::insertPointField_uint8(const std::string_view& fieldName
   vec.push_back(value);
 }
 
-void CGenericPointsMap::reserveField_float(const std::string_view& fieldName, size_t n)
+void CGenericPointsMap::reserveField_float(const std::string& fieldName, size_t n)
 {
-  m_float_fields[fieldName].reserve(n);
+  auto it = m_float_fields.find(fieldName);
+  ASSERT_(it != m_float_fields.end());
+  it->second.reserve(n);
 }
-void CGenericPointsMap::reserveField_double(const std::string_view& fieldName, size_t n)
+void CGenericPointsMap::reserveField_double(const std::string& fieldName, size_t n)
 {
-  m_double_fields[fieldName].reserve(n);
+  auto it = m_double_fields.find(fieldName);
+  ASSERT_(it != m_double_fields.end());
+  it->second.reserve(n);
 }
-void CGenericPointsMap::reserveField_uint16(const std::string_view& fieldName, size_t n)
+void CGenericPointsMap::reserveField_uint16(const std::string& fieldName, size_t n)
 {
-  m_uint16_fields[fieldName].reserve(n);
+  auto it = m_uint16_fields.find(fieldName);
+  ASSERT_(it != m_uint16_fields.end());
+  it->second.reserve(n);
 }
-void CGenericPointsMap::reserveField_uint8(const std::string_view& fieldName, size_t n)
+void CGenericPointsMap::reserveField_uint8(const std::string& fieldName, size_t n)
 {
-  m_uint8_fields[fieldName].reserve(n);
+  auto it = m_uint8_fields.find(fieldName);
+  ASSERT_(it != m_uint8_fields.end());
+  it->second.reserve(n);
 }
 
-void CGenericPointsMap::resizeField_float(const std::string_view& fieldName, size_t n)
+void CGenericPointsMap::resizeField_float(const std::string& fieldName, size_t n)
 {
-  m_float_fields[fieldName].resize(n, 0);
+  auto it = m_float_fields.find(fieldName);
+  ASSERT_(it != m_float_fields.end());
+  it->second.resize(n, 0);
 }
-void CGenericPointsMap::resizeField_double(const std::string_view& fieldName, size_t n)
+void CGenericPointsMap::resizeField_double(const std::string& fieldName, size_t n)
 {
-  m_double_fields[fieldName].resize(n, 0);
+  auto it = m_double_fields.find(fieldName);
+  ASSERT_(it != m_double_fields.end());
+  it->second.resize(n, 0);
 }
-void CGenericPointsMap::resizeField_uint16(const std::string_view& fieldName, size_t n)
+void CGenericPointsMap::resizeField_uint16(const std::string& fieldName, size_t n)
 {
-  m_uint16_fields[fieldName].resize(n, 0);
+  auto it = m_uint16_fields.find(fieldName);
+  ASSERT_(it != m_uint16_fields.end());
+  it->second.resize(n, 0);
 }
-void CGenericPointsMap::resizeField_uint8(const std::string_view& fieldName, size_t n)
+void CGenericPointsMap::resizeField_uint8(const std::string& fieldName, size_t n)
 {
-  m_uint8_fields[fieldName].resize(n, 0);
+  auto it = m_uint8_fields.find(fieldName);
+  ASSERT_(it != m_uint8_fields.end());
+  it->second.resize(n, 0);
 }
 
 namespace mrpt::maps::detail

--- a/libs/maps/src/maps/CGenericPointsMap_unittest.cpp
+++ b/libs/maps/src/maps/CGenericPointsMap_unittest.cpp
@@ -1,0 +1,433 @@
+/* +------------------------------------------------------------------------+
+   |                     Mobile Robot Programming Toolkit (MRPT)            |
+   |                          https://www.mrpt.org/                         |
+   |                                                                        |
+   | Copyright (c) 2005-2026, Individual contributors, see AUTHORS file     |
+   | See: https://www.mrpt.org/Authors - All rights reserved.               |
+   | Released under BSD License. See: https://www.mrpt.org/License          |
+   +------------------------------------------------------------------------+ */
+
+// Unit tests for CGenericPointsMap field-order stability,
+// thread-safety of the field registration API, and basic operations.
+
+#include <gtest/gtest.h>
+#include <mrpt/io/CMemoryStream.h>
+#include <mrpt/maps/CGenericPointsMap.h>
+#include <mrpt/serialization/CArchive.h>
+
+#include <atomic>
+#include <string>
+#include <thread>
+#include <vector>
+
+using mrpt::maps::CGenericPointsMap;
+
+// ---------------------------------------------------------------------------
+//  Helpers
+// ---------------------------------------------------------------------------
+
+/// Build a small map with known field values so tests can assert on content.
+static CGenericPointsMap makeTestMap()
+{
+  CGenericPointsMap m;
+  m.registerField_float("intensity");
+  m.registerField_float("t");
+  m.registerField_uint16("ring");
+  m.registerField_uint8("color_r");
+  m.registerField_double("gps_time");
+
+  const size_t N = 5;
+  m.resize(N);
+  for (size_t i = 0; i < N; ++i)
+  {
+    m.setPointFast(i, float(i), float(i * 10), float(i * 100));
+    m.setPointField_float(i, "intensity", float(i) + 0.5f);
+    m.setPointField_float(i, "t", float(i) * 0.001f);
+    m.setPointField_uint16(i, "ring", static_cast<uint16_t>(i + 1));
+    m.setPointField_uint8(i, "color_r", static_cast<uint8_t>(i * 50));
+    m.setPointField_double(i, "gps_time", 1000.0 + i);
+  }
+  return m;
+}
+
+// =========================================================================
+//  Thread safety: field keys survive cross-thread transfer
+// =========================================================================
+
+TEST(CGenericPointsMap, FieldKeysValidAfterCreatingThreadExits)
+{
+  std::unique_ptr<CGenericPointsMap> mapPtr;
+
+  std::thread builder(
+      [&mapPtr]()
+      {
+        auto m = std::make_unique<CGenericPointsMap>();
+        m->registerField_float("intensity");
+        m->registerField_uint16("ring");
+        m->registerField_uint8("label");
+        m->registerField_double("gps_time");
+
+        m->resize(3);
+        for (size_t i = 0; i < 3; ++i)
+        {
+          m->setPointFast(i, float(i), 0, 0);
+          m->setPointField_float(i, "intensity", float(i) + 0.1f);
+          m->setPointField_uint16(i, "ring", uint16_t(i));
+          m->setPointField_uint8(i, "label", uint8_t(i + 10));
+          m->setPointField_double(i, "gps_time", 100.0 + i);
+        }
+        mapPtr = std::move(m);
+      });
+  builder.join();
+
+  ASSERT_NE(mapPtr, nullptr);
+  const auto& m = *mapPtr;
+
+  EXPECT_TRUE(m.hasPointField("intensity"));
+  EXPECT_TRUE(m.hasPointField("ring"));
+  EXPECT_TRUE(m.hasPointField("label"));
+  EXPECT_TRUE(m.hasPointField("gps_time"));
+
+  EXPECT_FLOAT_EQ(m.getPointField_float(1, "intensity"), 1.1f);
+  EXPECT_EQ(m.getPointField_uint16(2, "ring"), 2u);
+  EXPECT_EQ(m.getPointField_uint8(0, "label"), 10u);
+  EXPECT_DOUBLE_EQ(m.getPointField_double(1, "gps_time"), 101.0);
+
+  const auto fnames = m.getPointFieldNames_float();
+  EXPECT_FALSE(fnames.empty());
+}
+
+TEST(CGenericPointsMap, DeserializeOnDifferentThread)
+{
+  mrpt::io::CMemoryStream buf;
+  {
+    const auto src = makeTestMap();
+    auto ar = mrpt::serialization::archiveFrom(buf);
+    ar << src;
+  }
+
+  std::shared_ptr<CGenericPointsMap> mapPtr;
+  buf.Seek(0);
+  std::thread loader(
+      [&]()
+      {
+        auto ar = mrpt::serialization::archiveFrom(buf);
+        mrpt::serialization::CSerializable::Ptr obj;
+        ar >> obj;
+        mapPtr = std::dynamic_pointer_cast<CGenericPointsMap>(obj);
+      });
+  loader.join();
+
+  ASSERT_NE(mapPtr, nullptr);
+  const auto& m = *mapPtr;
+
+  EXPECT_TRUE(m.hasPointField("intensity"));
+  EXPECT_TRUE(m.hasPointField("t"));
+  EXPECT_TRUE(m.hasPointField("ring"));
+  EXPECT_TRUE(m.hasPointField("color_r"));
+  EXPECT_TRUE(m.hasPointField("gps_time"));
+  EXPECT_FLOAT_EQ(m.getPointField_float(2, "intensity"), 2.5f);
+}
+
+TEST(CGenericPointsMap, CopyAssignAcrossThreads)
+{
+  const auto src = makeTestMap();
+  std::unique_ptr<CGenericPointsMap> dstPtr;
+
+  std::thread copier([&]() { dstPtr = std::make_unique<CGenericPointsMap>(src); });
+  copier.join();
+
+  ASSERT_NE(dstPtr, nullptr);
+  EXPECT_TRUE(dstPtr->hasPointField("intensity"));
+  EXPECT_FLOAT_EQ(dstPtr->getPointField_float(0, "intensity"), 0.5f);
+  EXPECT_DOUBLE_EQ(dstPtr->getPointField_double(2, "gps_time"), 1002.0);
+}
+
+// =========================================================================
+//  reserveField / resizeField on unregistered fields must throw
+// =========================================================================
+
+TEST(CGenericPointsMap, ReserveFieldUnregisteredFieldThrows)
+{
+  CGenericPointsMap m;
+  m.registerField_float("intensity");
+  m.resize(5);
+
+  EXPECT_ANY_THROW(m.reserveField_float("bogus", 100));
+  EXPECT_ANY_THROW(m.reserveField_double("bogus", 100));
+  EXPECT_ANY_THROW(m.reserveField_uint16("bogus", 100));
+  EXPECT_ANY_THROW(m.reserveField_uint8("bogus", 100));
+}
+
+TEST(CGenericPointsMap, ResizeFieldUnregisteredFieldThrows)
+{
+  CGenericPointsMap m;
+  m.registerField_float("intensity");
+  m.resize(5);
+
+  EXPECT_ANY_THROW(m.resizeField_float("bogus", 100));
+  EXPECT_ANY_THROW(m.resizeField_double("bogus", 100));
+  EXPECT_ANY_THROW(m.resizeField_uint16("bogus", 100));
+  EXPECT_ANY_THROW(m.resizeField_uint8("bogus", 100));
+}
+
+// =========================================================================
+//  getPointAllFieldsFast / setPointAllFieldsFast round-trip
+// =========================================================================
+
+TEST(CGenericPointsMap, AllFieldsSelfRoundTrip)
+{
+  CGenericPointsMap m;
+  for (int i = 0; i < 20; ++i) m.registerField_float("field_" + std::to_string(i));
+
+  m.resize(1);
+  for (int i = 0; i < 20; ++i)
+    m.setPointField_float(0, "field_" + std::to_string(i), float(i) + 0.25f);
+
+  m.setPointFast(0, 1.0f, 2.0f, 3.0f);
+
+  std::vector<float> blob;
+  m.getPointAllFieldsFast(0, blob);
+
+  // Wipe values.
+  for (int i = 0; i < 20; ++i) m.setPointField_float(0, "field_" + std::to_string(i), 0.0f);
+
+  // Restore from blob.
+  m.setPointAllFieldsFast(0, blob);
+
+  for (int i = 0; i < 20; ++i)
+  {
+    EXPECT_FLOAT_EQ(m.getPointField_float(0, "field_" + std::to_string(i)), float(i) + 0.25f)
+        << "Mismatch at field_" << i;
+  }
+}
+
+// =========================================================================
+//  Copy-constructed map must preserve field order
+// =========================================================================
+
+TEST(CGenericPointsMap, CopyPreservesFieldOrder)
+{
+  const auto src = makeTestMap();
+  std::vector<float> blobSrc;
+  src.getPointAllFieldsFast(2, blobSrc);
+
+  CGenericPointsMap dst(src);
+  std::vector<float> blobDst;
+  dst.getPointAllFieldsFast(2, blobDst);
+
+  ASSERT_EQ(blobSrc.size(), blobDst.size());
+  for (size_t i = 0; i < blobSrc.size(); ++i)
+  {
+    EXPECT_FLOAT_EQ(blobSrc[i], blobDst[i]) << "Mismatch at blob index " << i;
+  }
+}
+
+// =========================================================================
+//  Serialize -> deserialize must preserve field order
+// =========================================================================
+
+TEST(CGenericPointsMap, SerializeDeserializePreservesFieldOrder)
+{
+  const auto src = makeTestMap();
+  std::vector<float> blobSrc;
+  src.getPointAllFieldsFast(3, blobSrc);
+
+  mrpt::io::CMemoryStream buf;
+  {
+    auto ar = mrpt::serialization::archiveFrom(buf);
+    ar << src;
+  }
+  buf.Seek(0);
+
+  CGenericPointsMap dst;
+  {
+    auto ar = mrpt::serialization::archiveFrom(buf);
+    mrpt::serialization::CSerializable::Ptr obj;
+    ar >> obj;
+    ASSERT_NE(obj, nullptr);
+    dst = *dynamic_cast<CGenericPointsMap*>(obj.get());
+  }
+
+  std::vector<float> blobDst;
+  dst.getPointAllFieldsFast(3, blobDst);
+
+  ASSERT_EQ(blobSrc.size(), blobDst.size());
+  for (size_t i = 0; i < blobSrc.size(); ++i)
+  {
+    EXPECT_FLOAT_EQ(blobSrc[i], blobDst[i]) << "Mismatch at blob index " << i;
+  }
+}
+
+// =========================================================================
+//  General regression: field access basics
+// =========================================================================
+
+TEST(CGenericPointsMap, RegisterAndAccessAllTypes)
+{
+  CGenericPointsMap m;
+  m.registerField_float("f1");
+  m.registerField_double("d1");
+  m.registerField_uint16("u16");
+  m.registerField_uint8("u8");
+
+  m.resize(2);
+  m.setPointFast(0, 1.0f, 2.0f, 3.0f);
+  m.setPointField_float(0, "f1", 1.5f);
+  m.setPointField_double(0, "d1", 2.5);
+  m.setPointField_uint16(0, "u16", 300);
+  m.setPointField_uint8(0, "u8", 42);
+
+  EXPECT_FLOAT_EQ(m.getPointField_float(0, "f1"), 1.5f);
+  EXPECT_DOUBLE_EQ(m.getPointField_double(0, "d1"), 2.5);
+  EXPECT_EQ(m.getPointField_uint16(0, "u16"), 300);
+  EXPECT_EQ(m.getPointField_uint8(0, "u8"), 42);
+}
+
+TEST(CGenericPointsMap, UnregisterFieldRemovesData)
+{
+  CGenericPointsMap m;
+  m.registerField_float("toRemove");
+  m.registerField_float("toKeep");
+  m.resize(3);
+  m.setPointField_float(0, "toRemove", 99.0f);
+  m.setPointField_float(0, "toKeep", 42.0f);
+
+  EXPECT_TRUE(m.unregisterField("toRemove"));
+  EXPECT_FALSE(m.hasPointField("toRemove"));
+  EXPECT_TRUE(m.hasPointField("toKeep"));
+
+  // Re-register must work and start fresh.
+  m.registerField_float("toRemove");
+  EXPECT_FLOAT_EQ(m.getPointField_float(0, "toRemove"), 0.0f);
+}
+
+TEST(CGenericPointsMap, ClearAndReuse)
+{
+  CGenericPointsMap m;
+  m.registerField_float("f1");
+  m.resize(5);
+  m.clear();
+
+  EXPECT_FALSE(m.hasPointField("f1"));
+  EXPECT_EQ(m.size(), 0u);
+
+  m.registerField_float("f2");
+  m.resize(2);
+  m.setPointField_float(0, "f2", 7.0f);
+  EXPECT_FLOAT_EQ(m.getPointField_float(0, "f2"), 7.0f);
+}
+
+// =========================================================================
+//  Stress: many threads create and destroy maps concurrently
+// =========================================================================
+
+TEST(CGenericPointsMap, ConcurrentCreateDestroy)
+{
+  constexpr int kThreads = 8;
+  constexpr int kIterations = 200;
+  std::atomic<int> failures{0};
+
+  auto worker = [&](int id)
+  {
+    for (int iter = 0; iter < kIterations; ++iter)
+    {
+      try
+      {
+        CGenericPointsMap m;
+        const std::string fname = "field_" + std::to_string(id) + "_" + std::to_string(iter);
+        m.registerField_float(fname);
+        m.registerField_uint8("u8_" + std::to_string(id));
+        m.resize(10);
+        for (size_t i = 0; i < 10; ++i)
+        {
+          m.setPointFast(i, float(i), 0, 0);
+          m.setPointField_float(i, fname, float(i) + 0.1f);
+          m.setPointField_uint8(i, "u8_" + std::to_string(id), uint8_t(i));
+        }
+
+        for (size_t i = 0; i < 10; ++i)
+        {
+          const float v = m.getPointField_float(i, fname);
+          if (std::abs(v - (float(i) + 0.1f)) > 1e-5f) ++failures;
+        }
+      }
+      catch (...)
+      {
+        ++failures;
+      }
+    }
+  };
+
+  std::vector<std::thread> threads;
+  threads.reserve(kThreads);
+  for (int i = 0; i < kThreads; ++i) threads.emplace_back(worker, i);
+  for (auto& t : threads) t.join();
+
+  EXPECT_EQ(failures.load(), 0);
+}
+
+// =========================================================================
+//  Produce on N threads, consume on main
+// =========================================================================
+
+TEST(CGenericPointsMap, ProduceOnThreadsConsumeOnMain)
+{
+  constexpr int kThreads = 4;
+  std::vector<std::unique_ptr<CGenericPointsMap>> maps(kThreads);
+
+  std::vector<std::thread> producers;
+  producers.reserve(kThreads);
+  for (int id = 0; id < kThreads; ++id)
+  {
+    producers.emplace_back(
+        [&maps, id]()
+        {
+          auto m = std::make_unique<CGenericPointsMap>();
+          const std::string fname = "val_" + std::to_string(id);
+          m->registerField_float(fname);
+          m->resize(5);
+          for (size_t i = 0; i < 5; ++i)
+          {
+            m->setPointFast(i, float(i), 0, 0);
+            m->setPointField_float(i, fname, float(id * 100 + i));
+          }
+          maps[id] = std::move(m);
+        });
+  }
+  for (auto& t : producers) t.join();
+
+  for (int id = 0; id < kThreads; ++id)
+  {
+    ASSERT_NE(maps[id], nullptr) << "Thread " << id << " didn't produce a map";
+    const auto& m = *maps[id];
+    const std::string fname = "val_" + std::to_string(id);
+    EXPECT_TRUE(m.hasPointField(fname)) << "Field missing for thread " << id;
+    for (size_t i = 0; i < 5; ++i)
+    {
+      EXPECT_FLOAT_EQ(m.getPointField_float(i, fname), float(id * 100 + i))
+          << "Value mismatch: thread=" << id << " point=" << i;
+    }
+  }
+}
+
+// =========================================================================
+//  Edge case: field names that are substrings of each other
+// =========================================================================
+
+TEST(CGenericPointsMap, SubstringFieldNames)
+{
+  CGenericPointsMap m;
+  m.registerField_float("ring");
+  m.registerField_float("ring_id");
+  m.registerField_float("r");
+
+  m.resize(1);
+  m.setPointField_float(0, "ring", 1.0f);
+  m.setPointField_float(0, "ring_id", 2.0f);
+  m.setPointField_float(0, "r", 3.0f);
+
+  EXPECT_FLOAT_EQ(m.getPointField_float(0, "ring"), 1.0f);
+  EXPECT_FLOAT_EQ(m.getPointField_float(0, "ring_id"), 2.0f);
+  EXPECT_FLOAT_EQ(m.getPointField_float(0, "r"), 3.0f);
+}

--- a/libs/maps/src/maps/CPointsMap.cpp
+++ b/libs/maps/src/maps/CPointsMap.cpp
@@ -1982,10 +1982,10 @@ void CPointsMap::loadFromVelodyneScan(
   }
 }
 
-std::vector<std::string_view> CPointsMap::getPointFieldNames_float_except_xyz() const
+std::vector<std::string> CPointsMap::getPointFieldNames_float_except_xyz() const
 {
   const auto all = getPointFieldNames_float();
-  std::vector<std::string_view> result;
+  std::vector<std::string> result;
   result.reserve(all.size());
 
   for (auto name : all)
@@ -2237,7 +2237,7 @@ std::string listAllFields(const mrpt::maps::CPointsMap& pcd)
 {
   std::string ret;
 
-  auto appendFields = [&ret](const std::vector<std::string_view>& fields)
+  auto appendFields = [&ret](const std::vector<std::string>& fields)
   {
     for (const auto& f : fields)
     {

--- a/libs/maps/src/maps/CPointsMapXYZI.cpp
+++ b/libs/maps/src/maps/CPointsMapXYZI.cpp
@@ -319,19 +319,19 @@ void CPointsMapXYZI::loadFromRangeScan(
 /* ------------------------------------------------------------------
  String-keyed field access virtual interface implementation
    ------------------------------------------------------------------ */
-bool CPointsMapXYZI::hasPointField(const std::string_view& fieldName) const
+bool CPointsMapXYZI::hasPointField(const std::string& fieldName) const
 {
   if (fieldName == POINT_FIELD_INTENSITY) return true;
   return CPointsMap::hasPointField(fieldName);
 }
-std::vector<std::string_view> CPointsMapXYZI::getPointFieldNames_float() const
+std::vector<std::string> CPointsMapXYZI::getPointFieldNames_float() const
 {
-  std::vector<std::string_view> names = CPointsMap::getPointFieldNames_float();
+  std::vector<std::string> names = CPointsMap::getPointFieldNames_float();
   names.push_back(POINT_FIELD_INTENSITY);
   return names;
 }
 
-float CPointsMapXYZI::getPointField_float(size_t index, const std::string_view& fieldName) const
+float CPointsMapXYZI::getPointField_float(size_t index, const std::string& fieldName) const
 {
   if (fieldName == POINT_FIELD_INTENSITY)
   {
@@ -342,8 +342,7 @@ float CPointsMapXYZI::getPointField_float(size_t index, const std::string_view& 
   return 0;
 }
 
-void CPointsMapXYZI::setPointField_float(
-    size_t index, const std::string_view& fieldName, float value)
+void CPointsMapXYZI::setPointField_float(size_t index, const std::string& fieldName, float value)
 {
   if (fieldName == POINT_FIELD_INTENSITY && hasIntensityField())
   {
@@ -355,7 +354,7 @@ void CPointsMapXYZI::setPointField_float(
   }
 }
 
-void CPointsMapXYZI::insertPointField_float(const std::string_view& fieldName, float value)
+void CPointsMapXYZI::insertPointField_float(const std::string& fieldName, float value)
 {
   if (fieldName == POINT_FIELD_INTENSITY)
   {
@@ -367,11 +366,11 @@ void CPointsMapXYZI::insertPointField_float(const std::string_view& fieldName, f
   }
 }
 
-void CPointsMapXYZI::reserveField_float(const std::string_view& fieldName, size_t n)
+void CPointsMapXYZI::reserveField_float(const std::string& fieldName, size_t n)
 {
   if (fieldName == POINT_FIELD_INTENSITY) m_intensity.reserve(n);
 }
-void CPointsMapXYZI::resizeField_float(const std::string_view& fieldName, size_t n)
+void CPointsMapXYZI::resizeField_float(const std::string& fieldName, size_t n)
 {
   if (fieldName == POINT_FIELD_INTENSITY) m_intensity.resize(n, 0);
 }

--- a/libs/maps/src/maps/CPointsMapXYZIRT.cpp
+++ b/libs/maps/src/maps/CPointsMapXYZIRT.cpp
@@ -464,28 +464,28 @@ void CPointsMapXYZIRT::loadFromRangeScan(
 /* ------------------------------------------------------------------
  String-keyed field access virtual interface implementation
    ------------------------------------------------------------------ */
-bool CPointsMapXYZIRT::hasPointField(const std::string_view& fieldName) const
+bool CPointsMapXYZIRT::hasPointField(const std::string& fieldName) const
 {
   if (fieldName == POINT_FIELD_INTENSITY) return true;
   if (fieldName == POINT_FIELD_RING_ID) return true;
   if (fieldName == POINT_FIELD_TIMESTAMP) return true;
   return CPointsMap::hasPointField(fieldName);
 }
-std::vector<std::string_view> CPointsMapXYZIRT::getPointFieldNames_float() const
+std::vector<std::string> CPointsMapXYZIRT::getPointFieldNames_float() const
 {
-  std::vector<std::string_view> names = CPointsMap::getPointFieldNames_float();
+  std::vector<std::string> names = CPointsMap::getPointFieldNames_float();
   names.push_back(POINT_FIELD_INTENSITY);
   names.push_back(POINT_FIELD_TIMESTAMP);
   return names;
 }
-std::vector<std::string_view> CPointsMapXYZIRT::getPointFieldNames_uint16() const
+std::vector<std::string> CPointsMapXYZIRT::getPointFieldNames_uint16() const
 {
-  std::vector<std::string_view> names = CPointsMap::getPointFieldNames_uint16();
+  std::vector<std::string> names = CPointsMap::getPointFieldNames_uint16();
   names.push_back(POINT_FIELD_RING_ID);
   return names;
 }
 
-float CPointsMapXYZIRT::getPointField_float(size_t index, const std::string_view& fieldName) const
+float CPointsMapXYZIRT::getPointField_float(size_t index, const std::string& fieldName) const
 {
   if (fieldName == POINT_FIELD_INTENSITY)
   {
@@ -501,8 +501,7 @@ float CPointsMapXYZIRT::getPointField_float(size_t index, const std::string_view
   }
   return 0;
 }
-uint16_t CPointsMapXYZIRT::getPointField_uint16(
-    size_t index, const std::string_view& fieldName) const
+uint16_t CPointsMapXYZIRT::getPointField_uint16(size_t index, const std::string& fieldName) const
 {
   if (fieldName == POINT_FIELD_RING_ID)
   {
@@ -513,8 +512,7 @@ uint16_t CPointsMapXYZIRT::getPointField_uint16(
   return 0;
 }
 
-void CPointsMapXYZIRT::setPointField_float(
-    size_t index, const std::string_view& fieldName, float value)
+void CPointsMapXYZIRT::setPointField_float(size_t index, const std::string& fieldName, float value)
 {
   if (fieldName == POINT_FIELD_INTENSITY)
   {
@@ -530,7 +528,7 @@ void CPointsMapXYZIRT::setPointField_float(
   }
 }
 void CPointsMapXYZIRT::setPointField_uint16(
-    size_t index, const std::string_view& fieldName, uint16_t value)
+    size_t index, const std::string& fieldName, uint16_t value)
 {
   if (fieldName == POINT_FIELD_RING_ID)
   {
@@ -542,7 +540,7 @@ void CPointsMapXYZIRT::setPointField_uint16(
   }
 }
 
-void CPointsMapXYZIRT::insertPointField_float(const std::string_view& fieldName, float value)
+void CPointsMapXYZIRT::insertPointField_float(const std::string& fieldName, float value)
 {
   if (fieldName == POINT_FIELD_INTENSITY)
   {
@@ -557,7 +555,7 @@ void CPointsMapXYZIRT::insertPointField_float(const std::string_view& fieldName,
     CPointsMap::insertPointField_float(fieldName, value);
   }
 }
-void CPointsMapXYZIRT::insertPointField_uint16(const std::string_view& fieldName, uint16_t value)
+void CPointsMapXYZIRT::insertPointField_uint16(const std::string& fieldName, uint16_t value)
 {
   if (fieldName == POINT_FIELD_RING_ID)
   {
@@ -569,21 +567,21 @@ void CPointsMapXYZIRT::insertPointField_uint16(const std::string_view& fieldName
   }
 }
 
-void CPointsMapXYZIRT::reserveField_float(const std::string_view& fieldName, size_t n)
+void CPointsMapXYZIRT::reserveField_float(const std::string& fieldName, size_t n)
 {
   if (fieldName == POINT_FIELD_INTENSITY) m_intensity.reserve(n);
   if (fieldName == POINT_FIELD_TIMESTAMP) m_time.reserve(n);
 }
-void CPointsMapXYZIRT::reserveField_uint16(const std::string_view& fieldName, size_t n)
+void CPointsMapXYZIRT::reserveField_uint16(const std::string& fieldName, size_t n)
 {
   if (fieldName == POINT_FIELD_RING_ID) m_ring.reserve(n);
 }
-void CPointsMapXYZIRT::resizeField_float(const std::string_view& fieldName, size_t n)
+void CPointsMapXYZIRT::resizeField_float(const std::string& fieldName, size_t n)
 {
   if (fieldName == POINT_FIELD_INTENSITY) m_intensity.resize(n, 0);
   if (fieldName == POINT_FIELD_TIMESTAMP) m_time.resize(n, 0);
 }
-void CPointsMapXYZIRT::resizeField_uint16(const std::string_view& fieldName, size_t n)
+void CPointsMapXYZIRT::resizeField_uint16(const std::string& fieldName, size_t n)
 {
   if (fieldName == POINT_FIELD_RING_ID) m_ring.resize(n, 0);
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Field-name handling now uses owning strings so field keys remain valid across threads and object lifetime.
  * Deterministic per-type field ordering for consistent bulk get/set behavior.

* **Bug Fixes**
  * Serialization/deserialization and reserve/resize now robust against transient names and cross-thread transfers.
  * Reserve/resize now enforce existing fields (invalid names produce errors); unregister/clear reliably removes fields.

* **Tests**
  * New unit tests for registration, bulk packing/unpacking, serialization, multithreading, negative cases, and edge conditions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->