### PR TITLE
feat(maps): add uint32_t per-point data channels to CGenericPointsMap

### DIFF
--- a/modules/mrpt_maps/include/mrpt/maps/CGenericPointsMap.h
+++ b/modules/mrpt_maps/include/mrpt/maps/CGenericPointsMap.h
@@ -29,7 +29,8 @@ namespace mrpt::maps
 /** A map of 3D points (X,Y,Z) plus any number of custom, string-keyed
  * per-point data channels.
  *
- * Supported channel data types are `float`, `double`, `uint16_t`, and `uint8_t`.
+ * Supported channel data types are `float`, `double`, `uint16_t`, `uint8_t`, and
+ * `uint32_t`.
  *
  * Before inserting points, you must register the fields you want to use via
  * `registerField_float()`, `registerField_double()`, ...
@@ -78,6 +79,7 @@ class CGenericPointsMap : public CPointsMap
   bool registerField_double(const std::string& fieldName) override;
   bool registerField_uint16(const std::string& fieldName) override;
   bool registerField_uint8(const std::string& fieldName) override;
+  bool registerField_uint32(const std::string& fieldName) override;
 
   /** Removes a data channel.
    * \return True if the field existed and was removed, false otherwise.
@@ -103,6 +105,11 @@ class CGenericPointsMap : public CPointsMap
   const std::map<std::string, mrpt::aligned_std_vector<uint8_t>>& uint8_fields() const
   {
     return m_uint8_fields;
+  }
+  /** Returns the map of uint32_t fields: map<field_name, vector_of_data> */
+  const std::map<std::string, mrpt::aligned_std_vector<uint32_t>>& uint32_fields() const
+  {
+    return m_uint32_fields;
   }
 
   /** @} */
@@ -133,16 +140,19 @@ class CGenericPointsMap : public CPointsMap
   std::vector<std::string> getPointFieldNames_double() const override;
   std::vector<std::string> getPointFieldNames_uint16() const override;
   std::vector<std::string> getPointFieldNames_uint8() const override;
+  std::vector<std::string> getPointFieldNames_uint32() const override;
 
   float getPointField_float(size_t index, const std::string& fieldName) const override;
   double getPointField_double(size_t index, const std::string& fieldName) const override;
   uint16_t getPointField_uint16(size_t index, const std::string& fieldName) const override;
   uint8_t getPointField_uint8(size_t index, const std::string& fieldName) const override;
+  uint32_t getPointField_uint32(size_t index, const std::string& fieldName) const override;
 
   void setPointField_float(size_t index, const std::string& fieldName, float value) override;
   void setPointField_double(size_t index, const std::string& fieldName, double value) override;
   void setPointField_uint16(size_t index, const std::string& fieldName, uint16_t value) override;
   void setPointField_uint8(size_t index, const std::string& fieldName, uint8_t value) override;
+  void setPointField_uint32(size_t index, const std::string& fieldName, uint32_t value) override;
 
   /** Appends a value to the given field.
    * The field must be registered.
@@ -172,15 +182,24 @@ class CGenericPointsMap : public CPointsMap
    */
   void insertPointField_uint8(const std::string& fieldName, uint8_t value) override;
 
+  /** Appends a value to the given field.
+   * The field must be registered.
+   * Asserts that the field vector's size is exactly `this->size() - 1`
+   * (i.e. you just called `insertPointFast()`).
+   */
+  void insertPointField_uint32(const std::string& fieldName, uint32_t value) override;
+
   void reserveField_float(const std::string& fieldName, size_t n) override;
   void reserveField_double(const std::string& fieldName, size_t n) override;
   void reserveField_uint16(const std::string& fieldName, size_t n) override;
   void reserveField_uint8(const std::string& fieldName, size_t n) override;
+  void reserveField_uint32(const std::string& fieldName, size_t n) override;
 
   void resizeField_float(const std::string& fieldName, size_t n) override;
   void resizeField_double(const std::string& fieldName, size_t n) override;
   void resizeField_uint16(const std::string& fieldName, size_t n) override;
   void resizeField_uint8(const std::string& fieldName, size_t n) override;
+  void resizeField_uint32(const std::string& fieldName, size_t n) override;
 
   auto getPointsBufferRef_float_field(const std::string& fieldName) const
       -> const mrpt::aligned_std_vector<float>* override
@@ -217,6 +236,15 @@ class CGenericPointsMap : public CPointsMap
       -> const mrpt::aligned_std_vector<uint8_t>* override
   {
     if (auto it = m_uint8_fields.find(fieldName); it != m_uint8_fields.end())
+    {
+      return &it->second;
+    }
+    return nullptr;
+  }
+  auto getPointsBufferRef_uint32_field(const std::string& fieldName) const
+      -> const mrpt::aligned_std_vector<uint32_t>* override
+  {
+    if (auto it = m_uint32_fields.find(fieldName); it != m_uint32_fields.end())
     {
       return &it->second;
     }
@@ -263,6 +291,15 @@ class CGenericPointsMap : public CPointsMap
     }
     return nullptr;
   }
+  auto getPointsBufferRef_uint32_field(const std::string& fieldName)
+      -> mrpt::aligned_std_vector<uint32_t>* override
+  {
+    if (auto it = m_uint32_fields.find(fieldName); it != m_uint32_fields.end())
+    {
+      return &it->second;
+    }
+    return nullptr;
+  }
 
   /** @} */
 
@@ -271,6 +308,7 @@ class CGenericPointsMap : public CPointsMap
   std::map<std::string, mrpt::aligned_std_vector<double>> m_double_fields;
   std::map<std::string, mrpt::aligned_std_vector<uint16_t>> m_uint16_fields;
   std::map<std::string, mrpt::aligned_std_vector<uint8_t>> m_uint8_fields;
+  std::map<std::string, mrpt::aligned_std_vector<uint32_t>> m_uint32_fields;
 
  private:
   /** Clear the map, erasing all the points and all fields */

--- a/modules/mrpt_maps/include/mrpt/maps/CPointsMap.h
+++ b/modules/mrpt_maps/include/mrpt/maps/CPointsMap.h
@@ -425,6 +425,15 @@ class CPointsMap :
    */
   virtual bool registerField_uint8([[maybe_unused]] const std::string& fieldName) { return false; }
 
+  /** Registers a new data channel of type `uint32_t`.
+   * If the map is not empty, the new channel is filled with default values (0)
+   * to match the current point count.
+   * \return true if the field could effectively be added to the underlying point map class.
+   * \sa hasPointField(), getPointFieldNames_uint32()
+   * \note (New in MRPT 3.0.0)
+   */
+  virtual bool registerField_uint32([[maybe_unused]] const std::string& fieldName) { return false; }
+
   /** Registers a new data channel of type `double`.
    * If the map is not empty, the new channel is filled with default values (0)
    * to match the current point count.
@@ -623,6 +632,9 @@ class CPointsMap :
   virtual std::vector<std::string> getPointFieldNames_uint16() const { return {}; }
   /** Get list of all uint8_t channel names */
   virtual std::vector<std::string> getPointFieldNames_uint8() const { return {}; }
+  /** Get list of all uint32_t channel names.
+   * \note (New in MRPT 3.0.0) */
+  virtual std::vector<std::string> getPointFieldNames_uint32() const { return {}; }
 
   /** Get list of all float channel names, except x,y,z */
   std::vector<std::string> getPointFieldNames_float_except_xyz() const;
@@ -682,6 +694,17 @@ class CPointsMap :
     return 0;
   }
 
+  /** Read the value of a uint32_t channel for a given point.
+   * Returns 0 if field does not exist.
+   * \exception std::exception on index out of bounds or if field exists but
+   * is not uint32_t.
+   */
+  virtual uint32_t getPointField_uint32(
+      [[maybe_unused]] size_t index, [[maybe_unused]] const std::string& fieldName) const
+  {
+    return 0;
+  }
+
   /** Sets the value of a float channel for a given point.
    * \exception std::exception on index out of bounds or if field does not
    * exist or is not float.
@@ -734,6 +757,17 @@ class CPointsMap :
   {
   }
 
+  /** Sets the value of a uint32_t channel for a given point.
+   * \exception std::exception on index out of bounds or if field does not
+   * exist or is not uint32_t.
+   */
+  virtual void setPointField_uint32(
+      [[maybe_unused]] size_t index,
+      [[maybe_unused]] const std::string& fieldName,
+      [[maybe_unused]] uint32_t value)
+  {
+  }
+
   /** Appends a value to a float channel (for use after insertPointFast()) */
   virtual void insertPointField_float(
       [[maybe_unused]] const std::string& fieldName, [[maybe_unused]] float value)
@@ -754,6 +788,11 @@ class CPointsMap :
       [[maybe_unused]] const std::string& fieldName, [[maybe_unused]] uint8_t value)
   {
   }
+  /** Appends a value to a uint32_t channel (for use after insertPointFast()) */
+  virtual void insertPointField_uint32(
+      [[maybe_unused]] const std::string& fieldName, [[maybe_unused]] uint32_t value)
+  {
+  }
 
   virtual void reserveField_float(
       [[maybe_unused]] const std::string& fieldName, [[maybe_unused]] size_t n)
@@ -771,6 +810,10 @@ class CPointsMap :
       [[maybe_unused]] const std::string& fieldName, [[maybe_unused]] size_t n)
   {
   }
+  virtual void reserveField_uint32(
+      [[maybe_unused]] const std::string& fieldName, [[maybe_unused]] size_t n)
+  {
+  }
 
   virtual void resizeField_float(
       [[maybe_unused]] const std::string& fieldName, [[maybe_unused]] size_t n)
@@ -785,6 +828,10 @@ class CPointsMap :
   {
   }
   virtual void resizeField_uint8(
+      [[maybe_unused]] const std::string& fieldName, [[maybe_unused]] size_t n)
+  {
+  }
+  virtual void resizeField_uint32(
       [[maybe_unused]] const std::string& fieldName, [[maybe_unused]] size_t n)
   {
   }
@@ -821,6 +868,11 @@ class CPointsMap :
   {
     return nullptr;
   }
+  virtual auto getPointsBufferRef_uint32_field([[maybe_unused]] const std::string& fieldName) const
+      -> const mrpt::aligned_std_vector<uint32_t>*
+  {
+    return nullptr;
+  }
 
   virtual auto getPointsBufferRef_float_field(const std::string& fieldName)
       -> mrpt::aligned_std_vector<float>*
@@ -851,6 +903,11 @@ class CPointsMap :
   }
   virtual auto getPointsBufferRef_uint8_field([[maybe_unused]] const std::string& fieldName)
       -> mrpt::aligned_std_vector<uint8_t>*
+  {
+    return nullptr;
+  }
+  virtual auto getPointsBufferRef_uint32_field([[maybe_unused]] const std::string& fieldName)
+      -> mrpt::aligned_std_vector<uint32_t>*
   {
     return nullptr;
   }
@@ -958,6 +1015,14 @@ class CPointsMap :
         allAdded = allAdded && added;
       }
     }
+    for (const auto& f : source.getPointFieldNames_uint32())
+    {
+      if (!this->hasPointField(f))
+      {
+        const bool added = this->registerField_uint32(f);
+        allAdded = allAdded && added;
+      }
+    }
     return allAdded;
   }
 
@@ -1000,6 +1065,13 @@ class CPointsMap :
       mrpt::aligned_std_vector<uint8_t>* dst_buf = nullptr;
     };
     std::vector<UInt8FieldMapping> uint8_fields;
+
+    struct UInt32FieldMapping
+    {
+      const mrpt::aligned_std_vector<uint32_t>* src_buf = nullptr;
+      mrpt::aligned_std_vector<uint32_t>* dst_buf = nullptr;
+    };
+    std::vector<UInt32FieldMapping> uint32_fields;
   };
 
   /** Prepare efficient data structures for repeated insertion from another point map with
@@ -1034,6 +1106,11 @@ class CPointsMap :
     for (const auto& f : ctx.uint8_fields)
     {
       f.dst_buf->push_back(f.src_buf ? (*f.src_buf)[i] : uint8_t{0});
+    }
+
+    for (const auto& f : ctx.uint32_fields)
+    {
+      f.dst_buf->push_back(f.src_buf ? (*f.src_buf)[i] : uint32_t{0});
     }
 
     mark_as_modified();

--- a/modules/mrpt_maps/python/mrpt/maps/__init__.py
+++ b/modules/mrpt_maps/python/mrpt/maps/__init__.py
@@ -5,6 +5,7 @@ Provides:
   - CMetricMap          : Abstract base class for all metric maps
   - CPointsMap          : Abstract base class for point cloud maps
   - CSimplePointsMap    : Concrete XYZ point cloud map
+  - CGenericPointsMap   : XYZ point cloud + arbitrary string-keyed data channels
   - COccupancyGridMap2D : Probabilistic 2D occupancy grid map
 """
 
@@ -17,6 +18,7 @@ from mrpt.maps._bindings import (
     CMetricMap,
     CPointsMap,
     CSimplePointsMap,
+    CGenericPointsMap,
     COccupancyGridMap2D,
 )
 
@@ -24,5 +26,6 @@ __all__ = [
     "CMetricMap",
     "CPointsMap",
     "CSimplePointsMap",
+    "CGenericPointsMap",
     "COccupancyGridMap2D",
 ]

--- a/modules/mrpt_maps/python_bindings/mrpt_maps_py.cpp
+++ b/modules/mrpt_maps/python_bindings/mrpt_maps_py.cpp
@@ -12,6 +12,7 @@
  SPDX-License-Identifier: BSD-3-Clause
 */
 
+#include <mrpt/maps/CGenericPointsMap.h>
 #include <mrpt/maps/CMetricMap.h>
 #include <mrpt/maps/COccupancyGridMap2D.h>
 #include <mrpt/maps/CSimplePointsMap.h>
@@ -124,6 +125,78 @@ PYBIND11_MODULE(_bindings, m)
       .def(
           "__repr__", [](const mrpt::maps::CSimplePointsMap& mp)
           { return "CSimplePointsMap(" + std::to_string(mp.size()) + " points)"; });
+
+  // -------------------------------------------------------------------------
+  // CGenericPointsMap — XYZ point cloud + arbitrary string-keyed data channels
+  // -------------------------------------------------------------------------
+  py::class_<
+      mrpt::maps::CGenericPointsMap, mrpt::maps::CPointsMap,
+      std::shared_ptr<mrpt::maps::CGenericPointsMap>>(m, "CGenericPointsMap")
+      .def(py::init<>())
+      // Register custom per-point data channels:
+      .def(
+          "registerField_float", &mrpt::maps::CGenericPointsMap::registerField_float, "fieldName"_a,
+          "Register a new per-point data channel of type float32")
+      .def(
+          "registerField_double", &mrpt::maps::CGenericPointsMap::registerField_double,
+          "fieldName"_a, "Register a new per-point data channel of type float64")
+      .def(
+          "registerField_uint16", &mrpt::maps::CGenericPointsMap::registerField_uint16,
+          "fieldName"_a, "Register a new per-point data channel of type uint16")
+      .def(
+          "registerField_uint8", &mrpt::maps::CGenericPointsMap::registerField_uint8, "fieldName"_a,
+          "Register a new per-point data channel of type uint8")
+      .def(
+          "registerField_uint32", &mrpt::maps::CGenericPointsMap::registerField_uint32,
+          "fieldName"_a, "Register a new per-point data channel of type uint32 (New in MRPT 3.0.0)")
+      .def(
+          "unregisterField", &mrpt::maps::CGenericPointsMap::unregisterField, "fieldName"_a,
+          "Removes a data channel; returns True if it existed")
+      .def("hasPointField", &mrpt::maps::CGenericPointsMap::hasPointField, "fieldName"_a)
+      .def("resize", &mrpt::maps::CGenericPointsMap::resize, "newLength"_a)
+      // Field name enumeration:
+      .def("getPointFieldNames_float", &mrpt::maps::CGenericPointsMap::getPointFieldNames_float)
+      .def("getPointFieldNames_double", &mrpt::maps::CGenericPointsMap::getPointFieldNames_double)
+      .def("getPointFieldNames_uint16", &mrpt::maps::CGenericPointsMap::getPointFieldNames_uint16)
+      .def("getPointFieldNames_uint8", &mrpt::maps::CGenericPointsMap::getPointFieldNames_uint8)
+      .def(
+          "getPointFieldNames_uint32", &mrpt::maps::CGenericPointsMap::getPointFieldNames_uint32,
+          "List all uint32 channel names (New in MRPT 3.0.0)")
+      // Per-point field getters:
+      .def(
+          "getPointField_float", &mrpt::maps::CGenericPointsMap::getPointField_float, "index"_a,
+          "fieldName"_a)
+      .def(
+          "getPointField_double", &mrpt::maps::CGenericPointsMap::getPointField_double, "index"_a,
+          "fieldName"_a)
+      .def(
+          "getPointField_uint16", &mrpt::maps::CGenericPointsMap::getPointField_uint16, "index"_a,
+          "fieldName"_a)
+      .def(
+          "getPointField_uint8", &mrpt::maps::CGenericPointsMap::getPointField_uint8, "index"_a,
+          "fieldName"_a)
+      .def(
+          "getPointField_uint32", &mrpt::maps::CGenericPointsMap::getPointField_uint32, "index"_a,
+          "fieldName"_a, "Read a uint32 channel value (New in MRPT 3.0.0)")
+      // Per-point field setters:
+      .def(
+          "setPointField_float", &mrpt::maps::CGenericPointsMap::setPointField_float, "index"_a,
+          "fieldName"_a, "value"_a)
+      .def(
+          "setPointField_double", &mrpt::maps::CGenericPointsMap::setPointField_double, "index"_a,
+          "fieldName"_a, "value"_a)
+      .def(
+          "setPointField_uint16", &mrpt::maps::CGenericPointsMap::setPointField_uint16, "index"_a,
+          "fieldName"_a, "value"_a)
+      .def(
+          "setPointField_uint8", &mrpt::maps::CGenericPointsMap::setPointField_uint8, "index"_a,
+          "fieldName"_a, "value"_a)
+      .def(
+          "setPointField_uint32", &mrpt::maps::CGenericPointsMap::setPointField_uint32, "index"_a,
+          "fieldName"_a, "value"_a, "Set a uint32 channel value (New in MRPT 3.0.0)")
+      .def(
+          "__repr__", [](const mrpt::maps::CGenericPointsMap& mp)
+          { return "CGenericPointsMap(" + std::to_string(mp.size()) + " points)"; });
 
   // -------------------------------------------------------------------------
   // COccupancyGridMap2D — probabilistic 2D occupancy grid

--- a/modules/mrpt_maps/src/maps/CGenericPointsMap.cpp
+++ b/modules/mrpt_maps/src/maps/CGenericPointsMap.cpp
@@ -98,6 +98,10 @@ void CGenericPointsMap::reserve(size_t newLength)
   {
     field.second.reserve(newLength);
   }
+  for (auto& field : m_uint32_fields)
+  {
+    field.second.reserve(newLength);
+  }
 }
 
 void CGenericPointsMap::resize(size_t newLength)
@@ -118,6 +122,10 @@ void CGenericPointsMap::resize(size_t newLength)
     field.second.resize(newLength, 0);
   }
   for (auto& field : m_uint8_fields)
+  {
+    field.second.resize(newLength, 0);
+  }
+  for (auto& field : m_uint32_fields)
   {
     field.second.resize(newLength, 0);
   }
@@ -145,10 +153,14 @@ void CGenericPointsMap::setSize(size_t newLength)
   {
     field.second.assign(newLength, 0);
   }
+  for (auto& field : m_uint32_fields)
+  {
+    field.second.assign(newLength, 0);
+  }
   mark_as_modified();
 }
 
-uint8_t CGenericPointsMap::serializeGetVersion() const { return 3; }
+uint8_t CGenericPointsMap::serializeGetVersion() const { return 4; }
 void CGenericPointsMap::serializeTo(mrpt::serialization::CArchive& out) const
 {
   // XYZ
@@ -209,6 +221,18 @@ void CGenericPointsMap::serializeTo(mrpt::serialization::CArchive& out) const
     }
   }
 
+  // uint32 fields (v4)
+  out.WriteAs<uint32_t>(m_uint32_fields.size());
+  for (const auto& [name, v] : m_uint32_fields)
+  {
+    out << name;
+    out.WriteAs<uint32_t>(v.size());
+    if (!v.empty())
+    {
+      out.WriteBufferFixEndianness(v.data(), v.size());
+    }
+  }
+
   insertionOptions.writeToStream(out);
   likelihoodOptions.writeToStream(out);
 }
@@ -240,6 +264,7 @@ void CGenericPointsMap::serializeFrom(mrpt::serialization::CArchive& in, uint8_t
     case 1:
     case 2:
     case 3:
+    case 4:
     {
       mark_as_modified();
 
@@ -310,6 +335,20 @@ void CGenericPointsMap::serializeFrom(mrpt::serialization::CArchive& in, uint8_t
           lambdaReadVector(itU8->second);
         }
       }
+      // uint32 fields (v4)
+      if (version >= 4)
+      {
+        const auto n = in.ReadAs<uint32_t>();
+        for (uint32_t i = 0; i < n; i++)
+        {
+          std::string name;
+          in >> name;
+          this->registerField_uint32(name);
+          auto itU32 = m_uint32_fields.find(name);
+          ASSERT_(itU32 != m_uint32_fields.end());
+          lambdaReadVector(itU32->second);
+        }
+      }
 
       insertionOptions.readFromStream(in);
       likelihoodOptions.readFromStream(in);
@@ -329,6 +368,7 @@ void CGenericPointsMap::internal_clear()
   m_double_fields.clear();
   m_uint16_fields.clear();
   m_uint8_fields.clear();
+  m_uint32_fields.clear();
   mark_as_modified();
 }
 
@@ -372,6 +412,16 @@ bool CGenericPointsMap::registerField_uint8(const std::string& fieldName)
   return true;
 }
 
+bool CGenericPointsMap::registerField_uint32(const std::string& fieldName)
+{
+  if (hasPointField(fieldName))
+  {
+    THROW_EXCEPTION_FMT("Field '%s' already exists.", fieldName.c_str());
+  }
+  m_uint32_fields[fieldName].resize(size(), 0);
+  return true;
+}
+
 bool CGenericPointsMap::unregisterField(const std::string& fieldName)
 {
   if (m_float_fields.erase(fieldName) > 0)
@@ -390,13 +440,17 @@ bool CGenericPointsMap::unregisterField(const std::string& fieldName)
   {
     return true;
   }
+  if (m_uint32_fields.erase(fieldName) > 0)
+  {
+    return true;
+  }
   return false;
 }
 
 void CGenericPointsMap::getPointAllFieldsFast(size_t index, std::vector<float>& point_data) const
 {
   const size_t nFields = 3 + m_float_fields.size() + m_double_fields.size() +
-                         m_uint16_fields.size() + m_uint8_fields.size();
+                         m_uint16_fields.size() + m_uint8_fields.size() + m_uint32_fields.size();
   point_data.resize(nFields);
   point_data[0] = m_x[index];
   point_data[1] = m_y[index];
@@ -407,12 +461,13 @@ void CGenericPointsMap::getPointAllFieldsFast(size_t index, std::vector<float>& 
   for (const auto& [name, vec] : m_double_fields) point_data[i++] = static_cast<float>(vec[index]);
   for (const auto& [name, vec] : m_uint16_fields) point_data[i++] = static_cast<float>(vec[index]);
   for (const auto& [name, vec] : m_uint8_fields) point_data[i++] = static_cast<float>(vec[index]);
+  for (const auto& [name, vec] : m_uint32_fields) point_data[i++] = static_cast<float>(vec[index]);
 }
 
 void CGenericPointsMap::setPointAllFieldsFast(size_t index, const std::vector<float>& point_data)
 {
   const size_t nFields = 3 + m_float_fields.size() + m_double_fields.size() +
-                         m_uint16_fields.size() + m_uint8_fields.size();
+                         m_uint16_fields.size() + m_uint8_fields.size() + m_uint32_fields.size();
   ASSERT_EQUAL_(point_data.size(), nFields);
   m_x[index] = point_data[0];
   m_y[index] = point_data[1];
@@ -423,6 +478,7 @@ void CGenericPointsMap::setPointAllFieldsFast(size_t index, const std::vector<fl
   for (auto& [name, vec] : m_double_fields) vec[index] = static_cast<double>(point_data[i++]);
   for (auto& [name, vec] : m_uint16_fields) vec[index] = static_cast<uint16_t>(point_data[i++]);
   for (auto& [name, vec] : m_uint8_fields) vec[index] = static_cast<uint8_t>(point_data[i++]);
+  for (auto& [name, vec] : m_uint32_fields) vec[index] = static_cast<uint32_t>(point_data[i++]);
 }
 
 bool CGenericPointsMap::hasPointField(const std::string& fieldName) const
@@ -431,7 +487,8 @@ bool CGenericPointsMap::hasPointField(const std::string& fieldName) const
          m_float_fields.count(fieldName) ||       //
          m_double_fields.count(fieldName) ||      //
          m_uint16_fields.count(fieldName) ||      //
-         m_uint8_fields.count(fieldName);
+         m_uint8_fields.count(fieldName) ||       //
+         m_uint32_fields.count(fieldName);
 }
 
 std::vector<std::string> CGenericPointsMap::getPointFieldNames_float() const
@@ -456,6 +513,12 @@ std::vector<std::string> CGenericPointsMap::getPointFieldNames_uint8() const
 {
   std::vector<std::string> names = CPointsMap::getPointFieldNames_uint8();
   for (const auto& f : m_uint8_fields) names.push_back(f.first);
+  return names;
+}
+std::vector<std::string> CGenericPointsMap::getPointFieldNames_uint32() const
+{
+  std::vector<std::string> names = CPointsMap::getPointFieldNames_uint32();
+  for (const auto& f : m_uint32_fields) names.push_back(f.first);
   return names;
 }
 
@@ -503,6 +566,17 @@ uint8_t CGenericPointsMap::getPointField_uint8(size_t index, const std::string& 
   return it->second[index];
 }
 
+uint32_t CGenericPointsMap::getPointField_uint32(size_t index, const std::string& fieldName) const
+{
+  auto it = m_uint32_fields.find(fieldName);
+  if (it == m_uint32_fields.end())
+  {
+    return 0;
+  }
+  ASSERT_LT_(index, it->second.size());
+  return it->second[index];
+}
+
 void CGenericPointsMap::setPointField_float(size_t index, const std::string& fieldName, float value)
 {
   auto it = m_float_fields.find(fieldName);
@@ -541,6 +615,17 @@ void CGenericPointsMap::setPointField_uint8(
 {
   auto it = m_uint8_fields.find(fieldName);
   if (it == m_uint8_fields.end())
+  {
+    THROW_EXCEPTION_FMT("Field '%s' is not registered.", fieldName.c_str());
+  }
+  ASSERT_LT_(index, it->second.size());
+  it->second[index] = value;
+}
+void CGenericPointsMap::setPointField_uint32(
+    size_t index, const std::string& fieldName, uint32_t value)
+{
+  auto it = m_uint32_fields.find(fieldName);
+  if (it == m_uint32_fields.end())
   {
     THROW_EXCEPTION_FMT("Field '%s' is not registered.", fieldName.c_str());
   }
@@ -600,6 +685,19 @@ void CGenericPointsMap::insertPointField_uint8(const std::string& fieldName, uin
   vec.push_back(value);
 }
 
+void CGenericPointsMap::insertPointField_uint32(const std::string& fieldName, uint32_t value)
+{
+  auto it = m_uint32_fields.find(fieldName);
+  if (it == m_uint32_fields.end())
+  {
+    THROW_EXCEPTION_FMT("Field '%s' is not registered.", fieldName.c_str());
+  }
+  auto& vec = it->second;
+  if (vec.size() < m_x.size() - 1) vec.resize(m_x.size() - 1, 0);  // Pad
+  ASSERT_EQUAL_(vec.size(), m_x.size() - 1);
+  vec.push_back(value);
+}
+
 void CGenericPointsMap::reserveField_float(const std::string& fieldName, size_t n)
 {
   auto it = m_float_fields.find(fieldName);
@@ -622,6 +720,12 @@ void CGenericPointsMap::reserveField_uint8(const std::string& fieldName, size_t 
 {
   auto it = m_uint8_fields.find(fieldName);
   ASSERT_(it != m_uint8_fields.end());
+  it->second.reserve(n);
+}
+void CGenericPointsMap::reserveField_uint32(const std::string& fieldName, size_t n)
+{
+  auto it = m_uint32_fields.find(fieldName);
+  ASSERT_(it != m_uint32_fields.end());
   it->second.reserve(n);
 }
 
@@ -647,6 +751,12 @@ void CGenericPointsMap::resizeField_uint8(const std::string& fieldName, size_t n
 {
   auto it = m_uint8_fields.find(fieldName);
   ASSERT_(it != m_uint8_fields.end());
+  it->second.resize(n, 0);
+}
+void CGenericPointsMap::resizeField_uint32(const std::string& fieldName, size_t n)
+{
+  auto it = m_uint32_fields.find(fieldName);
+  ASSERT_(it != m_uint32_fields.end());
   it->second.resize(n, 0);
 }
 

--- a/modules/mrpt_maps/src/maps/CPointsMap.cpp
+++ b/modules/mrpt_maps/src/maps/CPointsMap.cpp
@@ -2049,6 +2049,16 @@ CPointsMap::InsertCtx CPointsMap::prepareForInsertPointsFrom(const CPointsMap& s
     ctx.uint8_fields.push_back({src_buf, dst_buf});
   }
 
+  for (const auto& name : this->getPointFieldNames_uint32())
+  {
+    auto* dst_buf = this->getPointsBufferRef_uint32_field(name);
+    if (!dst_buf) continue;
+
+    const auto* src_buf = source.getPointsBufferRef_uint32_field(name);
+    if (src_buf && src_buf->empty()) src_buf = nullptr;
+    ctx.uint32_fields.push_back({src_buf, dst_buf});
+  }
+
   return ctx;
 }
 
@@ -2231,6 +2241,7 @@ std::string listAllFields(const mrpt::maps::CPointsMap& pcd)
   appendFields(pcd.getPointFieldNames_double());
   appendFields(pcd.getPointFieldNames_uint16());
   appendFields(pcd.getPointFieldNames_uint8());
+  appendFields(pcd.getPointFieldNames_uint32());
 
   return ret;
 }

--- a/modules/mrpt_maps/src/obs/CObservationPointCloud.cpp
+++ b/modules/mrpt_maps/src/obs/CObservationPointCloud.cpp
@@ -169,6 +169,26 @@ void CObservationPointCloud::getDescriptionAsText(std::ostream& o) const
         }
       }
     }
+
+    for (const auto& field : pointcloud->getPointFieldNames_uint32())
+    {
+      if (const auto* buf = pointcloud->getPointsBufferRef_uint32_field(field); buf)
+      {
+        if (buf->empty())
+        {
+          o << mrpt::format(
+              "%-20.*s (uint32)  (0 entries)\n", static_cast<int>(field.size()), field.data());
+        }
+        else
+        {
+          const auto [itMin, itMax] = minmax_ignore_nan(buf->begin(), buf->end());
+          o << mrpt::format(
+              "%-20.*s (uint32)  range: [%u, %u] (%zu entries)\n", static_cast<int>(field.size()),
+              field.data(), static_cast<unsigned int>(*itMin), static_cast<unsigned int>(*itMax),
+              buf->size());
+        }
+      }
+    }
   }
 
   if (m_externally_stored != ExternalStorageFormat::None)

--- a/modules/mrpt_maps/src/obs/customizable_obs_viz.cpp
+++ b/modules/mrpt_maps/src/obs/customizable_obs_viz.cpp
@@ -290,6 +290,7 @@ void mrpt::obs::recolorize3Dpc(
   const mrpt::aligned_std_vector<double>* fieldData_d = nullptr;
   const mrpt::aligned_std_vector<uint16_t>* fieldData_u16 = nullptr;
   const mrpt::aligned_std_vector<uint8_t>* fieldData_u8 = nullptr;
+  const mrpt::aligned_std_vector<uint32_t>* fieldData_u32 = nullptr;
 
   if (fieldData_f = originalPts->getPointsBufferRef_float_field(p.colorizeByField); fieldData_f)
   {
@@ -337,8 +338,21 @@ void mrpt::obs::recolorize3Dpc(
       dataLimits.second = static_cast<float>(uMax);
     }
   }
+  else if (fieldData_u32 = originalPts->getPointsBufferRef_uint32_field(p.colorizeByField);
+           fieldData_u32)
+  {
+    dataPoints = fieldData_u32->size();
 
-  if (!fieldData_f && !fieldData_u16 && !fieldData_d && !fieldData_u8)
+    if (dataPoints)
+    {
+      uint32_t uMin = 0, uMax = 0;
+      mrpt::math::minimum_maximum(*fieldData_u32, uMin, uMax);
+      dataLimits.first = static_cast<float>(uMin);
+      dataLimits.second = static_cast<float>(uMax);
+    }
+  }
+
+  if (!fieldData_f && !fieldData_u16 && !fieldData_d && !fieldData_u8 && !fieldData_u32)
   {
     return;
   }
@@ -392,6 +406,11 @@ void mrpt::obs::recolorize3Dpc(
         effectiveLimits = histogramPercentileLimits(
             fieldData_u8->data(), dataPoints, pct, pct, bb.first, bb.second);
       }
+      else if (fieldData_u32)
+      {
+        effectiveLimits = histogramPercentileLimits(
+            fieldData_u32->data(), dataPoints, pct, pct, bb.first, bb.second);
+      }
     }
   }
 
@@ -422,6 +441,11 @@ void mrpt::obs::recolorize3Dpc(
       if (fieldData_u16)
       {
         const float coord = static_cast<float>(fieldData_u16->at(i));
+        return std::clamp((coord - colMin) * coord_range_1, 0.0f, 1.0f);
+      }
+      if (fieldData_u32)
+      {
+        const float coord = static_cast<float>(fieldData_u32->at(i));
         return std::clamp((coord - colMin) * coord_range_1, 0.0f, 1.0f);
       }
       return 0.0f;

--- a/modules/mrpt_maps/tests/CGenericPointsMap_unittest.cpp
+++ b/modules/mrpt_maps/tests/CGenericPointsMap_unittest.cpp
@@ -34,6 +34,7 @@ static CGenericPointsMap makeTestMap()
   m.registerField_float("t");
   m.registerField_uint16("ring");
   m.registerField_uint8("color_r");
+  m.registerField_uint32("rgba");
   m.registerField_double("gps_time");
 
   const size_t N = 5;
@@ -45,6 +46,7 @@ static CGenericPointsMap makeTestMap()
     m.setPointField_float(i, "t", float(i) * 0.001f);
     m.setPointField_uint16(i, "ring", static_cast<uint16_t>(i + 1));
     m.setPointField_uint8(i, "color_r", static_cast<uint8_t>(i * 50));
+    m.setPointField_uint32(i, "rgba", static_cast<uint32_t>(i) * 100000u + 1u);
     m.setPointField_double(i, "gps_time", 1000.0 + static_cast<double>(i));
   }
   return m;
@@ -125,8 +127,10 @@ TEST(CGenericPointsMap, DeserializeOnDifferentThread)
   EXPECT_TRUE(m.hasPointField("t"));
   EXPECT_TRUE(m.hasPointField("ring"));
   EXPECT_TRUE(m.hasPointField("color_r"));
+  EXPECT_TRUE(m.hasPointField("rgba"));
   EXPECT_TRUE(m.hasPointField("gps_time"));
   EXPECT_FLOAT_EQ(m.getPointField_float(2, "intensity"), 2.5f);
+  EXPECT_EQ(m.getPointField_uint32(3, "rgba"), 300001u);
 }
 
 TEST(CGenericPointsMap, CopyAssignAcrossThreads)
@@ -270,6 +274,7 @@ TEST(CGenericPointsMap, RegisterAndAccessAllTypes)
   m.registerField_double("d1");
   m.registerField_uint16("u16");
   m.registerField_uint8("u8");
+  m.registerField_uint32("u32");
 
   m.resize(2);
   m.setPointFast(0, 1.0f, 2.0f, 3.0f);
@@ -277,11 +282,28 @@ TEST(CGenericPointsMap, RegisterAndAccessAllTypes)
   m.setPointField_double(0, "d1", 2.5);
   m.setPointField_uint16(0, "u16", 300);
   m.setPointField_uint8(0, "u8", 42);
+  m.setPointField_uint32(0, "u32", 4000000000u);
 
   EXPECT_FLOAT_EQ(m.getPointField_float(0, "f1"), 1.5f);
   EXPECT_DOUBLE_EQ(m.getPointField_double(0, "d1"), 2.5);
   EXPECT_EQ(m.getPointField_uint16(0, "u16"), 300);
   EXPECT_EQ(m.getPointField_uint8(0, "u8"), 42);
+  EXPECT_EQ(m.getPointField_uint32(0, "u32"), 4000000000u);
+
+  // Field-name enumeration includes the uint32 channel:
+  const auto u32names = m.getPointFieldNames_uint32();
+  EXPECT_EQ(u32names.size(), 1u);
+  EXPECT_EQ(u32names.at(0), "u32");
+
+  // reserve/resize on a registered uint32 field does not throw:
+  EXPECT_NO_THROW(m.reserveField_uint32("u32", 100));
+  EXPECT_NO_THROW(m.resizeField_uint32("u32", 4));
+  EXPECT_ANY_THROW(m.reserveField_uint32("bogus", 100));
+  EXPECT_ANY_THROW(m.resizeField_uint32("bogus", 100));
+
+  // unregister removes the uint32 field:
+  EXPECT_TRUE(m.unregisterField("u32"));
+  EXPECT_FALSE(m.hasPointField("u32"));
 }
 
 TEST(CGenericPointsMap, UnregisterFieldRemovesData)

--- a/modules/mrpt_maps/tests/python_maps_test.py
+++ b/modules/mrpt_maps/tests/python_maps_test.py
@@ -3,7 +3,7 @@
 import sys
 
 try:
-    from mrpt.maps import CSimplePointsMap, COccupancyGridMap2D
+    from mrpt.maps import CSimplePointsMap, CGenericPointsMap, COccupancyGridMap2D
 except ImportError as e:
     msg = str(e)
     if "_bindings" in msg and "No module named" in msg:
@@ -42,6 +42,17 @@ check("insertPoint", m.size() == 4)
 
 m.clear()
 check("clear", m.size() == 0)
+
+print("CGenericPointsMap")
+gm = CGenericPointsMap()
+check("register uint32 field", gm.registerField_uint32("rgba") is True)
+gm.resize(3)
+gm.setPointField_uint32(1, "rgba", 4000000000)
+check("get uint32 field", gm.getPointField_uint32(1, "rgba") == 4000000000)
+check("uint32 field name listed", "rgba" in gm.getPointFieldNames_uint32())
+check("hasPointField", gm.hasPointField("rgba"))
+check("unregister field", gm.unregisterField("rgba") is True)
+check("field removed", not gm.hasPointField("rgba"))
 
 print("COccupancyGridMap2D")
 grid = COccupancyGridMap2D(-5.0, 5.0, -5.0, 5.0, 0.05)


### PR DESCRIPTION
Extend the string-keyed field interface with a uint32_t channel type, mirroring the existing float/double/uint16/uint8 channels:

- CPointsMap: new virtual interface (registerField_uint32, get/setPointField_uint32, insert/reserve/resizeField_uint32, getPointsBufferRef_uint32_field, getPointFieldNames_uint32) plus uint32 handling in InsertCtx / insertPointFrom / registerPointFieldsFrom.
- CGenericPointsMap: storage, accessors, reserve/resize/setSize/clear, getPointAllFieldsFast, and serialization (bumped to v4, backwards compatible read of v0..v3).
- CObservationPointCloud::getDescriptionAsText: list uint32 fields.
- customizable_obs_viz (recolorize3Dpc): colorize-by uint32 channels.
- Python bindings: wrap CGenericPointsMap incl. uint32 field API.
- Unit tests (C++ and Python) extended with uint32 coverage.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added support for storing unsigned 32-bit integer values as custom per-point data fields in point maps.
  * Extended Python module with new point map class and field management methods.

* **Improvements**
  * Enhanced point field enumeration and access to include the new data type.
  * Updated serialization to support the additional field type.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/MRPT/mrpt/pull/1358?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->