### PR TITLE
fix(mrpt_maps): make CPointsMap/CGenericPointsMap tests build on MSVC

### DIFF
--- a/modules/mrpt_maps/tests/CGenericPointsMap_unittest.cpp
+++ b/modules/mrpt_maps/tests/CGenericPointsMap_unittest.cpp
@@ -14,7 +14,6 @@
 #include <mrpt/io/CMemoryStream.h>
 #include <mrpt/maps/CGenericPointsMap.h>
 #include <mrpt/serialization/CArchive.h>
-#include <unistd.h>
 
 #include <atomic>
 #include <filesystem>
@@ -22,8 +21,27 @@
 #include <thread>
 #include <vector>
 
+#ifdef _WIN32
+#include <process.h>  // _getpid()
+#else
+#include <unistd.h>  // getpid()
+#endif
+
 using mrpt::maps::CGenericPointsMap;
 using mrpt::maps::CPointsMap;
+
+namespace
+{
+/// Portable current-process id, used to build unique temp file names.
+long currentProcessId()
+{
+#ifdef _WIN32
+  return static_cast<long>(_getpid());
+#else
+  return static_cast<long>(getpid());
+#endif
+}
+}  // namespace
 
 // ---------------------------------------------------------------------------
 //  Helpers
@@ -596,8 +614,8 @@ TEST(CGenericPointsMap, PLYRoundTripPreservesIntensity)
   static std::atomic<int> counter{0};
   const auto dir = std::filesystem::temp_directory_path();
   const std::string file =
-      (dir / ("mrpt_CGenericPointsMap_unittest_" + std::to_string(static_cast<long>(getpid())) +
-              "_" + std::to_string(counter++) + ".ply"))
+      (dir / ("mrpt_CGenericPointsMap_unittest_" + std::to_string(currentProcessId()) + "_" +
+              std::to_string(counter++) + ".ply"))
           .string();
 
   ASSERT_TRUE(src.saveToPlyFile(file));

--- a/modules/mrpt_maps/tests/CPointsMap_unittest.cpp
+++ b/modules/mrpt_maps/tests/CPointsMap_unittest.cpp
@@ -24,7 +24,6 @@
 #include <mrpt/poses/CPoint2D.h>
 #include <mrpt/poses/CPose2D.h>
 #include <mrpt/poses/CPose3D.h>
-#include <unistd.h>
 
 #include <array>
 #include <atomic>
@@ -33,6 +32,12 @@
 #include <fstream>
 #include <sstream>
 #include <stdexcept>
+
+#ifdef _WIN32
+#include <process.h>  // _getpid()
+#else
+#include <unistd.h>  // getpid()
+#endif
 
 using namespace mrpt;
 using namespace mrpt::maps;
@@ -268,13 +273,22 @@ void do_tests_loadSaveStreams()
 
 namespace
 {
+/// Portable current-process id, used to build unique temp file names.
+long currentProcessId()
+{
+#ifdef _WIN32
+  return static_cast<long>(_getpid());
+#else
+  return static_cast<long>(getpid());
+#endif
+}
+
 /// Builds a unique path in the system temp directory for round-trip file tests.
 std::string makeTempFilePath(const std::string& suffix)
 {
   static std::atomic<int> counter{0};
   const auto dir = std::filesystem::temp_directory_path();
-  const std::string fname = "mrpt_CPointsMap_unittest_" +
-                            std::to_string(static_cast<long>(getpid())) + "_" +
+  const std::string fname = "mrpt_CPointsMap_unittest_" + std::to_string(currentProcessId()) + "_" +
                             std::to_string(counter++) + suffix;
   return (dir / fname).string();
 }


### PR DESCRIPTION
## Summary
- Fixes the currently failing Windows CI build on `develop`: `CPointsMap_unittest.cpp` and `CGenericPointsMap_unittest.cpp` unconditionally `#include <unistd.h>` just to call `getpid()` for unique temp file names. That header doesn't exist on MSVC, breaking the `mrpt_maps` test build on Windows.
- Guards the include (`<process.h>`/`_getpid()` on Windows, `<unistd.h>`/`getpid()` elsewhere) behind `_WIN32`.

## Test plan
- [x] `colcon build --packages-up-to mrpt_maps --cmake-args -DBUILD_TESTING=ON` (Linux, local)
- [x] `test_mrpt_maps` full suite: 442 passed / 5 skipped (unrelated KDTree-index feature gate), 0 failed
- [ ] CI Windows job green

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved cross-platform compatibility for temporary files used during map data validation.
  * Tests now run correctly on Windows and other supported platforms without relying on platform-specific process ID handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->