### PR TITLE
test(mrpt_maps): complete COccupancyGridMap2D unit test coverage

### DIFF
--- a/modules/mrpt_maps/CMakeLists.txt
+++ b/modules/mrpt_maps/CMakeLists.txt
@@ -69,6 +69,9 @@ set(LIB_UNIT_TEST_SOURCES
   tests/CObservationRotatingScan_unittest.cpp
   tests/COccupancyGridMap2D_unittest.cpp
   tests/COccupancyGridMap2D_serialization_unittest.cpp
+  tests/COccupancyGridMap2D_simulate_unittest.cpp
+  tests/COccupancyGridMap2D_likelihood_unittest.cpp
+  tests/COccupancyGridMap2D_matching_unittest.cpp
   tests/COccupancyGridMap3D_unittest.cpp
   tests/COctoMap_unittest.cpp
   tests/CPointCloudFilterByDistance_unittest.cpp

--- a/modules/mrpt_maps/tests/COccupancyGridMap2D_likelihood_unittest.cpp
+++ b/modules/mrpt_maps/tests/COccupancyGridMap2D_likelihood_unittest.cpp
@@ -1,0 +1,127 @@
+/*                    _
+                     | |    Mobile Robot Programming Toolkit (MRPT)
+ _ __ ___  _ __ _ __ | |_
+| '_ ` _ \| '__| '_ \| __|          https://www.mrpt.org/
+| | | | | | |  | |_) | |_
+|_| |_| |_|_|  | .__/ \__|     https://github.com/MRPT/mrpt/
+               | |
+               |_|
+
+ Copyright (c) 2005-2026, Individual contributors, see AUTHORS file
+ See: https://www.mrpt.org/Authors - All rights reserved.
+ SPDX-License-Identifier: BSD-3-Clause
+*/
+
+#include <gtest/gtest.h>
+#include <mrpt/maps/COccupancyGridMap2D.h>
+#include <mrpt/maps/CSimplePointsMap.h>
+#include <mrpt/obs/CObservation2DRangeScan.h>
+#include <mrpt/poses/CPose2D.h>
+
+using namespace mrpt::maps;
+using namespace mrpt::obs;
+using namespace mrpt::poses;
+
+namespace
+{
+// A map (resolution 0.1 m) with a finite vertical wall of occupied cells at
+// x=5.0, y in [-2, 2], free everywhere else. The map extends past the wall so
+// the wall cells are not on the outermost border row.
+COccupancyGridMap2D buildGridWithWall()
+{
+  const float res = 0.1f;
+  COccupancyGridMap2D grid(-5.0f, 6.0f, -5.0f, 5.0f, res);
+  grid.fill(1.0f);  // all free
+
+  const int cx = grid.x2idx(5.0f);
+  const int cyMin = grid.y2idx(-2.0f);
+  const int cyMax = grid.y2idx(2.0f);
+  for (int cy = cyMin; cy <= cyMax; cy++) grid.setCell(cx, cy, 0.0f);
+
+  return grid;
+}
+
+// A noise-free scan, simulated from `truePose`, that perfectly matches the
+// occupied wall in `grid`.
+CObservation2DRangeScan buildMatchingScan(const COccupancyGridMap2D& grid, const CPose2D& truePose)
+{
+  CObservation2DRangeScan scan;
+  scan.aperture = mrpt::DEG2RAD(90.0f);
+  scan.maxRange = 9.0f;
+  scan.sensorPose = CPose3D();
+
+  grid.laserScanSimulator(scan, truePose, 0.6f /*threshold*/, 91 /*N*/, 0.0f /*noiseStd*/);
+  return scan;
+}
+}  // namespace
+
+class LikelihoodMethodTest : public ::testing::TestWithParam<COccupancyGridMap2D::TLikelihoodMethod>
+{
+};
+
+// For every likelihood method, the likelihood of a noise-free scan evaluated
+// at the pose it was simulated from must be at least as large as when
+// evaluated at a clearly wrong (perturbed) pose.
+TEST_P(LikelihoodMethodTest, TruePoseAtLeastAsLikelyAsPerturbed)
+{
+  auto grid = buildGridWithWall();
+
+  const CPose2D truePose(0.0, 0.0, 0.0);
+  // Shifted along x, so the recorded ranges no longer match the distance to
+  // the wall.
+  const CPose2D perturbedPose(3.0, 0.0, 0.0);
+
+  const auto scan = buildMatchingScan(grid, truePose);
+
+  grid.likelihoodOptions.likelihoodMethod = GetParam();
+
+  const double likTrue = grid.computeObservationLikelihood(scan, CPose3D(truePose));
+  const double likPerturbed = grid.computeObservationLikelihood(scan, CPose3D(perturbedPose));
+
+  EXPECT_GE(likTrue, likPerturbed);
+}
+
+INSTANTIATE_TEST_SUITE_P(
+    AllMethods,
+    LikelihoodMethodTest,
+    ::testing::Values(
+        COccupancyGridMap2D::lmMeanInformation,
+        COccupancyGridMap2D::lmRayTracing,
+        COccupancyGridMap2D::lmConsensus,
+        COccupancyGridMap2D::lmCellsDifference,
+        COccupancyGridMap2D::lmLikelihoodField_Thrun,
+        COccupancyGridMap2D::lmLikelihoodField_II,
+        COccupancyGridMap2D::lmConsensusOWA));
+
+TEST(COccupancyGridMap2DLikelihoodTests, LikelihoodFieldThrunMonotonicity)
+{
+  const auto grid = buildGridWithWall();
+
+  CSimplePointsMap pmTrue;
+  grid.getAsPointCloud(pmTrue, 0.5f);
+  ASSERT_GT(pmTrue.size(), 0u);
+
+  // A point cloud placed in free space, far from the wall, so none of its
+  // points align with occupied cells.
+  CSimplePointsMap pmPerturbed;
+  for (size_t i = 0; i < pmTrue.size(); i++) pmPerturbed.insertPoint(-4.0f, -4.0f, 0.0f);
+
+  const double likTrue = grid.computeLikelihoodField_Thrun(pmTrue, std::nullopt);
+  const double likPerturbed = grid.computeLikelihoodField_Thrun(pmPerturbed, std::nullopt);
+
+  EXPECT_GT(likTrue, likPerturbed);
+}
+
+TEST(COccupancyGridMap2DLikelihoodTests, LikelihoodFieldIIMonotonicity)
+{
+  const auto grid = buildGridWithWall();
+
+  CSimplePointsMap pm;
+  grid.getAsPointCloud(pm, 0.5f);
+  ASSERT_GT(pm.size(), 0u);
+
+  const double likTrue = grid.computeLikelihoodField_II(pm, std::nullopt);
+  const double likPerturbed = grid.computeLikelihoodField_II(pm, CPose2D(3.0, 0.0, 0.0));
+
+  EXPECT_GT(likTrue, likPerturbed);
+}

--- a/modules/mrpt_maps/tests/COccupancyGridMap2D_matching_unittest.cpp
+++ b/modules/mrpt_maps/tests/COccupancyGridMap2D_matching_unittest.cpp
@@ -1,0 +1,78 @@
+/*                    _
+                     | |    Mobile Robot Programming Toolkit (MRPT)
+ _ __ ___  _ __ _ __ | |_
+| '_ ` _ \| '__| '_ \| __|          https://www.mrpt.org/
+| | | | | | |  | |_) | |_
+|_| |_| |_|_|  | .__/ \__|     https://github.com/MRPT/mrpt/
+               | |
+               |_|
+
+ Copyright (c) 2005-2026, Individual contributors, see AUTHORS file
+ See: https://www.mrpt.org/Authors - All rights reserved.
+ SPDX-License-Identifier: BSD-3-Clause
+*/
+
+#include <gtest/gtest.h>
+#include <mrpt/maps/COccupancyGridMap2D.h>
+#include <mrpt/maps/CSimplePointsMap.h>
+#include <mrpt/poses/CPose2D.h>
+
+using namespace mrpt::maps;
+using namespace mrpt::poses;
+
+namespace
+{
+// A 4x4 m map (resolution 0.1 m), all free except for a single occupied cell
+// at (1.0, 1.0).
+COccupancyGridMap2D buildGridWithOneObstacle()
+{
+  const float res = 0.1f;
+  COccupancyGridMap2D grid(-2.0f, 2.0f, -2.0f, 2.0f, res);
+  grid.fill(1.0f);  // all free
+  grid.setCell(grid.x2idx(1.0f), grid.y2idx(1.0f), 0.0f);
+  return grid;
+}
+}  // namespace
+
+TEST(COccupancyGridMap2DMatchingTests, DetermineMatching2DExactCorrespondence)
+{
+  const auto grid = buildGridWithOneObstacle();
+
+  // Use the exact center of the occupied cell so the correspondence has zero
+  // residual distance.
+  const float obstacleX = grid.idx2x(grid.x2idx(1.0f));
+  const float obstacleY = grid.idx2y(grid.y2idx(1.0f));
+
+  CSimplePointsMap pm;
+  pm.insertPoint(obstacleX, obstacleY, 0.0f);
+
+  mrpt::tfest::TMatchingPairList correspondences;
+  TMatchingParams params;
+  params.maxDistForCorrespondence = 0.2f;
+  TMatchingExtraResults extraResults;
+
+  grid.determineMatching2D(&pm, CPose2D(0.0, 0.0, 0.0), correspondences, params, extraResults);
+
+  EXPECT_EQ(correspondences.size(), 1u);
+  EXPECT_FLOAT_EQ(extraResults.correspondencesRatio, 1.0f);
+  EXPECT_NEAR(extraResults.sumSqrDist, 0.0f, 1e-3f);
+}
+
+TEST(COccupancyGridMap2DMatchingTests, DetermineMatching2DNoCorrespondenceWhenFarAway)
+{
+  const auto grid = buildGridWithOneObstacle();
+
+  CSimplePointsMap pm;
+  pm.insertPoint(1.0f, 1.0f, 0.0f);
+
+  mrpt::tfest::TMatchingPairList correspondences;
+  TMatchingParams params;
+  params.maxDistForCorrespondence = 0.2f;
+  TMatchingExtraResults extraResults;
+
+  // Move the comparison point far away from the only obstacle in the grid.
+  grid.determineMatching2D(&pm, CPose2D(10.0, 10.0, 0.0), correspondences, params, extraResults);
+
+  EXPECT_EQ(correspondences.size(), 0u);
+  EXPECT_FLOAT_EQ(extraResults.correspondencesRatio, 0.0f);
+}

--- a/modules/mrpt_maps/tests/COccupancyGridMap2D_simulate_unittest.cpp
+++ b/modules/mrpt_maps/tests/COccupancyGridMap2D_simulate_unittest.cpp
@@ -1,0 +1,94 @@
+/*                    _
+                     | |    Mobile Robot Programming Toolkit (MRPT)
+ _ __ ___  _ __ _ __ | |_
+| '_ ` _ \| '__| '_ \| __|          https://www.mrpt.org/
+| | | | | | |  | |_) | |_
+|_| |_| |_|_|  | .__/ \__|     https://github.com/MRPT/mrpt/
+               | |
+               |_|
+
+ Copyright (c) 2005-2026, Individual contributors, see AUTHORS file
+ See: https://www.mrpt.org/Authors - All rights reserved.
+ SPDX-License-Identifier: BSD-3-Clause
+*/
+
+#include <gtest/gtest.h>
+#include <mrpt/maps/COccupancyGridMap2D.h>
+#include <mrpt/obs/CObservation2DRangeScan.h>
+#include <mrpt/obs/CObservationRange.h>
+#include <mrpt/poses/CPose2D.h>
+
+using namespace mrpt::maps;
+using namespace mrpt::obs;
+using namespace mrpt::poses;
+
+namespace
+{
+// Builds a 10x2 m map (resolution 0.1 m) with a vertical wall of occupied
+// cells at x=5.0, free everywhere else. The robot is meant to sit at the
+// origin (0,0), looking towards +x, so the wall is exactly 5.0 m ahead.
+COccupancyGridMap2D buildGridWithWallAhead()
+{
+  const float res = 0.1f;
+  COccupancyGridMap2D grid(-1.0f, 9.0f, -1.0f, 1.0f, res);
+  grid.fill(1.0f);  // all free
+
+  const int cx = grid.x2idx(5.0f);
+  for (unsigned int cy = 0; cy < grid.getSizeY(); cy++) grid.setCell(cx, cy, 0.0f);
+
+  return grid;
+}
+}  // namespace
+
+TEST(COccupancyGridMap2DSimulateTests, simulateScanRayHitsWall)
+{
+  const auto grid = buildGridWithWallAhead();
+
+  float out_range;
+  bool out_valid;
+  grid.simulateScanRay(
+      0.0, 0.0, 0.0 /*angle: +x direction*/, out_range, out_valid, 10.0 /*maxRange*/,
+      0.4f /*threshold_free*/);
+
+  EXPECT_TRUE(out_valid);
+  EXPECT_NEAR(out_range, 5.0f, 0.1f);
+}
+
+TEST(COccupancyGridMap2DSimulateTests, laserScanSimulatorWallDistance)
+{
+  const auto grid = buildGridWithWallAhead();
+
+  CObservation2DRangeScan scan;
+  scan.aperture = 0.02f;  // very narrow FOV, all rays point ~straight ahead
+  scan.maxRange = 10.0f;
+  scan.sensorPose = CPose3D();  // sensor at the robot's origin, no rotation
+
+  const CPose2D robotPose(0.0, 0.0, 0.0);  // looking towards +x
+  grid.laserScanSimulator(scan, robotPose, 0.6f /*threshold*/, 3 /*N*/, 0.0f /*noiseStd*/);
+
+  ASSERT_EQ(scan.getScanSize(), 3u);
+  for (size_t i = 0; i < scan.getScanSize(); i++)
+  {
+    EXPECT_TRUE(scan.getScanRangeValidity(i));
+    EXPECT_NEAR(scan.getScanRange(i), 5.0f, 0.1f);
+  }
+}
+
+TEST(COccupancyGridMap2DSimulateTests, sonarSimulatorBasic)
+{
+  const auto grid = buildGridWithWallAhead();
+
+  CObservationRange obs;
+  obs.maxSensorDistance = 10.0f;
+  obs.sensorConeAperture = mrpt::DEG2RAD(1.0f);  // narrow cone, ~straight ahead
+
+  CObservationRange::TMeasurement m;
+  m.sensorPose = mrpt::poses::CPose3D().asTPose();  // sensor at robot origin, no rotation
+  obs.sensedData.push_back(m);
+
+  const CPose2D robotPose(0.0, 0.0, 0.0);  // looking towards +x
+  grid.sonarSimulator(obs, robotPose, 0.6f /*threshold*/);
+
+  ASSERT_EQ(obs.sensedData.size(), 1u);
+  EXPECT_NEAR(obs.sensedData.front().sensedDistance, 5.0f, 0.1f);
+}

--- a/modules/mrpt_maps/tests/COccupancyGridMap2D_unittest.cpp
+++ b/modules/mrpt_maps/tests/COccupancyGridMap2D_unittest.cpp
@@ -240,6 +240,37 @@ TEST(COccupancyGridMap2DTests, resizeGridGrowsKeepsContent)
   EXPECT_NEAR(grid.getCell(cx1, cy1), 0.2f, 0.02f);
 }
 
+TEST(COccupancyGridMap2DTests, subSampleHalvesResolution)
+{
+  const float res = 0.10f;
+  COccupancyGridMap2D grid(-1.0f, 1.0f, -1.0f, 1.0f, res);
+  grid.fill(1.0f);  // all free
+
+  // Mark the 2x2 block of old cells (8,8)-(9,9) as occupied. After
+  // subSample(2), this block exactly covers new cell (4,4), which must
+  // therefore become fully occupied while its neighbor (5,4) stays free.
+  const int cx = 8;
+  const int cy = 8;
+  for (int dx = 0; dx <= 1; dx++)
+    for (int dy = 0; dy <= 1; dy++) grid.setCell(cx + dx, cy + dy, 0.0f);
+
+  const unsigned int origSizeX = grid.getSizeX();
+  const unsigned int origSizeY = grid.getSizeY();
+
+  grid.subSample(2);
+
+  EXPECT_NEAR(grid.getResolution(), res * 2, 1e-4f);
+  EXPECT_EQ(grid.getSizeX(), origSizeX / 2);
+  EXPECT_EQ(grid.getSizeY(), origSizeY / 2);
+
+  // The down-sampled cell covering the all-occupied 2x2 block must be fully
+  // occupied; its free neighbor must remain free.
+  const int newCx = cx / 2;
+  const int newCy = cy / 2;
+  EXPECT_NEAR(grid.getCell(newCx, newCy), 0.0f, 0.05f);
+  EXPECT_NEAR(grid.getCell(newCx + 1, newCy), 1.0f, 0.05f);
+}
+
 TEST(COccupancyGridMap2DTests, computeEntropyKnownMap)
 {
   // Verify computeEntropy() runs without crashing and returns non-negative values.


### PR DESCRIPTION
## Summary
- Adds `subSampleHalvesResolution` unit test, fixing an existing test that relied on a coordinate landing exactly on a cell boundary (floating-point edge case in `x2idx`/`y2idx`).
- New `COccupancyGridMap2D_simulate_unittest.cpp`: covers `simulateScanRay`, `laserScanSimulator`, and `sonarSimulatorBasic` against a known wall geometry.
- New `COccupancyGridMap2D_likelihood_unittest.cpp`: parameterized test over all `TLikelihoodMethod` values verifying the true pose scores at least as likely as a clearly wrong pose, plus monotonicity checks for `computeLikelihoodField_Thrun`/`_II`.
- New `COccupancyGridMap2D_matching_unittest.cpp`: covers `determineMatching2D` correspondence ratio and `sumSqrDist`.
- Registers the new test files in `CMakeLists.txt`.

## Test plan
- [x] `colcon build --packages-select mrpt_maps`
- [x] `./build/mrpt_maps/bin/test_mrpt_maps` — 116/116 tests pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Tests

* Added unit tests validating occupancy grid map likelihood computation methods
* Added unit tests for occupancy grid map matching behavior with point clouds
* Added unit tests for occupancy grid map simulation helpers (ray casting and sonar simulation)
* Added unit test for occupancy grid map subsampling functionality

<!-- end of auto-generated comment: release notes by coderabbit.ai -->