### PR TITLE
mrpt_opengl: Export opengl dependency

### DIFF
--- a/modules/mrpt_opengl/package.xml
+++ b/modules/mrpt_opengl/package.xml
@@ -17,7 +17,7 @@
   <depend>mrpt_img</depend>
 
   <build_depend>eigen</build_depend>
-  <build_depend>opengl</build_depend>
+  <build_export_depend>opengl</build_export_depend>
 
   <export>
     <build_type>cmake</build_type>


### PR DESCRIPTION
Packages depending on mrpt_opengl need to have opengl headers available. Therefore, we change opengl dependency from build_depend to build_export_depend.

Without this change, building e.g. mrpt_imgui leads to the following error:

    In file included from /build/mrpt3-release-release-humble-mrpt_imgui-3.0.2-1/include/mrpt/imgui/CImGuiSceneView.h:24,
                     from /build/mrpt3-release-release-humble-mrpt_imgui-3.0.2-1/src/CImGuiSceneView.cpp:18:
    /nix/store/pjjjv71f9n44k3nqc19dlcbs7bj12m4q-ros-humble-mrpt-opengl-3.0.2-r1/include/mrpt/opengl/opengl_api.h:44:10: fatal error: GL/gl.h: No such file or directory
       44 | #include <GL/gl.h>
          |          ^~~~~~~~~

## Description

<!-- What does this PR do, and why? -->

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change (changes existing behavior/API)
- [x] Refactor / code cleanup (no functional change)
- [ ] Documentation
- [ ] CI / build system

## Affected modules / apps

mrpt_opengl, mrpt_imgui,

## Related issues

<!-- e.g. Closes #XXX -->

## Testing

Building with the Nix package manager.

## Checklist

- [x] I have read [`CONTRIBUTING.md`](https://github.com/MRPT/mrpt/blob/develop/.github/CONTRIBUTING.md)
- [x] Code follows the [MRPT coding style](https://github.com/MRPT/mrpt/blob/develop/doc/source/MRPT_Coding_Style.rst) and passes `clang-format`
- [ ] Builds successfully with `colcon build`
- [ ] Added/updated unit tests where applicable
- [ ] Updated [`changelog.md`](https://github.com/MRPT/mrpt/blob/develop/doc/source/doxygen-docs/changelog.md) (if user-visible)
- [ ] Updated [`AUTHORS`](https://github.com/MRPT/mrpt/blob/develop/AUTHORS) (if first contribution)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated OpenGL build dependency configuration to ensure proper exposure to downstream packages, improving build compatibility for dependent libraries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->