### PR TITLE
Add rawlog-edit CLI test coverage and fix related bugs

### DIFF
--- a/modules/mrpt_libapps_cli/CMakeLists.txt
+++ b/modules/mrpt_libapps_cli/CMakeLists.txt
@@ -43,6 +43,7 @@ set(LIB_SOURCES
 
 set(LIB_UNIT_TEST_SOURCES
   tests/RawlogGrabberApp_unittest.cpp
+  tests/rawlog-edit_unittest.cpp
 )
 
 set(LIB_PUBLIC_HEADERS

--- a/modules/mrpt_libapps_cli/include/mrpt/apps_cli/CRawlogProcessor.h
+++ b/modules/mrpt_libapps_cli/include/mrpt/apps_cli/CRawlogProcessor.h
@@ -19,6 +19,7 @@
 #include <mrpt/obs/CRawlog.h>
 #include <mrpt/serialization/CArchive.h>
 #include <mrpt/system/CTicTac.h>
+#include <mrpt/system/filesystem.h>
 #include <mrpt/system/os.h>
 
 #include <iostream>
@@ -30,6 +31,19 @@ class App;
 
 namespace mrpt::apps
 {
+/** Builds the common path prefix used to derive the names of additional
+ * output files from an input rawlog file path, e.g. "/path/to/foo.rawlog"
+ * becomes "/path/to/foo". */
+inline std::string buildOutputFilesPrefix(const std::string& inputRawlogFile)
+{
+  std::string dir = mrpt::system::extractFileDirectory(inputRawlogFile);
+  if (!dir.empty())
+  {
+    dir += "/";
+  }
+  return dir + mrpt::system::extractFileName(inputRawlogFile);
+}
+
 /** A virtual class that implements the common stuff around parsing a rawlog
  * file and (optionally) display a progress indicator to the console.
  * \ingroup mrpt_apps_grp
@@ -174,25 +188,29 @@ class CRawlogProcessorOnEachObservation : public CRawlogProcessor
   {
     // Process each observation individually, either from "obs" or each
     // within a "SF":
+    // Note: a reference to the actual smart pointer (held in "obs" or
+    // inside "SF") must be used here so that, if a derived processor resets
+    // it (e.g. to filter out an observation), the change is reflected in
+    // what is later read by OnPostProcess().
     for (size_t idxObs = 0; true; idxObs++)
     {
-      mrpt::obs::CObservation::Ptr obs_indiv;
+      mrpt::obs::CObservation::Ptr* obs_indiv = nullptr;
       if (obs)
       {
         if (idxObs > 0) break;
-        obs_indiv = obs;
+        obs_indiv = &obs;
       }
       else if (SF)
       {
         if (idxObs >= SF->size()) break;
-        obs_indiv = SF->getObservationByIndex(idxObs);
+        obs_indiv = &SF->getObservationByIndex(idxObs);
       }
       else
         break;  // shouldn't...
 
-      // Process "obs_indiv":
-      ASSERT_(obs_indiv);
-      if (!processOneObservation(obs_indiv))
+      // Process "*obs_indiv":
+      ASSERT_(*obs_indiv);
+      if (!processOneObservation(*obs_indiv))
       {
         return false;
       }

--- a/modules/mrpt_libapps_cli/src/rawlog-edit_enose.cpp
+++ b/modules/mrpt_libapps_cli/src/rawlog-edit_enose.cpp
@@ -48,7 +48,7 @@ DECLARE_OP_FUNCTION(op_export_enose_txt)
     {
       getArgValue<string>(cmdline, "input", m_inFile);
 
-      m_filPrefix = extractFileDirectory(m_inFile) + extractFileName(m_inFile);
+      m_filPrefix = buildOutputFilesPrefix(m_inFile);
     }
 
     // Return false on any error.

--- a/modules/mrpt_libapps_cli/src/rawlog-edit_export_txt.cpp
+++ b/modules/mrpt_libapps_cli/src/rawlog-edit_export_txt.cpp
@@ -46,7 +46,7 @@ DECLARE_OP_FUNCTION(op_export_txt)
     {
       getArgValue<string>(cmdline, "input", m_inFile);
 
-      m_filPrefix = extractFileDirectory(m_inFile) + extractFileName(m_inFile);
+      m_filPrefix = buildOutputFilesPrefix(m_inFile);
     }
 
     // return false on any error.

--- a/modules/mrpt_libapps_cli/src/rawlog-edit_gps.cpp
+++ b/modules/mrpt_libapps_cli/src/rawlog-edit_gps.cpp
@@ -369,7 +369,7 @@ DECLARE_OP_FUNCTION(op_export_gps_txt)
         CRawlogProcessorOnEachObservation(in_rawlog, cmdline, _verbose), m_GPS_entriesSaved(0)
     {
       getArgValue<string>(cmdline, "input", m_inFile);
-      m_filPrefix = extractFileDirectory(m_inFile) + extractFileName(m_inFile);
+      m_filPrefix = buildOutputFilesPrefix(m_inFile);
     }
 
     // return false on any error.
@@ -564,7 +564,7 @@ DECLARE_OP_FUNCTION(op_export_gps_all)
         CRawlogProcessorOnEachObservation(in_rawlog, cmdline, _verbose), m_GPS_entriesSaved(0)
     {
       getArgValue<string>(cmdline, "input", m_inFile);
-      m_filPrefix = extractFileDirectory(m_inFile) + extractFileName(m_inFile);
+      m_filPrefix = buildOutputFilesPrefix(m_inFile);
     }
 
     // return false on any error.

--- a/modules/mrpt_libapps_cli/src/rawlog-edit_rawdaq.cpp
+++ b/modules/mrpt_libapps_cli/src/rawlog-edit_rawdaq.cpp
@@ -93,7 +93,7 @@ DECLARE_OP_FUNCTION(op_export_rawdaq_txt)
     {
       getArgValue<string>(cmdline, "input", m_inFile);
 
-      m_filPrefix = extractFileDirectory(m_inFile) + extractFileName(m_inFile);
+      m_filPrefix = buildOutputFilesPrefix(m_inFile);
     }
 
     // return false on any error.

--- a/modules/mrpt_libapps_cli/tests/rawlog-edit_unittest.cpp
+++ b/modules/mrpt_libapps_cli/tests/rawlog-edit_unittest.cpp
@@ -1,0 +1,599 @@
+/*                    _
+                     | |    Mobile Robot Programming Toolkit (MRPT)
+ _ __ ___  _ __ _ __ | |_
+| '_ ` _ \| '__| '_ \| __|          https://www.mrpt.org/
+| | | | | | |  | |_) | |_
+|_| |_| |_|_|  | .__/ \__|     https://github.com/MRPT/mrpt/
+               | |
+               |_|
+
+ Copyright (c) 2005-2026, Individual contributors, see AUTHORS file
+ See: https://www.mrpt.org/Authors - All rights reserved.
+ SPDX-License-Identifier: BSD-3-Clause
+*/
+
+// Black-box tests for the `rawlog-edit` CLI tool: they invoke the built
+// executable as a subprocess and check its exit code and/or output, using
+// the small sample datasets in mrpt_data/datasets/.
+
+#include <gtest/gtest.h>
+#include <mrpt/system/filesystem.h>
+#include <mrpt/system/os.h>
+#include <test_mrpt_common.h>
+
+#include <fstream>
+#include <string>
+#include <vector>
+
+namespace
+{
+// Locates the `rawlog-edit` binary, either in the colcon build/install tree
+// (next to this test's source tree) or in the PATH.
+std::string findRawlogEditBinary()
+{
+#ifdef _WIN32
+  const std::string exeName = "rawlog-edit.exe";
+#else
+  const std::string exeName = "rawlog-edit";
+#endif
+
+  const std::string base = mrpt::UNITTEST_BASEDIR();
+  const std::vector<std::string> candidates = {
+      base + "/../../install/mrpt_apps_cli/bin/" + exeName,
+      base + "/../../build/mrpt_apps_cli/bin/" + exeName,
+  };
+  for (const auto& c : candidates)
+  {
+    if (mrpt::system::fileExists(c))
+    {
+      return c;
+    }
+  }
+
+  // Fallback: search the PATH.
+  std::string out;
+#ifdef _WIN32
+  const std::string findCmd = "where " + exeName;
+#else
+  const std::string findCmd = "command -v " + exeName;
+#endif
+  if (mrpt::system::executeCommand(findCmd, &out) == 0 && !out.empty())
+  {
+    while (!out.empty() && (out.back() == '\n' || out.back() == '\r'))
+    {
+      out.pop_back();
+    }
+    if (!out.empty())
+    {
+      return out;
+    }
+  }
+  return {};
+}
+
+struct CmdResult
+{
+  int exitCode = -1;
+  std::string output;
+};
+
+}  // namespace
+
+class RawlogEditCLITest : public ::testing::Test
+{
+ protected:
+  void SetUp() override
+  {
+    m_bin = findRawlogEditBinary();
+    if (m_bin.empty())
+    {
+      GTEST_SKIP() << "rawlog-edit binary not found, skipping CLI tests.";
+    }
+
+    m_tempDir = mrpt::system::getTempFileName() + "_rawlog_edit_test";
+    ASSERT_(mrpt::system::createDirectory(m_tempDir));
+  }
+
+  void TearDown() override
+  {
+    if (!m_tempDir.empty())
+    {
+      mrpt::system::deleteFilesInDirectory(m_tempDir, true /*and the dir*/);
+    }
+  }
+
+  // Copies a dataset file from mrpt_data/datasets/ into the (writable) temp
+  // dir, and returns the path to the copy.
+  [[nodiscard]] std::string datasetCopy(const std::string& name) const
+  {
+    const std::string src = mrpt::system::pathJoin({mrpt::mrpt_data_dir(), "datasets", name});
+    ASSERT_FILE_EXISTS_(src);
+
+    const std::string dst = mrpt::system::pathJoin({m_tempDir, name});
+    ASSERT_(mrpt::system::copyFile(src, dst));
+    return dst;
+  }
+
+  // Runs rawlog-edit with the given arguments, capturing stdout+stderr.
+  // Runs the binary with the current working directory set to m_tempDir,
+  // since some operations (--export-gps-all, --externalize, ...) write
+  // additional output files relative to the current directory.
+  [[nodiscard]] CmdResult run(const std::vector<std::string>& args) const
+  {
+    std::string cmd = "cd \"" + m_tempDir + "\" && \"" + m_bin + "\"";
+    for (const auto& a : args)
+    {
+      cmd += " \"" + a + "\"";
+    }
+    cmd += " 2>&1";
+
+    CmdResult r;
+    r.exitCode = mrpt::system::executeCommand(cmd, &r.output);
+    return r;
+  }
+
+  std::string m_bin;
+  std::string m_tempDir;
+};
+
+// ===========================================================================
+// Generic CLI behavior
+// ===========================================================================
+
+TEST_F(RawlogEditCLITest, Help_PrintsUsage)
+{
+  const auto r = run({"--help"});
+  EXPECT_EQ(r.exitCode, 0);
+  EXPECT_NE(r.output.find("rawlog-edit"), std::string::npos);
+}
+
+TEST_F(RawlogEditCLITest, Version_PrintsVersion)
+{
+  const auto r = run({"--version"});
+  EXPECT_EQ(r.exitCode, 0);
+}
+
+TEST_F(RawlogEditCLITest, NoOperationSelected_Fails)
+{
+  const auto in = datasetCopy("test_rtk_path.rawlog");
+  const auto r = run({"-i", in, "-q"});
+  EXPECT_NE(r.exitCode, 0);
+}
+
+TEST_F(RawlogEditCLITest, TwoOperationsSelected_Fails)
+{
+  const auto in = datasetCopy("test_rtk_path.rawlog");
+  const auto r = run({"-i", in, "--info", "--describe", "-q"});
+  EXPECT_NE(r.exitCode, 0);
+}
+
+TEST_F(RawlogEditCLITest, MissingInputFile_Fails)
+{
+  const auto r = run({"--info", "-i", m_tempDir + "/does_not_exist.rawlog", "-q"});
+  EXPECT_NE(r.exitCode, 0);
+}
+
+// ===========================================================================
+// --info / --describe
+// ===========================================================================
+
+TEST_F(RawlogEditCLITest, Info_TestRtkPath)
+{
+  const auto in = datasetCopy("test_rtk_path.rawlog");
+  const auto r = run({"--info", "-i", in, "-q"});
+  EXPECT_EQ(r.exitCode, 0);
+  EXPECT_NE(r.output.find("Overall number of objects"), std::string::npos);
+  EXPECT_NE(r.output.find("GPS_RTK_FRONT_L"), std::string::npos);
+  EXPECT_NE(r.output.find("GPS_RTK_FRONT_R"), std::string::npos);
+  EXPECT_NE(r.output.find("GPS_RTK_REAR"), std::string::npos);
+}
+
+TEST_F(RawlogEditCLITest, Info_RotScan2DWithParseWarning)
+{
+  // This small dataset triggers an internal "EOF?" parsing exception that
+  // is caught and reported, but the overall command must still succeed.
+  const auto in = datasetCopy("rot_scan_2d.rawlog");
+  const auto r = run({"--info", "-i", in, "-q"});
+  EXPECT_EQ(r.exitCode, 0);
+  EXPECT_NE(r.output.find("Physical file size"), std::string::npos);
+}
+
+TEST_F(RawlogEditCLITest, Describe_LocalizationDemo)
+{
+  const auto in = datasetCopy("localization_demo.rawlog");
+  const auto r = run({"--describe", "-i", in, "-q"});
+  EXPECT_EQ(r.exitCode, 0);
+  EXPECT_NE(r.output.find("CObservation2DRangeScan"), std::string::npos);
+}
+
+// ===========================================================================
+// --list-* operations
+// ===========================================================================
+
+TEST_F(RawlogEditCLITest, ListTimestamps_TestRtkPath)
+{
+  const auto in = datasetCopy("test_rtk_path.rawlog");
+  const auto out = m_tempDir + "/timestamps.txt";
+  const auto r = run({"--list-timestamps", "-i", in, "--text-file-output", out, "-q"});
+  EXPECT_EQ(r.exitCode, 0);
+  EXPECT_TRUE(mrpt::system::fileExists(out));
+
+  std::ifstream f(out);
+  ASSERT_TRUE(f.is_open());
+  std::string line;
+  size_t nLines = 0;
+  while (std::getline(f, line))
+  {
+    nLines++;
+  }
+  EXPECT_GT(nLines, 1U);
+}
+
+TEST_F(RawlogEditCLITest, ListPoses_TestRtkPath)
+{
+  const auto in = datasetCopy("test_rtk_path.rawlog");
+  const auto out = m_tempDir + "/poses.txt";
+  const auto r = run({"--list-poses", "-i", in, "--text-file-output", out, "-q"});
+  EXPECT_EQ(r.exitCode, 0);
+  EXPECT_TRUE(mrpt::system::fileExists(out));
+}
+
+TEST_F(RawlogEditCLITest, ListImages_LocalizationDemo)
+{
+  const auto in = datasetCopy("localization_demo.rawlog");
+  const auto out = m_tempDir + "/images.txt";
+  const auto r = run({"--list-images", "-i", in, "--text-file-output", out, "-q"});
+  EXPECT_EQ(r.exitCode, 0);
+  EXPECT_TRUE(mrpt::system::fileExists(out));
+}
+
+TEST_F(RawlogEditCLITest, ListRangeBearing_KfSlamDemo)
+{
+  const auto in = datasetCopy("kf-slam_demo.rawlog");
+  const auto out = m_tempDir + "/rangebearing.txt";
+  const auto r = run({"--list-range-bearing", "-i", in, "--text-file-output", out, "-q"});
+  EXPECT_EQ(r.exitCode, 0);
+  EXPECT_TRUE(mrpt::system::fileExists(out));
+
+  std::ifstream f(out);
+  ASSERT_TRUE(f.is_open());
+  std::string line;
+  size_t nLines = 0;
+  while (std::getline(f, line))
+  {
+    nLines++;
+  }
+  // Header (2 lines) + at least one data row:
+  EXPECT_GT(nLines, 2U);
+}
+
+// ===========================================================================
+// --cut
+// ===========================================================================
+
+TEST_F(RawlogEditCLITest, Cut_NoArgs_Fails)
+{
+  const auto in = datasetCopy("test_rtk_path.rawlog");
+  const auto out = m_tempDir + "/cut.rawlog";
+  const auto r = run({"--cut", "-i", in, "-o", out, "-q"});
+  EXPECT_NE(r.exitCode, 0);
+}
+
+TEST_F(RawlogEditCLITest, Cut_FromToIndex_TestRtkPath)
+{
+  const auto in = datasetCopy("test_rtk_path.rawlog");
+  const auto out = m_tempDir + "/cut.rawlog";
+  const auto r =
+      run({"--cut", "--from-index", "100", "--to-index", "200", "-i", in, "-o", out, "-q"});
+  EXPECT_EQ(r.exitCode, 0);
+  ASSERT_TRUE(mrpt::system::fileExists(out));
+
+  const auto info = run({"--info", "-i", out, "-q"});
+  EXPECT_EQ(info.exitCode, 0);
+  // 200 - 100 + 1 = 101 entries kept.
+  EXPECT_NE(info.output.find("Overall number of objects         : 101"), std::string::npos);
+}
+
+// ===========================================================================
+// --export-* operations
+// ===========================================================================
+
+TEST_F(RawlogEditCLITest, ExportTxt_TestRtkPath)
+{
+  const auto in = datasetCopy("test_rtk_path.rawlog");
+  const auto r = run({"--export-txt", "-i", in, "-q"});
+  EXPECT_EQ(r.exitCode, 0);
+}
+
+TEST_F(RawlogEditCLITest, Export2DScansTxt_EmptyLabel_Fails)
+{
+  // localization_demo.rawlog has 2D range scans with an empty sensorLabel,
+  // which the generic TXT exporter rejects.
+  const auto in = datasetCopy("localization_demo.rawlog");
+  const auto r = run({"--export-2d-scans-txt", "-i", in, "-q"});
+  EXPECT_NE(r.exitCode, 0);
+  EXPECT_NE(r.output.find("non-empty sensorLabels"), std::string::npos);
+}
+
+TEST_F(RawlogEditCLITest, ExportGpsAll_TestRtkPath)
+{
+  const auto in = datasetCopy("test_rtk_path.rawlog");
+  const auto r = run({"--export-gps-all", "-i", in, "-q"});
+  EXPECT_EQ(r.exitCode, 0);
+  EXPECT_TRUE(
+      mrpt::system::fileExists(m_tempDir + "/test_rtk_path_GPS_RTK_FRONT_L_MSG_NMEA_GGA.txt"));
+}
+
+TEST_F(RawlogEditCLITest, ExportGpsKml_TestRtkPath)
+{
+  const auto in = datasetCopy("test_rtk_path.rawlog");
+  const auto r = run({"--export-gps-kml", "-i", in, "-q"});
+  EXPECT_EQ(r.exitCode, 0);
+  EXPECT_TRUE(mrpt::system::fileExists(m_tempDir + "/test_rtk_path.kml"));
+}
+
+TEST_F(RawlogEditCLITest, ExportGpsGasKml_NoMatchingObservations)
+{
+  // No gas sensor present: must not fail, simply produce no output.
+  const auto in = datasetCopy("test_rtk_path.rawlog");
+  const auto r = run({"--export-gps-gas-kml", "-i", in, "-q"});
+  EXPECT_EQ(r.exitCode, 0);
+}
+
+TEST_F(RawlogEditCLITest, ExportImuTxt_NoMatchingObservations)
+{
+  const auto in = datasetCopy("test_rtk_path.rawlog");
+  const auto r = run({"--export-imu-txt", "-i", in, "-q"});
+  EXPECT_EQ(r.exitCode, 0);
+}
+
+TEST_F(RawlogEditCLITest, ExportAnemometerTxt_NoMatchingObservations)
+{
+  const auto in = datasetCopy("test_rtk_path.rawlog");
+  const auto r = run({"--export-anemometer-txt", "-i", in, "-q"});
+  EXPECT_EQ(r.exitCode, 0);
+}
+
+TEST_F(RawlogEditCLITest, ExportEnoseTxt_NoMatchingObservations)
+{
+  const auto in = datasetCopy("test_rtk_path.rawlog");
+  const auto r = run({"--export-enose-txt", "-i", in, "-q"});
+  EXPECT_EQ(r.exitCode, 0);
+}
+
+TEST_F(RawlogEditCLITest, ExportRawDaqTxt_NoMatchingObservations)
+{
+  const auto in = datasetCopy("test_rtk_path.rawlog");
+  const auto r = run({"--export-rawdaq-txt", "-i", in, "-q"});
+  EXPECT_EQ(r.exitCode, 0);
+}
+
+// ===========================================================================
+// --remove-label / --keep-label
+// ===========================================================================
+
+TEST_F(RawlogEditCLITest, RemoveLabel_TestRtkPath)
+{
+  const auto in = datasetCopy("test_rtk_path.rawlog");
+  const auto out = m_tempDir + "/removed.rawlog";
+  const auto r = run({"--remove-label", "GPS_RTK_FRONT_L", "-i", in, "-o", out, "-q"});
+  EXPECT_EQ(r.exitCode, 0);
+
+  const auto info = run({"--info", "-i", out, "-q"});
+  EXPECT_EQ(info.exitCode, 0);
+  EXPECT_EQ(info.output.find("GPS_RTK_FRONT_L"), std::string::npos);
+  EXPECT_NE(info.output.find("GPS_RTK_FRONT_R"), std::string::npos);
+  EXPECT_NE(info.output.find("GPS_RTK_REAR"), std::string::npos);
+}
+
+TEST_F(RawlogEditCLITest, RemoveLabel_EmptyArg_Fails)
+{
+  const auto in = datasetCopy("test_rtk_path.rawlog");
+  const auto out = m_tempDir + "/removed.rawlog";
+  const auto r = run({"--remove-label", "", "-i", in, "-o", out, "-q"});
+  EXPECT_NE(r.exitCode, 0);
+}
+
+TEST_F(RawlogEditCLITest, KeepLabel_TestRtkPath)
+{
+  const auto in = datasetCopy("test_rtk_path.rawlog");
+  const auto out = m_tempDir + "/kept.rawlog";
+  const auto r = run({"--keep-label", "GPS_RTK_REAR", "-i", in, "-o", out, "-q"});
+  EXPECT_EQ(r.exitCode, 0);
+
+  const auto info = run({"--info", "-i", out, "-q"});
+  EXPECT_EQ(info.exitCode, 0);
+  EXPECT_EQ(info.output.find("GPS_RTK_FRONT_L"), std::string::npos);
+  EXPECT_EQ(info.output.find("GPS_RTK_FRONT_R"), std::string::npos);
+  EXPECT_NE(info.output.find("GPS_RTK_REAR"), std::string::npos);
+  // Only the GPS_RTK_REAR observations (77) should remain.
+  EXPECT_NE(info.output.find("Overall number of objects         : 77"), std::string::npos);
+}
+
+// ===========================================================================
+// --remap-timestamps
+// ===========================================================================
+
+TEST_F(RawlogEditCLITest, RemapTimestamps_TestRtkPath)
+{
+  const auto in = datasetCopy("test_rtk_path.rawlog");
+  const auto out = m_tempDir + "/remapped.rawlog";
+  const auto r = run({"--remap-timestamps", "1.0;1000000000", "-i", in, "-o", out, "-q"});
+  EXPECT_EQ(r.exitCode, 0);
+
+  const auto info = run({"--info", "-i", out, "-q"});
+  EXPECT_EQ(info.exitCode, 0);
+  // Original earliest timestamp is 1226225355.0, so the new one must be
+  // 1226225355.0 + 1e9 = 2226225355.0
+  EXPECT_NE(info.output.find("Earliest timestamp                : 2226225355"), std::string::npos);
+}
+
+TEST_F(RawlogEditCLITest, RemapTimestamps_BadFormat_Fails)
+{
+  const auto in = datasetCopy("test_rtk_path.rawlog");
+  const auto out = m_tempDir + "/remapped.rawlog";
+  const auto r = run({"--remap-timestamps", "not-a-valid-expression", "-i", in, "-o", out, "-q"});
+  EXPECT_NE(r.exitCode, 0);
+}
+
+// ===========================================================================
+// --rename-externals
+// ===========================================================================
+
+TEST_F(RawlogEditCLITest, RenameExternals_NoExternalFiles)
+{
+  const auto in = datasetCopy("test_rtk_path.rawlog");
+  const auto out = m_tempDir + "/renamed.rawlog";
+  const auto r = run({"--rename-externals", "-i", in, "-o", out, "-q"});
+  EXPECT_EQ(r.exitCode, 0);
+  EXPECT_TRUE(mrpt::system::fileExists(out));
+}
+
+// ===========================================================================
+// --sensors-pose
+// ===========================================================================
+
+TEST_F(RawlogEditCLITest, SensorsPose_TestRtkPath)
+{
+  const auto in = datasetCopy("test_rtk_path.rawlog");
+  const auto out = m_tempDir + "/sensorpose.rawlog";
+
+  const auto iniFile = m_tempDir + "/sensor_poses.ini";
+  {
+    std::ofstream f(iniFile);
+    ASSERT_TRUE(f.is_open());
+    f << "[FRONT_L]\n"
+      << "sensorLabel=GPS_RTK_FRONT_L\n"
+      << "pose_x=1.0\n"
+      << "pose_y=2.0\n"
+      << "pose_z=0.5\n"
+      << "pose_yaw=0\n"
+      << "pose_pitch=0\n"
+      << "pose_roll=0\n";
+  }
+
+  const auto r = run({"--sensors-pose", iniFile, "-i", in, "-o", out, "-q"});
+  EXPECT_EQ(r.exitCode, 0);
+  EXPECT_TRUE(mrpt::system::fileExists(out));
+}
+
+TEST_F(RawlogEditCLITest, SensorsPose_MissingFile_Fails)
+{
+  const auto in = datasetCopy("test_rtk_path.rawlog");
+  const auto out = m_tempDir + "/sensorpose.rawlog";
+  const auto r =
+      run({"--sensors-pose", m_tempDir + "/does_not_exist.ini", "-i", in, "-o", out, "-q"});
+  EXPECT_NE(r.exitCode, 0);
+}
+
+// ===========================================================================
+// --recalc-odometry
+// ===========================================================================
+
+TEST_F(RawlogEditCLITest, RecalcOdometry_MissingArgs_Fails)
+{
+  const auto in = datasetCopy("test_rtk_path.rawlog");
+  const auto out = m_tempDir + "/recalc.rawlog";
+  const auto r = run({"--recalc-odometry", "-i", in, "-o", out, "-q"});
+  EXPECT_NE(r.exitCode, 0);
+}
+
+TEST_F(RawlogEditCLITest, RecalcOdometry_NoOdometryEntries)
+{
+  const auto in = datasetCopy("test_rtk_path.rawlog");
+  const auto out = m_tempDir + "/recalc.rawlog";
+  const auto r = run(
+      {"--recalc-odometry", "--odo-KL", "0.1", "--odo-KR", "0.1", "--odo-D", "0.4", "-i", in, "-o",
+       out, "-q"});
+  EXPECT_EQ(r.exitCode, 0);
+  EXPECT_TRUE(mrpt::system::fileExists(out));
+}
+
+// ===========================================================================
+// --camera-params
+// ===========================================================================
+
+TEST_F(RawlogEditCLITest, CameraParams_BadFormat_Fails)
+{
+  const auto in = datasetCopy("test_rtk_path.rawlog");
+  const auto out = m_tempDir + "/camparams.rawlog";
+  const auto r = run({"--camera-params", "JustOneToken", "-i", in, "-o", out, "-q"});
+  EXPECT_NE(r.exitCode, 0);
+}
+
+TEST_F(RawlogEditCLITest, CameraParams_MissingFile_Fails)
+{
+  const auto in = datasetCopy("test_rtk_path.rawlog");
+  const auto out = m_tempDir + "/camparams.rawlog";
+  const auto r = run(
+      {"--camera-params", "SOME_LABEL," + m_tempDir + "/does_not_exist.ini", "-i", in, "-o", out,
+       "-q"});
+  EXPECT_NE(r.exitCode, 0);
+}
+
+// ===========================================================================
+// --externalize / --de-externalize
+// ===========================================================================
+
+TEST_F(RawlogEditCLITest, Externalize_NoConvertibleObservations)
+{
+  const auto in = datasetCopy("test_rtk_path.rawlog");
+  const auto out = m_tempDir + "/externalized.rawlog";
+  const auto r = run({"--externalize", "-i", in, "-o", out, "-q"});
+  EXPECT_EQ(r.exitCode, 0);
+  EXPECT_TRUE(mrpt::system::fileExists(out));
+  EXPECT_TRUE(mrpt::system::directoryExists(m_tempDir + "/externalized_Images"));
+}
+
+TEST_F(RawlogEditCLITest, DeExternalize_NoExternalReferences)
+{
+  const auto in = datasetCopy("test_rtk_path.rawlog");
+  const auto out = m_tempDir + "/deexternalized.rawlog";
+  const auto r = run({"--de-externalize", "-i", in, "-o", out, "-q"});
+  EXPECT_EQ(r.exitCode, 0);
+  EXPECT_TRUE(mrpt::system::fileExists(out));
+}
+
+// ===========================================================================
+// --generate-3d-pointclouds / --undistort
+// ===========================================================================
+
+TEST_F(RawlogEditCLITest, GenerateThreeDPointClouds_NoMatchingObservations)
+{
+  const auto in = datasetCopy("test_rtk_path.rawlog");
+  const auto out = m_tempDir + "/pointclouds.rawlog";
+  const auto r = run({"--generate-3d-pointclouds", "-i", in, "-o", out, "-q"});
+  EXPECT_EQ(r.exitCode, 0);
+  EXPECT_TRUE(mrpt::system::fileExists(out));
+}
+
+TEST_F(RawlogEditCLITest, Undistort_NoMatchingObservations)
+{
+  const auto in = datasetCopy("test_rtk_path.rawlog");
+  const auto out = m_tempDir + "/undistorted.rawlog";
+  const auto r = run({"--undistort", "-i", in, "-o", out, "-q"});
+  EXPECT_EQ(r.exitCode, 0);
+  EXPECT_TRUE(mrpt::system::fileExists(out));
+}
+
+// ===========================================================================
+// Output file overwrite protection
+// ===========================================================================
+
+TEST_F(RawlogEditCLITest, OutputOverwrite_RequiresFlag)
+{
+  const auto in = datasetCopy("test_rtk_path.rawlog");
+  const auto out = m_tempDir + "/overwrite.rawlog";
+
+  const auto r1 = run({"--cut", "--from-index", "0", "-i", in, "-o", out, "-q", "-w"});
+  EXPECT_EQ(r1.exitCode, 0);
+  ASSERT_TRUE(mrpt::system::fileExists(out));
+
+  // Without -w/--overwrite, re-running must fail since the output exists.
+  const auto r2 = run({"--cut", "--from-index", "0", "-i", in, "-o", out, "-q"});
+  EXPECT_NE(r2.exitCode, 0);
+
+  // With -w/--overwrite, it must succeed.
+  const auto r3 = run({"--cut", "--from-index", "0", "-i", in, "-o", out, "-q", "-w"});
+  EXPECT_EQ(r3.exitCode, 0);
+}

--- a/modules/mrpt_system/src/filesystem.cpp
+++ b/modules/mrpt_system/src/filesystem.cpp
@@ -342,7 +342,7 @@ bool mrpt::system::copyFile(
     return true;
   }
 
-  if (outErrStr)
+  if (outErrStr != nullptr)
   {
     *outErrStr = ec.message();
   }

--- a/modules/mrpt_system/src/os.cpp
+++ b/modules/mrpt_system/src/os.cpp
@@ -23,6 +23,9 @@
 #include <mrpt/version.h>
 #include <sys/stat.h>
 #include <sys/types.h>
+#ifndef _WIN32
+#include <sys/wait.h>
+#endif
 
 #include <cctype>
 #include <cerrno>
@@ -698,7 +701,10 @@ int executeCommand(
   {
     sout << "Popen Execution failed!"
          << "\n";
-    *output = sout.str();
+    if (output)
+    {
+      *output = sout.str();
+    }
     return -1;
   }
 
@@ -710,6 +716,10 @@ int executeCommand(
 
   // Close
   exit_code = pclose(in);
+  if (exit_code != -1 && WIFEXITED(exit_code))
+  {
+    exit_code = WEXITSTATUS(exit_code);
+  }
 #else
   try
   {


### PR DESCRIPTION
## Summary
- Adds a black-box test suite (`modules/mrpt_libapps_cli/tests/rawlog-edit_unittest.cpp`) for the `rawlog-edit` CLI tool, invoking the built binary against sample datasets in `mrpt_data/datasets/`. Covers `--info`, `--describe`, `--list-*`, `--export-*`, `--cut`, `--remove-label`, `--keep-label`, `--remap-timestamps`, `--rename-externals`, `--sensors-pose`, `--recalc-odometry`, `--camera-params`, `--externalize`, `--de-externalize`, `--generate-3d-pointclouds`, `--undistort`, and various error paths (41 test cases total).
- Fixes a bug in `CRawlogProcessor` (`modules/mrpt_libapps_cli/include/mrpt/apps_cli/CRawlogProcessor.h`) where `--cut`, `--remove-label` and `--keep-label` did not actually filter the output rawlog, because the per-observation pointer used by filtering operations was a value copy instead of a reference into `obs`/`SF`.
- Fixes a bug shared by `rawlog-edit_gps.cpp`, `rawlog-edit_export_txt.cpp`, `rawlog-edit_enose.cpp` and `rawlog-edit_rawdaq.cpp`, where the output file prefix was built by concatenating the input file's directory and base name without a path separator, producing a malformed path (and silently no output files) whenever the input rawlog path had a directory component.
- Fixes `mrpt::system::executeCommand` to decode the real process exit code (instead of the raw `waitpid` status) and to avoid dereferencing a null `output` pointer on `popen` failure.

## Test plan
- [x] `colcon build --packages-up-to mrpt_libapps_cli` succeeds
- [x] `colcon test --packages-select mrpt_system mrpt_libapps_cli` passes (41/41 new tests pass)
- [x] CI build/test on GitHub Actions

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Windows compatibility and more reliable Unix exit-code handling for executed commands.
  * `rawlog-edit` now consistently uses a rawlog-derived output filename prefix across export operations (ENOSE/TXT/CSV/GPS/RAWDAQ).
  * Per-observation processing updates now correctly carry through to later post-processing steps.
* **Tests**
  * Added comprehensive end-to-end GoogleTest coverage for the `rawlog-edit` CLI, including help/version, listing, filtering, transformations, exporters, and overwrite protection. 
  * Included new rawlog edit unit tests in the build.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->