### PR TITLE
feat(math): KDTreeCapable save/load of the KD-tree index (2D and 3D)

### DIFF
--- a/modules/mrpt_maps/src/maps/CReflectivityGridMap2D.cpp
+++ b/modules/mrpt_maps/src/maps/CReflectivityGridMap2D.cpp
@@ -161,7 +161,7 @@ bool CReflectivityGridMap2D::internal_insertObservation(
     *cell = static_cast<cell_t>(cell_new);
 
     return true;  // Done!
-  }  // end if "CObservationGasSensors"
+  }               // end if "CObservationGasSensors"
 
   return false;
 

--- a/modules/mrpt_maps/tests/CPointsMap_unittest.cpp
+++ b/modules/mrpt_maps/tests/CPointsMap_unittest.cpp
@@ -21,6 +21,7 @@
 
 #include <array>
 #include <sstream>
+#include <stdexcept>
 
 using namespace mrpt;
 using namespace mrpt::maps;
@@ -578,4 +579,93 @@ TEST(CSimplePointsMapTests, nn_radius_search_3D)
   ASSERT_EQ(idxs.size(), 1u);
   ASSERT_EQ(dists.size(), 1u);
   EXPECT_FLOAT_EQ(dists[0], 0.0f);
+}
+
+// ----------------------------------------------------------------------
+// Tests for KDTreeCapable::kdtree_save_index_2D/3D() and
+// kdtree_load_index_2D/3D(), over the same 3x3x3 demo point cloud.
+// ----------------------------------------------------------------------
+
+TEST(CSimplePointsMapTests, kdtreeSaveLoadIndex3D)
+{
+  const auto pts = load_demo_9pts_map<CSimplePointsMap>();
+
+  std::stringstream ss;
+  ASSERT_TRUE(pts.kdtree_save_index_3D(ss));
+
+  // A fresh map with the identical points (same count) can load the index:
+  auto pts2 = load_demo_9pts_map<CSimplePointsMap>();
+  pts2.kdtree_load_index_3D(ss);
+
+  float closestX, closestY, closestZ, distSqr;
+  const size_t idx =
+      pts2.kdTreeClosestPoint3D(2.1f, 2.1f, 2.1f, closestX, closestY, closestZ, distSqr);
+
+  EXPECT_EQ(idx, demo9_N - 1);
+  EXPECT_FLOAT_EQ(closestX, 2.0f);
+  EXPECT_FLOAT_EQ(closestY, 2.0f);
+  EXPECT_FLOAT_EQ(closestZ, 2.0f);
+  EXPECT_NEAR(distSqr, 0.03f, 1e-5f);
+}
+
+TEST(CSimplePointsMapTests, kdtreeSaveLoadIndex2D)
+{
+  const auto pts = load_demo_9pts_map<CSimplePointsMap>();
+
+  std::stringstream ss;
+  ASSERT_TRUE(pts.kdtree_save_index_2D(ss));
+
+  auto pts2 = load_demo_9pts_map<CSimplePointsMap>();
+  pts2.kdtree_load_index_2D(ss);
+
+  float closestX, closestY, distSqr;
+  const size_t idx = pts2.kdTreeClosestPoint2D(0.1f, 0.1f, closestX, closestY, distSqr);
+
+  EXPECT_EQ(idx, 0u);
+  EXPECT_FLOAT_EQ(closestX, 0.0f);
+  EXPECT_FLOAT_EQ(closestY, 0.0f);
+  EXPECT_NEAR(distSqr, 0.02f, 1e-5f);
+}
+
+TEST(CSimplePointsMapTests, kdtreeSaveIndexAfterOtherDimensionQueried)
+{
+  // Regression test: querying one dimension first must not make the other
+  // dimension's save_index() spuriously return false (shared uptodate flag).
+  const auto pts = load_demo_9pts_map<CSimplePointsMap>();
+
+  float cx, cy, cz, distSqr;
+  pts.kdTreeClosestPoint2D(0.1f, 0.1f, cx, cy, distSqr);
+
+  std::stringstream ss;
+  ASSERT_TRUE(pts.kdtree_save_index_3D(ss));
+
+  auto pts2 = load_demo_9pts_map<CSimplePointsMap>();
+  pts2.kdtree_load_index_3D(ss);
+  const size_t idx = pts2.kdTreeClosestPoint3D(2.1f, 2.1f, 2.1f, cx, cy, cz, distSqr);
+  EXPECT_EQ(idx, demo9_N - 1);
+}
+
+TEST(CSimplePointsMapTests, kdtreeSaveIndexEmptyMap)
+{
+  const CSimplePointsMap emptyPts;
+
+  std::stringstream ss2D, ss3D;
+  // No points: nothing is written, and the call returns false.
+  EXPECT_FALSE(emptyPts.kdtree_save_index_2D(ss2D));
+  EXPECT_FALSE(emptyPts.kdtree_save_index_3D(ss3D));
+}
+
+TEST(CSimplePointsMapTests, kdtreeLoadIndexPointCountMismatchThrows)
+{
+  const auto pts = load_demo_9pts_map<CSimplePointsMap>();
+
+  std::stringstream ss;
+  ASSERT_TRUE(pts.kdtree_save_index_3D(ss));
+
+  // A map with a different point count must fail the point-count header
+  // check performed by kdtree_load_index_3D().
+  CSimplePointsMap mismatched;
+  mismatched.insertPoint(0.0f, 0.0f, 0.0f);
+
+  EXPECT_THROW(mismatched.kdtree_load_index_3D(ss), std::exception);
 }

--- a/modules/mrpt_math/include/mrpt/math/KDTreeCapable.h
+++ b/modules/mrpt_math/include/mrpt/math/KDTreeCapable.h
@@ -16,15 +16,25 @@
 // nanoflann library:
 #include <mrpt/core/common.h>
 #include <mrpt/core/exceptions.h>
+#include <mrpt/core/format.h>
 #include <mrpt/math/TPoint2D.h>
 #include <mrpt/math/TPoint3D.h>
 
 #include <array>
 #include <atomic>
+#include <cstdint>
+#include <istream>
 #include <memory>  // unique_ptr
 #include <mutex>
 #include <nanoflann.hpp>
 #include <optional>
+#include <ostream>
+
+/** Feature-detection macro for the `mrpt::math::KDTreeCapable` KD-tree index
+ *  save/load API (`kdtree_save_index_2D()`/`kdtree_load_index_2D()` and their 3D
+ *  counterparts). Downstream code that must build against both this and older
+ *  MRPT versions can `#if defined(MRPT_HAS_KDTREE_SAVE_LOAD_INDEX)`. */
+#define MRPT_HAS_KDTREE_SAVE_LOAD_INDEX 1
 
 // Smooth transition to nanoflann>=1.5.0 for older versions:
 namespace nanoflann
@@ -842,6 +852,149 @@ class KDTreeCapable
   void kdTreeEnsureIndexBuilt3D() { rebuild_kdTree_3D(); }
   void kdTreeEnsureIndexBuilt2D() { rebuild_kdTree_2D(); }
 
+  /** @name KD-tree index (de)serialization
+   *  @{ */
+
+  /** Serializes the current 3D KD-tree index into the given binary stream,
+   *  building it first if needed. Returns `false` (writing nothing) if the map
+   *  has no points.
+   *
+   *  IMPORTANT: only the tree *topology* is written, NOT the point data. To
+   *  restore it later, first load the points so that `kdtree_get_point_count()`
+   *  and `kdtree_get_pt()` return the identical dataset, then call
+   *  `kdtree_load_index_3D()`. A point-count header is written so that
+   *  `kdtree_load_index_3D()` can detect a mismatched dataset.
+   *
+   *  The typical use case is caching the (costly to build) index alongside a
+   *  serialized point cloud, so it does not have to be rebuilt on load.
+   *  \sa kdtree_load_index_3D */
+  bool kdtree_save_index_3D(std::ostream& out) const
+  {
+    rebuild_kdTree_3D();  // ensure it is built (locks/unlocks internally)
+    std::lock_guard<std::mutex> lck(m_kdtree_mtx);
+    if (!m_kdtree3d_data.index) return false;  // no points: nothing to save
+    const uint64_t n = m_kdtree3d_data.m_num_points;
+    out.write(reinterpret_cast<const char*>(&n), sizeof(n));
+    ASSERTMSG_(
+        static_cast<bool>(out), "kdtree_save_index_3D(): failed to write point-count header.");
+    m_kdtree3d_data.index->saveIndex(out);
+    ASSERTMSG_(static_cast<bool>(out), "kdtree_save_index_3D(): failed to write serialized index.");
+    return true;
+  }
+
+  /** Restores a 3D KD-tree index previously written by `kdtree_save_index_3D()`,
+   *  avoiding the (costly) rebuild that would otherwise happen on the next query.
+   *
+   *  The associated points MUST already be present and identical to those used
+   *  when the index was saved; this is verified against the stored point-count
+   *  header (throws `std::runtime_error` on mismatch). On success the index is
+   *  marked up-to-date and will NOT be rebuilt on the next query, until the
+   *  derived class calls `kdtree_mark_as_outdated()` (e.g. if points change).
+   *  \sa kdtree_save_index_3D */
+  void kdtree_load_index_3D(std::istream& in) const
+  {
+    using tree3d_t = typename TKDTreeDataHolder<3>::kdtree_index_t;
+
+    const size_t N = derived().kdtree_get_point_count();
+
+    uint64_t savedN = 0;
+    in.read(reinterpret_cast<char*>(&savedN), sizeof(savedN));
+    ASSERTMSG_(static_cast<bool>(in), "kdtree_load_index_3D(): failed to read point-count header.");
+    ASSERTMSG_(
+        savedN == static_cast<uint64_t>(N),
+        mrpt::format(
+            "kdtree_load_index_3D(): saved index point count (%llu) does not "
+            "match the currently loaded points (%zu). The points must be "
+            "restored before loading the index.",
+            static_cast<unsigned long long>(savedN), N));
+
+    // Build the new index into a local variable first, so the object is only
+    // mutated once the load is known to have succeeded (a failed read must
+    // never leave the cached trees cleared but "up-to-date").
+    std::unique_ptr<tree3d_t> newIndex;
+    if (N)
+    {
+      // SkipInitialBuildIndex: construct the index WITHOUT building it, since
+      // loadIndex() below installs the deserialized tree instead.
+      newIndex = std::make_unique<tree3d_t>(
+          3, derived(),
+          nanoflann::KDTreeSingleIndexAdaptorParams(
+              kdtree_search_params.leaf_max_size,
+              nanoflann::KDTreeSingleIndexAdaptorFlags::SkipInitialBuildIndex));
+      newIndex->loadIndex(in);
+      ASSERTMSG_(static_cast<bool>(in), "kdtree_load_index_3D(): failed to read serialized index.");
+    }
+
+    std::lock_guard<std::mutex> lck(m_kdtree_mtx);
+    m_kdtree2d_data.clear();
+    m_kdtree3d_data.clear();
+    m_kdtree3d_data.m_num_points = N;
+    m_kdtree3d_data.m_dim = 3;
+    m_kdtree3d_data.index = std::move(newIndex);
+    m_kdtree_is_uptodate = true;
+  }
+
+  /** 2D counterpart of kdtree_save_index_3D(). \sa kdtree_load_index_2D */
+  bool kdtree_save_index_2D(std::ostream& out) const
+  {
+    rebuild_kdTree_2D();  // ensure it is built (locks/unlocks internally)
+    std::lock_guard<std::mutex> lck(m_kdtree_mtx);
+    if (!m_kdtree2d_data.index) return false;  // no points: nothing to save
+    const uint64_t n = m_kdtree2d_data.m_num_points;
+    out.write(reinterpret_cast<const char*>(&n), sizeof(n));
+    ASSERTMSG_(
+        static_cast<bool>(out), "kdtree_save_index_2D(): failed to write point-count header.");
+    m_kdtree2d_data.index->saveIndex(out);
+    ASSERTMSG_(static_cast<bool>(out), "kdtree_save_index_2D(): failed to write serialized index.");
+    return true;
+  }
+
+  /** 2D counterpart of kdtree_load_index_3D(). \sa kdtree_save_index_2D */
+  void kdtree_load_index_2D(std::istream& in) const
+  {
+    using tree2d_t = typename TKDTreeDataHolder<2>::kdtree_index_t;
+
+    const size_t N = derived().kdtree_get_point_count();
+
+    uint64_t savedN = 0;
+    in.read(reinterpret_cast<char*>(&savedN), sizeof(savedN));
+    ASSERTMSG_(static_cast<bool>(in), "kdtree_load_index_2D(): failed to read point-count header.");
+    ASSERTMSG_(
+        savedN == static_cast<uint64_t>(N),
+        mrpt::format(
+            "kdtree_load_index_2D(): saved index point count (%llu) does not "
+            "match the currently loaded points (%zu). The points must be "
+            "restored before loading the index.",
+            static_cast<unsigned long long>(savedN), N));
+
+    // Build the new index into a local variable first, so the object is only
+    // mutated once the load is known to have succeeded (a failed read must
+    // never leave the cached trees cleared but "up-to-date").
+    std::unique_ptr<tree2d_t> newIndex;
+    if (N)
+    {
+      // SkipInitialBuildIndex: construct the index WITHOUT building it, since
+      // loadIndex() below installs the deserialized tree instead.
+      newIndex = std::make_unique<tree2d_t>(
+          2, derived(),
+          nanoflann::KDTreeSingleIndexAdaptorParams(
+              kdtree_search_params.leaf_max_size,
+              nanoflann::KDTreeSingleIndexAdaptorFlags::SkipInitialBuildIndex));
+      newIndex->loadIndex(in);
+      ASSERTMSG_(static_cast<bool>(in), "kdtree_load_index_2D(): failed to read serialized index.");
+    }
+
+    std::lock_guard<std::mutex> lck(m_kdtree_mtx);
+    m_kdtree2d_data.clear();
+    m_kdtree3d_data.clear();
+    m_kdtree2d_data.m_num_points = N;
+    m_kdtree2d_data.m_dim = 2;
+    m_kdtree2d_data.index = std::move(newIndex);
+    m_kdtree_is_uptodate = true;
+  }
+
+  /** @} */
+
   /* @} */
 
  protected:
@@ -893,7 +1046,7 @@ class KDTreeCapable
   /// asking the child class for the data points.
   void rebuild_kdTree_2D() const
   {
-    if (m_kdtree_is_uptodate)
+    if (m_kdtree_is_uptodate && m_kdtree2d_data.index)
     {
       return;
     }
@@ -929,7 +1082,7 @@ class KDTreeCapable
   /// asking the child class for the data points.
   void rebuild_kdTree_3D() const
   {
-    if (m_kdtree_is_uptodate)
+    if (m_kdtree_is_uptodate && m_kdtree3d_data.index)
     {
       return;
     }


### PR DESCRIPTION
## Summary
- Port from mrpt-2.x (MRPT/mrpt#1373): adds `kdtree_save_index_2D/3D()` and `kdtree_load_index_2D/3D()` to `mrpt::math::KDTreeCapable`, allowing a built KD-tree index to be serialized/restored without rebuilding (e.g. to cache alongside a serialized point cloud). Only the tree topology is stored; a point-count header is validated on load.
- Adds `MRPT_HAS_KDTREE_SAVE_LOAD_INDEX` feature-detection macro.
- Adds unit tests in `modules/mrpt_maps/tests/CPointsMap_unittest.cpp` using `CSimplePointsMap` (not present in the original 2.x commit): 2D/3D round-trip, empty-map save behavior, and point-count-mismatch error handling.

## Test plan
- [x] `colcon build --packages-up-to mrpt_math` builds cleanly
- [x] `colcon build --packages-up-to mrpt_maps` builds cleanly
- [x] `test_mrpt_maps --gtest_filter="CSimplePointsMapTests.kdtree*"` — 4/4 new tests pass
- [x] Full `CSimplePointsMapTests.*` / `CGenericPointsMapTests.*` suite — 19/19 pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added the ability to save and load KD-tree search indexes for both 2D and 3D point maps.
* **Bug Fixes**
  * Improved reliability when reusing a map after queries in another dimension.
  * Saving now safely handles empty maps.
  * Loading validates the stored point count and errors on mismatches.
* **Tests**
  * Added unit tests covering successful reload with matching point counts, empty-map behavior, and point-count mismatch handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->