### PR TITLE
fix(system): guard COutputLogger's callback list against concurrent register/log

### DIFF
--- a/libs/system/include/mrpt/system/COutputLogger.h
+++ b/libs/system/include/mrpt/system/COutputLogger.h
@@ -338,6 +338,13 @@ class COutputLogger
   mutable std::deque<TMsg> m_history;
   std::shared_ptr<std::mutex> m_historyMtx = std::make_shared<std::mutex>();
 
+  /** Guards m_listCallbacks: logRegisterCallback()/logDeregisterCallback() may
+   * be called (e.g. by a GUI thread hooking into a logger) concurrently with
+   * logStr() running on the logger's own thread, which iterates the list.
+   * A shared_ptr, like m_historyMtx above, so COutputLogger stays copy-
+   * assignable (std::mutex itself is not; loggerReset() relies on this via
+   * `*this = COutputLogger()`). */
+  std::shared_ptr<std::mutex> m_listCallbacksMtx = std::make_shared<std::mutex>();
   std::deque<output_logger_callback_t> m_listCallbacks;
 };
 

--- a/libs/system/src/COutputLogger.cpp
+++ b/libs/system/src/COutputLogger.cpp
@@ -79,10 +79,19 @@ void COutputLogger::logStr(const VerbosityLevel level, std::string_view msg_str)
 
   if (level >= m_min_verbosity_level && logging_enable_console_output) msg.dumpToConsole();
 
-  // User callbacks:
+  // User callbacks: copy the list under the lock, then invoke the callbacks
+  // outside of it, so a slow/blocking callback doesn't hold up whoever else
+  // is concurrently registering/deregistering (or logging from another
+  // thread), and so a callback that itself calls logRegisterCallback() /
+  // logDeregisterCallback() on this same logger cannot deadlock.
   if (level >= m_min_verbosity_level_callbacks)
   {
-    for (const auto& c : m_listCallbacks) c(msg.body, msg.level, msg.name, msg.timestamp);
+    std::deque<output_logger_callback_t> callbacksCopy;
+    {
+      auto lck = mrpt::lockHelper(*m_listCallbacksMtx);
+      callbacksCopy = m_listCallbacks;
+    }
+    for (const auto& c : callbacksCopy) c(msg.body, msg.level, msg.name, msg.timestamp);
   }
 }
 
@@ -256,6 +265,7 @@ void COutputLogger::TMsg::dumpToConsole() const
 
 void COutputLogger::logRegisterCallback(output_logger_callback_t userFunc)
 {
+  auto lck = mrpt::lockHelper(*m_listCallbacksMtx);
   m_listCallbacks.emplace_back(userFunc);
 }
 
@@ -269,6 +279,7 @@ size_t getAddress(std::function<T(U...)> f)
 
 bool COutputLogger::logDeregisterCallback(output_logger_callback_t userFunc)
 {
+  auto lck = mrpt::lockHelper(*m_listCallbacksMtx);
   for (auto it = m_listCallbacks.begin(); it != m_listCallbacks.end(); ++it)
   {
     if (getAddress(*it) == getAddress(userFunc))


### PR DESCRIPTION
## Summary
- `COutputLogger::m_listCallbacks` was read (`logStr()`, iterating over it to invoke callbacks) and written (`logRegisterCallback()` / `logDeregisterCallback()`) without any synchronization, even though these can legitimately happen from different threads -- e.g. a GUI thread hooking a live logger via `logRegisterCallback()` while that logger's own thread is concurrently calling `logStr()`. That's a data race / UB, not just a theoretical edge case.
- Guards `m_listCallbacks` with a `shared_ptr<mutex>`, mirroring the existing `m_historyMtx` pattern (a plain `std::mutex` member would make `COutputLogger` non-copy-assignable, breaking `loggerReset()`'s `*this = COutputLogger()`).
- `logStr()` copies the callback list under the lock and invokes callbacks *outside* it, so a slow/blocking user callback can't stall a concurrent registration, and a callback that itself calls `logRegisterCallback()`/`logDeregisterCallback()` on the same logger can't deadlock.

## Context
Found while hardening [MOLAorg/mola](https://github.com/MOLAorg/mola)'s new `mola_viz_imgui` Console log window, which periodically discovers already-running modules and registers a log callback on each from a dedicated GUI thread -- exactly the race this fixes.

## Test plan
- [x] `libs/system` builds clean with the change.
- [x] Downstream consumer (`mola_viz_imgui`, which derives from `COutputLogger`) rebuilds and runs correctly against the patched library (verified via a throwaway repro harness registering callbacks on live, actively-logging loggers from a separate thread).
- [ ] Existing MRPT `system` unit tests / CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Dnw8SX9MWvxpwoTgkR155K

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved thread safety for logging callbacks, reducing the risk of crashes or missed notifications when callbacks are added, removed, or triggered at the same time.
  * Logging now processes callback notifications more reliably under concurrent use.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->