### PR TITLE
mrpt_opengl: Add opengl build_depend back

### DIFF
--- a/modules/mrpt_opengl/package.xml
+++ b/modules/mrpt_opengl/package.xml
@@ -17,6 +17,7 @@
   <depend>mrpt_img</depend>
 
   <build_depend>eigen</build_depend>
+  <build_depend>opengl</build_depend>
   <build_export_depend>opengl</build_export_depend>
 
   <export>


### PR DESCRIPTION
This PR addresses [this comment](https://github.com/MRPT/mrpt/commit/6181b2d40c73852ae94232ada6be582055e53788#commitcomment-189004738).

In a recent commit, build_depend was replaced with build_export_depend. But it seems that both build_depend and build_export_depend need to be specified. Without build_depend, ROS build farm complains about OpenGL not being available:

    Could NOT find OpenGL (missing: OPENGL_opengl_LIBRARY OPENGL_glx_LIBRARY OPENGL_INCLUDE_DIR)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated build dependencies to ensure proper compilation and linking support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->