### PR TITLE
Increase unit test coverage for mrpt_math, mrpt_io, mrpt_system

### DIFF
--- a/modules/mrpt_io/CMakeLists.txt
+++ b/modules/mrpt_io/CMakeLists.txt
@@ -65,7 +65,9 @@ set(LIB_SOURCES
 )
 
 set(LIB_UNIT_TEST_SOURCES
+  tests/CFileStream_unittest.cpp
   tests/CMemoryStream_unittest.cpp
+  tests/CPipe_unittest.cpp
   tests/CTextFileLinesParser_unittest.cpp
   tests/vector_loadsave_unittest.cpp
   tests/zip_unittest.cpp

--- a/modules/mrpt_io/tests/CFileStream_unittest.cpp
+++ b/modules/mrpt_io/tests/CFileStream_unittest.cpp
@@ -1,0 +1,126 @@
+/*                    _
+                     | |    Mobile Robot Programming Toolkit (MRPT)
+ _ __ ___  _ __ _ __ | |_
+| '_ ` _ \| '__| '_ \| __|          https://www.mrpt.org/
+| | | | | | |  | |_) | |_
+|_| |_| |_|_|  | .__/ \__|     https://github.com/MRPT/mrpt/
+               | |
+               |_|
+
+ Copyright (c) 2005-2026, Individual contributors, see AUTHORS file
+ See: https://www.mrpt.org/Authors - All rights reserved.
+ SPDX-License-Identifier: BSD-3-Clause
+*/
+
+#include <gtest/gtest.h>
+#include <mrpt/io/CFileStream.h>
+#include <mrpt/system/filesystem.h>
+
+#include <cstdio>
+
+using namespace mrpt::io;
+
+TEST(CFileStream, OpenNonExistingForReadFails)
+{
+  const std::string fname = mrpt::system::getTempFileName() + "_does_not_exist";
+  CFileStream f;
+  EXPECT_FALSE(f.open(fname, fomRead));
+  EXPECT_FALSE(f.fileOpenCorrectly());
+}
+
+TEST(CFileStream, WriteReadCycle)
+{
+  const std::string fname = mrpt::system::getTempFileName() + "_CFileStream_test";
+
+  {
+    CFileStream fout(fname, fomWrite);
+    ASSERT_TRUE(fout.fileOpenCorrectly());
+
+    const std::string data = "0123456789";
+    EXPECT_EQ(fout.Write(data.data(), data.size()), data.size());
+    EXPECT_EQ(fout.getPositionO(), data.size());
+  }
+
+  {
+    CFileStream fin(fname, fomRead);
+    ASSERT_TRUE(fin.fileOpenCorrectly());
+    EXPECT_TRUE(fin.is_open());
+
+    EXPECT_EQ(fin.getTotalBytesCount(), 10U);
+
+    char buf[10];
+    EXPECT_EQ(fin.Read(buf, 10), 10U);
+    EXPECT_EQ(std::string(buf, 10), "0123456789");
+    EXPECT_EQ(fin.getPositionI(), 10U);
+
+    EXPECT_FALSE(fin.checkEOF());
+    char extra = 0;
+    fin.Read(&extra, 1);
+    EXPECT_TRUE(fin.checkEOF());
+
+    fin.clearError();
+    EXPECT_FALSE(fin.checkEOF());
+
+    // Seek back to the start and verify positions:
+    EXPECT_EQ(fin.Seek(0, CStream::sFromBeginning), 0U);
+    EXPECT_EQ(fin.getPosition(), 0U);
+
+    EXPECT_EQ(fin.Seek(2, CStream::sFromBeginning), 2U);
+    char two = 0;
+    EXPECT_EQ(fin.Read(&two, 1), 1U);
+    EXPECT_EQ(two, '2');
+  }
+
+  std::remove(fname.c_str());
+}
+
+TEST(CFileStream, ReadLine)
+{
+  const std::string fname = mrpt::system::getTempFileName() + "_CFileStream_readline_test";
+
+  {
+    CFileStream fout(fname, fomWrite);
+    ASSERT_TRUE(fout.fileOpenCorrectly());
+    const std::string data = "line1\nline2\n";
+    fout.Write(data.data(), data.size());
+  }
+
+  {
+    CFileStream fin(fname, fomRead);
+    ASSERT_TRUE(fin.fileOpenCorrectly());
+
+    std::string line;
+    EXPECT_TRUE(fin.readLine(line));
+    EXPECT_EQ(line, "line1");
+
+    EXPECT_TRUE(fin.readLine(line));
+    EXPECT_EQ(line, "line2");
+
+    // No more lines:
+    EXPECT_FALSE(fin.readLine(line));
+  }
+
+  std::remove(fname.c_str());
+}
+
+TEST(CFileStream, ConstructorThrowsOnInvalidFile)
+{
+  const std::string fname = mrpt::system::getTempFileName() + "_does_not_exist_dir/file.txt";
+  EXPECT_THROW(CFileStream(fname, fomRead), std::runtime_error);
+}
+
+TEST(CFileStream, UninitializedStreamReadWriteReturnZero)
+{
+  CFileStream f;
+  EXPECT_FALSE(f.fileOpenCorrectly());
+  EXPECT_EQ(f.getPosition(), 0U);
+  EXPECT_EQ(f.getTotalBytesCount(), 0U);
+  EXPECT_EQ(f.getPositionI(), 0U);
+  EXPECT_EQ(f.getPositionO(), 0U);
+  EXPECT_TRUE(f.checkEOF());
+  EXPECT_EQ(f.Seek(0), 0U);
+
+  char buf[4];
+  EXPECT_EQ(f.Read(buf, 4), 0U);
+  EXPECT_EQ(f.Write(buf, 4), 0U);
+}

--- a/modules/mrpt_io/tests/CPipe_unittest.cpp
+++ b/modules/mrpt_io/tests/CPipe_unittest.cpp
@@ -1,0 +1,80 @@
+/*                    _
+                     | |    Mobile Robot Programming Toolkit (MRPT)
+ _ __ ___  _ __ _ __ | |_
+| '_ ` _ \| '__| '_ \| __|          https://www.mrpt.org/
+| | | | | | |  | |_) | |_
+|_| |_| |_|_|  | .__/ \__|     https://github.com/MRPT/mrpt/
+               | |
+               |_|
+
+ Copyright (c) 2005-2026, Individual contributors, see AUTHORS file
+ See: https://www.mrpt.org/Authors - All rights reserved.
+ SPDX-License-Identifier: BSD-3-Clause
+*/
+
+#include <gtest/gtest.h>
+#include <mrpt/io/CPipe.h>
+
+using namespace mrpt::io;
+
+TEST(CPipe, WriteReadRoundTrip)
+{
+  std::unique_ptr<CPipeReadEndPoint> readPipe;
+  std::unique_ptr<CPipeWriteEndPoint> writePipe;
+  CPipe::createPipe(readPipe, writePipe);
+
+  ASSERT_TRUE(readPipe);
+  ASSERT_TRUE(writePipe);
+
+  const std::string data = "Hello, pipe!";
+  EXPECT_EQ(writePipe->Write(data.data(), data.size()), data.size());
+
+  char buf[32] = {0};
+  EXPECT_EQ(readPipe->Read(buf, data.size()), data.size());
+  EXPECT_EQ(std::string(buf, data.size()), data);
+}
+
+TEST(CPipe, SerializeAndReconstructEndPoint)
+{
+  std::unique_ptr<CPipeReadEndPoint> readPipe;
+  std::unique_ptr<CPipeWriteEndPoint> writePipe;
+  CPipe::createPipe(readPipe, writePipe);
+
+  const std::string serialized = readPipe->serialize();
+  EXPECT_FALSE(serialized.empty());
+
+  CPipeReadEndPoint reconstructed(serialized);
+
+  const std::string data = "abc";
+  EXPECT_EQ(writePipe->Write(data.data(), data.size()), data.size());
+
+  char buf[8] = {0};
+  EXPECT_EQ(reconstructed.Read(buf, data.size()), data.size());
+  EXPECT_EQ(std::string(buf, data.size()), data);
+}
+
+TEST(CPipe, SeekAndCountsAreNoOps)
+{
+  std::unique_ptr<CPipeReadEndPoint> readPipe;
+  std::unique_ptr<CPipeWriteEndPoint> writePipe;
+  CPipe::createPipe(readPipe, writePipe);
+
+  EXPECT_EQ(readPipe->Seek(0), 0U);
+  EXPECT_EQ(readPipe->getTotalBytesCount(), 0U);
+  EXPECT_EQ(readPipe->getPosition(), 0U);
+}
+
+TEST(CPipe, SerializeOnClosedPipeThrows)
+{
+  std::unique_ptr<CPipeReadEndPoint> readPipe;
+  std::unique_ptr<CPipeWriteEndPoint> writePipe;
+  CPipe::createPipe(readPipe, writePipe);
+
+  readPipe->close();
+  EXPECT_THROW(readPipe->serialize(), std::exception);
+}
+
+TEST(CPipe, InvalidSerializedStringThrows)
+{
+  EXPECT_THROW(CPipeReadEndPoint(std::string("not-a-number")), std::exception);
+}

--- a/modules/mrpt_math/CMakeLists.txt
+++ b/modules/mrpt_math/CMakeLists.txt
@@ -112,11 +112,15 @@ set(LIB_UNIT_TEST_SOURCES
   tests/matrix_ops5_unittest.cpp
   tests/matrix_yaml_unittest.cpp
   tests/poly_roots_unittest.cpp
+  tests/ransac_unittest.cpp
   tests/robust_kernels_unittest.cpp
   tests/slerp_unittest.cpp
   tests/TBoundingBox_unittest.cpp
+  tests/TObject2D_unittest.cpp
+  tests/TObject3D_unittest.cpp
   tests/TOrientedBox_unittest.cpp
   tests/TPoseOrPoint_unittest.cpp
+  tests/TTwist3D_unittest.cpp
   tests/wrap2pi_unittest.cpp
 )
 

--- a/modules/mrpt_math/src/TObject2D.cpp
+++ b/modules/mrpt_math/src/TObject2D.cpp
@@ -114,7 +114,10 @@ mrpt::serialization::CArchive& mrpt::math::operator<<(
     out.WriteAs<uint8_t>(4);
     out << o.getAs<TPolygon2D>();
   }
-  THROW_EXCEPTION("Unexpected type index");
+  else
+  {
+    THROW_EXCEPTION("Unexpected type index");
+  }
   return out;
 }
 

--- a/modules/mrpt_math/src/TObject3D.cpp
+++ b/modules/mrpt_math/src/TObject3D.cpp
@@ -126,7 +126,10 @@ mrpt::serialization::CArchive& mrpt::math::operator<<(
     out.WriteAs<uint8_t>(5);
     out << o.getAs<TPlane>();
   }
-  THROW_EXCEPTION("Unexpected type index");
+  else
+  {
+    THROW_EXCEPTION("Unexpected type index");
+  }
   return out;
 }
 

--- a/modules/mrpt_math/tests/TObject2D_unittest.cpp
+++ b/modules/mrpt_math/tests/TObject2D_unittest.cpp
@@ -1,0 +1,134 @@
+/*                    _
+                     | |    Mobile Robot Programming Toolkit (MRPT)
+ _ __ ___  _ __ _ __ | |_
+| '_ ` _ \| '__| '_ \| __|          https://www.mrpt.org/
+| | | | | | |  | |_) | |_
+|_| |_| |_|_|  | .__/ \__|     https://github.com/MRPT/mrpt/
+               | |
+               |_|
+
+ Copyright (c) 2005-2026, Individual contributors, see AUTHORS file
+ See: https://www.mrpt.org/Authors - All rights reserved.
+ SPDX-License-Identifier: BSD-3-Clause
+*/
+
+#include <gtest/gtest.h>
+#include <mrpt/io/CMemoryStream.h>
+#include <mrpt/math/TObject2D.h>
+#include <mrpt/math/TObject3D.h>
+#include <mrpt/serialization/CArchive.h>
+
+using namespace mrpt::math;
+
+namespace
+{
+template <typename T>
+T roundTripSerialize(const T& obj)
+{
+  mrpt::io::CMemoryStream membuf;
+  auto arch = mrpt::serialization::archiveFrom(membuf);
+  arch << obj;
+  membuf.Seek(0);
+  T obj2;
+  arch >> obj2;
+  return obj2;
+}
+}  // namespace
+
+TEST(TObject2D, EmptySerialization)
+{
+  TObject2D obj;
+  EXPECT_TRUE(obj.empty());
+
+  TObject2D obj2 = roundTripSerialize(obj);
+  EXPECT_TRUE(obj2.empty());
+  EXPECT_EQ(obj.asString(), obj2.asString());
+
+  TObject3D obj3d = obj.generate3DObject();
+  EXPECT_TRUE(obj3d.empty());
+}
+
+TEST(TObject2D, PointSerializationAndGenerate3D)
+{
+  TObject2D obj = TObject2D::From(TPoint2D(1, 2));
+  ASSERT_TRUE(obj.isPoint());
+
+  TObject2D obj2 = roundTripSerialize(obj);
+  ASSERT_TRUE(obj2.isPoint());
+  EXPECT_EQ(obj.getAs<TPoint2D>(), obj2.getAs<TPoint2D>());
+
+  TObject3D obj3d = obj.generate3DObject();
+  ASSERT_TRUE(obj3d.isPoint());
+  EXPECT_EQ(obj3d.getAs<TPoint3D>().x, 1);
+  EXPECT_EQ(obj3d.getAs<TPoint3D>().y, 2);
+
+  EXPECT_FALSE(obj.asString().empty());
+}
+
+TEST(TObject2D, SegmentSerializationAndGenerate3D)
+{
+  TObject2D obj = TObject2D::From(TSegment2D(TPoint2D(0, 0), TPoint2D(1, 1)));
+  ASSERT_TRUE(obj.isSegment());
+
+  TObject2D obj2 = roundTripSerialize(obj);
+  ASSERT_TRUE(obj2.isSegment());
+  EXPECT_EQ(obj.getAs<TSegment2D>(), obj2.getAs<TSegment2D>());
+
+  TObject3D obj3d = obj.generate3DObject();
+  EXPECT_TRUE(obj3d.isSegment());
+}
+
+TEST(TObject2D, LineSerializationAndGenerate3D)
+{
+  TObject2D obj = TObject2D::From(TLine2D::FromTwoPoints({0, 0}, {1, 0}));
+  ASSERT_TRUE(obj.isLine());
+
+  TObject2D obj2 = roundTripSerialize(obj);
+  ASSERT_TRUE(obj2.isLine());
+
+  TObject3D obj3d = obj.generate3DObject();
+  EXPECT_TRUE(obj3d.isLine());
+}
+
+TEST(TObject2D, PolygonSerializationAndGenerate3D)
+{
+  TPolygon2D poly{TPoint2D(0, 0), TPoint2D(1, 0), TPoint2D(0, 1)};
+  TObject2D obj = TObject2D::From(poly);
+  ASSERT_TRUE(obj.isPolygon());
+
+  TObject2D obj2 = roundTripSerialize(obj);
+  ASSERT_TRUE(obj2.isPolygon());
+  EXPECT_EQ(obj.getAs<TPolygon2D>().size(), obj2.getAs<TPolygon2D>().size());
+
+  TObject3D obj3d = obj.generate3DObject();
+  EXPECT_TRUE(obj3d.isPolygon());
+}
+
+TEST(TObject2D, GetterHelpers)
+{
+  TObject2D obj = TObject2D::From(TPoint2D(1, 2));
+
+  TPoint2D pt;
+  EXPECT_TRUE(obj.getPoint(pt));
+  EXPECT_EQ(pt, TPoint2D(1, 2));
+
+  TSegment2D seg;
+  EXPECT_FALSE(obj.getSegment(seg));
+
+  TLine2D line;
+  EXPECT_FALSE(obj.getLine(line));
+
+  TPolygon2D poly;
+  EXPECT_FALSE(obj.getPolygon(poly));
+}
+
+TEST(TObject2D, DeserializeInvalidTypeIndexThrows)
+{
+  mrpt::io::CMemoryStream membuf;
+  auto arch = mrpt::serialization::archiveFrom(membuf);
+  arch.WriteAs<uint8_t>(255);
+  membuf.Seek(0);
+
+  TObject2D obj;
+  EXPECT_THROW(arch >> obj, std::exception);
+}

--- a/modules/mrpt_math/tests/TObject3D_unittest.cpp
+++ b/modules/mrpt_math/tests/TObject3D_unittest.cpp
@@ -1,0 +1,137 @@
+/*                    _
+                     | |    Mobile Robot Programming Toolkit (MRPT)
+ _ __ ___  _ __ _ __ | |_
+| '_ ` _ \| '__| '_ \| __|          https://www.mrpt.org/
+| | | | | | |  | |_) | |_
+|_| |_| |_|_|  | .__/ \__|     https://github.com/MRPT/mrpt/
+               | |
+               |_|
+
+ Copyright (c) 2005-2026, Individual contributors, see AUTHORS file
+ See: https://www.mrpt.org/Authors - All rights reserved.
+ SPDX-License-Identifier: BSD-3-Clause
+*/
+
+#include <gtest/gtest.h>
+#include <mrpt/io/CMemoryStream.h>
+#include <mrpt/math/TObject2D.h>
+#include <mrpt/math/TObject3D.h>
+#include <mrpt/serialization/CArchive.h>
+
+using namespace mrpt::math;
+
+namespace
+{
+template <typename T>
+T roundTripSerialize(const T& obj)
+{
+  mrpt::io::CMemoryStream membuf;
+  auto arch = mrpt::serialization::archiveFrom(membuf);
+  arch << obj;
+  membuf.Seek(0);
+  T obj2;
+  arch >> obj2;
+  return obj2;
+}
+}  // namespace
+
+TEST(TObject3D, EmptySerialization)
+{
+  TObject3D obj;
+  EXPECT_TRUE(obj.empty());
+
+  TObject3D obj2 = roundTripSerialize(obj);
+  EXPECT_TRUE(obj2.empty());
+  EXPECT_EQ(obj.asString(), obj2.asString());
+}
+
+TEST(TObject3D, PointSerializationAndGenerate2D)
+{
+  TObject3D obj = TObject3D::From(TPoint3D(1, 2, 3));
+  ASSERT_TRUE(obj.isPoint());
+
+  TObject3D obj2 = roundTripSerialize(obj);
+  ASSERT_TRUE(obj2.isPoint());
+  EXPECT_EQ(obj.getAs<TPoint3D>(), obj2.getAs<TPoint3D>());
+
+  TObject2D obj2d = obj.generate2DObject();
+  ASSERT_TRUE(obj2d.isPoint());
+  EXPECT_EQ(obj2d.getAs<TPoint2D>().x, 1);
+  EXPECT_EQ(obj2d.getAs<TPoint2D>().y, 2);
+
+  EXPECT_FALSE(obj.asString().empty());
+}
+
+TEST(TObject3D, SegmentSerializationAndGenerate2D)
+{
+  TObject3D obj = TObject3D::From(TSegment3D(TPoint3D(0, 0, 0), TPoint3D(1, 1, 1)));
+  ASSERT_TRUE(obj.isSegment());
+
+  TObject3D obj2 = roundTripSerialize(obj);
+  ASSERT_TRUE(obj2.isSegment());
+  EXPECT_EQ(obj.getAs<TSegment3D>(), obj2.getAs<TSegment3D>());
+
+  TObject2D obj2d = obj.generate2DObject();
+  EXPECT_TRUE(obj2d.isSegment());
+}
+
+TEST(TObject3D, LineSerializationAndGenerate2D)
+{
+  TObject3D obj = TObject3D::From(TLine3D::FromTwoPoints({0, 0, 0}, {1, 0, 0}));
+  ASSERT_TRUE(obj.isLine());
+
+  TObject3D obj2 = roundTripSerialize(obj);
+  ASSERT_TRUE(obj2.isLine());
+
+  TObject2D obj2d = obj.generate2DObject();
+  EXPECT_TRUE(obj2d.isLine());
+}
+
+TEST(TObject3D, PolygonSerializationAndGenerate2D)
+{
+  TPolygon3D poly{TPoint3D(0, 0, 0), TPoint3D(1, 0, 0), TPoint3D(0, 1, 0)};
+  TObject3D obj = TObject3D::From(poly);
+  ASSERT_TRUE(obj.isPolygon());
+
+  TObject3D obj2 = roundTripSerialize(obj);
+  ASSERT_TRUE(obj2.isPolygon());
+  EXPECT_EQ(obj.getAs<TPolygon3D>().size(), obj2.getAs<TPolygon3D>().size());
+
+  TObject2D obj2d = obj.generate2DObject();
+  EXPECT_TRUE(obj2d.isPolygon());
+}
+
+TEST(TObject3D, PlaneSerializationAndGenerate2DThrows)
+{
+  TObject3D obj = TObject3D::From(TPlane::FromPointAndNormal({0, 0, 0}, {0, 0, 1}));
+  ASSERT_TRUE(obj.isPlane());
+
+  TObject3D obj2 = roundTripSerialize(obj);
+  ASSERT_TRUE(obj2.isPlane());
+
+  // A 3D plane cannot be cast down to 2D.
+  EXPECT_THROW((void)obj.generate2DObject(), std::exception);
+
+  EXPECT_FALSE(obj.asString().empty());
+}
+
+TEST(TObject3D, GetterHelpers)
+{
+  TObject3D obj = TObject3D::From(TPoint3D(1, 2, 3));
+
+  TPoint3D pt;
+  EXPECT_TRUE(obj.getPoint(pt));
+  EXPECT_EQ(pt, TPoint3D(1, 2, 3));
+
+  TSegment3D seg;
+  EXPECT_FALSE(obj.getSegment(seg));
+
+  TLine3D line;
+  EXPECT_FALSE(obj.getLine(line));
+
+  TPolygon3D poly;
+  EXPECT_FALSE(obj.getPolygon(poly));
+
+  TPlane plane;
+  EXPECT_FALSE(obj.getPlane(plane));
+}

--- a/modules/mrpt_math/tests/TTwist3D_unittest.cpp
+++ b/modules/mrpt_math/tests/TTwist3D_unittest.cpp
@@ -113,7 +113,7 @@ TEST(TTwist3D, RotateYaw90)
 {
   // 90 deg yaw rotation: x axis maps to y axis
   TTwist3D tw(1.0, 0.0, 0.0, 0.0, 0.0, 1.0);
-  TPose3D rot(0, 0, 0, M_PI_2, 0, 0);
+  TPose3D rot(0, 0, 0, M_PI / 2, 0, 0);
   TTwist3D rotated = tw.rotated(rot);
 
   EXPECT_NEAR(rotated.vx, 0.0, 1e-9);

--- a/modules/mrpt_math/tests/TTwist3D_unittest.cpp
+++ b/modules/mrpt_math/tests/TTwist3D_unittest.cpp
@@ -1,0 +1,140 @@
+/*                    _
+                     | |    Mobile Robot Programming Toolkit (MRPT)
+ _ __ ___  _ __ _ __ | |_
+| '_ ` _ \| '__| '_ \| __|          https://www.mrpt.org/
+| | | | | | |  | |_) | |_
+|_| |_| |_|_|  | .__/ \__|     https://github.com/MRPT/mrpt/
+               | |
+               |_|
+
+ Copyright (c) 2005-2026, Individual contributors, see AUTHORS file
+ See: https://www.mrpt.org/Authors - All rights reserved.
+ SPDX-License-Identifier: BSD-3-Clause
+*/
+
+#include <gtest/gtest.h>
+#include <mrpt/io/CMemoryStream.h>
+#include <mrpt/math/TPose3D.h>
+#include <mrpt/math/TTwist3D.h>
+#include <mrpt/serialization/CArchive.h>
+
+using namespace mrpt::math;
+
+TEST(TTwist3D, ComponentAccess)
+{
+  TTwist3D tw(1.0, 2.0, 3.0, 4.0, 5.0, 6.0);
+  EXPECT_DOUBLE_EQ(tw[0], 1.0);
+  EXPECT_DOUBLE_EQ(tw[1], 2.0);
+  EXPECT_DOUBLE_EQ(tw[2], 3.0);
+  EXPECT_DOUBLE_EQ(tw[3], 4.0);
+  EXPECT_DOUBLE_EQ(tw[4], 5.0);
+  EXPECT_DOUBLE_EQ(tw[5], 6.0);
+
+  EXPECT_DOUBLE_EQ(tw(0, 0), 1.0);
+  EXPECT_DOUBLE_EQ(tw(5, 0), 6.0);
+
+  EXPECT_THROW(tw[6], std::out_of_range);
+
+  const TTwist3D ctw = tw;
+  EXPECT_THROW(ctw[6], std::out_of_range);
+
+  tw[0] = 10.0;
+  EXPECT_DOUBLE_EQ(tw.vx, 10.0);
+}
+
+TEST(TTwist3D, EqualityOperators)
+{
+  TTwist3D a(1, 2, 3, 4, 5, 6);
+  TTwist3D b(1, 2, 3, 4, 5, 6);
+  TTwist3D c(1, 2, 3, 4, 5, 7);
+
+  EXPECT_TRUE(a == b);
+  EXPECT_FALSE(a != b);
+  EXPECT_FALSE(a == c);
+  EXPECT_TRUE(a != c);
+}
+
+TEST(TTwist3D, ScaleOperator)
+{
+  TTwist3D tw(1, 2, 3, 4, 5, 6);
+  tw *= 2.0;
+  EXPECT_TRUE(tw == TTwist3D(2, 4, 6, 8, 10, 12));
+}
+
+TEST(TTwist3D, VectorConversions)
+{
+  std::vector<double> v = {1, 2, 3, 4, 5, 6};
+  auto tw = TTwist3D::FromVector(v);
+  EXPECT_TRUE(tw == TTwist3D(1, 2, 3, 4, 5, 6));
+
+  std::vector<double> out;
+  tw.asVector(out);
+  EXPECT_EQ(out, v);
+
+  auto out2 = tw.asVector<std::vector<double>>();
+  EXPECT_EQ(out2, v);
+
+  TTwist3D tw2;
+  tw2.fromVector(v);
+  EXPECT_TRUE(tw2 == tw);
+}
+
+TEST(TTwist3D, AsStringAndFromString)
+{
+  TTwist3D tw(1.0, 2.0, 3.0, 0.0, 0.0, 0.0);
+  std::string s;
+  tw.asString(s);
+  EXPECT_FALSE(s.empty());
+
+  TTwist3D tw2 = TTwist3D::FromString(s);
+  EXPECT_NEAR(tw2.vx, tw.vx, 1e-6);
+  EXPECT_NEAR(tw2.vy, tw.vy, 1e-6);
+  EXPECT_NEAR(tw2.vz, tw.vz, 1e-6);
+  EXPECT_NEAR(tw2.wx, tw.wx, 1e-6);
+  EXPECT_NEAR(tw2.wy, tw.wy, 1e-6);
+  EXPECT_NEAR(tw2.wz, tw.wz, 1e-6);
+
+  EXPECT_THROW(TTwist3D::FromString("malformed"), std::exception);
+  EXPECT_THROW(TTwist3D::FromString("[1 2 3]"), std::exception);
+}
+
+TEST(TTwist3D, RotateIdentity)
+{
+  TTwist3D tw(1.0, 2.0, 3.0, 0.1, 0.2, 0.3);
+  TTwist3D rotated = tw.rotated(TPose3D::Identity());
+  EXPECT_TRUE(rotated == tw);
+
+  TTwist3D tw2 = tw;
+  tw2.rotate(TPose3D::Identity());
+  EXPECT_TRUE(tw2 == tw);
+}
+
+TEST(TTwist3D, RotateYaw90)
+{
+  // 90 deg yaw rotation: x axis maps to y axis
+  TTwist3D tw(1.0, 0.0, 0.0, 0.0, 0.0, 1.0);
+  TPose3D rot(0, 0, 0, M_PI_2, 0, 0);
+  TTwist3D rotated = tw.rotated(rot);
+
+  EXPECT_NEAR(rotated.vx, 0.0, 1e-9);
+  EXPECT_NEAR(rotated.vy, 1.0, 1e-9);
+  EXPECT_NEAR(rotated.vz, 0.0, 1e-9);
+  EXPECT_NEAR(rotated.wx, 0.0, 1e-9);
+  EXPECT_NEAR(rotated.wy, 0.0, 1e-9);
+  EXPECT_NEAR(rotated.wz, 1.0, 1e-9);
+}
+
+TEST(TTwist3D, Serialization)
+{
+  TTwist3D tw(1.5, -2.5, 3.5, 0.1, -0.2, 0.3);
+
+  mrpt::io::CMemoryStream membuf;
+  auto arch = mrpt::serialization::archiveFrom(membuf);
+  arch << tw;
+
+  membuf.Seek(0);
+  TTwist3D tw2;
+  arch >> tw2;
+
+  EXPECT_TRUE(tw == tw2);
+}

--- a/modules/mrpt_math/tests/ransac_unittest.cpp
+++ b/modules/mrpt_math/tests/ransac_unittest.cpp
@@ -24,7 +24,8 @@ namespace
 // Model: a 2D line y = a*x + b, represented as a 1x2 matrix [a b].
 // Fit a line through the two selected points.
 void fitLine(
-    const CMatrixDouble& allData, const std::vector<size_t>& useIndices,
+    const CMatrixDouble& allData,
+    const std::vector<size_t>& useIndices,
     std::vector<CMatrixDouble>& fitModels)
 {
   ASSERT_EQUAL_(useIndices.size(), 2U);
@@ -51,8 +52,10 @@ void fitLine(
 }
 
 void lineDistance(
-    const CMatrixDouble& allData, const std::vector<CMatrixDouble>& testModels,
-    const double distanceThreshold, unsigned int& out_bestModelIndex,
+    const CMatrixDouble& allData,
+    const std::vector<CMatrixDouble>& testModels,
+    const double distanceThreshold,
+    unsigned int& out_bestModelIndex,
     std::vector<size_t>& out_inlierIndices)
 {
   out_inlierIndices.clear();
@@ -102,14 +105,17 @@ TEST(RANSAC, FitLineWithOutliers)
   for (size_t i = 0; i < N_INLIERS; i++)
   {
     const double x = mrpt::random::getRandomGenerator().drawUniform(-10.0, 10.0);
-    const double y = TRUE_A * x + TRUE_B + mrpt::random::getRandomGenerator().drawGaussian1D(0, 0.01);
+    const double y =
+        TRUE_A * x + TRUE_B + mrpt::random::getRandomGenerator().drawGaussian1D(0, 0.01);
     data(0, static_cast<int>(i)) = x;
     data(1, static_cast<int>(i)) = y;
   }
   for (size_t i = 0; i < N_OUTLIERS; i++)
   {
-    data(0, static_cast<int>(N_INLIERS + i)) = mrpt::random::getRandomGenerator().drawUniform(-10.0, 10.0);
-    data(1, static_cast<int>(N_INLIERS + i)) = mrpt::random::getRandomGenerator().drawUniform(-50.0, 50.0);
+    data(0, static_cast<int>(N_INLIERS + i)) =
+        mrpt::random::getRandomGenerator().drawUniform(-10.0, 10.0);
+    data(1, static_cast<int>(N_INLIERS + i)) =
+        mrpt::random::getRandomGenerator().drawUniform(-50.0, 50.0);
   }
 
   RANSAC ransac;

--- a/modules/mrpt_math/tests/ransac_unittest.cpp
+++ b/modules/mrpt_math/tests/ransac_unittest.cpp
@@ -1,0 +1,159 @@
+/*                    _
+                     | |    Mobile Robot Programming Toolkit (MRPT)
+ _ __ ___  _ __ _ __ | |_
+| '_ ` _ \| '__| '_ \| __|          https://www.mrpt.org/
+| | | | | | |  | |_) | |_
+|_| |_| |_|_|  | .__/ \__|     https://github.com/MRPT/mrpt/
+               | |
+               |_|
+
+ Copyright (c) 2005-2026, Individual contributors, see AUTHORS file
+ See: https://www.mrpt.org/Authors - All rights reserved.
+ SPDX-License-Identifier: BSD-3-Clause
+*/
+
+#include <gtest/gtest.h>
+#include <mrpt/math/CMatrixDynamic.h>
+#include <mrpt/math/ransac.h>
+#include <mrpt/random/RandomGenerators.h>
+
+using namespace mrpt::math;
+
+namespace
+{
+// Model: a 2D line y = a*x + b, represented as a 1x2 matrix [a b].
+// Fit a line through the two selected points.
+void fitLine(
+    const CMatrixDouble& allData, const std::vector<size_t>& useIndices,
+    std::vector<CMatrixDouble>& fitModels)
+{
+  ASSERT_EQUAL_(useIndices.size(), 2U);
+
+  const double x1 = allData(0, static_cast<int>(useIndices[0]));
+  const double y1 = allData(1, static_cast<int>(useIndices[0]));
+  const double x2 = allData(0, static_cast<int>(useIndices[1]));
+  const double y2 = allData(1, static_cast<int>(useIndices[1]));
+
+  if (std::abs(x2 - x1) < 1e-12)
+  {
+    // Vertical line: cannot be represented by this model, reject.
+    fitModels.clear();
+    return;
+  }
+
+  const double a = (y2 - y1) / (x2 - x1);
+  const double b = y1 - a * x1;
+
+  fitModels.resize(1);
+  fitModels[0].setSize(1, 2);
+  fitModels[0](0, 0) = a;
+  fitModels[0](0, 1) = b;
+}
+
+void lineDistance(
+    const CMatrixDouble& allData, const std::vector<CMatrixDouble>& testModels,
+    const double distanceThreshold, unsigned int& out_bestModelIndex,
+    std::vector<size_t>& out_inlierIndices)
+{
+  out_inlierIndices.clear();
+  out_bestModelIndex = 0;
+  if (testModels.empty())
+  {
+    return;
+  }
+
+  const double a = testModels[0](0, 0);
+  const double b = testModels[0](0, 1);
+  const double norm = std::sqrt(a * a + 1);
+
+  const auto N = static_cast<size_t>(allData.cols());
+  for (size_t i = 0; i < N; i++)
+  {
+    const double x = allData(0, static_cast<int>(i));
+    const double y = allData(1, static_cast<int>(i));
+    const double d = std::abs(a * x - y + b) / norm;
+    if (d < distanceThreshold)
+    {
+      out_inlierIndices.push_back(i);
+    }
+  }
+}
+
+bool lineDegenerate(
+    [[maybe_unused]] const CMatrixDouble& allData,
+    [[maybe_unused]] const std::vector<size_t>& useIndices)
+{
+  return false;
+}
+}  // namespace
+
+TEST(RANSAC, FitLineWithOutliers)
+{
+  mrpt::random::getRandomGenerator().randomize(1234);
+
+  // Ground-truth line: y = 2*x + 1
+  const double TRUE_A = 2.0;
+  const double TRUE_B = 1.0;
+
+  constexpr size_t N_INLIERS = 50;
+  constexpr size_t N_OUTLIERS = 20;
+
+  CMatrixDouble data(2, N_INLIERS + N_OUTLIERS);
+  for (size_t i = 0; i < N_INLIERS; i++)
+  {
+    const double x = mrpt::random::getRandomGenerator().drawUniform(-10.0, 10.0);
+    const double y = TRUE_A * x + TRUE_B + mrpt::random::getRandomGenerator().drawGaussian1D(0, 0.01);
+    data(0, static_cast<int>(i)) = x;
+    data(1, static_cast<int>(i)) = y;
+  }
+  for (size_t i = 0; i < N_OUTLIERS; i++)
+  {
+    data(0, static_cast<int>(N_INLIERS + i)) = mrpt::random::getRandomGenerator().drawUniform(-10.0, 10.0);
+    data(1, static_cast<int>(N_INLIERS + i)) = mrpt::random::getRandomGenerator().drawUniform(-50.0, 50.0);
+  }
+
+  RANSAC ransac;
+  std::vector<size_t> inliers;
+  CMatrixDouble bestModel;
+
+  const bool found = ransac.execute(
+      data, &fitLine, &lineDistance, &lineDegenerate,
+      /*distanceThreshold=*/0.5,
+      /*minimumSizeSamplesToFit=*/2, inliers, bestModel,
+      /*p=*/0.999,
+      /*maxIter=*/200);
+
+  ASSERT_TRUE(found);
+  EXPECT_GE(inliers.size(), N_INLIERS - 5);
+
+  ASSERT_EQ(bestModel.rows(), 1);
+  ASSERT_EQ(bestModel.cols(), 2);
+  EXPECT_NEAR(bestModel(0, 0), TRUE_A, 0.2);
+  EXPECT_NEAR(bestModel(0, 1), TRUE_B, 0.5);
+}
+
+TEST(RANSAC, NoModelFoundWithAllDegenerateData)
+{
+  // A single repeated point cannot define a line: fitLine() rejects all
+  // (vertical/degenerate) samples since x1 == x2 always.
+  CMatrixDouble data(2, 5);
+  for (int i = 0; i < 5; i++)
+  {
+    data(0, i) = 1.0;  // same x for all points -> vertical line, rejected by fitLine
+    data(1, i) = static_cast<double>(i);
+  }
+
+  RANSAC ransac;
+  std::vector<size_t> inliers;
+  CMatrixDouble bestModel;
+
+  const bool found = ransac.execute(
+      data, &fitLine, &lineDistance, &lineDegenerate,
+      /*distanceThreshold=*/0.1,
+      /*minimumSizeSamplesToFit=*/2, inliers, bestModel,
+      /*p=*/0.999,
+      /*maxIter=*/50);
+
+  EXPECT_FALSE(found);
+  EXPECT_TRUE(inliers.empty());
+}

--- a/modules/mrpt_system/CMakeLists.txt
+++ b/modules/mrpt_system/CMakeLists.txt
@@ -50,6 +50,7 @@ set(LIB_SOURCES
 )
 
 set(LIB_UNIT_TEST_SOURCES
+  tests/CDirectoryExplorer_unittest.cpp
   tests/CTimeLogger_unittest.cpp
   tests/string_utils_unittest.cpp
   tests/filesystem_unittest.cpp

--- a/modules/mrpt_system/src/CDirectoryExplorer.cpp
+++ b/modules/mrpt_system/src/CDirectoryExplorer.cpp
@@ -94,6 +94,11 @@ CDirectoryExplorer::TFileInfoList CDirectoryExplorer::explore(
   if (mask & FILE_ATTRIB_ARCHIVE) mask |= FILE_ATTRIBUTE_NORMAL;
   do
   {
+    if (!strcmp(f.cFileName, ".") || !strcmp(f.cFileName, ".."))
+    {
+      continue;
+    }
+
     if ((mask & f.dwFileAttributes) != 0)  // Passes the user masks:
     {
       // File name:

--- a/modules/mrpt_system/tests/CDirectoryExplorer_unittest.cpp
+++ b/modules/mrpt_system/tests/CDirectoryExplorer_unittest.cpp
@@ -37,7 +37,10 @@ class TempDirFixture : public ::testing::Test
     ASSERT_TRUE(mrpt::system::createDirectory(dir + "/subdir"));
   }
 
-  void TearDown() override { mrpt::system::deleteFilesInDirectory(dir, /*deleteDirectoryAsWell=*/true); }
+  void TearDown() override
+  {
+    mrpt::system::deleteFilesInDirectory(dir, /*deleteDirectoryAsWell=*/true);
+  }
 };
 }  // namespace
 

--- a/modules/mrpt_system/tests/CDirectoryExplorer_unittest.cpp
+++ b/modules/mrpt_system/tests/CDirectoryExplorer_unittest.cpp
@@ -1,0 +1,109 @@
+/*                    _
+                     | |    Mobile Robot Programming Toolkit (MRPT)
+ _ __ ___  _ __ _ __ | |_
+| '_ ` _ \| '__| '_ \| __|          https://www.mrpt.org/
+| | | | | | |  | |_) | |_
+|_| |_| |_|_|  | .__/ \__|     https://github.com/MRPT/mrpt/
+               | |
+               |_|
+
+ Copyright (c) 2005-2026, Individual contributors, see AUTHORS file
+ See: https://www.mrpt.org/Authors - All rights reserved.
+ SPDX-License-Identifier: BSD-3-Clause
+*/
+
+#include <gtest/gtest.h>
+#include <mrpt/system/CDirectoryExplorer.h>
+#include <mrpt/system/filesystem.h>
+
+#include <fstream>
+
+using namespace mrpt::system;
+
+namespace
+{
+class TempDirFixture : public ::testing::Test
+{
+ protected:
+  std::string dir;
+
+  void SetUp() override
+  {
+    dir = mrpt::system::getTempFileName() + "_dir";
+    ASSERT_TRUE(mrpt::system::createDirectory(dir));
+
+    std::ofstream(dir + "/a.txt") << "hello";
+    std::ofstream(dir + "/b.log") << "world";
+    ASSERT_TRUE(mrpt::system::createDirectory(dir + "/subdir"));
+  }
+
+  void TearDown() override { mrpt::system::deleteFilesInDirectory(dir, /*deleteDirectoryAsWell=*/true); }
+};
+}  // namespace
+
+TEST_F(TempDirFixture, ExploreFilesAndDirectories)
+{
+  auto files = CDirectoryExplorer::explore(dir, FILE_ATTRIB_ARCHIVE | FILE_ATTRIB_DIRECTORY);
+
+  // a.txt, b.log, subdir
+  EXPECT_EQ(files.size(), 3U);
+
+  size_t numFiles = 0;
+  size_t numDirs = 0;
+  for (const auto& f : files)
+  {
+    if (f.isDir)
+    {
+      numDirs++;
+      EXPECT_EQ(f.name, "subdir");
+    }
+    else
+    {
+      numFiles++;
+    }
+  }
+  EXPECT_EQ(numFiles, 2U);
+  EXPECT_EQ(numDirs, 1U);
+}
+
+TEST_F(TempDirFixture, ExploreFilesOnly)
+{
+  auto files = CDirectoryExplorer::explore(dir, FILE_ATTRIB_ARCHIVE);
+
+  EXPECT_EQ(files.size(), 2U);
+  for (const auto& f : files)
+  {
+    EXPECT_FALSE(f.isDir);
+    EXPECT_GT(f.fileSize, 0U);
+  }
+}
+
+TEST_F(TempDirFixture, SortByName)
+{
+  auto files = CDirectoryExplorer::explore(dir, FILE_ATTRIB_ARCHIVE);
+  ASSERT_EQ(files.size(), 2U);
+
+  CDirectoryExplorer::sortByName(files, true);
+  EXPECT_TRUE(files.front().wholePath < files.back().wholePath);
+
+  CDirectoryExplorer::sortByName(files, false);
+  EXPECT_TRUE(files.front().wholePath > files.back().wholePath);
+}
+
+TEST_F(TempDirFixture, FilterByExtension)
+{
+  auto files = CDirectoryExplorer::explore(dir, FILE_ATTRIB_ARCHIVE);
+  ASSERT_EQ(files.size(), 2U);
+
+  CDirectoryExplorer::filterByExtension(files, "txt");
+  ASSERT_EQ(files.size(), 1U);
+  EXPECT_EQ(files.front().name, "a.txt");
+}
+
+TEST(CDirectoryExplorer, ExploreNonExistingDirectoryThrows)
+{
+  const std::string fname = mrpt::system::getTempFileName() + "_does_not_exist";
+  EXPECT_THROW(
+      (void)CDirectoryExplorer::explore(fname, FILE_ATTRIB_ARCHIVE | FILE_ATTRIB_DIRECTORY),
+      std::exception);
+}


### PR DESCRIPTION
## Summary
- Add new unit tests for `TTwist3D`, `TObject2D`/`TObject3D` (variant serialization round-trips and 2D/3D casting), RANSAC line fitting (`ransac.h`), `CFileStream`, `CPipe`, and `CDirectoryExplorer`.
- Fix a bug in `TObject2D::operator<<` and `TObject3D::operator<<` where serialization always threw `"Unexpected type index"` regardless of the actual variant content (an unconditional `THROW_EXCEPTION` ran after the if/else-if chain instead of being in an `else` branch).

## Test plan
- [x] `colcon build --packages-select mrpt_math mrpt_io mrpt_system --cmake-args -DENABLE_COVERAGE=ON -DBUILD_TESTING=ON` builds cleanly.
- [x] `test_mrpt_math` (195 tests), `test_mrpt_io` (15 tests), `test_mrpt_system` (27 tests) all pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented spurious exceptions during 2D/3D geometry serialization; directory exploration now skips "."/".." entries on Windows.

* **Tests**
  * Added broad unit tests: file/pipe I/O and streams, 2D/3D geometry serialization and helpers, twist math, RANSAC line fitting, and directory exploration to improve reliability and catch regressions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->