### PR TITLE
feat(mrpt_config): add OptionsCapable mixin, implement in map classes

### DIFF
--- a/modules/mrpt_config/CMakeLists.txt
+++ b/modules/mrpt_config/CMakeLists.txt
@@ -30,6 +30,7 @@ set(LIB_SOURCES
 set(LIB_UNIT_TEST_SOURCES
   tests/yaml2config_unittest.cpp
   tests/CConfigFileMemory_unittest.cpp
+  tests/OptionsCapable_unittest.cpp
 )
 
 set(LIB_PUBLIC_HEADERS
@@ -40,6 +41,7 @@ set(LIB_PUBLIC_HEADERS
   include/mrpt/config/CLoadableOptions.h
   include/mrpt/config/CConfigFileMemory.h
   include/mrpt/config/CConfigFilePrefixer.h
+  include/mrpt/config/OptionsCapable.h
 )
 
 mrpt_add_library(

--- a/modules/mrpt_config/include/mrpt/config/OptionsCapable.h
+++ b/modules/mrpt_config/include/mrpt/config/OptionsCapable.h
@@ -1,0 +1,82 @@
+/*                    _
+                     | |    Mobile Robot Programming Toolkit (MRPT)
+ _ __ ___  _ __ _ __ | |_
+| '_ ` _ \| '__| '_ \| __|          https://www.mrpt.org/
+| | | | | | |  | |_) | |_
+|_| |_| |_|_|  | .__/ \__|     https://github.com/MRPT/mrpt/
+               | |
+               |_|
+
+ Copyright (c) 2005-2026, Individual contributors, see AUTHORS file
+ See: https://www.mrpt.org/Authors - All rights reserved.
+ SPDX-License-Identifier: BSD-3-Clause
+*/
+#pragma once
+
+#include <mrpt/config/CConfigFileBase.h>
+#include <mrpt/config/CLoadableOptions.h>
+
+#include <map>
+#include <string>
+
+namespace mrpt::config
+{
+/** Mixin interface for classes that expose one or more `CLoadableOptions`
+ * structures (e.g. "insertionOptions", "likelihoodOptions", "renderOptions")
+ * in a generic, name-indexed way, so that callers never need to know the
+ * concrete class nor the exact set/names of options structures it defines --
+ * works uniformly for all present and future classes implementing this
+ * interface.
+ *
+ * "Creation options" (those that configure a class' internal structure, e.g.
+ * a voxel/grid size) are handled separately via trySetCreationOptions(),
+ * since changing them may be incompatible with already-built internal state.
+ *
+ * \ingroup mrpt_config_grp
+ */
+class OptionsCapable
+{
+ public:
+  OptionsCapable() = default;
+  OptionsCapable(const OptionsCapable&) = default;
+  OptionsCapable& operator=(const OptionsCapable&) = default;
+  OptionsCapable(OptionsCapable&&) = default;
+  OptionsCapable& operator=(OptionsCapable&&) = default;
+  virtual ~OptionsCapable() = default;
+
+  /** Maps an options-group name (e.g. "insertionOptions") to a pointer to
+   * the corresponding, live `CLoadableOptions` member. Pointers remain valid
+   * as long as `this` is alive, and point directly to the actual option
+   * members (no copies), so writes through them (e.g. via
+   * `loadFromConfigFile()`) take effect immediately.
+   *
+   * Implementations should list every `CLoadableOptions` member they define,
+   * INCLUDING "creationOptions" if present (so it can be discovered/exported
+   * generically); however, callers must use trySetCreationOptions(), not a
+   * direct write through this pointer, to safely *modify* creation options.
+   */
+  [[nodiscard]] virtual std::map<std::string, mrpt::config::CLoadableOptions*> optionsByName() = 0;
+
+  /** Attempts to apply new "creation options" (i.e. those that configure an
+   * internal structure, such as a voxel/grid size), read from the given
+   * `section` of `cfg`.
+   *
+   * Many creation-time parameters are just runtime thresholds with no effect
+   * on already-built internal structures, so applying them in place is
+   * often possible even after the object holds data. Others (e.g. a voxel
+   * size) cannot be changed without discarding existing contents.
+   *
+   * \return true if the new options were applied; false if doing so would
+   * require destroying the object's current contents (in which case it is
+   * left unmodified) -- or if this class does not define any
+   * "creationOptions" group at all (the default implementation).
+   */
+  virtual bool trySetCreationOptions(
+      [[maybe_unused]] const mrpt::config::CConfigFileBase& cfg,
+      [[maybe_unused]] const std::string& section)
+  {
+    return false;
+  }
+};
+
+}  // namespace mrpt::config

--- a/modules/mrpt_config/include/mrpt/config/OptionsCapable.h
+++ b/modules/mrpt_config/include/mrpt/config/OptionsCapable.h
@@ -71,7 +71,7 @@ class OptionsCapable
    * left unmodified) -- or if this class does not define any
    * "creationOptions" group at all (the default implementation).
    */
-  virtual bool trySetCreationOptions(
+  [[nodiscard]] virtual bool trySetCreationOptions(
       [[maybe_unused]] const mrpt::config::CConfigFileBase& cfg,
       [[maybe_unused]] const std::string& section)
   {

--- a/modules/mrpt_config/tests/OptionsCapable_unittest.cpp
+++ b/modules/mrpt_config/tests/OptionsCapable_unittest.cpp
@@ -1,0 +1,133 @@
+/*                    _
+                     | |    Mobile Robot Programming Toolkit (MRPT)
+ _ __ ___  _ __ _ __ | |_
+| '_ ` _ \| '__| '_ \| __|          https://www.mrpt.org/
+| | | | | | |  | |_) | |_
+|_| |_| |_|_|  | .__/ \__|     https://github.com/MRPT/mrpt/
+               | |
+               |_|
+
+ Copyright (c) 2005-2026, Individual contributors, see AUTHORS file
+ See: https://www.mrpt.org/Authors - All rights reserved.
+ SPDX-License-Identifier: BSD-3-Clause
+*/
+
+#include <gtest/gtest.h>
+#include <mrpt/config/CConfigFileMemory.h>
+#include <mrpt/config/OptionsCapable.h>
+
+namespace
+{
+struct TDummyInsertionOptions : public mrpt::config::CLoadableOptions
+{
+  double threshold = 0.5;
+
+  void loadFromConfigFile(
+      const mrpt::config::CConfigFileBase& source, const std::string& section) override
+  {
+    threshold = source.read_double(section, "threshold", threshold);
+  }
+  void saveToConfigFile(
+      mrpt::config::CConfigFileBase& target, const std::string& section) const override
+  {
+    target.write(section, "threshold", threshold);
+  }
+};
+
+struct TDummyCreationOptions : public mrpt::config::CLoadableOptions
+{
+  double voxel_size = 0.1;
+
+  void loadFromConfigFile(
+      const mrpt::config::CConfigFileBase& source, const std::string& section) override
+  {
+    voxel_size = source.read_double(section, "voxel_size", voxel_size);
+  }
+  void saveToConfigFile(
+      mrpt::config::CConfigFileBase& target, const std::string& section) const override
+  {
+    target.write(section, "voxel_size", voxel_size);
+  }
+};
+
+/** Minimal, self-contained implementation used only to exercise the
+ * mrpt::config::OptionsCapable interface. */
+class DummyOptionsCapable : public mrpt::config::OptionsCapable
+{
+ public:
+  TDummyCreationOptions creationOptions;
+  TDummyInsertionOptions insertionOptions;
+
+  bool hasData = false;
+
+  [[nodiscard]] std::map<std::string, mrpt::config::CLoadableOptions*> optionsByName() override
+  {
+    return {
+        { "creationOptions",  &creationOptions},
+        {"insertionOptions", &insertionOptions},
+    };
+  }
+
+  bool trySetCreationOptions(
+      const mrpt::config::CConfigFileBase& cfg, const std::string& section) override
+  {
+    const double newVoxelSize = cfg.read_double(section, "voxel_size", creationOptions.voxel_size);
+    if (hasData && newVoxelSize != creationOptions.voxel_size)
+    {
+      return false;  // would require rebuilding internal state
+    }
+    creationOptions.loadFromConfigFile(cfg, section);
+    return true;
+  }
+};
+
+}  // namespace
+
+TEST(OptionsCapable, OptionsByNameExposesLiveMembers)
+{
+  DummyOptionsCapable obj;
+
+  auto opts = obj.optionsByName();
+  ASSERT_EQ(opts.size(), 2U);
+  ASSERT_TRUE(opts.count("creationOptions"));
+  ASSERT_TRUE(opts.count("insertionOptions"));
+
+  mrpt::config::CConfigFileMemory cfg;
+  cfg.write("insertionOptions", "threshold", 1.25);
+  opts.at("insertionOptions")->loadFromConfigFile(cfg, "insertionOptions");
+
+  // The map returned by optionsByName() must point to the real, live member:
+  EXPECT_DOUBLE_EQ(obj.insertionOptions.threshold, 1.25);
+}
+
+TEST(OptionsCapable, DefaultTrySetCreationOptionsReturnsFalse)
+{
+  class NoCreationOptions : public mrpt::config::OptionsCapable
+  {
+   public:
+    [[nodiscard]] std::map<std::string, mrpt::config::CLoadableOptions*> optionsByName() override
+    {
+      return {};
+    }
+  };
+
+  NoCreationOptions obj;
+  mrpt::config::CConfigFileMemory cfg;
+  EXPECT_FALSE(obj.trySetCreationOptions(cfg, "creationOptions"));
+}
+
+TEST(OptionsCapable, TrySetCreationOptionsRefusesIncompatibleChangeWhenDataPresent)
+{
+  DummyOptionsCapable obj;
+  obj.hasData = true;
+
+  mrpt::config::CConfigFileMemory cfg;
+  cfg.write("creationOptions", "voxel_size", 0.2);
+
+  EXPECT_FALSE(obj.trySetCreationOptions(cfg, "creationOptions"));
+  EXPECT_DOUBLE_EQ(obj.creationOptions.voxel_size, 0.1);  // left unmodified
+
+  obj.hasData = false;
+  EXPECT_TRUE(obj.trySetCreationOptions(cfg, "creationOptions"));
+  EXPECT_DOUBLE_EQ(obj.creationOptions.voxel_size, 0.2);
+}

--- a/modules/mrpt_maps/include/mrpt/maps/CBeaconMap.h
+++ b/modules/mrpt_maps/include/mrpt/maps/CBeaconMap.h
@@ -14,6 +14,7 @@
 #pragma once
 
 #include <mrpt/config/CLoadableOptions.h>
+#include <mrpt/config/OptionsCapable.h>
 #include <mrpt/maps/CBeacon.h>
 #include <mrpt/maps/CMetricMap.h>
 #include <mrpt/math/CMatrixF.h>
@@ -45,7 +46,7 @@ namespace mrpt::maps
  * \ingroup mrpt_maps_grp
  * \sa CMetricMap
  */
-class CBeaconMap : public mrpt::maps::CMetricMap
+class CBeaconMap : public mrpt::maps::CMetricMap, public mrpt::config::OptionsCapable
 {
   DEFINE_SERIALIZABLE(CBeaconMap, mrpt::maps)
 
@@ -195,6 +196,9 @@ class CBeaconMap : public mrpt::maps::CMetricMap
      */
     float SOG_separationConstant{3.0f};
   } insertionOptions;
+
+  // mrpt::config::OptionsCapable interface:
+  [[nodiscard]] std::map<std::string, mrpt::config::CLoadableOptions*> optionsByName() override;
 
   /** Save to a MATLAB script which displays 3D error ellipses for the map.
    *	\param file		The name of the file to save the script to.

--- a/modules/mrpt_maps/include/mrpt/maps/CGasConcentrationGridMap2D.h
+++ b/modules/mrpt_maps/include/mrpt/maps/CGasConcentrationGridMap2D.h
@@ -14,6 +14,7 @@
 
 #pragma once
 
+#include <mrpt/config/OptionsCapable.h>
 #include <mrpt/maps/CRandomFieldGridMap2D.h>
 #include <mrpt/obs/CObservationGasSensors.h>
 
@@ -34,7 +35,7 @@ namespace mrpt::maps
  * mrpt::maps::CMultiMetricMap
  * \ingroup mrpt_maps_grp
  */
-class CGasConcentrationGridMap2D : public CRandomFieldGridMap2D
+class CGasConcentrationGridMap2D : public CRandomFieldGridMap2D, public mrpt::config::OptionsCapable
 {
   DEFINE_SERIALIZABLE(CGasConcentrationGridMap2D, mrpt::maps)
  public:
@@ -90,6 +91,9 @@ class CGasConcentrationGridMap2D : public CRandomFieldGridMap2D
     /** @} */
 
   } insertionOptions;
+
+  // mrpt::config::OptionsCapable interface:
+  [[nodiscard]] std::map<std::string, mrpt::config::CLoadableOptions*> optionsByName() override;
 
   /** Returns a 3D object representing the map */
   void getVisualizationInto(mrpt::viz::CSetOfObjects& outObj) const override;

--- a/modules/mrpt_maps/include/mrpt/maps/CHeightGridMap2D.h
+++ b/modules/mrpt_maps/include/mrpt/maps/CHeightGridMap2D.h
@@ -15,6 +15,7 @@
 #pragma once
 
 #include <mrpt/config/CLoadableOptions.h>
+#include <mrpt/config/OptionsCapable.h>
 #include <mrpt/containers/CDynamicGrid.h>
 #include <mrpt/img/color_maps.h>
 #include <mrpt/maps/CHeightGridMap2D_Base.h>
@@ -67,7 +68,8 @@ struct THeightGridmapCell
 class CHeightGridMap2D :
     public mrpt::maps::CMetricMap,
     public mrpt::containers::CDynamicGrid<THeightGridmapCell>,
-    public CHeightGridMap2D_Base
+    public CHeightGridMap2D_Base,
+    public mrpt::config::OptionsCapable
 {
   DEFINE_SERIALIZABLE(CHeightGridMap2D, mrpt::maps)
  public:
@@ -126,6 +128,9 @@ class CHeightGridMap2D :
 
     mrpt::img::TColormap colorMap{mrpt::img::cmJET};
   } insertionOptions;
+
+  // mrpt::config::OptionsCapable interface:
+  [[nodiscard]] std::map<std::string, mrpt::config::CLoadableOptions*> optionsByName() override;
 
   /** See docs in base class: in this class it always returns 0 */
   float compute3DMatchingRatio(

--- a/modules/mrpt_maps/include/mrpt/maps/CHeightGridMap2D_MRF.h
+++ b/modules/mrpt_maps/include/mrpt/maps/CHeightGridMap2D_MRF.h
@@ -14,6 +14,7 @@
 
 #pragma once
 
+#include <mrpt/config/OptionsCapable.h>
 #include <mrpt/maps/CHeightGridMap2D_Base.h>
 #include <mrpt/maps/CRandomFieldGridMap2D.h>
 
@@ -35,7 +36,10 @@ namespace mrpt::maps
  * \note New in MRPT 1.4.0
  * \ingroup mrpt_maps_grp
  */
-class CHeightGridMap2D_MRF : public CRandomFieldGridMap2D, public CHeightGridMap2D_Base
+class CHeightGridMap2D_MRF :
+    public CRandomFieldGridMap2D,
+    public CHeightGridMap2D_Base,
+    public mrpt::config::OptionsCapable
 {
   DEFINE_SERIALIZABLE(CHeightGridMap2D_MRF, mrpt::maps)
  public:
@@ -62,6 +66,9 @@ class CHeightGridMap2D_MRF : public CRandomFieldGridMap2D, public CHeightGridMap
         const std::string& section) override;                 // See base docs
     void dumpToTextStream(std::ostream& out) const override;  // See base docs
   } insertionOptions;
+
+  // mrpt::config::OptionsCapable interface:
+  [[nodiscard]] std::map<std::string, mrpt::config::CLoadableOptions*> optionsByName() override;
 
   /** Returns a 3D object representing the map */
   void getVisualizationInto(mrpt::viz::CSetOfObjects& outObj) const override;

--- a/modules/mrpt_maps/include/mrpt/maps/COccupancyGridMap2D.h
+++ b/modules/mrpt_maps/include/mrpt/maps/COccupancyGridMap2D.h
@@ -14,6 +14,7 @@
 #pragma once
 
 #include <mrpt/config/CLoadableOptions.h>
+#include <mrpt/config/OptionsCapable.h>
 #include <mrpt/containers/CDynamicGrid.h>
 #include <mrpt/containers/NonCopiableData.h>
 #include <mrpt/core/safe_pointers.h>
@@ -66,7 +67,8 @@ namespace mrpt::maps
 class COccupancyGridMap2D :
     public CMetricMap,
     public CLogOddsGridMap2D<OccGridCellTraits::cellType>,
-    public mrpt::maps::NearestNeighborsCapable
+    public mrpt::maps::NearestNeighborsCapable,
+    public mrpt::config::OptionsCapable
 {
   DEFINE_SERIALIZABLE(COccupancyGridMap2D, mrpt::maps)
  public:
@@ -609,6 +611,9 @@ class COccupancyGridMap2D :
      * if set to true (default=false). */
     bool enableLikelihoodCache{true};
   } likelihoodOptions;
+
+  // mrpt::config::OptionsCapable interface:
+  [[nodiscard]] std::map<std::string, mrpt::config::CLoadableOptions*> optionsByName() override;
 
   /** Auxiliary private class. */
   using TPairLikelihoodIndex = std::pair<double, mrpt::math::TPoint2D>;

--- a/modules/mrpt_maps/include/mrpt/maps/COccupancyGridMap3D.h
+++ b/modules/mrpt_maps/include/mrpt/maps/COccupancyGridMap3D.h
@@ -14,6 +14,7 @@
 #pragma once
 
 #include <mrpt/config/CLoadableOptions.h>
+#include <mrpt/config/OptionsCapable.h>
 #include <mrpt/maps/CLogOddsGridMap3D.h>
 #include <mrpt/maps/CLogOddsGridMapLUT.h>
 #include <mrpt/maps/CMetricMap.h>
@@ -47,7 +48,8 @@ namespace mrpt::maps
 class COccupancyGridMap3D :
     public CMetricMap,
     public CLogOddsGridMap3D<OccGridCellTraits::cellType>,
-    public mrpt::maps::NearestNeighborsCapable
+    public mrpt::maps::NearestNeighborsCapable,
+    public mrpt::config::OptionsCapable
 {
   DEFINE_SERIALIZABLE(COccupancyGridMap3D, mrpt::maps)
  public:
@@ -316,6 +318,9 @@ class COccupancyGridMap3D :
   };
 
   TLikelihoodOptions likelihoodOptions;
+
+  // mrpt::config::OptionsCapable interface:
+  [[nodiscard]] std::map<std::string, mrpt::config::CLoadableOptions*> optionsByName() override;
 
   /** Options for the conversion of a mrpt::maps::COccupancyGridMap3D into a
    * mrpt::viz::COctoMapVoxels */

--- a/modules/mrpt_maps/include/mrpt/maps/COctoMapBase.h
+++ b/modules/mrpt_maps/include/mrpt/maps/COctoMapBase.h
@@ -15,6 +15,7 @@
 #pragma once
 
 #include <mrpt/config/CLoadableOptions.h>
+#include <mrpt/config/OptionsCapable.h>
 #include <mrpt/core/pimpl.h>
 #include <mrpt/core/safe_pointers.h>
 #include <mrpt/maps/CMetricMap.h>
@@ -43,7 +44,7 @@ namespace mrpt::maps
  * \ingroup mrpt_maps_grp
  */
 template <class octree_t, class octree_node_t>
-class COctoMapBase : public mrpt::maps::CMetricMap
+class COctoMapBase : public mrpt::maps::CMetricMap, public mrpt::config::OptionsCapable
 {
  public:
   using myself_t = COctoMapBase<octree_t, octree_node_t>;
@@ -238,6 +239,15 @@ class COctoMapBase : public mrpt::maps::CMetricMap
   };
 
   TLikelihoodOptions likelihoodOptions;
+
+  // mrpt::config::OptionsCapable interface:
+  [[nodiscard]] std::map<std::string, mrpt::config::CLoadableOptions*> optionsByName() override
+  {
+    return {
+        { "insertionOptions",  &insertionOptions},
+        {"likelihoodOptions", &likelihoodOptions},
+    };
+  }
 
   void saveMetricMapRepresentationToFile(const std::string& filNamePrefix) const override;
 

--- a/modules/mrpt_maps/include/mrpt/maps/CPointsMap.h
+++ b/modules/mrpt_maps/include/mrpt/maps/CPointsMap.h
@@ -14,6 +14,7 @@
 #pragma once
 
 #include <mrpt/config/CLoadableOptions.h>
+#include <mrpt/config/OptionsCapable.h>
 #include <mrpt/core/Stringifyable.h>
 #include <mrpt/core/aligned_std_vector.h>
 #include <mrpt/core/optional_ref.h>
@@ -84,7 +85,8 @@ class CPointsMap :
     public mrpt::math::KDTreeCapable<CPointsMap>,
     public mrpt::viz::PLY_Importer,
     public mrpt::viz::PLY_Exporter,
-    public mrpt::maps::NearestNeighborsCapable
+    public mrpt::maps::NearestNeighborsCapable,
+    public mrpt::config::OptionsCapable
 {
   DEFINE_VIRTUAL_SERIALIZABLE(CPointsMap, mrpt::maps)
 
@@ -358,6 +360,9 @@ class CPointsMap :
     mrpt::img::TColormap colormap{mrpt::img::cmNONE};
   };
   TRenderOptions renderOptions;
+
+  // mrpt::config::OptionsCapable interface:
+  [[nodiscard]] std::map<std::string, mrpt::config::CLoadableOptions*> optionsByName() override;
 
   /** Insert the contents of another map into this one with some geometric
    * transformation, without fusing close points.

--- a/modules/mrpt_maps/include/mrpt/maps/CRandomFieldGridMap3D.h
+++ b/modules/mrpt_maps/include/mrpt/maps/CRandomFieldGridMap3D.h
@@ -15,6 +15,7 @@
 #pragma once
 
 #include <mrpt/config/CLoadableOptions.h>
+#include <mrpt/config/OptionsCapable.h>
 #include <mrpt/containers/CDynamicGrid3D.h>
 #include <mrpt/graphs/ScalarFactorGraph.h>
 #include <mrpt/math/TPoint3D.h>
@@ -76,7 +77,8 @@ struct TRandomFieldVoxel
 class CRandomFieldGridMap3D :
     public mrpt::containers::CDynamicGrid3D<TRandomFieldVoxel>,
     public mrpt::serialization::CSerializable,
-    public mrpt::system::COutputLogger
+    public mrpt::system::COutputLogger,
+    public mrpt::config::OptionsCapable
 {
   using BASE = mrpt::containers::CDynamicGrid3D<TRandomFieldVoxel>;
 
@@ -146,6 +148,9 @@ class CRandomFieldGridMap3D :
 
   /** \sa updateMapEstimation() */
   TInsertionOptions insertionOptions;
+
+  // mrpt::config::OptionsCapable interface:
+  [[nodiscard]] std::map<std::string, mrpt::config::CLoadableOptions*> optionsByName() override;
 
   /** Changes the size of the grid, maintaining previous contents. \sa setSize
    */

--- a/modules/mrpt_maps/include/mrpt/maps/CReflectivityGridMap2D.h
+++ b/modules/mrpt_maps/include/mrpt/maps/CReflectivityGridMap2D.h
@@ -15,6 +15,7 @@
 #pragma once
 
 #include <mrpt/config/CLoadableOptions.h>
+#include <mrpt/config/OptionsCapable.h>
 #include <mrpt/containers/CDynamicGrid.h>
 #include <mrpt/img/CImage.h>
 #include <mrpt/maps/CLogOddsGridMap2D.h>
@@ -43,7 +44,8 @@ namespace mrpt::maps
 class CReflectivityGridMap2D :
     public CMetricMap,
     public mrpt::containers::CDynamicGrid<int8_t>,
-    public CLogOddsGridMap2D<int8_t>
+    public CLogOddsGridMap2D<int8_t>,
+    public mrpt::config::OptionsCapable
 {
   DEFINE_SERIALIZABLE(CReflectivityGridMap2D, mrpt::maps)
 
@@ -95,6 +97,9 @@ class CReflectivityGridMap2D :
                           //! CObservationReflectivity instances with a differing
                           //! channel. (Default=-1)
   } insertionOptions;
+
+  // mrpt::config::OptionsCapable interface:
+  [[nodiscard]] std::map<std::string, mrpt::config::CLoadableOptions*> optionsByName() override;
 
   /** See docs in base class: in this class this always returns 0 */
   float compute3DMatchingRatio(

--- a/modules/mrpt_maps/include/mrpt/maps/CVoxelMapOccupancyBase.h
+++ b/modules/mrpt_maps/include/mrpt/maps/CVoxelMapOccupancyBase.h
@@ -15,6 +15,7 @@
 #pragma once
 
 #include <mrpt/config/CLoadableOptions.h>
+#include <mrpt/config/OptionsCapable.h>
 #include <mrpt/maps/CLogOddsGridMapLUT.h>
 #include <mrpt/maps/CSimplePointsMap.h>
 #include <mrpt/maps/CVoxelMapBase.h>
@@ -122,7 +123,8 @@ template <typename voxel_node_t, typename occupancy_t = int8_t>
 class CVoxelMapOccupancyBase :
     public CVoxelMapBase<voxel_node_t>,
     public detail::logoddscell_traits<occupancy_t>,
-    public mrpt::maps::NearestNeighborsCapable
+    public mrpt::maps::NearestNeighborsCapable,
+    public mrpt::config::OptionsCapable
 {
  protected:
   using occupancy_value_t = occupancy_t;
@@ -189,6 +191,15 @@ class CVoxelMapOccupancyBase :
   TVoxelMap_LikelihoodOptions likelihoodOptions;
 
   TVoxelMap_RenderingOptions renderingOptions;
+
+  // mrpt::config::OptionsCapable interface:
+  [[nodiscard]] std::map<std::string, mrpt::config::CLoadableOptions*> optionsByName() override
+  {
+    return {
+        { "insertionOptions",  &insertionOptions},
+        {"likelihoodOptions", &likelihoodOptions},
+    };
+  }
 
   /** Performs Bayesian fusion of a new observation of a cell.
    * This method increases the "occupancy-ness" of a cell, managing possible

--- a/modules/mrpt_maps/include/mrpt/maps/CWirelessPowerGridMap2D.h
+++ b/modules/mrpt_maps/include/mrpt/maps/CWirelessPowerGridMap2D.h
@@ -14,6 +14,7 @@
 
 #pragma once
 
+#include <mrpt/config/OptionsCapable.h>
 #include <mrpt/maps/CRandomFieldGridMap2D.h>
 #include <mrpt/obs/CObservationWirelessPower.h>
 
@@ -34,7 +35,7 @@ namespace mrpt::maps
  * mrpt::maps::CMultiMetricMap
  * \ingroup mrpt_maps_grp
  */
-class CWirelessPowerGridMap2D : public CRandomFieldGridMap2D
+class CWirelessPowerGridMap2D : public CRandomFieldGridMap2D, public mrpt::config::OptionsCapable
 {
   DEFINE_SERIALIZABLE(CWirelessPowerGridMap2D, mrpt::maps)
  public:
@@ -63,6 +64,9 @@ class CWirelessPowerGridMap2D : public CRandomFieldGridMap2D
     void dumpToTextStream(std::ostream& out) const override;  // See base docs
 
   } insertionOptions;
+
+  // mrpt::config::OptionsCapable interface:
+  [[nodiscard]] std::map<std::string, mrpt::config::CLoadableOptions*> optionsByName() override;
 
   /** Returns a 3D object representing the map  */
   void getVisualizationInto(mrpt::viz::CSetOfObjects& outObj) const override;

--- a/modules/mrpt_maps/src/maps/CBeaconMap.cpp
+++ b/modules/mrpt_maps/src/maps/CBeaconMap.cpp
@@ -1151,3 +1151,11 @@ void CBeaconMap::saveToTextFile(const string& fil) const
   os::fclose(f);
   MRPT_END
 }
+
+std::map<std::string, mrpt::config::CLoadableOptions*> CBeaconMap::optionsByName()
+{
+  return {
+      { "insertionOptions",  &insertionOptions},
+      {"likelihoodOptions", &likelihoodOptions},
+  };
+}

--- a/modules/mrpt_maps/src/maps/CGasConcentrationGridMap2D.cpp
+++ b/modules/mrpt_maps/src/maps/CGasConcentrationGridMap2D.cpp
@@ -1261,3 +1261,10 @@ bool CGasConcentrationGridMap2D::load_Gaussian_Wind_Grid_From_File()
     return false;
   }
 }
+
+std::map<std::string, mrpt::config::CLoadableOptions*> CGasConcentrationGridMap2D::optionsByName()
+{
+  return {
+      {"insertionOptions", &insertionOptions},
+  };
+}

--- a/modules/mrpt_maps/src/maps/CHeightGridMap2D.cpp
+++ b/modules/mrpt_maps/src/maps/CHeightGridMap2D.cpp
@@ -410,3 +410,10 @@ float CHeightGridMap2D::compute3DMatchingRatio(
 }
 
 CHeightGridMap2D::TMapRepresentation CHeightGridMap2D::getMapType() { return m_mapType; }
+
+std::map<std::string, mrpt::config::CLoadableOptions*> CHeightGridMap2D::optionsByName()
+{
+  return {
+      {"insertionOptions", &insertionOptions},
+  };
+}

--- a/modules/mrpt_maps/src/maps/CHeightGridMap2D_MRF.cpp
+++ b/modules/mrpt_maps/src/maps/CHeightGridMap2D_MRF.cpp
@@ -307,3 +307,10 @@ void CHeightGridMap2D_MRF::getAs3DObject(
   CRandomFieldGridMap2D::getAs3DObject(meanObj, varObj);
   MRPT_END
 }
+
+std::map<std::string, mrpt::config::CLoadableOptions*> CHeightGridMap2D_MRF::optionsByName()
+{
+  return {
+      {"insertionOptions", &insertionOptions},
+  };
+}

--- a/modules/mrpt_maps/src/maps/COccupancyGridMap2D_common.cpp
+++ b/modules/mrpt_maps/src/maps/COccupancyGridMap2D_common.cpp
@@ -913,3 +913,11 @@ void COccupancyGridMap2D::nn_radius_search(
     if (maxPoints && results.size() >= maxPoints) break;
   }
 }
+
+std::map<std::string, mrpt::config::CLoadableOptions*> COccupancyGridMap2D::optionsByName()
+{
+  return {
+      { "insertionOptions",  &insertionOptions},
+      {"likelihoodOptions", &likelihoodOptions},
+  };
+}

--- a/modules/mrpt_maps/src/maps/COccupancyGridMap3D.cpp
+++ b/modules/mrpt_maps/src/maps/COccupancyGridMap3D.cpp
@@ -714,3 +714,11 @@ void COccupancyGridMap3D::nn_radius_search(
     if (maxPoints && results.size() >= maxPoints) break;
   }
 }
+
+std::map<std::string, mrpt::config::CLoadableOptions*> COccupancyGridMap3D::optionsByName()
+{
+  return {
+      { "insertionOptions",  &insertionOptions},
+      {"likelihoodOptions", &likelihoodOptions},
+  };
+}

--- a/modules/mrpt_maps/src/maps/CPointsMap.cpp
+++ b/modules/mrpt_maps/src/maps/CPointsMap.cpp
@@ -2375,3 +2375,12 @@ bool CPointsMap::saveToKittiVelodyneFile(const std::string& filename) const
     return false;
   }
 }
+
+std::map<std::string, mrpt::config::CLoadableOptions*> CPointsMap::optionsByName()
+{
+  return {
+      { "insertionOptions",  &insertionOptions},
+      {"likelihoodOptions", &likelihoodOptions},
+      {    "renderOptions",     &renderOptions},
+  };
+}

--- a/modules/mrpt_maps/src/maps/CRandomFieldGridMap3D.cpp
+++ b/modules/mrpt_maps/src/maps/CRandomFieldGridMap3D.cpp
@@ -408,3 +408,10 @@ void CRandomFieldGridMap3D::TPriorFactorGMRF::evalJacobian(double& dr_dx_i, doub
   dr_dx_i = +1.0;
   dr_dx_j = -1.0;
 }
+
+std::map<std::string, mrpt::config::CLoadableOptions*> CRandomFieldGridMap3D::optionsByName()
+{
+  return {
+      {"insertionOptions", &insertionOptions},
+  };
+}

--- a/modules/mrpt_maps/src/maps/CReflectivityGridMap2D.cpp
+++ b/modules/mrpt_maps/src/maps/CReflectivityGridMap2D.cpp
@@ -394,3 +394,10 @@ float CReflectivityGridMap2D::compute3DMatchingRatio(
 {
   return 0;
 }
+
+std::map<std::string, mrpt::config::CLoadableOptions*> CReflectivityGridMap2D::optionsByName()
+{
+  return {
+      {"insertionOptions", &insertionOptions},
+  };
+}

--- a/modules/mrpt_maps/src/maps/CWirelessPowerGridMap2D.cpp
+++ b/modules/mrpt_maps/src/maps/CWirelessPowerGridMap2D.cpp
@@ -340,3 +340,10 @@ void CWirelessPowerGridMap2D::getVisualizationInto(mrpt::viz::CSetOfObjects& o) 
   CRandomFieldGridMap2D::getVisualizationInto(o);
   MRPT_END
 }
+
+std::map<std::string, mrpt::config::CLoadableOptions*> CWirelessPowerGridMap2D::optionsByName()
+{
+  return {
+      {"insertionOptions", &insertionOptions},
+  };
+}


### PR DESCRIPTION
## Summary

- Adds `mrpt::config::OptionsCapable`, a virtual mixin interface living next to `CLoadableOptions` in `mrpt_config`. It exposes a class' `CLoadableOptions` members generically, by name (`optionsByName()`), plus a safe `trySetCreationOptions()` hook for options that configure internal structure (e.g. a voxel/grid size) and may be unsafe to change once data has been inserted.
- This is a backport of `mola::OptionsCapable` from [MOLAorg/mola](https://github.com/MOLAorg/mola), where it is used by generic `.mm`/`.ini` export-import tooling to read/write a map's options without knowing its concrete class.
- Implements the new interface in every `mrpt_maps` class that holds `CLoadableOptions`-derived members as its own insertion/likelihood/render options: `COccupancyGridMap2D`, `COccupancyGridMap3D`, `CPointsMap`, `CHeightGridMap2D`, `CHeightGridMap2D_MRF`, `CWirelessPowerGridMap2D`, `CGasConcentrationGridMap2D`, `CRandomFieldGridMap3D`, `CReflectivityGridMap2D`, `CBeaconMap`, `COctoMapBase` and `CVoxelMapOccupancyBase` (the last two are template base classes, so their concrete derived classes, e.g. `COctoMap`, `CVoxelMap`, get the interface automatically).

## Test plan

- [x] New unit tests in `modules/mrpt_config/tests/OptionsCapable_unittest.cpp` covering `optionsByName()` exposing live members and the default/overridden `trySetCreationOptions()` behavior.
- [x] `colcon build --packages-select mrpt_config mrpt_maps` succeeds.
- [x] `test_mrpt_config` passes (12/12 tests, including the 3 new ones).
- [x] Verified the pre-existing `test_mrpt_maps` build failure (missing `kdtree_save_index_3D`/`kdtree_load_index_3D` in `CPointsMap_unittest.cpp`) reproduces identically on unmodified `develop`, i.e. unrelated to this change.
- [x] `clang-format-14` applied to all changed C++ files.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Several map types now expose their configurable/loadable options by name, enabling programmatic inspection and updates.
  * Added a standardized hook to apply creation-time configuration for compatible components.
* **Bug Fixes**
  * Improved configuration behavior to reject incompatible creation updates when the object already contains existing data.
* **Tests**
  * Added unit tests covering named option exposure and creation-time configuration acceptance/rejection behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->