### PR TITLE
refactor: limit visibility of eigen3 as build dep

### DIFF
--- a/agents.md
+++ b/agents.md
@@ -71,6 +71,7 @@ Do not hardcode compiler flags (like -std=c++17 or -fPIC). The MRPT CMake wrappe
 
 Do not use raw pointers for ownership. Default to std::shared_ptr or std::unique_ptr, and use MRPT's smart pointer macros where applicable.
 
+Do not expose Eigen3 headers in public API files unless explicitly allowed by the user. Keep Eigen3 specific #include's in private "src/" files.
 
 ## 5. Pybind11 modules
 

--- a/apps/mrpt_apps_gui/2d-slam-demo/CMakeLists.txt
+++ b/apps/mrpt_apps_gui/2d-slam-demo/CMakeLists.txt
@@ -12,6 +12,9 @@ find_package(mrpt_common REQUIRED)
 find_package(mrpt_gui REQUIRED)
 find_package(mrpt_slam REQUIRED)
 find_package(CLI11 REQUIRED)
+# This app uses Eigen directly (mrpt::math::multiply_HCHt requires <Eigen/Dense>
+# in the calling translation unit):
+find_package(Eigen3 REQUIRED)
 mrpt_find_wxwidgets()
 if(NOT wxWidgets_FOUND)
   message(STATUS "wxWidgets not found — skipping ${PROJECT_NAME}")
@@ -36,6 +39,7 @@ mrpt_add_executable(
     mrpt::mrpt_slam
     CLI11::CLI11
     wxWidgets::wxWidgets
+    Eigen3::Eigen
 )
 
 

--- a/apps/mrpt_apps_gui/2d-slam-demo/slamdemoMain.cpp
+++ b/apps/mrpt_apps_gui/2d-slam-demo/slamdemoMain.cpp
@@ -41,6 +41,9 @@
 #include <mrpt/serialization/CArchive.h>
 #include <mrpt/viz/Scene.h>
 
+// Needed by mrpt::math::multiply_HCHt() (instantiates Eigen in the calling TU):
+#include <Eigen/Dense>
+
 using namespace std;
 using namespace mrpt;
 using namespace mrpt::io;

--- a/apps/mrpt_apps_gui/2d-slam-demo/slamdemoMain.h
+++ b/apps/mrpt_apps_gui/2d-slam-demo/slamdemoMain.h
@@ -296,7 +296,7 @@ class slamdemoFrame : public wxFrame
 
   /** A registry of all data for the simulation, used to compute errors, etc..
    */
-  std::vector<THistoric, Eigen::aligned_allocator<THistoric>> m_historicData;
+  std::vector<THistoric> m_historicData;
 
   /** Reset the simulator and re-generate the ground truth map
    *  map_type can be:

--- a/apps/mrpt_apps_gui/RawLogViewer/main_show_selected_object.cpp
+++ b/apps/mrpt_apps_gui/RawLogViewer/main_show_selected_object.cpp
@@ -28,7 +28,7 @@
 #include <mrpt/obs/CObservationRotatingScan.h>  // not included in obs.h since it's in mrpt-maps
 #include <mrpt/poses/CPosePDFParticles.h>
 
-#include <iomanip>
+#include <Eigen/Dense>
 
 using namespace mrpt;
 using namespace mrpt::viz;
@@ -508,7 +508,10 @@ void xRawLogViewerFrame::SelectObjectInTreeView(const CSerializable::Ptr& sel_ob
       mrpt::img::CImage img_range;
 
       float maxActualRange = obs->rangeImage.maxCoeff();
-      if (maxActualRange == 0) maxActualRange = 1.0f;
+      if (maxActualRange == 0)
+      {
+        maxActualRange = 1.0f;
+      }
 
       img_range.setFromMatrix(
           obs->rangeImage.asEigen().cast<float>() * (1.0f / maxActualRange),
@@ -527,7 +530,10 @@ void xRawLogViewerFrame::SelectObjectInTreeView(const CSerializable::Ptr& sel_ob
       mrpt::img::CImage img_intensity;
 
       float maxActualInt = obs->intensityImage.maxCoeff();
-      if (maxActualInt == 0) maxActualInt = 1.0f;
+      if (maxActualInt == 0)
+      {
+        maxActualInt = 1.0f;
+      }
 
       img_intensity.setFromMatrix(
           obs->intensityImage.asEigen().cast<float>() * (1.0f / maxActualInt),

--- a/apps/mrpt_apps_gui/package.xml
+++ b/apps/mrpt_apps_gui/package.xml
@@ -18,6 +18,8 @@
   <depend>mrpt_kinematics</depend>
   <depend>mrpt_nav</depend>
 
+  <build_depend>libeigen3-dev</build_depend>
+
   <export>
     <build_type>cmake</build_type>
   </export>

--- a/modules/mrpt_bayes/CMakeLists.txt
+++ b/modules/mrpt_bayes/CMakeLists.txt
@@ -16,6 +16,7 @@ find_package(mrpt_common REQUIRED)
 find_package(mrpt_config REQUIRED)
 find_package(mrpt_math REQUIRED)
 find_package(mrpt_random REQUIRED)
+find_package(Eigen3 REQUIRED)
 
 
 # define lib:
@@ -47,7 +48,8 @@ mrpt_add_library(
     mrpt::mrpt_config
     mrpt::mrpt_math
     mrpt::mrpt_random
-#  PRIVATE_LINK_LIBRARIES
+  PRIVATE_LINK_LIBRARIES
+    Eigen3::Eigen
   CMAKE_DEPENDENCIES
     mrpt_config
     mrpt_math

--- a/modules/mrpt_bayes/include/mrpt/bayes/CKalmanFilterCapable_impl.h
+++ b/modules/mrpt_bayes/include/mrpt/bayes/CKalmanFilterCapable_impl.h
@@ -21,10 +21,126 @@
 #include <mrpt/containers/stl_containers_utils.h>
 #include <mrpt/math/ops_matrices.h>  // extractSubmatrixSymmetrical()
 
-#include <Eigen/Dense>
+#include <sstream>
 
 namespace mrpt::bayes
 {
+namespace kf_detail
+{
+// Eigen-free helper: R += A * B  (accumulate)
+template <typename MAT_R, typename MAT_A, typename MAT_B>
+static void matmul_acc(MAT_R& r, const MAT_A& a, const MAT_B& b)
+{
+  for (int i = 0; i < (int)a.rows(); ++i)
+  {
+    for (int j = 0; j < (int)b.cols(); ++j)
+    {
+      for (int k = 0; k < (int)a.cols(); ++k)
+      {
+        r(i, j) += a(i, k) * b(k, j);
+      }
+    }
+  }
+}
+// Eigen-free helper: R = A * B
+template <typename MAT_R, typename MAT_A, typename MAT_B>
+static void matmul(MAT_R& r, const MAT_A& a, const MAT_B& b)
+{
+  r.setZero(a.rows(), b.cols());
+  matmul_acc(r, a, b);
+}
+// Eigen-free helper: R += A * B^T  (accumulate)
+template <typename MAT_R, typename MAT_A, typename MAT_B>
+static void matmul_ABt_acc(MAT_R& r, const MAT_A& a, const MAT_B& b)
+{
+  for (int i = 0; i < (int)a.rows(); ++i)
+  {
+    for (int j = 0; j < (int)b.rows(); ++j)
+    {
+      for (int k = 0; k < (int)a.cols(); ++k)
+      {
+        r(i, j) += a(i, k) * b(j, k);
+      }
+    }
+  }
+}
+// Eigen-free helper: R = A * B^T
+template <typename MAT_R, typename MAT_A, typename MAT_B>
+static void matmul_ABt(MAT_R& r, const MAT_A& a, const MAT_B& b)
+{
+  r.setZero(a.rows(), b.rows());
+  matmul_ABt_acc(r, a, b);
+}
+// Symmetrize: M = 0.5*(M + M^T)
+template <typename MAT>
+static void symmetrize(MAT& m)
+{
+  for (int r = 0; r < (int)m.rows(); ++r)
+  {
+    for (int c = r + 1; c < (int)m.cols(); ++c)
+    {
+      const auto avg = static_cast<typename MAT::Scalar>(0.5) * (m(r, c) + m(c, r));
+      m(r, c) = avg;
+      m(c, r) = avg;
+    }
+  }
+}
+// Element-wise: dst += scale * src
+template <typename MAT>
+static void mat_scale_acc(MAT& dst, const MAT& src, typename MAT::Scalar scale)
+{
+  for (int r = 0; r < (int)dst.rows(); ++r)
+  {
+    for (int c = 0; c < (int)dst.cols(); ++c)
+    {
+      dst(r, c) += scale * src(r, c);
+    }
+  }
+}
+// Element-wise: dst -= src
+template <typename MAT>
+static void mat_sub_inplace(MAT& dst, const MAT& src)
+{
+  for (int r = 0; r < (int)dst.rows(); ++r)
+  {
+    for (int c = 0; c < (int)dst.cols(); ++c)
+    {
+      dst(r, c) -= src(r, c);
+    }
+  }
+}
+// Print any matrix to string (works for non-square too)
+template <typename MAT>
+static std::string mat_to_str(const MAT& m)
+{
+  std::ostringstream ss;
+  for (int r = 0; r < (int)m.rows(); ++r)
+  {
+    for (int c = 0; c < (int)m.cols(); ++c)
+    {
+      ss << m(r, c) << " ";
+    }
+    ss << "\n";
+  }
+  return ss.str();
+}
+// Element-wise sum of absolute differences
+template <typename MAT>
+static typename MAT::Scalar mat_diff_sum_abs(const MAT& a, const MAT& b)
+{
+  typename MAT::Scalar s = 0;
+  for (int r = 0; r < (int)a.rows(); ++r)
+  {
+    for (int c = 0; c < (int)a.cols(); ++c)
+    {
+      auto d = a(r, c) - b(r, c);
+      s += d < 0 ? -d : d;
+    }
+  }
+  return s;
+}
+}  // namespace kf_detail
+
 // The main entry point in the Kalman Filter class:
 template <size_t VEH_SIZE, size_t OBS_SIZE, size_t FEAT_SIZE, size_t ACT_SIZE, typename KFTYPE>
 void CKalmanFilterCapable<VEH_SIZE, OBS_SIZE, FEAT_SIZE, ACT_SIZE, KFTYPE>::runOneKalmanIteration()
@@ -47,7 +163,7 @@ void CKalmanFilterCapable<VEH_SIZE, OBS_SIZE, FEAT_SIZE, ACT_SIZE, KFTYPE>::runO
   m_timLogger.leave("KF:1.OnGetAction");
 
   // Sanity check:
-  if (FEAT_SIZE)
+  if (FEAT_SIZE != 0)
   {
     ASSERTDEB_((((m_xkk.size() - VEH_SIZE) / FEAT_SIZE) * FEAT_SIZE) == (m_xkk.size() - VEH_SIZE));
   }
@@ -85,7 +201,10 @@ void CKalmanFilterCapable<VEH_SIZE, OBS_SIZE, FEAT_SIZE, ACT_SIZE, KFTYPE>::runO
     m_user_didnt_implement_jacobian = false;  // Set to true by the default
     // method if not reimplemented
     // in base class.
-    if (KF_options.use_analytic_transition_jacobian) OnTransitionJacobian(dfv_dxv);
+    if (KF_options.use_analytic_transition_jacobian)
+    {
+      OnTransitionJacobian(dfv_dxv);
+    }
 
     if (m_user_didnt_implement_jacobian || !KF_options.use_analytic_transition_jacobian ||
         KF_options.debug_verify_analytic_jacobians)
@@ -128,10 +247,22 @@ void CKalmanFilterCapable<VEH_SIZE, OBS_SIZE, FEAT_SIZE, ACT_SIZE, KFTYPE>::runO
     // ====================================
     //  3.1:  Pxx submatrix
     // ====================================
-    // Replace old covariance:
-    m_pkk.asEigen().template block<VEH_SIZE, VEH_SIZE>(0, 0) =
-        Q.asEigen() + dfv_dxv.asEigen() * m_pkk.template block<VEH_SIZE, VEH_SIZE>(0, 0) *
-                          dfv_dxv.asEigen().transpose();
+    // Replace old covariance: Pxx = Q + F * Pxx * F^T
+    {
+      KFMatrix_VxV pxx_old(m_pkk.template blockCopy<VEH_SIZE, VEH_SIZE>(0, 0));
+      KFMatrix_VxV tmp1;
+      KFMatrix_VxV tmp2;
+      kf_detail::matmul(tmp1, dfv_dxv, pxx_old);   // tmp1 = F * Pxx
+      kf_detail::matmul_ABt(tmp2, tmp1, dfv_dxv);  // tmp2 = F * Pxx * F^T
+      for (size_t r = 0; r < VEH_SIZE; r++)
+      {
+        for (size_t c = 0; c < VEH_SIZE; c++)
+        {
+          tmp2(r, c) += Q(r, c);
+        }
+      }
+      m_pkk.insertMatrix(0, 0, tmp2);
+    }
 
     // ====================================
     //  3.2:  All Pxy_i
@@ -140,19 +271,19 @@ void CKalmanFilterCapable<VEH_SIZE, OBS_SIZE, FEAT_SIZE, ACT_SIZE, KFTYPE>::runO
     KFMatrix_VxF aux;
     for (size_t i = 0; i < N_map; i++)
     {
-      aux = dfv_dxv.asEigen() *
-            m_pkk.template block<VEH_SIZE, FEAT_SIZE>(0, VEH_SIZE + i * FEAT_SIZE);
-
-      m_pkk.asEigen().template block<VEH_SIZE, FEAT_SIZE>(0, VEH_SIZE + i * FEAT_SIZE) =
-          aux.asEigen();
-      m_pkk.asEigen().template block<FEAT_SIZE, VEH_SIZE>(VEH_SIZE + i * FEAT_SIZE, 0) =
-          aux.asEigen().transpose();
+      KFMatrix_VxF pxy(m_pkk.template blockCopy<VEH_SIZE, FEAT_SIZE>(0, VEH_SIZE + i * FEAT_SIZE));
+      kf_detail::matmul(aux, dfv_dxv, pxy);
+      m_pkk.insertMatrix(0, VEH_SIZE + i * FEAT_SIZE, aux);
+      m_pkk.insertMatrixTransposed(VEH_SIZE + i * FEAT_SIZE, 0, aux);
     }
 
     // =============================================================
     //  4. NOW WE CAN OVERWRITE THE NEW STATE VECTOR
     // =============================================================
-    for (size_t i = 0; i < VEH_SIZE; i++) m_xkk[i] = xv[i];
+    for (size_t i = 0; i < VEH_SIZE; i++)
+    {
+      m_xkk[i] = xv[i];
+    }
 
     // Normalize, if necessary.
     OnNormalizeStateVector();
@@ -181,12 +312,16 @@ void CKalmanFilterCapable<VEH_SIZE, OBS_SIZE, FEAT_SIZE, ACT_SIZE, KFTYPE>::runO
   // Decide if some of the covariances shouldn't be predicted.
   m_predictLMidxs.clear();
   if (FEAT_SIZE == 0)
+  {
     // In non-SLAM problems, just do one prediction, for the entire system
     // state:
     m_predictLMidxs.assign(1, 0);
+  }
   else
+  {
     // On normal SLAM problems:
     OnPreComputingPredictions(m_all_predictions, m_predictLMidxs);
+  }
 
   m_timLogger.leave("KF:4.decide pred obs");
 
@@ -244,7 +379,10 @@ void CKalmanFilterCapable<VEH_SIZE, OBS_SIZE, FEAT_SIZE, ACT_SIZE, KFTYPE>::runO
                                             "OnPreComputingPredictions().");
 
       ASSERTDEB_(FEAT_SIZE != 0);
-      for (size_t j = 0; j < nNew; j++) m_predictLMidxs.push_back(missing_predictions_to_add[j]);
+      for (size_t j = 0; j < nNew; j++)
+      {
+        m_predictLMidxs.push_back(missing_predictions_to_add[j]);
+      }
 
       N_pred = m_predictLMidxs.size();
       missing_predictions_to_add.clear();
@@ -262,7 +400,10 @@ void CKalmanFilterCapable<VEH_SIZE, OBS_SIZE, FEAT_SIZE, ACT_SIZE, KFTYPE>::runO
       // Try the analitic Jacobian first:
       m_user_didnt_implement_jacobian = false;  // Set to true by the default method if not
       // reimplemented in base class.
-      if (KF_options.use_analytic_observation_jacobian) OnObservationJacobians(lm_idx, Hx, Hy);
+      if (KF_options.use_analytic_observation_jacobian)
+      {
+        OnObservationJacobians(lm_idx, Hx, Hy);
+      }
 
       if (m_user_didnt_implement_jacobian || !KF_options.use_analytic_observation_jacobian ||
           KF_options.debug_verify_analytic_jacobians)
@@ -301,26 +442,26 @@ void CKalmanFilterCapable<VEH_SIZE, OBS_SIZE, FEAT_SIZE, ACT_SIZE, KFTYPE>::runO
           KFMatrix_OxV Hx_gt(mrpt::math::UNINITIALIZED_MATRIX);
           KFMatrix_OxF Hy_gt(mrpt::math::UNINITIALIZED_MATRIX);
           OnObservationJacobians(lm_idx, Hx_gt, Hy_gt);
-          if (KFMatrix(Hx - Hx_gt).sum_abs() > KF_options.debug_verify_analytic_jacobians_threshold)
+          if (kf_detail::mat_diff_sum_abs(Hx, Hx_gt) >
+              KF_options.debug_verify_analytic_jacobians_threshold)
           {
             std::cerr << "[KalmanFilter] ERROR: User analytical "
                          "observation Hx Jacobians are wrong: \n"
                       << " Real Hx: \n"
-                      << Hx.asEigen() << "\n Analytical Hx:\n"
-                      << Hx_gt.asEigen() << "Diff:\n"
-                      << (Hx.asEigen() - Hx_gt.asEigen()) << "\n";
+                      << kf_detail::mat_to_str(Hx) << "\n Analytical Hx:\n"
+                      << kf_detail::mat_to_str(Hx_gt) << "\n";
             THROW_EXCEPTION(
                 "ERROR: User analytical observation Hx Jacobians "
                 "are wrong (More details dumped to cerr)");
           }
-          if (KFMatrix(Hy - Hy_gt).sum_abs() > KF_options.debug_verify_analytic_jacobians_threshold)
+          if (kf_detail::mat_diff_sum_abs(Hy, Hy_gt) >
+              KF_options.debug_verify_analytic_jacobians_threshold)
           {
             std::cerr << "[KalmanFilter] ERROR: User analytical "
                          "observation Hy Jacobians are wrong: \n"
                       << " Real Hy: \n"
-                      << Hy.asEigen() << "\n Analytical Hx:\n"
-                      << Hy_gt.asEigen() << "Diff:\n"
-                      << Hy.asEigen() - Hy_gt.asEigen() << "\n";
+                      << kf_detail::mat_to_str(Hy) << "\n Analytical Hy:\n"
+                      << kf_detail::mat_to_str(Hy_gt) << "\n";
             THROW_EXCEPTION(
                 "ERROR: User analytical observation Hy Jacobians "
                 "are wrong (More details dumped to cerr)");
@@ -342,14 +483,14 @@ void CKalmanFilterCapable<VEH_SIZE, OBS_SIZE, FEAT_SIZE, ACT_SIZE, KFTYPE>::runO
     if (FEAT_SIZE > 0)
     {  // SLAM-like problem:
       // Covariance of the vehicle pose
-      const auto Px = m_pkk.template block<VEH_SIZE, VEH_SIZE>(0, 0);
+      const auto Px = m_pkk.template blockCopy<VEH_SIZE, VEH_SIZE>(0, 0);
 
       for (size_t i = 0; i < N_pred; ++i)
       {
         const size_t lm_idx_i = m_predictLMidxs[i];
         // Pxyi^t
         const auto Pxyi_t =
-            m_pkk.template block<FEAT_SIZE, VEH_SIZE>(VEH_SIZE + lm_idx_i * FEAT_SIZE, 0);
+            m_pkk.template blockCopy<FEAT_SIZE, VEH_SIZE>(VEH_SIZE + lm_idx_i * FEAT_SIZE, 0);
 
         // Only do j>=i (upper triangle), since m_S is symmetric:
         for (size_t j = i; j < N_pred; ++j)
@@ -359,26 +500,40 @@ void CKalmanFilterCapable<VEH_SIZE, OBS_SIZE, FEAT_SIZE, ACT_SIZE, KFTYPE>::runO
           mrpt::math::CMatrixFixed<KFTYPE, OBS_SIZE, OBS_SIZE> Sij;
 
           const auto Pxyj =
-              m_pkk.template block<VEH_SIZE, FEAT_SIZE>(0, VEH_SIZE + lm_idx_j * FEAT_SIZE);
-          const auto Pyiyj = m_pkk.template block<FEAT_SIZE, FEAT_SIZE>(
+              m_pkk.template blockCopy<VEH_SIZE, FEAT_SIZE>(0, VEH_SIZE + lm_idx_j * FEAT_SIZE);
+          const auto Pyiyj = m_pkk.template blockCopy<FEAT_SIZE, FEAT_SIZE>(
               VEH_SIZE + lm_idx_i * FEAT_SIZE, VEH_SIZE + lm_idx_j * FEAT_SIZE);
 
-          // clang-format off
-					Sij = m_Hxs[i].asEigen() * Px     * m_Hxs[j].asEigen().transpose() +
-					      m_Hys[i].asEigen() * Pxyi_t * m_Hxs[j].asEigen().transpose() +
-					      m_Hxs[i].asEigen() * Pxyj   * m_Hys[j].asEigen().transpose() +
-					      m_Hys[i].asEigen() * Pyiyj  * m_Hys[j].asEigen().transpose();
-          // clang-format on
+          // Sij = Hxi*Px*Hxj^T + Hyi*Pxyi_t*Hxj^T + Hxi*Pxyj*Hyj^T + Hyi*Pyiyj*Hyj^T
+          // Compute as: (Hxi*Px + Hyi*Pxyi_t)*Hxj^T + (Hxi*Pxyj + Hyi*Pyiyj)*Hyj^T
+          mrpt::math::CMatrixFixed<KFTYPE, OBS_SIZE, VEH_SIZE> tmpOV;
+          mrpt::math::CMatrixFixed<KFTYPE, OBS_SIZE, FEAT_SIZE> tmpOF;
+          kf_detail::matmul(tmpOV, m_Hxs[i], Px);
+          kf_detail::matmul_acc(tmpOV, m_Hys[i], Pxyi_t);
+          kf_detail::matmul(tmpOF, m_Hxs[i], Pxyj);
+          kf_detail::matmul_acc(tmpOF, m_Hys[i], Pyiyj);
+          Sij.setZero();
+          kf_detail::matmul_ABt_acc(Sij, tmpOV, m_Hxs[j]);
+          kf_detail::matmul_ABt_acc(Sij, tmpOF, m_Hys[j]);
 
           m_S.insertMatrix(OBS_SIZE * i, OBS_SIZE * j, Sij);
 
           // Copy transposed to the symmetric lower-triangular part:
-          if (i != j) m_S.insertMatrixTransposed(OBS_SIZE * j, OBS_SIZE * i, Sij);
+          if (i != j)
+          {
+            m_S.insertMatrixTransposed(OBS_SIZE * j, OBS_SIZE * i, Sij);
+          }
         }
 
         // Sum the "R" term to the diagonal blocks:
         const size_t obs_idx_off = i * OBS_SIZE;
-        m_S.asEigen().template block<OBS_SIZE, OBS_SIZE>(obs_idx_off, obs_idx_off) += R.asEigen();
+        for (size_t r = 0; r < OBS_SIZE; r++)
+        {
+          for (size_t c = 0; c < OBS_SIZE; c++)
+          {
+            m_S(obs_idx_off + r, obs_idx_off + c) += R(r, c);
+          }
+        }
       }
     }
     else
@@ -386,7 +541,19 @@ void CKalmanFilterCapable<VEH_SIZE, OBS_SIZE, FEAT_SIZE, ACT_SIZE, KFTYPE>::runO
       ASSERTDEB_(N_pred == 1);
       ASSERTDEB_(m_S.cols() == OBS_SIZE);
 
-      m_S = m_Hxs[0].asEigen() * m_pkk.asEigen() * m_Hxs[0].asEigen().transpose() + R.asEigen();
+      // m_S = Hx * Pkk * Hx^T + R
+      kf_detail::matmul_ABt(m_S, m_Hxs[0], m_Hxs[0]);  // will be overridden below
+      // Actually: m_S = Hx * (Pkk * Hx^T) — two-step
+      KFMatrix tmpON;
+      kf_detail::matmul_ABt(tmpON, m_pkk, m_Hxs[0]);  // tmpON = Pkk * Hx^T  (n x OBS)
+      kf_detail::matmul(m_S, m_Hxs[0], tmpON);        // m_S = Hx * tmpON
+      for (size_t r = 0; r < OBS_SIZE; r++)
+      {
+        for (size_t c = 0; c < OBS_SIZE; c++)
+        {
+          m_S(r, c) += R(r, c);
+        }
+      }
     }
 
     m_timLogger.leave("KF:6.build m_S");
@@ -414,12 +581,17 @@ void CKalmanFilterCapable<VEH_SIZE, OBS_SIZE, FEAT_SIZE, ACT_SIZE, KFTYPE>::runO
     {
       for (int i : data_association)
       {
-        if (i < 0) continue;
+        if (i < 0)
+        {
+          continue;
+        }
         const auto assoc_idx_in_map = static_cast<size_t>(i);
         const size_t assoc_idx_in_pred =
             mrpt::containers::find_in_vector(assoc_idx_in_map, m_predictLMidxs);
         if (assoc_idx_in_pred == std::string::npos)
+        {
           missing_predictions_to_add.push_back(assoc_idx_in_map);
+        }
       }
     }
 
@@ -498,7 +670,10 @@ void CKalmanFilterCapable<VEH_SIZE, OBS_SIZE, FEAT_SIZE, ACT_SIZE, KFTYPE>::runO
 
               for (size_t i = 0; i < data_association.size(); ++i)
               {
-                if (data_association[i] < 0) continue;
+                if (data_association[i] < 0)
+                {
+                  continue;
+                }
 
                 const auto assoc_idx_in_map = static_cast<size_t>(data_association[i]);
                 const size_t assoc_idx_in_pred =
@@ -517,24 +692,28 @@ void CKalmanFilterCapable<VEH_SIZE, OBS_SIZE, FEAT_SIZE, ACT_SIZE, KFTYPE>::runO
                 //(assoc_idx_in_pred*OBS_SIZE,0, OBS_SIZE,
                 // row_len);
 
-                m_dh_dx_full_obs.template block<OBS_SIZE, VEH_SIZE>(S_idxs.size(), 0) =
-                    m_Hxs[assoc_idx_in_pred].asEigen();
-                m_dh_dx_full_obs.template block<OBS_SIZE, FEAT_SIZE>(
-                    S_idxs.size(), VEH_SIZE + assoc_idx_in_map * FEAT_SIZE) =
-                    m_Hys[assoc_idx_in_pred].asEigen();
+                m_dh_dx_full_obs.insertMatrix(S_idxs.size(), 0, m_Hxs[assoc_idx_in_pred]);
+                m_dh_dx_full_obs.insertMatrix(
+                    S_idxs.size(), VEH_SIZE + assoc_idx_in_map * FEAT_SIZE,
+                    m_Hys[assoc_idx_in_pred]);
 
                 upd_obs_info.emplace_back(assoc_idx_in_map, assoc_idx_in_pred);
 
                 // S_idxs.size() is used as counter for
                 // "m_dh_dx_full_obs".
                 for (size_t k = 0; k < OBS_SIZE; k++)
+                {
                   S_idxs.push_back(assoc_idx_in_pred * OBS_SIZE + k);
+                }
 
                 // ytilde_i = Z[i] - m_all_predictions[i]
                 KFArray_OBS ytilde_i = m_Z[i];
                 OnSubtractObservationVectors(
                     ytilde_i, m_all_predictions[m_predictLMidxs[assoc_idx_in_pred]]);
-                for (size_t k = 0; k < OBS_SIZE; k++) ytilde[ytilde_idx++] = ytilde_i[k];
+                for (size_t k = 0; k < OBS_SIZE; k++)
+                {
+                  ytilde[ytilde_idx++] = ytilde_i[k];
+                }
               }
               // Extract the subset that is involved in this
               // observation:
@@ -548,7 +727,10 @@ void CKalmanFilterCapable<VEH_SIZE, OBS_SIZE, FEAT_SIZE, ACT_SIZE, KFTYPE>::runO
               m_dh_dx_full_obs = m_Hxs[0];  // Was: dh_dx_full
               KFArray_OBS ytilde_i = m_Z[0];
               OnSubtractObservationVectors(ytilde_i, m_all_predictions[0]);
-              for (size_t k = 0; k < OBS_SIZE; k++) ytilde[ytilde_idx++] = ytilde_i[k];
+              for (size_t k = 0; k < OBS_SIZE; k++)
+              {
+                ytilde[ytilde_idx++] = ytilde_i[k];
+              }
               // Extract the subset that is involved in this
               // observation:
               S_observed = m_S;
@@ -560,12 +742,16 @@ void CKalmanFilterCapable<VEH_SIZE, OBS_SIZE, FEAT_SIZE, ACT_SIZE, KFTYPE>::runO
 
             m_K.setSize(m_pkk.rows(), S_observed.cols());
 
-            // K = m_pkk * (~dh_dx) * m_S.inverse_LLt() );
-            m_K.asEigen() = m_pkk.asEigen() * m_dh_dx_full_obs.asEigen().transpose();
+            // K = m_pkk * (~dh_dx) * m_S.inverse_LLt()
+            kf_detail::matmul_ABt(m_K, m_pkk, m_dh_dx_full_obs);
 
             // Inverse of S_observed -> m_S_1
             m_S_1 = S_observed.inverse_LLt();
-            m_K.asEigen() *= m_S_1.asEigen();
+            {
+              KFMatrix tmp;
+              kf_detail::matmul(tmp, m_K, m_S_1);
+              m_K = std::move(tmp);
+            }
 
             m_timLogger.leave("KF:8.update stage:1.FULLKF:build K");
 
@@ -573,17 +759,41 @@ void CKalmanFilterCapable<VEH_SIZE, OBS_SIZE, FEAT_SIZE, ACT_SIZE, KFTYPE>::runO
             if (nKF_iterations == 1)
             {
               m_timLogger.enter("KF:8.update stage:2.FULLKF:update xkk");
-              m_xkk.asEigen() += (m_K * ytilde).eval();
+              KFVector Kytilde;
+              kf_detail::matmul(Kytilde, m_K, ytilde);
+              for (int q = 0; q < (int)m_xkk.size(); q++)
+              {
+                m_xkk[q] += Kytilde[q];
+              }
               m_timLogger.leave("KF:8.update stage:2.FULLKF:update xkk");
             }
             else
             {
               m_timLogger.enter("KF:8.update stage:2.FULLKF:iter.update xkk");
 
-              auto HAx_column = KFVector(m_dh_dx_full_obs * (m_xkk - xkk_0));
+              // diff = m_xkk - xkk_0
+              KFVector diff(m_xkk.size());
+              for (int q = 0; q < (int)m_xkk.size(); q++)
+              {
+                diff[q] = m_xkk[q] - xkk_0[q];
+              }
+              // HAx_column = m_dh_dx_full_obs * diff
+              KFVector HAx_column;
+              kf_detail::matmul(HAx_column, m_dh_dx_full_obs, diff);
+              // ytilde2 = ytilde - HAx_column
+              KFVector ytilde2(ytilde.size());
+              for (int q = 0; q < (int)ytilde.size(); q++)
+              {
+                ytilde2[q] = ytilde[q] - HAx_column[q];
+              }
 
               m_xkk = xkk_0;
-              m_xkk.asEigen() += m_K * (ytilde - HAx_column);
+              KFVector Kytilde2;
+              kf_detail::matmul(Kytilde2, m_K, ytilde2);
+              for (int q = 0; q < (int)m_xkk.size(); q++)
+              {
+                m_xkk[q] += Kytilde2[q];
+              }
 
               m_timLogger.leave("KF:8.update stage:2.FULLKF:iter.update xkk");
             }
@@ -614,19 +824,20 @@ void CKalmanFilterCapable<VEH_SIZE, OBS_SIZE, FEAT_SIZE, ACT_SIZE, KFTYPE>::runO
                 KFMatrix out(pkk_in.rows(), pkk_in.cols());
                 if (KF_options.use_joseph_form)
                 {
-                  const auto IKH = m_aux_K_dh_dx.asEigen();
-                  const auto P = pkk_in.asEigen();
-                  out.asEigen() = (IKH * P * IKH.transpose()).eval();
-                  // K*S_observed*K^T (equivalent to K*R_block*K^T but cheaper)
-                  out.asEigen() +=
-                      (m_K.asEigen() * S_observed.asEigen() * m_K.asEigen().transpose()).eval();
+                  // out = (I-K*H) * P * (I-K*H)^T + K*S*K^T
+                  KFMatrix tmp1;
+                  KFMatrix tmp2;
+                  kf_detail::matmul(tmp1, m_aux_K_dh_dx, pkk_in);
+                  kf_detail::matmul_ABt(out, tmp1, m_aux_K_dh_dx);
+                  kf_detail::matmul(tmp1, m_K, S_observed);
+                  kf_detail::matmul_ABt(tmp2, tmp1, m_K);
+                  kf_detail::mat_scale_acc(out, tmp2, kftype(1));
                 }
                 else
                 {
-                  out.asEigen() = (m_aux_K_dh_dx.asEigen() * pkk_in.asEigen()).eval();
+                  kf_detail::matmul(out, m_aux_K_dh_dx, pkk_in);
                 }
-                const auto Peval = out.asEigen().eval();
-                out.asEigen() = 0.5 * (Peval + Peval.transpose());
+                kf_detail::symmetrize(out);
                 return out;
               };
 
@@ -656,32 +867,42 @@ void CKalmanFilterCapable<VEH_SIZE, OBS_SIZE, FEAT_SIZE, ACT_SIZE, KFTYPE>::runO
                   const size_t map_idx = upd_obs_info[i].first;
                   const size_t pred_idx = upd_obs_info[i].second;
                   const size_t idx_off = VEH_SIZE + map_idx * FEAT_SIZE;
-                  const auto K_i =
-                      m_K.asEigen().middleCols(i * OBS_SIZE, OBS_SIZE);  // n x OBS_SIZE
-                  dP.asEigen() += K_i * m_Hxs[pred_idx].asEigen() *
-                                  m_pkk.asEigen().template topRows<VEH_SIZE>();
-                  dP.asEigen() += K_i * m_Hys[pred_idx].asEigen() *
-                                  m_pkk.asEigen().middleRows(idx_off, FEAT_SIZE);
+                  // K_i = columns [i*OBS_SIZE, (i+1)*OBS_SIZE) of m_K
+                  KFMatrix K_i = m_K.blockCopy(0, i * OBS_SIZE, m_K.rows(), OBS_SIZE);
+                  // P_top = top VEH_SIZE rows of m_pkk
+                  KFMatrix P_top = m_pkk.blockCopy(0, 0, VEH_SIZE, m_pkk.cols());
+                  KFMatrix P_feat = m_pkk.blockCopy(idx_off, 0, FEAT_SIZE, m_pkk.cols());
+                  // dP += K_i * Hx * P_top
+                  KFMatrix Ki_Hx;
+                  kf_detail::matmul(Ki_Hx, K_i, m_Hxs[pred_idx]);
+                  kf_detail::matmul_acc(dP, Ki_Hx, P_top);
+                  // dP += K_i * Hy * P_feat
+                  KFMatrix Ki_Hy;
+                  kf_detail::matmul(Ki_Hy, K_i, m_Hys[pred_idx]);
+                  kf_detail::matmul_acc(dP, Ki_Hy, P_feat);
                 }
 
                 if (KF_options.use_joseph_form)
                 {
-                  // Joseph form via sparse dP (algebraically identical to
-                  // (I-KH)*P*(I-KH)^T + K*R*K^T):
-                  //   P' = P - dP - dP^T + K*S_observed*K^T
-                  m_pkk.asEigen() -= (dP.asEigen() + dP.asEigen().transpose()).eval();
-                  m_pkk.asEigen() +=
-                      (m_K.asEigen() * S_observed.asEigen() * m_K.asEigen().transpose()).eval();
+                  // P' = P - dP - dP^T + K*S_observed*K^T
+                  for (int r = 0; r < (int)m_pkk.rows(); r++)
+                  {
+                    for (int c = 0; c < (int)m_pkk.cols(); c++)
+                    {
+                      m_pkk(r, c) -= dP(r, c) + dP(c, r);
+                    }
+                  }
+                  KFMatrix tmp;
+                  KFMatrix KSKT;
+                  kf_detail::matmul(tmp, m_K, S_observed);
+                  kf_detail::matmul_ABt(KSKT, tmp, m_K);
+                  kf_detail::mat_scale_acc(m_pkk, KSKT, kftype(1));
                 }
                 else
                 {
-                  m_pkk.asEigen() -= dP.asEigen();
+                  kf_detail::mat_sub_inplace(m_pkk, dP);
                 }
-                // Symmetrize:
-                {
-                  const auto Peval = m_pkk.asEigen().eval();
-                  m_pkk.asEigen() = 0.5 * (Peval + Peval.transpose());
-                }
+                kf_detail::symmetrize(m_pkk);
 
                 if (KF_options.debug_sparse_vs_dense_P_update)
                 {
@@ -690,10 +911,22 @@ void CKalmanFilterCapable<VEH_SIZE, OBS_SIZE, FEAT_SIZE, ACT_SIZE, KFTYPE>::runO
                   m_pkk = pkk_before_sparse;
                   const KFMatrix pkk_dense_result = dense_P_update(m_pkk);
 
-                  const KFTYPE max_diff =
-                      static_cast<KFTYPE>((pkk_sparse_result.asEigen() - pkk_dense_result.asEigen())
-                                              .cwiseAbs()
-                                              .maxCoeff());
+                  KFTYPE max_diff = 0;
+                  for (int r = 0; r < (int)pkk_sparse_result.rows(); r++)
+                  {
+                    for (int c = 0; c < (int)pkk_sparse_result.cols(); c++)
+                    {
+                      auto d = pkk_sparse_result(r, c) - pkk_dense_result(r, c);
+                      if (d < 0)
+                      {
+                        d = -d;
+                      }
+                      if (d > max_diff)
+                      {
+                        max_diff = static_cast<KFTYPE>(d);
+                      }
+                    }
+                  }
                   if (max_diff > KFTYPE(1e-7))
                   {
                     MRPT_LOG_ERROR_FMT(
@@ -731,7 +964,7 @@ void CKalmanFilterCapable<VEH_SIZE, OBS_SIZE, FEAT_SIZE, ACT_SIZE, KFTYPE>::runO
         for (size_t obsIdx = 0; obsIdx < m_Z.size(); obsIdx++)
         {
           // Known & mapped landmark?
-          bool doit;
+          bool doit = false;
           size_t idxInTheFilter = 0;
 
           if (data_association.empty())
@@ -741,7 +974,10 @@ void CKalmanFilterCapable<VEH_SIZE, OBS_SIZE, FEAT_SIZE, ACT_SIZE, KFTYPE>::runO
           else
           {
             doit = data_association[obsIdx] >= 0;
-            if (doit) idxInTheFilter = data_association[obsIdx];
+            if (doit)
+            {
+              idxInTheFilter = data_association[obsIdx];
+            }
           }
 
           if (doit)
@@ -804,48 +1040,92 @@ void CKalmanFilterCapable<VEH_SIZE, OBS_SIZE, FEAT_SIZE, ACT_SIZE, KFTYPE>::runO
 
               // Require diagonal R for this scalar update algorithm:
               {
-                KFMatrix_OxO Rdiag;
-                Rdiag.setZero();
-                for (size_t _d = 0; _d < OBS_SIZE; _d++) Rdiag(_d, _d) = R(_d, _d);
+                KFTYPE off_diag_sum = 0;
+                for (size_t _r = 0; _r < OBS_SIZE; _r++)
+                {
+                  for (size_t _c = 0; _c < OBS_SIZE; _c++)
+                  {
+                    if (_r != _c)
+                    {
+                      auto d = R(_r, _c);
+                      off_diag_sum += d < 0 ? -d : d;
+                    }
+                  }
+                }
                 ASSERTMSG_(
-                    (R.asEigen() - Rdiag.asEigen()).cwiseAbs().sum() < KFTYPE(1e-12),
+                    off_diag_sum < KFTYPE(1e-12),
                     "kfEKFAlaDavison requires a diagonal observation noise matrix R. "
                     "Select another KF algorithm (e.g. kfEKFNaive) for correlated noise.");
               }
 
               // Innovation variance Sij for component j of the observation.
-              // Sij = R(j,j) + Hx_j*Pxx*Hx_j^T + 2*Hx_j*Pxyi^T*Hy_j^T + Hy_j*Pyiyi*Hy_j^T
-              const auto Hx_j = Hx.asEigen().row(j);
-              const auto Hy_j = Hy.asEigen().row(j);
-              const auto Pxx = m_pkk.asEigen().template block<VEH_SIZE, VEH_SIZE>(0, 0);
-              const auto Pxyi = m_pkk.asEigen().template block<VEH_SIZE, FEAT_SIZE>(0, idx_off);
-              const auto Pyiyi =
-                  m_pkk.asEigen().template block<FEAT_SIZE, FEAT_SIZE>(idx_off, idx_off);
+              // Sij = R(j,j) + Hx_j*Pxx*Hx_j^T + 2*Hx_j*Pxyi*Hy_j^T + Hy_j*Pyiyi*Hy_j^T
+              const auto Pxx_c = m_pkk.template blockCopy<VEH_SIZE, VEH_SIZE>(0, 0);
+              const auto Pxyi_c = m_pkk.template blockCopy<VEH_SIZE, FEAT_SIZE>(0, idx_off);
+              const auto Pyiyi_c = m_pkk.template blockCopy<FEAT_SIZE, FEAT_SIZE>(idx_off, idx_off);
 
-              KFTYPE Sij = R(j, j) + static_cast<KFTYPE>((Hx_j * Pxx * Hx_j.transpose()).value()) +
-                           static_cast<KFTYPE>(2.0 * (Hx_j * Pxyi * Hy_j.transpose()).value()) +
-                           static_cast<KFTYPE>((Hy_j * Pyiyi * Hy_j.transpose()).value());
-
-              // Kalman gain vector: Kij = P * h_j^T / Sij
-              // where h_j is the j-th row of the full Jacobian.
-              const size_t N = m_pkk.cols();
-              Eigen::Matrix<KFTYPE, Eigen::Dynamic, 1> h_j =
-                  Eigen::Matrix<KFTYPE, Eigen::Dynamic, 1>::Zero(N);
-              for (size_t q = 0; q < VEH_SIZE; q++) h_j[q] = Hx(j, q);
-              for (size_t q = 0; q < FEAT_SIZE; q++) h_j[idx_off + q] = Hy(j, q);
-
-              Eigen::Matrix<KFTYPE, Eigen::Dynamic, 1> Kij_vec = (m_pkk.asEigen() * h_j) / Sij;
-
-              // Update state: x' = x + Kij * ytilde(j)
-              m_xkk.asEigen() += Kij_vec * ytilde[j];
-
-              // Update covariance: P' = P - Sij * Kij * Kij^T (rank-1 update)
-              m_pkk.asEigen() -= Sij * (Kij_vec * Kij_vec.transpose());
-              // Symmetrize to suppress floating-point drift:
+              KFTYPE term1 = 0;
+              for (size_t v1 = 0; v1 < VEH_SIZE; v1++)
               {
-                const auto P_eval = m_pkk.asEigen().eval();
-                m_pkk.asEigen() = 0.5 * (P_eval + P_eval.transpose());
+                for (size_t v2 = 0; v2 < VEH_SIZE; v2++)
+                {
+                  term1 += Hx(j, v1) * Pxx_c(v1, v2) * Hx(j, v2);
+                }
               }
+              KFTYPE term2 = 0;
+              for (size_t v = 0; v < VEH_SIZE; v++)
+              {
+                for (size_t f = 0; f < FEAT_SIZE; f++)
+                {
+                  term2 += Hx(j, v) * Pxyi_c(v, f) * Hy(j, f);
+                }
+              }
+              KFTYPE term3 = 0;
+              for (size_t f1 = 0; f1 < FEAT_SIZE; f1++)
+              {
+                for (size_t f2 = 0; f2 < FEAT_SIZE; f2++)
+                {
+                  term3 += Hy(j, f1) * Pyiyi_c(f1, f2) * Hy(j, f2);
+                }
+              }
+              KFTYPE Sij = R(j, j) + term1 + KFTYPE(2) * term2 + term3;
+
+              // Kalman gain vector: Kij = P * h_j / Sij
+              const size_t N = m_pkk.cols();
+              KFVector h_j;
+              h_j.setZero(N, 1);
+              for (size_t q = 0; q < VEH_SIZE; q++)
+              {
+                h_j[q] = Hx(j, q);
+              }
+              for (size_t q = 0; q < FEAT_SIZE; q++)
+              {
+                h_j[idx_off + q] = Hy(j, q);
+              }
+
+              KFVector Kij_vec;
+              kf_detail::matmul(Kij_vec, m_pkk, h_j);
+              const KFTYPE inv_Sij = KFTYPE(1) / Sij;
+              for (int q = 0; q < (int)N; q++)
+              {
+                Kij_vec[q] *= inv_Sij;
+              }
+
+              // Update state: x' = x + Kij_vec * ytilde(j)
+              for (int q = 0; q < (int)N; q++)
+              {
+                m_xkk[q] += Kij_vec[q] * ytilde[j];
+              }
+
+              // Update covariance: P' = P - Sij * Kij * Kij^T (rank-1 downdate)
+              for (int r = 0; r < (int)N; r++)
+              {
+                for (int c = 0; c < (int)N; c++)
+                {
+                  m_pkk(r, c) -= Sij * Kij_vec[r] * Kij_vec[c];
+                }
+              }
+              kf_detail::symmetrize(m_pkk);
 
               m_timLogger.leave("KF:8.update stage:2.ScalarAtOnce.update");
             }  // end for j
@@ -898,7 +1178,7 @@ void CKalmanFilterCapable<VEH_SIZE, OBS_SIZE, FEAT_SIZE, ACT_SIZE, KFTYPE>::
     KF_aux_estimate_trans_jacobian(
         const KFArray_VEH& x, const std::pair<KFCLASS*, KFArray_ACT>& dat, KFArray_VEH& out_x)
 {
-  bool dumm;
+  bool dumm = false;
   out_x = x;
   dat.first->OnTransitionModel(dat.second, out_x, dumm);
 }
@@ -911,7 +1191,7 @@ void CKalmanFilterCapable<VEH_SIZE, OBS_SIZE, FEAT_SIZE, ACT_SIZE, KFTYPE>::
   std::vector<size_t> idxs_to_predict(1, dat.second);
   vector_KFArray_OBS prediction;
   // Overwrite (temporarily!) the affected part of the state vector:
-  std::memcpy(&dat.first->m_xkk[0], &x[0], sizeof(x[0]) * VEH_SIZE);
+  std::memcpy(&dat.first->m_xkk[0], x.data(), sizeof(x[0]) * VEH_SIZE);
   dat.first->OnObservationModel(idxs_to_predict, prediction);
   ASSERTDEB_(prediction.size() == 1);
   out_x = prediction[0];
@@ -926,7 +1206,7 @@ void CKalmanFilterCapable<VEH_SIZE, OBS_SIZE, FEAT_SIZE, ACT_SIZE, KFTYPE>::
   vector_KFArray_OBS prediction;
   const size_t lm_idx_in_statevector = VEH_SIZE + FEAT_SIZE * dat.second;
   // Overwrite (temporarily!) the affected part of the state vector:
-  std::memcpy(&dat.first->m_xkk[lm_idx_in_statevector], &x[0], sizeof(x[0]) * FEAT_SIZE);
+  std::memcpy(&dat.first->m_xkk[lm_idx_in_statevector], x.data(), sizeof(x[0]) * FEAT_SIZE);
   dat.first->OnObservationModel(idxs_to_predict, prediction);
   ASSERTDEB_(prediction.size() == 1);
   out_x = prediction[0];
@@ -978,11 +1258,14 @@ void addNewLandmarks(
       ASSERTDEB_(yn.size() == FEAT_SIZE);
 
       // Append to m_xkk:
-      size_t q;
+      size_t q = 0;
       size_t idx = obj.internal_getXkk().size();
       obj.internal_getXkk().resize(obj.internal_getXkk().size() + FEAT_SIZE);
 
-      for (q = 0; q < FEAT_SIZE; q++) obj.internal_getXkk()[idx + q] = yn[q];
+      for (q = 0; q < FEAT_SIZE; q++)
+      {
+        obj.internal_getXkk()[idx + q] = yn[q];
+      }
 
       // --------------------
       // Append to Pkk:
@@ -994,37 +1277,65 @@ void addNewLandmarks(
 
       // Fill the Pxyn term:
       // --------------------
-      auto Pxx =
-          typename KF::KFMatrix_VxV(obj.internal_getPkk().template block<VEH_SIZE, VEH_SIZE>(0, 0));
-      auto Pxyn = typename KF::KFMatrix_FxV(dyn_dxv * Pxx);
+      typename KF::KFMatrix_VxV Pxx =
+          obj.internal_getPkk().template blockCopy<VEH_SIZE, VEH_SIZE>(0, 0);
+      typename KF::KFMatrix_FxV Pxyn;
+      kf_detail::matmul(Pxyn, dyn_dxv, Pxx);
 
       obj.internal_getPkk().insertMatrix(idx, 0, Pxyn);
-      obj.internal_getPkk().insertMatrix(0, idx, Pxyn.transpose());
+      obj.internal_getPkk().insertMatrixTransposed(0, idx, Pxyn);
 
       // Fill the Pyiyn terms:
       // --------------------
       const size_t nLMs = (idx - VEH_SIZE) / FEAT_SIZE;  // Number of previous landmarks:
       for (q = 0; q < nLMs; q++)
       {
-        auto P_x_yq = typename KF::KFMatrix_VxF(
-            obj.internal_getPkk().template block<VEH_SIZE, FEAT_SIZE>(0, VEH_SIZE + q * FEAT_SIZE));
+        typename KF::KFMatrix_VxF P_x_yq =
+            obj.internal_getPkk().template blockCopy<VEH_SIZE, FEAT_SIZE>(
+                0, VEH_SIZE + q * FEAT_SIZE);
 
-        auto P_cross = typename KF::KFMatrix_FxF(dyn_dxv * P_x_yq);
+        typename KF::KFMatrix_FxF P_cross;
+        kf_detail::matmul(P_cross, dyn_dxv, P_x_yq);
 
         obj.internal_getPkk().insertMatrix(idx, VEH_SIZE + q * FEAT_SIZE, P_cross);
-        obj.internal_getPkk().insertMatrix(VEH_SIZE + q * FEAT_SIZE, idx, P_cross.transpose());
+        obj.internal_getPkk().insertMatrixTransposed(VEH_SIZE + q * FEAT_SIZE, idx, P_cross);
       }  // end each previous LM(q)
 
       // Fill the Pynyn term:
       //  P_yn_yn =  (dyn_dxv * Pxx * ~dyn_dxv) + (dyn_dhn * R *
       //  ~dyn_dhn);
       // --------------------
-      typename KF::KFMatrix_FxF P_yn_yn = mrpt::math::multiply_HCHt(dyn_dxv, Pxx);
+      // P_yn_yn = dyn_dxv * Pxx * dyn_dxv^T  (Eigen-free)
+      typename KF::KFMatrix_FxV tmp_vf;
+      typename KF::KFMatrix_FxF P_yn_yn;
+      kf_detail::matmul(tmp_vf, dyn_dxv, Pxx);  // actually FxV * VxV → FxV; but dyn_dxv is FxV
+      // NOTE: dyn_dxv is KFMatrix_FxV (FxV), Pxx is VxV → tmp_vf is FxV
+      kf_detail::matmul_ABt(P_yn_yn, tmp_vf, dyn_dxv);  // FxV * (FxV)^T → FxF
       if (use_dyn_dhn_jacobian)
-        // Accumulate in P_yn_yn
-        P_yn_yn += mrpt::math::multiply_HCHt(dyn_dhn, R);
+      {
+        // P_yn_yn += dyn_dhn * R * dyn_dhn^T  (Eigen-free)
+        typename KF::KFMatrix_FxO tmp_fo;
+        typename KF::KFMatrix_FxF tmp_ff;
+        kf_detail::matmul(tmp_fo, dyn_dhn, R);
+        kf_detail::matmul_ABt(tmp_ff, tmp_fo, dyn_dhn);
+        for (int _r = 0; _r < (int)P_yn_yn.rows(); _r++)
+        {
+          for (int _c = 0; _c < (int)P_yn_yn.cols(); _c++)
+          {
+            P_yn_yn(_r, _c) += tmp_ff(_r, _c);
+          }
+        }
+      }
       else
-        P_yn_yn += dyn_dhn_R_dyn_dhnT;
+      {
+        for (int _r = 0; _r < (int)P_yn_yn.rows(); _r++)
+        {
+          for (int _c = 0; _c < (int)P_yn_yn.cols(); _c++)
+          {
+            P_yn_yn(_r, _c) += dyn_dhn_R_dyn_dhnT(_r, _c);
+          }
+        }
+      }
 
       obj.internal_getPkk().insertMatrix(idx, idx, P_yn_yn);
 

--- a/modules/mrpt_bayes/include/mrpt/bayes/CKalmanFilterCapable_impl.h
+++ b/modules/mrpt_bayes/include/mrpt/bayes/CKalmanFilterCapable_impl.h
@@ -824,14 +824,25 @@ void CKalmanFilterCapable<VEH_SIZE, OBS_SIZE, FEAT_SIZE, ACT_SIZE, KFTYPE>::runO
                 KFMatrix out(pkk_in.rows(), pkk_in.cols());
                 if (KF_options.use_joseph_form)
                 {
-                  // out = (I-K*H) * P * (I-K*H)^T + K*S*K^T
+                  // out = (I-K*H) * P * (I-K*H)^T + K*R*K^T
+                  // NOTE: the additive term uses the measurement noise R, not
+                  // S = H*P*H^T + R. Using S here would double-count the
+                  // H*P*H^T*K^T term already present in (I-K*H)*P*(I-K*H)^T and
+                  // over-inflate the covariance.
                   KFMatrix tmp1;
                   KFMatrix tmp2;
                   kf_detail::matmul(tmp1, m_aux_K_dh_dx, pkk_in);
                   kf_detail::matmul_ABt(out, tmp1, m_aux_K_dh_dx);
-                  kf_detail::matmul(tmp1, m_K, S_observed);
-                  kf_detail::matmul_ABt(tmp2, tmp1, m_K);
-                  kf_detail::mat_scale_acc(out, tmp2, kftype(1));
+                  // K*R*K^T, with the block-diagonal observation noise R
+                  // (one OBS_SIZE x OBS_SIZE R block per observation):
+                  const size_t N_obs_blocks = m_K.cols() / OBS_SIZE;
+                  for (size_t i = 0; i < N_obs_blocks; i++)
+                  {
+                    KFMatrix K_i = m_K.blockCopy(0, i * OBS_SIZE, m_K.rows(), OBS_SIZE);
+                    kf_detail::matmul(tmp1, K_i, R);
+                    kf_detail::matmul_ABt(tmp2, tmp1, K_i);
+                    kf_detail::mat_scale_acc(out, tmp2, kftype(1));
+                  }
                 }
                 else
                 {

--- a/modules/mrpt_bayes/package.xml
+++ b/modules/mrpt_bayes/package.xml
@@ -20,6 +20,7 @@
   <depend>mrpt_config</depend>
   <depend>mrpt_math</depend>
 
+  <build_depend>libeigen3-dev</build_depend>
   <build_depend>pybind11-dev</build_depend>
   <build_depend>python3-dev</build_depend>
 

--- a/modules/mrpt_common/cmake/mrpt_cmake_functions.cmake
+++ b/modules/mrpt_common/cmake/mrpt_cmake_functions.cmake
@@ -882,6 +882,11 @@ function(mrpt_add_python_module MODULE_NAME CPP_SOURCES)
     mrpt_ament_cmake_python_get_python_install_dir()
     pybind11_add_module(_bindings MODULE ${CPP_SOURCES})
     target_link_libraries(_bindings PRIVATE ${PROJECT_NAME})
+    # pybind11/eigen.h includes <Eigen/Core> unconditionally; link Eigen3 directly
+    # so that bindings compile even when Eigen is PRIVATE to the parent library.
+    if (TARGET Eigen3::Eigen)
+      target_link_libraries(_bindings PRIVATE Eigen3::Eigen)
+    endif()
     target_include_directories(_bindings PRIVATE include)
 
     # Direct the .so into a staging python tree under the build directory so

--- a/modules/mrpt_containers/cmake/find_libfyaml.cmake
+++ b/modules/mrpt_containers/cmake/find_libfyaml.cmake
@@ -51,9 +51,6 @@ if(MRPT_HAS_LIBFYAML)
 			SOURCE_DIR ${LIBFYAML_DIR}
 			INSTALL_DIR "${LIBFYAML_INSTALL_DIR}"
 			CMAKE_ARGS
-			# libfyaml's CMakeLists uses cmake_minimum_required(VERSION 3.0),
-			# which recent CMake (>=4.0) rejects. Allow it to configure anyway.
-			-DCMAKE_POLICY_VERSION_MINIMUM=3.5
 			-DCMAKE_BUILD_TYPE:STRING=${CMAKE_BUILD_TYPE}
 			-DBUILD_SHARED_LIBS:BOOL=OFF
 			-DCMAKE_INSTALL_PREFIX:PATH=<INSTALL_DIR>
@@ -61,6 +58,10 @@ if(MRPT_HAS_LIBFYAML)
 			-DCMAKE_C_COMPILER=${CMAKE_C_COMPILER}
 			-DCMAKE_CXX_COMPILER=${CMAKE_CXX_COMPILER}
 			-DENABLE_LIBCLANG=OFF
+			# We embed libfyaml as a library only: never build its test suite
+			# (which otherwise FetchContent's the "check" framework, needing
+			# network access and breaking isolated/.deb builds).
+			-DBUILD_TESTING=OFF
 			-DCMAKE_POSITION_INDEPENDENT_CODE=ON
 			BUILD_BYPRODUCTS ${LIBFYAML_LIB}
 			)

--- a/modules/mrpt_containers/cmake/find_libfyaml.cmake
+++ b/modules/mrpt_containers/cmake/find_libfyaml.cmake
@@ -51,6 +51,9 @@ if(MRPT_HAS_LIBFYAML)
 			SOURCE_DIR ${LIBFYAML_DIR}
 			INSTALL_DIR "${LIBFYAML_INSTALL_DIR}"
 			CMAKE_ARGS
+			# libfyaml's CMakeLists uses cmake_minimum_required(VERSION 3.0),
+			# which recent CMake (>=4.0) rejects. Allow it to configure anyway.
+			-DCMAKE_POLICY_VERSION_MINIMUM=3.5
 			-DCMAKE_BUILD_TYPE:STRING=${CMAKE_BUILD_TYPE}
 			-DBUILD_SHARED_LIBS:BOOL=OFF
 			-DCMAKE_INSTALL_PREFIX:PATH=<INSTALL_DIR>

--- a/modules/mrpt_containers/src/yaml.cpp
+++ b/modules/mrpt_containers/src/yaml.cpp
@@ -12,7 +12,7 @@
  SPDX-License-Identifier: BSD-3-Clause
 */
 
-#include <libfyaml/libfyaml-core.h>
+#include <libfyaml.h>
 #include <mrpt/containers/config.h>
 #include <mrpt/containers/yaml.h>
 #include <mrpt/core/exceptions.h>

--- a/modules/mrpt_containers/src/yaml.cpp
+++ b/modules/mrpt_containers/src/yaml.cpp
@@ -12,7 +12,7 @@
  SPDX-License-Identifier: BSD-3-Clause
 */
 
-#include <libfyaml.h>
+#include <libfyaml/libfyaml-core.h>
 #include <mrpt/containers/config.h>
 #include <mrpt/containers/yaml.h>
 #include <mrpt/core/exceptions.h>

--- a/modules/mrpt_graphs/CMakeLists.txt
+++ b/modules/mrpt_graphs/CMakeLists.txt
@@ -15,6 +15,7 @@ find_package(mrpt_common REQUIRED)
 find_package(mrpt_poses REQUIRED)
 find_package(mrpt_io REQUIRED)
 find_package(mrpt_viz REQUIRED)
+find_package(Eigen3 REQUIRED)
 
 # define lib:
 set(LIB_SOURCES
@@ -50,11 +51,14 @@ mrpt_add_library(
     mrpt::mrpt_poses
     mrpt::mrpt_io
     mrpt::mrpt_viz
-#  PRIVATE_LINK_LIBRARIES
+  PRIVATE_LINK_LIBRARIES
+    Eigen3::Eigen
   CMAKE_DEPENDENCIES
     mrpt_poses
     mrpt_io
     mrpt_viz
+  UNITTEST_LINK_LIBRARIES
+    Eigen3::Eigen
 )
 
 # Python wrapper:

--- a/modules/mrpt_graphs/package.xml
+++ b/modules/mrpt_graphs/package.xml
@@ -21,6 +21,7 @@
   <depend>mrpt_io</depend>
   <depend>mrpt_viz</depend>
 
+  <build_depend>libeigen3-dev</build_depend>
   <build_depend>pybind11-dev</build_depend>
   <build_depend>python3-dev</build_depend>
 

--- a/modules/mrpt_graphslam/CMakeLists.txt
+++ b/modules/mrpt_graphslam/CMakeLists.txt
@@ -4,6 +4,7 @@ project(mrpt_graphslam LANGUAGES C CXX)
 find_package(mrpt_common REQUIRED)
 find_package(mrpt_slam REQUIRED)
 find_package(mrpt_gui REQUIRED)
+find_package(Eigen3 REQUIRED)
 
 # define lib:
 set(LIB_SOURCES
@@ -70,7 +71,9 @@ mrpt_add_library(
   PUBLIC_LINK_LIBRARIES
     mrpt::mrpt_slam
     mrpt::mrpt_gui
+    Eigen3::Eigen
   CMAKE_DEPENDENCIES
     mrpt_slam
     mrpt_gui
+    Eigen3
 )

--- a/modules/mrpt_graphslam/package.xml
+++ b/modules/mrpt_graphslam/package.xml
@@ -15,6 +15,8 @@
   <depend>mrpt_slam</depend>
   <depend>mrpt_gui</depend>
 
+  <build_depend>libeigen3-dev</build_depend>
+
   <export>
     <build_type>cmake</build_type>
   </export>

--- a/modules/mrpt_gui/CMakeLists.txt
+++ b/modules/mrpt_gui/CMakeLists.txt
@@ -5,6 +5,7 @@ project(mrpt_gui LANGUAGES C CXX)
 # Ensure core MRPT packages used here are available to CMake
 find_package(mrpt_common REQUIRED)
 find_package(mrpt_opengl REQUIRED)
+find_package(Eigen3 REQUIRED)
 
 include(./cmake/script_nanogui.cmake REQUIRED)
 include(./cmake/script_qt.cmake REQUIRED)
@@ -81,8 +82,10 @@ mrpt_add_library(
   PUBLIC_LINK_LIBRARIES
     mrpt::mrpt_opengl
     ${nanogui_dep}
+    Eigen3::Eigen  # Needed by nanogui public headers
   CMAKE_DEPENDENCIES
     mrpt_opengl
+    Eigen3 # Needed by nanogui public headers
 )
 
 # Install 3rdparty mathplot header so downstream apps can use it as

--- a/modules/mrpt_gui/package.xml
+++ b/modules/mrpt_gui/package.xml
@@ -14,6 +14,8 @@
 
   <depend>mrpt_opengl</depend>
 
+  <depend>libeigen3-dev</depend> <!-- Needed by nanogui public headers -->
+
   <build_depend>libxrandr</build_depend>
   <build_depend>libxxf86vm</build_depend>
   <build_depend>opengl</build_depend>

--- a/modules/mrpt_img/CMakeLists.txt
+++ b/modules/mrpt_img/CMakeLists.txt
@@ -16,6 +16,7 @@ find_package(mrpt_common REQUIRED)
 find_package(mrpt_io REQUIRED)
 find_package(mrpt_config REQUIRED)
 find_package(mrpt_math REQUIRED)
+find_package(Eigen3 REQUIRED)
 
 # Include Asian fonts in mrpt::img::CCanvas ?
 set(MRPT_HAS_ASIAN_FONTS ON CACHE BOOL "Enable Asian fonts in mrpt::img::CCanvas (increases library size).")
@@ -80,6 +81,8 @@ mrpt_add_library(
     mrpt::mrpt_config
     mrpt::mrpt_io
     mrpt::mrpt_math
+  PRIVATE_LINK_LIBRARIES
+    Eigen3::Eigen
   CMAKE_DEPENDENCIES
     mrpt_config
     mrpt_io

--- a/modules/mrpt_img/package.xml
+++ b/modules/mrpt_img/package.xml
@@ -21,6 +21,7 @@
   <depend>mrpt_config</depend>
   <depend>mrpt_math</depend>
 
+  <build_depend>libeigen3-dev</build_depend>
   <build_depend>libglfw3-dev</build_depend>
 
   <build_depend>pybind11-dev</build_depend>

--- a/modules/mrpt_libapps_gui/CMakeLists.txt
+++ b/modules/mrpt_libapps_gui/CMakeLists.txt
@@ -4,6 +4,7 @@ project(mrpt_libapps_gui LANGUAGES C CXX)
 find_package(mrpt_common REQUIRED)
 find_package(mrpt_libapps_cli REQUIRED)
 find_package(mrpt_gui REQUIRED)
+find_package(Eigen3 REQUIRED)
 find_package(CLI11 REQUIRED)
 find_package(Threads REQUIRED)
 find_package(wxWidgets COMPONENTS core base gl adv QUIET)
@@ -46,6 +47,8 @@ mrpt_add_library(
   PUBLIC_LINK_LIBRARIES
     mrpt::mrpt_libapps_cli
     mrpt::mrpt_gui
+  PRIVATE_LINK_LIBRARIES
+    Eigen3::Eigen
   CMAKE_DEPENDENCIES
     mrpt_libapps_cli
     mrpt_gui

--- a/modules/mrpt_libapps_gui/package.xml
+++ b/modules/mrpt_libapps_gui/package.xml
@@ -15,6 +15,8 @@
   <depend>mrpt_libapps_cli</depend>
   <depend>mrpt_gui</depend>
 
+  <build_depend>libeigen3-dev</build_depend>
+
   <export>
     <build_type>cmake</build_type>
   </export>

--- a/modules/mrpt_libapps_gui/src/KFSLAMApp.cpp
+++ b/modules/mrpt_libapps_gui/src/KFSLAMApp.cpp
@@ -29,6 +29,7 @@
 #include <mrpt/viz/CSetOfLines.h>
 #include <mrpt/viz/stock_objects.h>
 
+#include <Eigen/Dense>
 #include <fstream>
 
 using namespace mrpt::apps;

--- a/modules/mrpt_maps/CMakeLists.txt
+++ b/modules/mrpt_maps/CMakeLists.txt
@@ -13,6 +13,7 @@ project(mrpt_maps LANGUAGES C CXX)
 find_package(mrpt_common REQUIRED)
 find_package(mrpt_obs REQUIRED)
 find_package(mrpt_graphs REQUIRED)
+find_package(Eigen3 REQUIRED)
 
 include(./cmake/script_gridmap_options.cmake REQUIRED) # Gridmap options
 include(./cmake/script_octomap.cmake REQUIRED)     # Check for the octomap library
@@ -129,6 +130,8 @@ mrpt_add_library(
   PUBLIC_LINK_LIBRARIES
     mrpt::mrpt_obs
     mrpt::mrpt_graphs
+  PRIVATE_LINK_LIBRARIES
+    Eigen3::Eigen
   CMAKE_DEPENDENCIES
     mrpt_obs
     mrpt_graphs

--- a/modules/mrpt_maps/package.xml
+++ b/modules/mrpt_maps/package.xml
@@ -15,6 +15,7 @@
   <depend>mrpt_obs</depend>
   <depend>mrpt_graphs</depend>
 
+  <build_depend>libeigen3-dev</build_depend>
   <build_depend>pybind11-dev</build_depend>
   <build_depend>python3-dev</build_depend>
 

--- a/modules/mrpt_maps/src/maps/CPointsMap.cpp
+++ b/modules/mrpt_maps/src/maps/CPointsMap.cpp
@@ -38,6 +38,7 @@
 #include <mrpt/viz/CPointCloudColoured.h>
 #include <mrpt/viz/CSetOfObjects.h>
 
+#include <Eigen/Dense>
 #include <fstream>
 #include <sstream>
 

--- a/modules/mrpt_maps/src/maps/CPointsMap_crtp_common.h
+++ b/modules/mrpt_maps/src/maps/CPointsMap_crtp_common.h
@@ -17,6 +17,8 @@
 #include <mrpt/obs/CObservation2DRangeScan.h>
 #include <mrpt/obs/CObservation3DRangeScan.h>
 
+#include <Eigen/Dense>
+
 namespace mrpt::maps::detail
 {
 template <class Derived>

--- a/modules/mrpt_math/CMakeLists.txt
+++ b/modules/mrpt_math/CMakeLists.txt
@@ -220,26 +220,25 @@ mrpt_add_library(
     mrpt::mrpt_system
     mrpt::mrpt_serialization
     mrpt::mrpt_random
-    Eigen3::Eigen
     nanoflann::nanoflann
-#  PRIVATE_LINK_LIBRARIES
+  PRIVATE_LINK_LIBRARIES
+    Eigen3::Eigen
   CMAKE_DEPENDENCIES
     mrpt_system
     mrpt_serialization
     mrpt_random
   # Other imported targets:
     nanoflann # find_package() lib name
-    ${eigen_dep}
   UNITTEST_LINK_LIBRARIES
     mrpt::mrpt_io
+    Eigen3::Eigen
 )
 
 if (MSVC)
-  # On MSVC, public headers conditionally include *_impl.h which need Eigen.
-  # find_path gives a concrete filesystem path (no generator expressions),
-  # so it survives export/install and is visible to downstream consumers
-  # (e.g. mrpt_topography) even if their find_dependency(Eigen3) does not
-  # propagate the include dirs on its own.
+  # On MSVC, public headers conditionally include *_impl.h (guarded by _MSC_VER)
+  # which need Eigen. Eigen3::Eigen is linked PRIVATE so find_dependency(Eigen3)
+  # is NOT emitted in mrpt_math-config.cmake; instead, propagate the include dir
+  # as a concrete path so MSVC consumers compile without a separate find_package.
   find_path(_mrptmath_eigen_inc "Eigen/Dense"
     HINTS
       "${EIGEN3_INCLUDE_DIR}"

--- a/modules/mrpt_math/include/mrpt/math/MatrixBase.h
+++ b/modules/mrpt_math/include/mrpt/math/MatrixBase.h
@@ -264,7 +264,8 @@ class MatrixBase : public MatrixVectorBase<Scalar, Derived>
   CMatrixDynamic<Scalar> blockCopy(
       Index_t start_row, Index_t start_col, size_type_t BLOCK_ROWS, size_type_t BLOCK_COLS) const
   {
-    return extractMatrix(start_row, start_col, BLOCK_ROWS, BLOCK_COLS);
+    // Note: extractMatrix()'s argument order is (rows, cols, start_row, start_col):
+    return extractMatrix(BLOCK_ROWS, BLOCK_COLS, start_row, start_col);
   }
 
   template <size_type_t BLOCK_ROWS, size_type_t BLOCK_COLS>

--- a/modules/mrpt_math/include/mrpt/math/homog_matrices.h
+++ b/modules/mrpt_math/include/mrpt/math/homog_matrices.h
@@ -94,8 +94,8 @@ void homogeneousMatrixInverse(
   out_xyz[1] = tx * in_R(0, 1) + ty * in_R(1, 1) + tz * in_R(2, 1);
   out_xyz[2] = tx * in_R(0, 2) + ty * in_R(1, 2) + tz * in_R(2, 2);
 
-  // 3x3 rotation part: transpose
-  out_R = in_R.transpose();
+  // 3x3 rotation part: transpose (Eigen-free element-wise assignment)
+  out_R.insertMatrixTransposed(0, 0, in_R);
 
   MRPT_END
 }

--- a/modules/mrpt_math/package.xml
+++ b/modules/mrpt_math/package.xml
@@ -23,6 +23,7 @@
 
   <test_depend>mrpt_io</test_depend>
 
+  <build_depend>libeigen3-dev</build_depend>
   <build_depend>pybind11-dev</build_depend>
   <build_depend>python3-dev</build_depend>
 

--- a/modules/mrpt_nav/CMakeLists.txt
+++ b/modules/mrpt_nav/CMakeLists.txt
@@ -13,6 +13,7 @@ find_package(mrpt_common REQUIRED)
 find_package(mrpt_maps REQUIRED)
 find_package(mrpt_kinematics REQUIRED)
 find_package(mrpt_viz REQUIRED)
+find_package(Eigen3 REQUIRED)
 
 # define lib:
 set(LIB_SOURCES
@@ -119,6 +120,8 @@ mrpt_add_library(
     mrpt::mrpt_maps
     mrpt::mrpt_kinematics
     mrpt::mrpt_viz
+  PRIVATE_LINK_LIBRARIES
+    Eigen3::Eigen
   CMAKE_DEPENDENCIES
     mrpt_maps
     mrpt_kinematics

--- a/modules/mrpt_nav/package.xml
+++ b/modules/mrpt_nav/package.xml
@@ -16,6 +16,8 @@
   <depend>mrpt_kinematics</depend>
   <depend>mrpt_viz</depend>
 
+  <build_depend>libeigen3-dev</build_depend>
+
   <export>
     <build_type>cmake</build_type>
   </export>

--- a/modules/mrpt_obs/CMakeLists.txt
+++ b/modules/mrpt_obs/CMakeLists.txt
@@ -15,6 +15,7 @@ project(mrpt_obs LANGUAGES C CXX)
 find_package(mrpt_common REQUIRED)
 find_package(mrpt_viz REQUIRED)
 find_package(mrpt_tfest REQUIRED)
+find_package(Eigen3 REQUIRED)
 
 include(./cmake/script_tinyxml2.cmake REQUIRED)  # tinyxml2 lib
 
@@ -164,6 +165,8 @@ mrpt_add_library(
   PUBLIC_LINK_LIBRARIES
     mrpt::mrpt_viz
     mrpt::mrpt_tfest
+  PRIVATE_LINK_LIBRARIES
+    Eigen3::Eigen
   CMAKE_DEPENDENCIES
     mrpt_viz
     mrpt_tfest

--- a/modules/mrpt_obs/include/mrpt/obs/CObservation3DRangeScan_project3D_impl.h
+++ b/modules/mrpt_obs/include/mrpt/obs/CObservation3DRangeScan_project3D_impl.h
@@ -22,8 +22,6 @@
 #include <mrpt/obs/TRangeImageFilter.h>
 #include <mrpt/viz/pointcloud_adapters.h>
 
-#include <Eigen/Dense>  // block<>()
-
 namespace mrpt::obs::detail
 {
 // Auxiliary functions which implement SSE-optimized proyection of 3D point
@@ -271,7 +269,12 @@ void unprojectInto(
           // coordinates
           // wrt the depth camera, into the intensity camera:
           pca.getPointXYZ(i, pt_wrt_depth[0], pt_wrt_depth[1], pt_wrt_depth[2]);
-          pt_wrt_color = T_inv * pt_wrt_depth;
+          // pt_wrt_color = T_inv * pt_wrt_depth (Eigen-free 4x4 matvec)
+          for (int _r = 0; _r < 4; _r++)
+          {
+            pt_wrt_color[_r] = 0;
+            for (int _c = 0; _c < 4; _c++) pt_wrt_color[_r] += T_inv(_r, _c) * pt_wrt_depth[_c];
+          }
 
           // Project to image plane:
           if (pt_wrt_color[2] > 0)
@@ -351,7 +354,12 @@ void unprojectInto(
     for (size_t i = 0; i < nPts; i++)
     {
       pca.getPointXYZ(i, pt[0], pt[1], pt[2]);
-      pt_transf = HM * pt;
+      // pt_transf = HM * pt (Eigen-free 4x4 matvec)
+      for (int _r = 0; _r < 4; _r++)
+      {
+        pt_transf[_r] = 0;
+        for (int _c = 0; _c < 4; _c++) pt_transf[_r] += HM(_r, _c) * pt[_c];
+      }
       pca.setPointXYZ(i, pt_transf[0], pt_transf[1], pt_transf[2]);
     }
   }

--- a/modules/mrpt_obs/package.xml
+++ b/modules/mrpt_obs/package.xml
@@ -20,6 +20,7 @@
   <depend>mrpt_viz</depend>
   <depend>mrpt_tfest</depend>
 
+  <build_depend>libeigen3-dev</build_depend>
   <build_depend>pybind11-dev</build_depend>
   <build_depend>python3-dev</build_depend>
 

--- a/modules/mrpt_obs/src/CObservation3DRangeScan.cpp
+++ b/modules/mrpt_obs/src/CObservation3DRangeScan.cpp
@@ -29,6 +29,7 @@
 #include <mrpt/system/string_utils.h>
 #include <mrpt/viz/CPointCloud.h>
 
+#include <Eigen/Dense>
 #include <cstring>
 #include <limits>
 #include <mutex>

--- a/modules/mrpt_opengl/CMakeLists.txt
+++ b/modules/mrpt_opengl/CMakeLists.txt
@@ -15,6 +15,7 @@ find_package(mrpt_common REQUIRED)
 find_package(mrpt_viz REQUIRED)
 find_package(mrpt_poses REQUIRED)
 find_package(mrpt_img REQUIRED)
+find_package(Eigen3 REQUIRED)
 
 # Lists of directories with source files:
 #  See "DeclareMRPTLib.cmake" for explanations
@@ -86,10 +87,14 @@ mrpt_add_library(
     mrpt::mrpt_viz
     mrpt::mrpt_poses
     mrpt::mrpt_img
+  PRIVATE_LINK_LIBRARIES
+    Eigen3::Eigen
   CMAKE_DEPENDENCIES
     mrpt_viz
     mrpt_poses
     mrpt_img
+  UNITTEST_LINK_LIBRARIES
+    Eigen3::Eigen
 )
 
 mrpt_add_python_module(opengl python_bindings/${PROJECT_NAME}_py.cpp)

--- a/modules/mrpt_opengl/package.xml
+++ b/modules/mrpt_opengl/package.xml
@@ -16,6 +16,7 @@
   <depend>mrpt_poses</depend>
   <depend>mrpt_img</depend>
 
+  <build_depend>libeigen3-dev</build_depend>
   <build_depend>opengl</build_depend>
 
   <export>

--- a/modules/mrpt_poses/CMakeLists.txt
+++ b/modules/mrpt_poses/CMakeLists.txt
@@ -14,6 +14,7 @@ project(mrpt_poses LANGUAGES C CXX)
 # MRPT CMake scripts: "mrpt_xxx()"
 find_package(mrpt_common REQUIRED)
 find_package(mrpt_bayes REQUIRED)
+find_package(Eigen3 REQUIRED)
 
 # define lib:
 set(LIB_SOURCES
@@ -145,11 +146,13 @@ mrpt_add_library(
   UNIT_TEST_SOURCES ${LIB_UNIT_TEST_SOURCES}
   PUBLIC_LINK_LIBRARIES
     mrpt::mrpt_bayes
-#  PRIVATE_LINK_LIBRARIES
+  PRIVATE_LINK_LIBRARIES
+    Eigen3::Eigen
   CMAKE_DEPENDENCIES
     mrpt_bayes
   UNITTEST_LINK_LIBRARIES
     mrpt::mrpt_io
+    Eigen3::Eigen
 )
 
 target_precompile_headers(${PROJECT_NAME} PRIVATE

--- a/modules/mrpt_poses/package.xml
+++ b/modules/mrpt_poses/package.xml
@@ -19,6 +19,7 @@
   <depend>mrpt_common</depend>
   <depend>mrpt_bayes</depend>
 
+  <build_depend>libeigen3-dev</build_depend>
   <build_depend>pybind11-dev</build_depend>
   <build_depend>python3-dev</build_depend>
 

--- a/modules/mrpt_slam/CMakeLists.txt
+++ b/modules/mrpt_slam/CMakeLists.txt
@@ -4,6 +4,7 @@ project(mrpt_slam LANGUAGES C CXX)
 find_package(mrpt_common REQUIRED)
 find_package(mrpt_maps REQUIRED)
 find_package(mrpt_topography REQUIRED)
+find_package(Eigen3 REQUIRED)
 
 # Optional TBB support (used in PF_implementations.h):
 find_package(TBB QUIET)
@@ -80,9 +81,13 @@ mrpt_add_library(
   PUBLIC_LINK_LIBRARIES
     mrpt::mrpt_maps
     mrpt::mrpt_topography
+  PRIVATE_LINK_LIBRARIES
+    Eigen3::Eigen
   CMAKE_DEPENDENCIES
     mrpt_maps
     mrpt_topography
+  UNITTEST_LINK_LIBRARIES
+    Eigen3::Eigen
 )
 
 if (TBB_FOUND)

--- a/modules/mrpt_slam/package.xml
+++ b/modules/mrpt_slam/package.xml
@@ -15,6 +15,7 @@
   <depend>mrpt_maps</depend>
   <depend>mrpt_topography</depend>
 
+  <build_depend>libeigen3-dev</build_depend>
   <build_depend>pybind11-dev</build_depend>
   <build_depend>python3-dev</build_depend>
 

--- a/modules/mrpt_tfest/CMakeLists.txt
+++ b/modules/mrpt_tfest/CMakeLists.txt
@@ -14,6 +14,7 @@ project(mrpt_tfest LANGUAGES C CXX)
 # MRPT CMake scripts: "mrpt_xxx()"
 find_package(mrpt_common REQUIRED)
 find_package(mrpt_poses REQUIRED)
+find_package(Eigen3 REQUIRED)
 
 # define lib:
 set(LIB_SOURCES
@@ -50,7 +51,8 @@ mrpt_add_library(
   UNIT_TEST_SOURCES ${LIB_UNIT_TEST_SOURCES}
   PUBLIC_LINK_LIBRARIES
     mrpt::mrpt_poses
-#  PRIVATE_LINK_LIBRARIES
+  PRIVATE_LINK_LIBRARIES
+    Eigen3::Eigen
   CMAKE_DEPENDENCIES
     mrpt_poses
 )

--- a/modules/mrpt_tfest/package.xml
+++ b/modules/mrpt_tfest/package.xml
@@ -19,6 +19,7 @@
   <depend>mrpt_common</depend>
   <depend>mrpt_poses</depend>
 
+  <build_depend>libeigen3-dev</build_depend>
   <build_depend>pybind11-dev</build_depend>
   <build_depend>python3-dev</build_depend>
 

--- a/modules/mrpt_viz/CMakeLists.txt
+++ b/modules/mrpt_viz/CMakeLists.txt
@@ -14,6 +14,7 @@ project(mrpt_viz LANGUAGES C CXX)
 find_package(mrpt_common REQUIRED)
 find_package(mrpt_poses REQUIRED)
 find_package(mrpt_img REQUIRED)
+find_package(Eigen3 REQUIRED)
 
 include(./cmake/script_assimp.cmake REQUIRED)      # Check for system assimp lib (3D models)
 
@@ -164,7 +165,8 @@ mrpt_add_library(
   PUBLIC_LINK_LIBRARIES
     mrpt::mrpt_poses
     mrpt::mrpt_img
-#  PRIVATE_LINK_LIBRARIES
+  PRIVATE_LINK_LIBRARIES
+    Eigen3::Eigen
   CMAKE_DEPENDENCIES
     mrpt_poses
     mrpt_img

--- a/modules/mrpt_viz/package.xml
+++ b/modules/mrpt_viz/package.xml
@@ -20,6 +20,7 @@
   <depend>mrpt_poses</depend>
   <depend>mrpt_img</depend>
 
+  <build_depend>libeigen3-dev</build_depend>
   <build_depend>pybind11-dev</build_depend>
   <build_depend>python3-dev</build_depend>
 

--- a/mrpt_examples_cpp/bayes_tracking_example/main.cpp
+++ b/mrpt_examples_cpp/bayes_tracking_example/main.cpp
@@ -26,6 +26,7 @@
 #include <mrpt/random.h>
 #include <mrpt/system/os.h>
 
+#include <Eigen/Dense>
 #include <chrono>
 #include <iostream>
 #include <thread>

--- a/mrpt_examples_cpp/topography_gps_coords_example/CMakeLists.txt
+++ b/mrpt_examples_cpp/topography_gps_coords_example/CMakeLists.txt
@@ -13,10 +13,13 @@ find_package(mrpt_common REQUIRED)
 find_package(mrpt_topography REQUIRED)
 find_package(mrpt_poses REQUIRED)
 
+# This example uses Eigen directly (calls MRPT matrix methods that require
+# <Eigen/Dense> in the calling translation unit):
+find_package(Eigen3 REQUIRED)
 
 # Define the executable target:
 mrpt_add_executable(
   TARGET topography_gps_coords_example
   SOURCES main.cpp
-  LINK_LIBRARIES mrpt::mrpt_topography mrpt::mrpt_poses 
+  LINK_LIBRARIES mrpt::mrpt_topography mrpt::mrpt_poses Eigen3::Eigen
 )


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Standardized Eigen3 usage across many modules, updated build/linkage and package build manifests for consistent compilation (including Python bindings).

* **Refactor**
  * Rewrote Kalman/SLAM linear-algebra paths to use internal, Eigen-free math helpers and explicit loops for matrix operations.

* **Documentation**
  * Added guideline to avoid exposing Eigen headers in public API files.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->