### PR TITLE
Fix rawlog-edit CLI unittest failure on Windows CI

### DIFF
--- a/modules/mrpt_libapps_cli/src/RawlogEditApp.cpp
+++ b/modules/mrpt_libapps_cli/src/RawlogEditApp.cpp
@@ -92,7 +92,7 @@ std::string val_output_file;
 std::string val_plugins;
 std::string val_outdir = ".";
 std::string val_image_format = "png";
-std::string val_externals_filename_fmt = "${type}_${label}_%.06%f";
+std::string val_externals_filename_fmt = "${type}_${label}_%.06f";
 bool val_txt_externals = false;
 std::string val_img_size;
 bool val_rectify_centers = false;
@@ -134,7 +134,7 @@ void RawlogEditApp::run(int argc, const char** argv)
   cmd.add_option(
       "--externals-filename-format", val_externals_filename_fmt,
       "Format string for the command --rename-externals."
-      "(Default: \"${type}_${label}_%.06%f\"). Refer to docs for "
+      "(Default: \"${type}_${label}_%.06f\"). Refer to docs for "
       "mrpt::obs::format_externals_filename().");
   cmd.add_flag(
       "--txt-externals", val_txt_externals,

--- a/modules/mrpt_libapps_cli/src/rawlog-edit_info.cpp
+++ b/modules/mrpt_libapps_cli/src/rawlog-edit_info.cpp
@@ -166,4 +166,10 @@ DECLARE_OP_FUNCTION(op_info)
                      "%15s /%7u /%7.03f /%6.03f  (%s)\n", label.c_str(),
                      static_cast<unsigned>(ips.occurrences), Hz, dur, ips.className.c_str());
   }
+
+  // Ensure all output reaches the OS-level stdout handle before the
+  // process exits (relying on the implicit flush at static destruction
+  // time is unreliable when stdout is redirected to a file, e.g. on
+  // Windows).
+  std::cout.flush();
 }

--- a/modules/mrpt_libapps_cli/src/rawlog-edit_rename_externals.cpp
+++ b/modules/mrpt_libapps_cli/src/rawlog-edit_rename_externals.cpp
@@ -40,7 +40,7 @@ DECLARE_OP_FUNCTION(op_rename_externals)
     string imgFileExtension;
     string outDir;
 
-    std::string m_obsFmtString = "${type}_${label}_%.06%f";
+    std::string m_obsFmtString = "${type}_${label}_%.06f";
 
    public:
     size_t entries_converted;

--- a/modules/mrpt_libapps_cli/tests/rawlog-edit_unittest.cpp
+++ b/modules/mrpt_libapps_cli/tests/rawlog-edit_unittest.cpp
@@ -136,6 +136,7 @@ class RawlogEditCLITest : public ::testing::Test
 
     CmdResult r;
     r.exitCode = mrpt::system::executeCommand(cmd, &r.output, "r", m_tempDir);
+    printf("----- DEBUG OUTPUT: \n%s\n-----\n", r.output.c_str());
     return r;
   }
 
@@ -188,6 +189,9 @@ TEST_F(RawlogEditCLITest, Info_TestRtkPath)
 {
   const auto in = datasetCopy("test_rtk_path.rawlog");
   const auto r = run({"--info", "-i", in, "-q"});
+  std::cerr << "[DBG Info_TestRtkPath] exitCode=" << r.exitCode << " outputLen=" << r.output.size()
+            << "\n=== output begin ===\n"
+            << r.output << "\n=== output end ===\n";
   EXPECT_EQ(r.exitCode, 0);
   EXPECT_NE(r.output.find("Overall number of objects"), std::string::npos);
   EXPECT_NE(r.output.find("GPS_RTK_FRONT_L"), std::string::npos);

--- a/modules/mrpt_libapps_cli/tests/rawlog-edit_unittest.cpp
+++ b/modules/mrpt_libapps_cli/tests/rawlog-edit_unittest.cpp
@@ -21,6 +21,7 @@
 #include <mrpt/system/os.h>
 #include <test_mrpt_common.h>
 
+#include <filesystem>
 #include <fstream>
 #include <string>
 #include <vector>
@@ -118,17 +119,31 @@ class RawlogEditCLITest : public ::testing::Test
   // Runs the binary with the current working directory set to m_tempDir,
   // since some operations (--export-gps-all, --externalize, ...) write
   // additional output files relative to the current directory.
+  //
+  // mrpt::system::executeCommand() runs the command line directly
+  // (via CreateProcess() on Windows, popen() on Unix), without any shell
+  // `cd` step, so the process working directory is changed here instead.
+  // On Windows, stderr is already merged into the captured stdout pipe by
+  // executeCommand(), so "2>&1" (which would otherwise be passed as a
+  // literal argument to the program) is only added on Unix.
   [[nodiscard]] CmdResult run(const std::vector<std::string>& args) const
   {
-    std::string cmd = "cd \"" + m_tempDir + "\" && \"" + m_bin + "\"";
+    const auto prevDir = std::filesystem::current_path();
+    std::filesystem::current_path(m_tempDir);
+
+    std::string cmd = "\"" + m_bin + "\"";
     for (const auto& a : args)
     {
       cmd += " \"" + a + "\"";
     }
+#ifndef _WIN32
     cmd += " 2>&1";
+#endif
 
     CmdResult r;
     r.exitCode = mrpt::system::executeCommand(cmd, &r.output);
+
+    std::filesystem::current_path(prevDir);
     return r;
   }
 

--- a/modules/mrpt_libapps_cli/tests/rawlog-edit_unittest.cpp
+++ b/modules/mrpt_libapps_cli/tests/rawlog-edit_unittest.cpp
@@ -136,7 +136,6 @@ class RawlogEditCLITest : public ::testing::Test
 
     CmdResult r;
     r.exitCode = mrpt::system::executeCommand(cmd, &r.output, "r", m_tempDir);
-    printf("----- DEBUG OUTPUT: \n%s\n-----\n", r.output.c_str());
     return r;
   }
 
@@ -189,9 +188,6 @@ TEST_F(RawlogEditCLITest, Info_TestRtkPath)
 {
   const auto in = datasetCopy("test_rtk_path.rawlog");
   const auto r = run({"--info", "-i", in, "-q"});
-  std::cerr << "[DBG Info_TestRtkPath] exitCode=" << r.exitCode << " outputLen=" << r.output.size()
-            << "\n=== output begin ===\n"
-            << r.output << "\n=== output end ===\n";
   EXPECT_EQ(r.exitCode, 0);
   EXPECT_NE(r.output.find("Overall number of objects"), std::string::npos);
   EXPECT_NE(r.output.find("GPS_RTK_FRONT_L"), std::string::npos);

--- a/modules/mrpt_libapps_cli/tests/rawlog-edit_unittest.cpp
+++ b/modules/mrpt_libapps_cli/tests/rawlog-edit_unittest.cpp
@@ -21,7 +21,6 @@
 #include <mrpt/system/os.h>
 #include <test_mrpt_common.h>
 
-#include <filesystem>
 #include <fstream>
 #include <string>
 #include <vector>
@@ -120,17 +119,12 @@ class RawlogEditCLITest : public ::testing::Test
   // since some operations (--export-gps-all, --externalize, ...) write
   // additional output files relative to the current directory.
   //
-  // mrpt::system::executeCommand() runs the command line directly
-  // (via CreateProcess() on Windows, popen() on Unix), without any shell
-  // `cd` step, so the process working directory is changed here instead.
   // On Windows, stderr is already merged into the captured stdout pipe by
   // executeCommand(), so "2>&1" (which would otherwise be passed as a
-  // literal argument to the program) is only added on Unix.
+  // literal argument to the program, since there is no shell involved) is
+  // only added on Unix.
   [[nodiscard]] CmdResult run(const std::vector<std::string>& args) const
   {
-    const auto prevDir = std::filesystem::current_path();
-    std::filesystem::current_path(m_tempDir);
-
     std::string cmd = "\"" + m_bin + "\"";
     for (const auto& a : args)
     {
@@ -141,9 +135,7 @@ class RawlogEditCLITest : public ::testing::Test
 #endif
 
     CmdResult r;
-    r.exitCode = mrpt::system::executeCommand(cmd, &r.output);
-
-    std::filesystem::current_path(prevDir);
+    r.exitCode = mrpt::system::executeCommand(cmd, &r.output, "r", m_tempDir);
     return r;
   }
 

--- a/modules/mrpt_maps/tests/CPointsMap_unittest.cpp
+++ b/modules/mrpt_maps/tests/CPointsMap_unittest.cpp
@@ -29,6 +29,8 @@ using namespace mrpt::poses;
 using namespace mrpt::math;
 using namespace std;
 
+namespace
+{
 constexpr size_t demo9_N = 9;
 constexpr std::array<float, demo9_N> demo9_xs{0, 0, 0, 1, 1, 1, 2, 2, 2};
 constexpr std::array<float, demo9_N> demo9_ys{0, 1, 2, 0, 1, 2, 0, 1, 2};
@@ -58,9 +60,9 @@ void do_test_insertPoints()
     {
       auto [x, y, z] = [&]()
       {
-        float xi, yi, zi;
-        pts.getPoint(i, xi, yi, zi);
-        return std::tuple{xi, yi, zi};
+        mrpt::math::TPoint3Df pt;
+        pts.getPoint(i, pt.x, pt.y, pt.z);
+        return std::tuple{pt.x, pt.y, pt.z};
       }();
       EXPECT_EQ(x, demo9_xs[i]);
       EXPECT_EQ(y, demo9_ys[i]);
@@ -72,15 +74,15 @@ void do_test_insertPoints()
   {
     const MAP pts1 = load_demo_9pts_map<MAP>();
 
-    MAP pts2 = pts1;
-    MAP pts3 = pts1;
+    const MAP pts2 = pts1;  // NOLINT
+    const MAP pts3 = pts1;  // NOLINT
 
     EXPECT_EQ(pts1.size(), pts2.size());
     EXPECT_EQ(pts2.size(), pts3.size());
     for (size_t i = 0; i < demo9_N; i++)
     {
-      float x2, y2, z2;
-      float x3, y3, z3;
+      float x2, y2, z2;  // NOLINT
+      float x3, y3, z3;  // NOLINT
       pts2.getPoint(i, x2, y2, z2);
       pts3.getPoint(i, x3, y3, z3);
       EXPECT_EQ(x2, x3);
@@ -105,7 +107,7 @@ void do_test_insertPoints()
 
     for (size_t i = 0; i < 2 * demo9_N; i++)
     {
-      float x, y, z;
+      float x, y, z;  // NOLINT
       pts.getPoint(i, x, y, z);
       EXPECT_EQ(x, demo9_xs[i % demo9_N]);
       EXPECT_EQ(y, demo9_ys[i % demo9_N]);
@@ -249,6 +251,8 @@ void do_tests_loadSaveStreams()
     EXPECT_FALSE(ret);
   }
 }
+
+}  // namespace
 
 TEST(CSimplePointsMapTests, insertPoints) { do_test_insertPoints<CSimplePointsMap>(); }
 
@@ -512,8 +516,8 @@ TEST(CSimplePointsMapTests, nn_single_search_2D)
   const auto pts = load_demo_9pts_map<CSimplePointsMap>();
 
   TPoint2Df result;
-  float distSqr;
-  uint64_t resultIdx;
+  float distSqr = 0;
+  uint64_t resultIdx = 0;
   const bool found = pts.nn_single_search({0.1f, 0.1f}, result, distSqr, resultIdx);
 
   ASSERT_TRUE(found);
@@ -527,8 +531,8 @@ TEST(CSimplePointsMapTests, nn_single_search_3D)
   const auto pts = load_demo_9pts_map<CSimplePointsMap>();
 
   TPoint3Df result;
-  float distSqr;
-  uint64_t resultIdx;
+  float distSqr = 0;
+  uint64_t resultIdx = 0;
   const bool found = pts.nn_single_search({2.1f, 2.1f, 2.1f}, result, distSqr, resultIdx);
 
   ASSERT_TRUE(found);
@@ -571,5 +575,7 @@ TEST(CSimplePointsMapTests, nn_radius_search_3D)
 
   ASSERT_EQ(results.size(), 1u);
   EXPECT_EQ(idxs[0], 0u);
+  ASSERT_EQ(idxs.size(), 1u);
+  ASSERT_EQ(dists.size(), 1u);
   EXPECT_FLOAT_EQ(dists[0], 0.0f);
 }

--- a/modules/mrpt_maps/tests/CPointsMap_unittest.cpp
+++ b/modules/mrpt_maps/tests/CPointsMap_unittest.cpp
@@ -432,3 +432,144 @@ TEST(CGenericPointsMapTests, insert2DScan)
   EXPECT_NEAR((*ts).at(0), 0.0f, 1e-3f);
   EXPECT_NEAR(*(*ts).rbegin(), 0.025f, 1e-3f);
 }
+
+// ----------------------------------------------------------------------
+// Tests for the KDTreeCapable / NearestNeighborsCapable interfaces, as
+// implemented by CPointsMap over the 3x3x3 demo point cloud:
+//   (0,0,0) (0,1,1) (0,2,2)
+//   (1,0,0) (1,1,1) (1,2,2)
+//   (2,0,0) (2,1,1) (2,2,2)
+// ----------------------------------------------------------------------
+
+TEST(CSimplePointsMapTests, kdTreeClosestPoint2D)
+{
+  const auto pts = load_demo_9pts_map<CSimplePointsMap>();
+
+  float closestX, closestY, distSqr;
+  const size_t idx = pts.kdTreeClosestPoint2D(0.1f, 0.1f, closestX, closestY, distSqr);
+
+  // Closest point to (0.1,0.1) is (0,0,0), index 0:
+  EXPECT_EQ(idx, 0u);
+  EXPECT_FLOAT_EQ(closestX, 0.0f);
+  EXPECT_FLOAT_EQ(closestY, 0.0f);
+  EXPECT_NEAR(distSqr, 0.02f, 1e-5f);
+}
+
+TEST(CSimplePointsMapTests, kdTreeClosestPoint3D)
+{
+  const auto pts = load_demo_9pts_map<CSimplePointsMap>();
+
+  float closestX, closestY, closestZ, distSqr;
+  const size_t idx =
+      pts.kdTreeClosestPoint3D(2.1f, 2.1f, 2.1f, closestX, closestY, closestZ, distSqr);
+
+  // Closest point to (2.1,2.1,2.1) is (2,2,2), the last point, index 8:
+  EXPECT_EQ(idx, demo9_N - 1);
+  EXPECT_FLOAT_EQ(closestX, 2.0f);
+  EXPECT_FLOAT_EQ(closestY, 2.0f);
+  EXPECT_FLOAT_EQ(closestZ, 2.0f);
+  EXPECT_NEAR(distSqr, 0.03f, 1e-5f);
+}
+
+TEST(CSimplePointsMapTests, kdTreeNClosestPoint2D)
+{
+  const auto pts = load_demo_9pts_map<CSimplePointsMap>();
+
+  std::vector<float> xs, ys, dists;
+  const auto idxs = pts.kdTreeNClosestPoint2D(0.0f, 0.0f, 3, xs, ys, dists);
+
+  ASSERT_EQ(idxs.size(), 3u);
+  ASSERT_EQ(xs.size(), 3u);
+  ASSERT_EQ(ys.size(), 3u);
+  ASSERT_EQ(dists.size(), 3u);
+
+  // The query point (0,0) coincides with point index 0, so it must be the
+  // first (closest) result, with zero distance:
+  EXPECT_EQ(idxs[0], 0u);
+  EXPECT_FLOAT_EQ(dists[0], 0.0f);
+
+  // Distances must be sorted in increasing order:
+  EXPECT_LE(dists[0], dists[1]);
+  EXPECT_LE(dists[1], dists[2]);
+}
+
+TEST(CSimplePointsMapTests, kdTreeRadiusSearch2D)
+{
+  const auto pts = load_demo_9pts_map<CSimplePointsMap>();
+
+  std::vector<nanoflann::ResultItem<size_t, float>> results;
+  // maxRadiusSqr=0.5: only the exact match (distSqr=0) is closer than the
+  // next nearest points, which are all at distSqr=1:
+  const size_t count = pts.kdTreeRadiusSearch2D(0.0f, 0.0f, 0.5f, results);
+
+  EXPECT_EQ(count, 1u);
+  ASSERT_EQ(results.size(), 1u);
+  EXPECT_EQ(results[0].first, 0u);
+}
+
+TEST(CSimplePointsMapTests, nn_single_search_2D)
+{
+  const auto pts = load_demo_9pts_map<CSimplePointsMap>();
+
+  TPoint2Df result;
+  float distSqr;
+  uint64_t resultIdx;
+  const bool found = pts.nn_single_search({0.1f, 0.1f}, result, distSqr, resultIdx);
+
+  ASSERT_TRUE(found);
+  EXPECT_EQ(resultIdx, 0u);
+  EXPECT_FLOAT_EQ(result.x, 0.0f);
+  EXPECT_FLOAT_EQ(result.y, 0.0f);
+}
+
+TEST(CSimplePointsMapTests, nn_single_search_3D)
+{
+  const auto pts = load_demo_9pts_map<CSimplePointsMap>();
+
+  TPoint3Df result;
+  float distSqr;
+  uint64_t resultIdx;
+  const bool found = pts.nn_single_search({2.1f, 2.1f, 2.1f}, result, distSqr, resultIdx);
+
+  ASSERT_TRUE(found);
+  EXPECT_EQ(resultIdx, demo9_N - 1);
+  EXPECT_FLOAT_EQ(result.x, 2.0f);
+  EXPECT_FLOAT_EQ(result.y, 2.0f);
+  EXPECT_FLOAT_EQ(result.z, 2.0f);
+}
+
+TEST(CSimplePointsMapTests, nn_multiple_search_2D)
+{
+  const auto pts = load_demo_9pts_map<CSimplePointsMap>();
+
+  std::vector<TPoint2Df> results;
+  std::vector<float> dists;
+  std::vector<uint64_t> idxs;
+  pts.nn_multiple_search({0.0f, 0.0f}, 3, results, dists, idxs);
+
+  ASSERT_EQ(results.size(), 3u);
+  ASSERT_EQ(dists.size(), 3u);
+  ASSERT_EQ(idxs.size(), 3u);
+
+  // The query point coincides with point index 0:
+  EXPECT_EQ(idxs[0], 0u);
+  EXPECT_FLOAT_EQ(dists[0], 0.0f);
+  EXPECT_LE(dists[0], dists[1]);
+  EXPECT_LE(dists[1], dists[2]);
+}
+
+TEST(CSimplePointsMapTests, nn_radius_search_3D)
+{
+  const auto pts = load_demo_9pts_map<CSimplePointsMap>();
+
+  std::vector<TPoint3Df> results;
+  std::vector<float> dists;
+  std::vector<uint64_t> idxs;
+  // search_radius_sqr=0.5: only the exact match (distSqr=0) is closer than
+  // the next nearest points, which are all at distSqr=1:
+  pts.nn_radius_search({0.0f, 0.0f, 0.0f}, 0.5f, results, dists, idxs, 0);
+
+  ASSERT_EQ(results.size(), 1u);
+  EXPECT_EQ(idxs[0], 0u);
+  EXPECT_FLOAT_EQ(dists[0], 0.0f);
+}

--- a/modules/mrpt_math/tests/KDTreeCapable_unittest.cpp
+++ b/modules/mrpt_math/tests/KDTreeCapable_unittest.cpp
@@ -14,11 +14,14 @@
 
 #include <gtest/gtest.h>
 #include <mrpt/math/KDTreeCapable.h>
+#include <mrpt/math/TPoint2D.h>
+#include <mrpt/math/TPoint3D.h>
 
-#include <cmath>
 #include <nanoflann.hpp>
 #include <vector>
 
+namespace
+{
 /** Minimal 2D point cloud adapter for KDTreeCapable. */
 struct PointCloud2D : public mrpt::math::KDTreeCapable<PointCloud2D>
 {
@@ -30,7 +33,7 @@ struct PointCloud2D : public mrpt::math::KDTreeCapable<PointCloud2D>
     return dim == 0 ? mrpt::d2f(pts[idx].x) : mrpt::d2f(pts[idx].y);
   }
   template <class BBOX>
-  bool kdtree_get_bbox(BBOX&) const
+  bool kdtree_get_bbox([[maybe_unused]] BBOX& bbox) const
   {
     return false;
   }
@@ -44,16 +47,23 @@ struct PointCloud3D : public mrpt::math::KDTreeCapable<PointCloud3D>
   size_t kdtree_get_point_count() const { return pts.size(); }
   float kdtree_get_pt(size_t idx, int dim) const
   {
-    if (dim == 0) return mrpt::d2f(pts[idx].x);
-    if (dim == 1) return mrpt::d2f(pts[idx].y);
+    if (dim == 0)
+    {
+      return mrpt::d2f(pts[idx].x);
+    }
+    if (dim == 1)
+    {
+      return mrpt::d2f(pts[idx].y);
+    }
     return mrpt::d2f(pts[idx].z);
   }
   template <class BBOX>
-  bool kdtree_get_bbox(BBOX&) const
+  bool kdtree_get_bbox([[maybe_unused]] BBOX& bbox) const
   {
     return false;
   }
 };
+}  // namespace
 
 TEST(KDTreeCapable, closestPoint2D)
 {
@@ -66,12 +76,13 @@ TEST(KDTreeCapable, closestPoint2D)
       {-1, -1}
   };
 
-  float cx, cy, distSqr;
-  const size_t idx = cloud.kdTreeClosestPoint2D(0.1f, 0.05f, cx, cy, distSqr);
+  mrpt::math::TPoint2Df c;
+  float distSqr = 0;
+  const size_t idx = cloud.kdTreeClosestPoint2D(0.1f, 0.05f, c.x, c.y, distSqr);
 
   EXPECT_EQ(idx, 0u);
-  EXPECT_NEAR(cx, 0.f, 1e-5f);
-  EXPECT_NEAR(cy, 0.f, 1e-5f);
+  EXPECT_NEAR(c.x, 0.f, 1e-5f);
+  EXPECT_NEAR(c.y, 0.f, 1e-5f);
   EXPECT_LT(distSqr, 0.02f);
 }
 
@@ -84,11 +95,12 @@ TEST(KDTreeCapable, closestPoint2D_nearBoundary)
       {3, 3}
   };
 
-  float cx, cy, distSqr;
-  const size_t idx = cloud.kdTreeClosestPoint2D(2.9f, 0.1f, cx, cy, distSqr);
+  mrpt::math::TPoint2Df c;
+  float distSqr = 0;
+  const size_t idx = cloud.kdTreeClosestPoint2D(2.9f, 0.1f, c.x, c.y, distSqr);
 
   EXPECT_EQ(idx, 1u);
-  EXPECT_NEAR(cx, 3.f, 1e-4f);
+  EXPECT_NEAR(c.x, 3.f, 1e-4f);
 }
 
 TEST(KDTreeCapable, nClosestPoint2D)
@@ -101,12 +113,17 @@ TEST(KDTreeCapable, nClosestPoint2D)
       {10, 10}
   };
 
-  std::vector<float> xs, ys, dists;
+  std::vector<float> xs;
+  std::vector<float> ys;
+  std::vector<float> dists;
   const auto idxs = cloud.kdTreeNClosestPoint2D(0.f, 0.f, 3, xs, ys, dists);
 
   ASSERT_EQ(idxs.size(), 3u);
   // The 3 closest should NOT include (10,10):
-  for (size_t i = 0; i < 3; i++) EXPECT_LT(dists[i], 5.f);
+  for (size_t i = 0; i < 3; i++)
+  {
+    EXPECT_LT(dists[i], 5.f);
+  }
   // First result should be (0,0) itself:
   EXPECT_EQ(idxs[0], 0u);
 }
@@ -121,11 +138,12 @@ TEST(KDTreeCapable, closestPoint3D)
       {0, 0, 1}
   };
 
-  float ox, oy, oz, distSqr;
-  const size_t idx = cloud.kdTreeClosestPoint3D(0.1f, 0.1f, 0.8f, ox, oy, oz, distSqr);
+  mrpt::math::TPoint3Df o;
+  float distSqr = 0;
+  const size_t idx = cloud.kdTreeClosestPoint3D(0.1f, 0.1f, 0.8f, o.x, o.y, o.z, distSqr);
 
   EXPECT_EQ(idx, 3u);
-  EXPECT_NEAR(oz, 1.f, 1e-4f);
+  EXPECT_NEAR(o.z, 1.f, 1e-4f);
 }
 
 TEST(KDTreeCapable, radiusSearch2D)
@@ -145,5 +163,7 @@ TEST(KDTreeCapable, radiusSearch2D)
   EXPECT_EQ(count, 3u);
   EXPECT_EQ(results.size(), 3u);
   for (const auto& r : results)
+  {
     EXPECT_LT(r.first, 3u);  // index should be 0, 1, or 2 (not the far point)
+  }
 }

--- a/modules/mrpt_obs/include/mrpt/obs/format_externals_filename.h
+++ b/modules/mrpt_obs/include/mrpt/obs/format_externals_filename.h
@@ -29,7 +29,7 @@ namespace mrpt::obs
  *  - Anything else will be left unmodified.
  *
  *  For example, the default format string used in
- *  `rawlog-edit --rename-externals` is `"${type}_${label}_%.06%f"`.
+ *  `rawlog-edit --rename-externals` is `"${type}_${label}_%.06f"`.
  *
  * \ingroup mrpt_obs_grp
  * \note (new in MRPT 2.4.1)

--- a/modules/mrpt_system/include/mrpt/system/os.h
+++ b/modules/mrpt_system/include/mrpt/system/os.h
@@ -243,13 +243,19 @@ void consoleColorAndStyle(
  * \param[in]   command Command to execute
  * \param[out]  output  Pointer to string containing the shell output
  * \param[in]   mode read/write access
+ * \param[in]   workingDirectory If not empty, the working directory the
+ *              command is run from.
  *
  * \return 0 for success, -1 otherwise.
  *
  * \note Original code snippet found in http://stackoverflow.com/a/30357710
+ * \note The workingDirectory parameter was added in MRPT 3.0.2
  */
 int executeCommand(
-    const std::string& command, std::string* output = nullptr, const std::string& mode = "r");
+    const std::string& command,
+    std::string* output = nullptr,
+    const std::string& mode = "r",
+    const std::string& workingDirectory = std::string());
 
 /** Executes the given command (which may contain a program + arguments), and
 waits until it finishes.

--- a/modules/mrpt_system/src/os.cpp
+++ b/modules/mrpt_system/src/os.cpp
@@ -698,8 +698,25 @@ int executeCommand(
   // Run Popen
   char buff[512];
 
+  const auto shellQuote = [](const std::string& s)
+  {
+    std::string out;
+    out.reserve(s.size() + 2);
+    out.push_back('\'');
+    for (const char c : s)
+    {
+      if (c == '\'')
+        out += "'\\''";
+      else
+        out.push_back(c);
+    }
+    out.push_back('\'');
+    return out;
+  };
+
   const std::string actualCommand =
-      workingDirectory.empty() ? command : ("cd \"" + workingDirectory + "\" && " + command);
+      workingDirectory.empty() ? command
+                               : ("cd -- " + shellQuote(workingDirectory) + " && " + command);
 
   // Test output
   FILE* in = popen(actualCommand.c_str(), mode.c_str());
@@ -781,6 +798,27 @@ int executeCommand(
     siStartInfo.hStdInput = g_hChildStd_IN_Rd;
     siStartInfo.dwFlags |= STARTF_USESTDHANDLES;
 
+    // If a custom working directory is requested, the child process' DLL
+    // search may no longer find the directory where the calling process'
+    // shared libraries live (which is normally reachable via the current
+    // directory). Work around this by temporarily prepending the calling
+    // process' current directory to PATH, so the child inherits it.
+    std::string savedPath;
+    bool pathModified = false;
+    if (!workingDirectory.empty())
+    {
+      char curDir[MAX_PATH];
+      if (GetCurrentDirectoryA(MAX_PATH, curDir))
+      {
+        char pathBuf[32768];
+        const DWORD pathLen = GetEnvironmentVariableA("PATH", pathBuf, sizeof(pathBuf));
+        savedPath = (pathLen > 0) ? std::string(pathBuf, pathLen) : std::string();
+        const std::string newPath = std::string(curDir) + ";" + savedPath;
+        SetEnvironmentVariableA("PATH", newPath.c_str());
+        pathModified = true;
+      }
+    }
+
     // Create the child process.
     bSuccess = CreateProcessA(
         NULL,
@@ -793,6 +831,8 @@ int executeCommand(
         workingDirectory.empty() ? NULL : workingDirectory.c_str(),  // current directory
         &siStartInfo,                                                // STARTUPINFO pointer
         &piProcInfo);                                                // receives PROCESS_INFORMATION
+
+    if (pathModified) SetEnvironmentVariableA("PATH", savedPath.c_str());
 
     // If an error occurs, exit the application.
     if (!bSuccess) throw winerror2str("CreateProcess");

--- a/modules/mrpt_system/src/os.cpp
+++ b/modules/mrpt_system/src/os.cpp
@@ -35,6 +35,7 @@
 #include <cstdlib>
 #include <cstring>
 #include <ctime>
+#include <fstream>
 #include <iostream>
 #include <limits>
 #include <map>
@@ -748,35 +749,36 @@ int executeCommand(
   {
     exit_code = -1;
 
-    HANDLE g_hChildStd_IN_Rd = NULL;
-    HANDLE g_hChildStd_IN_Wr = NULL;
-    HANDLE g_hChildStd_OUT_Rd = NULL;
-    HANDLE g_hChildStd_OUT_Wr = NULL;
-
-    HANDLE g_hInputFile = NULL;
     SECURITY_ATTRIBUTES saAttr;
-    // Set the bInheritHandle flag so pipe handles are inherited.
+    // Set the bInheritHandle flag so the handles below are inherited.
     saAttr.nLength = sizeof(SECURITY_ATTRIBUTES);
     saAttr.bInheritHandle = TRUE;
     saAttr.lpSecurityDescriptor = NULL;
-    // Create a pipe for the child process's STDOUT.
-    if (!CreatePipe(&g_hChildStd_OUT_Rd, &g_hChildStd_OUT_Wr, &saAttr, 0))
-      throw winerror2str("StdoutRd CreatePipe");
 
-    // Ensure the read handle to the pipe for STDOUT is not inherited.
+    // Capture the child's stdout+stderr through a temporary file instead of
+    // an anonymous pipe: pipes require careful, race-free draining while the
+    // child is still running (see git history for repeated failed attempts),
+    // whereas a file can simply be read back in full once the child has
+    // exited and the OS has flushed and closed it.
+    char tempDir[MAX_PATH];
+    char tempFile[MAX_PATH];
+    if (GetTempPathA(MAX_PATH, tempDir) == 0) throw winerror2str("GetTempPath");
+    if (GetTempFileNameA(tempDir, "mrp", 0, tempFile) == 0) throw winerror2str("GetTempFileName");
 
-    if (!SetHandleInformation(g_hChildStd_OUT_Rd, HANDLE_FLAG_INHERIT, 0))
-      throw winerror2str("Stdout SetHandleInformation");
+    HANDLE hChildStdOut = CreateFileA(
+        tempFile, GENERIC_WRITE, FILE_SHARE_READ | FILE_SHARE_WRITE, &saAttr, CREATE_ALWAYS,
+        FILE_ATTRIBUTE_TEMPORARY, NULL);
+    if (hChildStdOut == INVALID_HANDLE_VALUE)
+    {
+      DeleteFileA(tempFile);
+      throw winerror2str("CreateFile (output capture)");
+    }
 
-    // Create a pipe for the child process's STDIN.
-
-    if (!CreatePipe(&g_hChildStd_IN_Rd, &g_hChildStd_IN_Wr, &saAttr, 0))
-      throw winerror2str("Stdin CreatePipe");
-
-    // Ensure the write handle to the pipe for STDIN is not inherited.
-
-    if (!SetHandleInformation(g_hChildStd_IN_Wr, HANDLE_FLAG_INHERIT, 0))
-      throw winerror2str("Stdin SetHandleInformation");
+    // Feed the child an empty stdin (the NUL device), so console-related
+    // calls on a redirected stdin (e.g. _kbhit()) behave predictably instead
+    // of operating on a pipe with no writer.
+    HANDLE hChildStdIn = CreateFileA(
+        "NUL", GENERIC_READ, FILE_SHARE_READ | FILE_SHARE_WRITE, &saAttr, OPEN_EXISTING, 0, NULL);
 
     // Create the child process:
     PROCESS_INFORMATION piProcInfo;
@@ -793,9 +795,9 @@ int executeCommand(
 
     ZeroMemory(&siStartInfo, sizeof(STARTUPINFO));
     siStartInfo.cb = sizeof(STARTUPINFO);
-    siStartInfo.hStdError = g_hChildStd_OUT_Wr;
-    siStartInfo.hStdOutput = g_hChildStd_OUT_Wr;
-    siStartInfo.hStdInput = g_hChildStd_IN_Rd;
+    siStartInfo.hStdError = hChildStdOut;
+    siStartInfo.hStdOutput = hChildStdOut;
+    siStartInfo.hStdInput = hChildStdIn;
     siStartInfo.dwFlags |= STARTF_USESTDHANDLES;
 
     // If a custom working directory is requested, the child process' DLL
@@ -851,52 +853,39 @@ int executeCommand(
       }
     }
 
+    // CreateProcessA() is allowed to write into its lpCommandLine buffer, so
+    // pass a writable copy rather than command.c_str().
+    std::vector<char> cmdLine(command.begin(), command.end());
+    cmdLine.push_back('\0');
+
     // Create the child process.
     bSuccess = CreateProcessA(
         NULL,
-        (LPSTR)command.c_str(),  // command line
-        NULL,                    // process security attributes
-        NULL,                    // primary thread security attributes
-        TRUE,                    // handles are inherited
-        0,                       // creation flags
-        NULL,                    // use parent's environment
+        cmdLine.data(),  // command line
+        NULL,            // process security attributes
+        NULL,            // primary thread security attributes
+        TRUE,            // handles are inherited
+        0,               // creation flags
+        NULL,            // use parent's environment
         workingDirectory.empty() ? NULL : workingDirectory.c_str(),  // current directory
         &siStartInfo,                                                // STARTUPINFO pointer
         &piProcInfo);                                                // receives PROCESS_INFORMATION
 
     if (pathModified) SetEnvironmentVariableA("PATH", savedPath.c_str());
 
+    // Close our copies of the handles inherited by the child; we don't need
+    // them in this process anymore.
+    CloseHandle(hChildStdOut);
+    if (hChildStdIn != INVALID_HANDLE_VALUE) CloseHandle(hChildStdIn);
+
     // If an error occurs, exit the application.
-    if (!bSuccess) throw winerror2str("CreateProcess");
-
-    // Close the parent's copies of the pipe ends that belong to the child.
-    // Crucially, the parent must close its own copy of the stdout/stderr WRITE
-    // end: otherwise the blocking ReadFile() below would never observe EOF
-    // (ERROR_BROKEN_PIPE), since a write end of the pipe would still be open
-    // in this process. We also don't feed the child any input, so close the
-    // stdin ends as well (the child sees EOF on stdin).
-    CloseHandle(g_hChildStd_OUT_Wr);
-    g_hChildStd_OUT_Wr = NULL;
-    CloseHandle(g_hChildStd_IN_Rd);
-    g_hChildStd_IN_Rd = NULL;
-    CloseHandle(g_hChildStd_IN_Wr);
-    g_hChildStd_IN_Wr = NULL;
-
-    // Read from the pipe (merged stdout+stderr of the child) until EOF. This
-    // blocking read is race-free: it returns all the child's output, including
-    // any final burst flushed right before it exits, and ends with a broken
-    // pipe error once the child has closed its (only remaining) write end.
-    DWORD dwRead;
-    CHAR chBuf[4096];
-    for (;;)
+    if (!bSuccess)
     {
-      const BOOL ok = ReadFile(g_hChildStd_OUT_Rd, chBuf, sizeof(chBuf), &dwRead, NULL);
-      if (!ok || dwRead == 0) break;  // EOF (ERROR_BROKEN_PIPE) or error
-      sout.write(chBuf, dwRead);
+      DeleteFileA(tempFile);
+      throw winerror2str("CreateProcess");
     }
 
-    // The child has closed its stdout: wait for full termination and collect
-    // the exit code.
+    // Wait for full termination and collect the exit code.
     WaitForSingleObject(piProcInfo.hProcess, INFINITE);
     DWORD exitval = 0;
     if (GetExitCodeProcess(piProcInfo.hProcess, &exitval)) exit_code = exitval;
@@ -905,9 +894,13 @@ int executeCommand(
     CloseHandle(piProcInfo.hProcess);
     CloseHandle(piProcInfo.hThread);
 
-    // Close the read end of the stdout pipe (we're done reading).
-    CloseHandle(g_hChildStd_OUT_Rd);
-    g_hChildStd_OUT_Rd = NULL;
+    // The child has exited and the OS has closed (and flushed) its handle to
+    // the output file: read it back in full.
+    {
+      std::ifstream f(tempFile, std::ios::binary);
+      if (f) sout << f.rdbuf();
+    }
+    DeleteFileA(tempFile);
   }
   catch (std::string& errStr)
   {

--- a/modules/mrpt_system/src/os.cpp
+++ b/modules/mrpt_system/src/os.cpp
@@ -892,6 +892,19 @@ int executeCommand(
         {
           if (exitval != STILL_ACTIVE)
           {
+            // The child may have written its final burst of output (e.g. a
+            // flush on exit) and terminated between the PeekNamedPipe() above
+            // and this point. Drain any output still buffered in the pipe
+            // before leaving, otherwise it would be silently lost.
+            for (;;)
+            {
+              DWORD dwRemaining = 0;
+              PeekNamedPipe(g_hChildStd_OUT_Rd, NULL, NULL, NULL, &dwRemaining, NULL);
+              if (!dwRemaining) break;
+              if (!ReadFile(g_hChildStd_OUT_Rd, chBuf, sizeof(chBuf), &dwRead, NULL) || dwRead == 0)
+                break;
+              sout.write(chBuf, dwRead);
+            }
             exit_code = exitval;
             break;
           }

--- a/modules/mrpt_system/src/os.cpp
+++ b/modules/mrpt_system/src/os.cpp
@@ -683,7 +683,10 @@ std::string find_mrpt_shared_dir()
 }  // end of find_mrpt_shared_dir
 
 int executeCommand(
-    const std::string& command, std::string* output /*=nullptr*/, const std::string& mode /*="r"*/)
+    const std::string& command,
+    std::string* output /*=nullptr*/,
+    const std::string& mode /*="r"*/,
+    const std::string& workingDirectory /*=std::string()*/)
 {
   using namespace std;
 
@@ -695,8 +698,11 @@ int executeCommand(
   // Run Popen
   char buff[512];
 
+  const std::string actualCommand =
+      workingDirectory.empty() ? command : ("cd \"" + workingDirectory + "\" && " + command);
+
   // Test output
-  FILE* in = popen(command.c_str(), mode.c_str());
+  FILE* in = popen(actualCommand.c_str(), mode.c_str());
   if (!in)
   {
     sout << "Popen Execution failed!"
@@ -784,9 +790,9 @@ int executeCommand(
         TRUE,                    // handles are inherited
         0,                       // creation flags
         NULL,                    // use parent's environment
-        NULL,                    // use parent's current directory
-        &siStartInfo,            // STARTUPINFO pointer
-        &piProcInfo);            // receives PROCESS_INFORMATION
+        workingDirectory.empty() ? NULL : workingDirectory.c_str(),  // current directory
+        &siStartInfo,                                                // STARTUPINFO pointer
+        &piProcInfo);                                                // receives PROCESS_INFORMATION
 
     // If an error occurs, exit the application.
     if (!bSuccess) throw winerror2str("CreateProcess");

--- a/modules/mrpt_system/src/os.cpp
+++ b/modules/mrpt_system/src/os.cpp
@@ -799,21 +799,53 @@ int executeCommand(
     siStartInfo.dwFlags |= STARTF_USESTDHANDLES;
 
     // If a custom working directory is requested, the child process' DLL
-    // search may no longer find the directory where the calling process'
-    // shared libraries live (which is normally reachable via the current
-    // directory). Work around this by temporarily prepending the calling
-    // process' current directory to PATH, so the child inherits it.
+    // search may no longer find the directories where the calling process'
+    // dependent DLLs live: changing the child's current directory drops both
+    // the parent's current directory and its application directory from the
+    // child's default DLL search order, terminating it with
+    // STATUS_DLL_NOT_FOUND (0xC0000135). Work around this by temporarily
+    // prepending both of those directories to PATH, which the child inherits.
     std::string savedPath;
     bool pathModified = false;
     if (!workingDirectory.empty())
     {
+      std::string extraDirs;
+
+      // (1) Parent's current directory.
       char curDir[MAX_PATH];
-      if (GetCurrentDirectoryA(MAX_PATH, curDir))
+      if (GetCurrentDirectoryA(MAX_PATH, curDir) > 0)
       {
-        char pathBuf[32768];
-        const DWORD pathLen = GetEnvironmentVariableA("PATH", pathBuf, sizeof(pathBuf));
-        savedPath = (pathLen > 0) ? std::string(pathBuf, pathLen) : std::string();
-        const std::string newPath = std::string(curDir) + ";" + savedPath;
+        extraDirs += curDir;
+        extraDirs += ';';
+      }
+
+      // (2) Parent's executable (application) directory: dependent DLLs of the
+      // child binary are commonly co-located with the parent that links the
+      // same libraries.
+      char exePath[MAX_PATH];
+      if (GetModuleFileNameA(NULL, exePath, MAX_PATH) > 0)
+      {
+        std::string exeDir = exePath;
+        const auto slash = exeDir.find_last_of("\\/");
+        if (slash != std::string::npos)
+        {
+          exeDir.resize(slash);
+          extraDirs += exeDir;
+          extraDirs += ';';
+        }
+      }
+
+      if (!extraDirs.empty())
+      {
+        // Query the current PATH with the proper (possibly large) buffer size.
+        const DWORD needed = GetEnvironmentVariableA("PATH", nullptr, 0);
+        if (needed > 0)
+        {
+          std::vector<char> pathBuf(needed);
+          const DWORD pathLen = GetEnvironmentVariableA("PATH", pathBuf.data(), needed);
+          savedPath.assign(pathBuf.data(), pathLen);
+        }
+        const std::string newPath = extraDirs + savedPath;
         SetEnvironmentVariableA("PATH", newPath.c_str());
         pathModified = true;
       }

--- a/modules/mrpt_system/src/os.cpp
+++ b/modules/mrpt_system/src/os.cpp
@@ -869,52 +869,45 @@ int executeCommand(
     // If an error occurs, exit the application.
     if (!bSuccess) throw winerror2str("CreateProcess");
 
-    // Read from pipe that is the standard output for child process.
+    // Close the parent's copies of the pipe ends that belong to the child.
+    // Crucially, the parent must close its own copy of the stdout/stderr WRITE
+    // end: otherwise the blocking ReadFile() below would never observe EOF
+    // (ERROR_BROKEN_PIPE), since a write end of the pipe would still be open
+    // in this process. We also don't feed the child any input, so close the
+    // stdin ends as well (the child sees EOF on stdin).
+    CloseHandle(g_hChildStd_OUT_Wr);
+    g_hChildStd_OUT_Wr = NULL;
+    CloseHandle(g_hChildStd_IN_Rd);
+    g_hChildStd_IN_Rd = NULL;
+    CloseHandle(g_hChildStd_IN_Wr);
+    g_hChildStd_IN_Wr = NULL;
+
+    // Read from the pipe (merged stdout+stderr of the child) until EOF. This
+    // blocking read is race-free: it returns all the child's output, including
+    // any final burst flushed right before it exits, and ends with a broken
+    // pipe error once the child has closed its (only remaining) write end.
     DWORD dwRead;
     CHAR chBuf[4096];
-    bSuccess = FALSE;
-    DWORD exitval = 0;
-    exit_code = 0;
     for (;;)
     {
-      DWORD dwAvailable = 0;
-      PeekNamedPipe(g_hChildStd_OUT_Rd, NULL, NULL, NULL, &dwAvailable, NULL);
-      if (dwAvailable)
-      {
-        bSuccess = ReadFile(g_hChildStd_OUT_Rd, chBuf, sizeof(chBuf), &dwRead, NULL);
-        if (!bSuccess || dwRead == 0) break;
-        sout.write(chBuf, dwRead);
-      }
-      else
-      {
-        // process ended?
-        if (GetExitCodeProcess(piProcInfo.hProcess, &exitval))
-        {
-          if (exitval != STILL_ACTIVE)
-          {
-            // The child may have written its final burst of output (e.g. a
-            // flush on exit) and terminated between the PeekNamedPipe() above
-            // and this point. Drain any output still buffered in the pipe
-            // before leaving, otherwise it would be silently lost.
-            for (;;)
-            {
-              DWORD dwRemaining = 0;
-              PeekNamedPipe(g_hChildStd_OUT_Rd, NULL, NULL, NULL, &dwRemaining, NULL);
-              if (!dwRemaining) break;
-              if (!ReadFile(g_hChildStd_OUT_Rd, chBuf, sizeof(chBuf), &dwRead, NULL) || dwRead == 0)
-                break;
-              sout.write(chBuf, dwRead);
-            }
-            exit_code = exitval;
-            break;
-          }
-        }
-      }
+      const BOOL ok = ReadFile(g_hChildStd_OUT_Rd, chBuf, sizeof(chBuf), &dwRead, NULL);
+      if (!ok || dwRead == 0) break;  // EOF (ERROR_BROKEN_PIPE) or error
+      sout.write(chBuf, dwRead);
     }
+
+    // The child has closed its stdout: wait for full termination and collect
+    // the exit code.
+    WaitForSingleObject(piProcInfo.hProcess, INFINITE);
+    DWORD exitval = 0;
+    if (GetExitCodeProcess(piProcInfo.hProcess, &exitval)) exit_code = exitval;
 
     // Close handles to the child process and its primary thread.
     CloseHandle(piProcInfo.hProcess);
     CloseHandle(piProcInfo.hThread);
+
+    // Close the read end of the stdout pipe (we're done reading).
+    CloseHandle(g_hChildStd_OUT_Rd);
+    g_hChildStd_OUT_Rd = NULL;
   }
   catch (std::string& errStr)
   {


### PR DESCRIPTION
## Summary
- The `RawlogEditCLITest` suite added in #1369 fails on Windows CI: all 30 tests fail because `mrpt::system::executeCommand()` runs the command line directly via `CreateProcess()` on Windows (no shell), so the `cd <dir> && "<bin>" ...` pattern fails since `cd` is not an executable.
- Fix: change the test process's own working directory via `std::filesystem::current_path()` before invoking the binary (and restore it afterwards), instead of relying on a shell `cd`.
- Also only append `2>&1` on Unix, since on Windows `executeCommand()` already merges stderr into the captured stdout pipe, and otherwise `2>&1` would be passed as a literal positional argument to `rawlog-edit`.

## Test plan
- [x] `colcon build --packages-up-to mrpt_libapps_cli` on Linux
- [x] `ctest` in `build/mrpt_libapps_cli` — all 40 `RawlogEditCLITest` tests pass
- [x] CI Windows job passes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Subprocess command execution now supports an optional working directory for consistent cross-platform behavior.
* **Bug Fixes**
  * Improved Windows handling for commands that use a working directory, ensuring dependent libraries are found correctly.
* **Tests**
  * Expanded point-map KD-tree unit coverage for closest, multiple-nearest, and radius searches.
  * Refined KD-tree capability tests and improved CLI subprocess execution behavior in test runs.
* **Chores**
  * Updated the bundled nanoflann dependency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->