### PR TITLE
Fix CTimeLogger thread-safety in reporting + minimize enter()/leave() overhead

### DIFF
--- a/modules/mrpt_containers/include/mrpt/containers/ts_hash_map.h
+++ b/modules/mrpt_containers/include/mrpt/containers/ts_hash_map.h
@@ -244,6 +244,10 @@ class ts_hash_map
 
   ts_hash_map& operator=(const ts_hash_map& o)
   {
+    if (this == &o)
+    {  // self-assignment would lock the (non-recursive) mutex twice
+      return *this;
+    }
     auto lck1 = mrpt::lockHelper(m_mtx);
     auto lck2 = mrpt::lockHelper(o.m_mtx);
     m_vec = o.m_vec;
@@ -252,6 +256,10 @@ class ts_hash_map
   }
   ts_hash_map& operator=(ts_hash_map&& o) noexcept
   {
+    if (this == &o)
+    {  // self-assignment would lock the (non-recursive) mutex twice
+      return *this;
+    }
     auto lck1 = mrpt::lockHelper(m_mtx);
     auto lck2 = mrpt::lockHelper(o.m_mtx);
     m_vec = std::move(o.m_vec);

--- a/modules/mrpt_containers/include/mrpt/containers/ts_hash_map.h
+++ b/modules/mrpt_containers/include/mrpt/containers/ts_hash_map.h
@@ -199,7 +199,39 @@ class ts_hash_map
   /** Number of elements accessed with write access so far */
   size_t m_size{0};
 
-  std::recursive_mutex m_mtx;  //!< for m_vec and m_size
+  std::mutex m_mtx;  //!< for m_vec and m_size
+
+  /** Compare a stored key against a lookup key. The std::string_view overload
+   * enables allocation-free lookups when KEY is std::string. */
+  static bool keys_equal(const KEY& a, const KEY& b) { return a == b; }
+  static bool keys_equal(const KEY& a, const std::string_view& b)
+  {
+    return std::string_view(a) == b;
+  }
+
+  /** Core of find_or_alloc()/operator[](), assumes m_mtx is already held. */
+  template <typename LOOKUP_KEY>
+  VALUE* find_or_alloc_unlocked(const LOOKUP_KEY& key) noexcept
+  {
+    mrpt::uint_select_by_bytecount_t<NUM_BYTES_HASH_TABLE> hash;
+    reduced_hash(key, hash);
+    auto& match_arr = m_vec[hash];
+    for (unsigned int i = 0; i < NUM_HAS_TABLE_COLLISIONS_ALLOWED; i++)
+    {
+      if (!match_arr[i].used)
+      {
+        m_size++;
+        match_arr[i].used = true;
+        match_arr[i].first = KEY(key);  // constructs the key only on insertion
+        return &match_arr[i].second;
+      }
+      if (keys_equal(match_arr[i].first, key))
+      {
+        return &match_arr[i].second;
+      }
+    }
+    return nullptr;
+  }
 
  public:
   /** @name Constructors, read/write access and other operations
@@ -251,25 +283,16 @@ class ts_hash_map
   VALUE* find_or_alloc(const KEY& key) noexcept
   {
     auto lck = mrpt::lockHelper(m_mtx);
+    return find_or_alloc_unlocked(key);
+  }
 
-    mrpt::uint_select_by_bytecount_t<NUM_BYTES_HASH_TABLE> hash;
-    reduced_hash(key, hash);
-    auto& match_arr = m_vec[hash];
-    for (unsigned int i = 0; i < NUM_HAS_TABLE_COLLISIONS_ALLOWED; i++)
-    {
-      if (!match_arr[i].used)
-      {
-        m_size++;
-        match_arr[i].used = true;
-        match_arr[i].first = key;
-        return &match_arr[i].second;
-      }
-      if (match_arr[i].first == key)
-      {
-        return &match_arr[i].second;
-      }
-    }
-    return nullptr;
+  /** \overload Allocation-free lookup by std::string_view (only usable when
+   * KEY is std::string): avoids constructing a temporary std::string for the
+   * common case of looking up an already-existing entry. */
+  VALUE* find_or_alloc(const std::string_view& key) noexcept
+  {
+    auto lck = mrpt::lockHelper(m_mtx);
+    return find_or_alloc_unlocked(key);
   }
 
   /** Write/read via [i] operator, that creates an element if it didn't exist
@@ -278,7 +301,7 @@ class ts_hash_map
   {
     auto lck = mrpt::lockHelper(m_mtx);
 
-    VALUE* v = find_or_alloc(key);
+    VALUE* v = find_or_alloc_unlocked(key);
     if (!v)
     {
       throw std::runtime_error("ts_hash_map: too many hash collisions!");
@@ -300,7 +323,9 @@ class ts_hash_map
         return const_iterator(m_vec, *this, hash, static_cast<int>(i));
       }
     }
-    return this->end();
+    // Build the end() iterator inline (do not call end(), which would try to
+    // re-lock the non-recursive m_mtx already held here):
+    return const_iterator(m_vec, *this, static_cast<int>(m_vec.size()), 0);
   }
 
   const_iterator begin() const

--- a/modules/mrpt_containers/include/mrpt/containers/ts_hash_map.h
+++ b/modules/mrpt_containers/include/mrpt/containers/ts_hash_map.h
@@ -328,6 +328,44 @@ class ts_hash_map
     auto lck = mrpt::lockHelper(m_mtx);
     return iterator(m_vec, *this, static_cast<int>(m_vec.size()), 0);
   }
+
+  /** Thread-safe traversal: invokes `f(const value_type&)` for each used entry
+   * while holding the internal mutex, so it is safe to run concurrently with
+   * find_or_alloc()/operator[]() from other threads (unlike the iterators
+   * returned by begin()/end(), whose increment is not internally
+   * synchronized). Keep the visitor cheap: it runs under the container lock. */
+  template <typename VisitorFn>
+  void visitAllEntries(VisitorFn f) const
+  {
+    auto lck = mrpt::lockHelper(m_mtx);
+    for (const auto& match_arr : m_vec)
+    {
+      for (const auto& e : match_arr)
+      {
+        if (e.used)
+        {
+          f(e);
+        }
+      }
+    }
+  }
+
+  /** \overload (non-const version) */
+  template <typename VisitorFn>
+  void visitAllEntries(VisitorFn f)
+  {
+    auto lck = mrpt::lockHelper(m_mtx);
+    for (auto& match_arr : m_vec)
+    {
+      for (auto& e : match_arr)
+      {
+        if (e.used)
+        {
+          f(e);
+        }
+      }
+    }
+  }
   /** @} */
 
 };  // end class ts_hash_map

--- a/modules/mrpt_containers/tests/ts_hash_map_unittest.cpp
+++ b/modules/mrpt_containers/tests/ts_hash_map_unittest.cpp
@@ -95,6 +95,39 @@ TEST(ts_hash_map, visitAllEntries)
   EXPECT_EQ(30.0, m["tres"]);
 }
 
+TEST(ts_hash_map, find_or_alloc_string_view)
+{
+  mrpt::containers::ts_hash_map<std::string, double> m;
+  m["uno"] = 1.0;
+
+  // Look up an existing key via std::string_view: must resolve to the SAME
+  // slot inserted through operator[] (i.e. reduced_hash()/keys_equal() must
+  // agree between std::string and std::string_view for identical content).
+  const std::string_view sv = "uno";
+  double* p = m.find_or_alloc(sv);
+  ASSERT_NE(p, nullptr);
+  EXPECT_EQ(*p, 1.0);
+  *p = 5.0;
+  EXPECT_EQ(m["uno"], 5.0) << "string_view lookup did not alias the string key";
+
+  // A new key via string_view must allocate a new entry:
+  double* q = m.find_or_alloc(std::string_view("dos"));
+  ASSERT_NE(q, nullptr);
+  *q = 2.0;
+  EXPECT_EQ(m["dos"], 2.0);
+}
+
+TEST(ts_hash_map, selfAssignment)
+{
+  // With a non-recursive mutex, an unguarded self-assignment would deadlock.
+  mrpt::containers::ts_hash_map<std::string, double> m;
+  m["uno"] = 1.0;
+  auto& ref = m;
+  m = ref;             // copy self-assignment
+  m = std::move(ref);  // move self-assignment
+  EXPECT_EQ(m["uno"], 1.0);
+}
+
 TEST(ts_hash_map, tooManyCollisionsThrows)
 {
   // These 6 keys were found to all reduce to the same uint8_t hash bucket

--- a/modules/mrpt_containers/tests/ts_hash_map_unittest.cpp
+++ b/modules/mrpt_containers/tests/ts_hash_map_unittest.cpp
@@ -68,6 +68,33 @@ TEST(ts_hash_map, stdstring_key)
   }
 }
 
+TEST(ts_hash_map, visitAllEntries)
+{
+  mrpt::containers::ts_hash_map<std::string, double> m;
+  m["uno"] = 1.0;
+  m["dos"] = 2.0;
+  m["tres"] = 3.0;
+
+  // const visitor: sum values and count used entries.
+  double sum = .0;
+  size_t count = 0;
+  const auto& cm = m;
+  cm.visitAllEntries(
+      [&](const auto& e)
+      {
+        sum += e.second;
+        count++;
+      });
+  EXPECT_EQ(count, 3U);
+  EXPECT_NEAR(sum, 6.0, 1e-12);
+
+  // non-const visitor: mutate in place.
+  m.visitAllEntries([](auto& e) { e.second *= 10.0; });
+  EXPECT_EQ(10.0, m["uno"]);
+  EXPECT_EQ(20.0, m["dos"]);
+  EXPECT_EQ(30.0, m["tres"]);
+}
+
 TEST(ts_hash_map, tooManyCollisionsThrows)
 {
   // These 6 keys were found to all reduce to the same uint8_t hash bucket

--- a/modules/mrpt_system/include/mrpt/system/CTimeLogger.h
+++ b/modules/mrpt_system/include/mrpt/system/CTimeLogger.h
@@ -158,6 +158,10 @@ class CTimeLogger : public mrpt::system::COutputLogger
   }
   CTimeLogger& operator=(const CTimeLogger& o)
   {
+    if (this == &o)
+    {
+      return *this;
+    }
     COutputLogger::operator=(o);
     m_tictac = o.m_tictac;
     m_enabled = o.m_enabled.load();
@@ -177,6 +181,10 @@ class CTimeLogger : public mrpt::system::COutputLogger
   }
   CTimeLogger& operator=(CTimeLogger&& o)
   {
+    if (this == &o)
+    {
+      return *this;
+    }
     COutputLogger::operator=(std::move(o));
     m_tictac = std::move(o.m_tictac);
     m_enabled = o.m_enabled.load();
@@ -199,6 +207,11 @@ class CTimeLogger : public mrpt::system::COutputLogger
   /** Resets all stats. By default (deep_clear=false), all section names are
    * remembered (not freed) so the cost of creating upon the first next call
    * is avoided.
+   *
+   * \note With deep_clear=true the section entries are actually freed, which
+   * invalidates the section resolved by any still-alive CTimeLoggerEntry; do
+   * not call clear(true) while there are outstanding CTimeLoggerEntry objects
+   * for this logger (deep_clear=false is safe, it only resets the counters).
    */
   void clear(bool deep_clear = false);
 
@@ -272,6 +285,11 @@ class CTimeLogger : public mrpt::system::COutputLogger
  *
  *    // tle dtor does nothing else, since you already called stop()
  * \endcode
+ *
+ * \note The target section is resolved once at construction and cached, so the
+ * elapsed time is recorded without a second lookup. As a consequence, the
+ * logger's `clear(true)` (deep clear) must not be called while an entry is
+ * alive, since it frees the section entries (`clear(false)` is safe).
  *
  * \ingroup mrpt_system_grp
  */

--- a/modules/mrpt_system/include/mrpt/system/CTimeLogger.h
+++ b/modules/mrpt_system/include/mrpt/system/CTimeLogger.h
@@ -18,10 +18,12 @@
 #include <mrpt/system/COutputLogger.h>
 #include <mrpt/system/CTicTac.h>
 
+#include <atomic>
 #include <deque>
 #include <map>
 #include <optional>
 #include <stack>
+#include <utility>
 #include <vector>
 
 namespace mrpt::system
@@ -57,7 +59,9 @@ class CTimeLogger : public mrpt::system::COutputLogger
 {
  private:
   CTicTac m_tictac;
-  bool m_enabled;
+  /** Accessed without the section mutexes from enter()/leave(); atomic to avoid
+   * a data race with enable()/disable() called from other threads. */
+  std::atomic<bool> m_enabled;
   std::string m_name;
   bool m_keep_whole_history{false};
 
@@ -116,6 +120,12 @@ class CTimeLogger : public mrpt::system::COutputLogger
   void do_enter(const std::string_view& func_name) noexcept;
   double do_leave(const std::string_view& func_name) noexcept;
 
+  /** Returns a consistent copy of all recorded sections (name + stats), taken
+   * while holding the container and per-section locks. Used by the report/save
+   * methods so they can format the results without iterating the live container
+   * concurrently with enter()/leave() from other threads. */
+  std::vector<std::pair<std::string, TCallData>> getSectionsSnapshot() const;
+
  public:
   /** Data of each call section: # of calls, minimum, maximum, average and
    * overall execution time (in seconds) \sa getStats */
@@ -131,11 +141,46 @@ class CTimeLogger : public mrpt::system::COutputLogger
   ~CTimeLogger() override;
 
   // We must define these 4 because of the definition of a virtual dtor
-  // (compiler will not generate the defaults)
-  CTimeLogger(const CTimeLogger& o) = default;
-  CTimeLogger& operator=(const CTimeLogger& o) = default;
-  CTimeLogger(CTimeLogger&& o) = default;
-  CTimeLogger& operator=(CTimeLogger&& o) = default;
+  // (compiler will not generate the defaults). They are hand-written (instead
+  // of "= default") since std::atomic<bool> is neither copyable nor movable.
+  CTimeLogger(const CTimeLogger& o) :
+      COutputLogger(o),
+      m_tictac(o.m_tictac),
+      m_enabled(o.m_enabled.load()),
+      m_name(o.m_name),
+      m_keep_whole_history(o.m_keep_whole_history),
+      m_data(o.m_data)
+  {
+  }
+  CTimeLogger& operator=(const CTimeLogger& o)
+  {
+    COutputLogger::operator=(o);
+    m_tictac = o.m_tictac;
+    m_enabled = o.m_enabled.load();
+    m_name = o.m_name;
+    m_keep_whole_history = o.m_keep_whole_history;
+    m_data = o.m_data;
+    return *this;
+  }
+  CTimeLogger(CTimeLogger&& o) :
+      COutputLogger(std::move(o)),
+      m_tictac(std::move(o.m_tictac)),
+      m_enabled(o.m_enabled.load()),
+      m_name(std::move(o.m_name)),
+      m_keep_whole_history(o.m_keep_whole_history),
+      m_data(std::move(o.m_data))
+  {
+  }
+  CTimeLogger& operator=(CTimeLogger&& o)
+  {
+    COutputLogger::operator=(std::move(o));
+    m_tictac = std::move(o.m_tictac);
+    m_enabled = o.m_enabled.load();
+    m_name = std::move(o.m_name);
+    m_keep_whole_history = o.m_keep_whole_history;
+    m_data = std::move(o.m_data);
+    return *this;
+  }
 
   /** Dump all stats to a multi-line text string. \sa dumpAllStats,
    * saveToCVSFile */
@@ -150,11 +195,6 @@ class CTimeLogger : public mrpt::system::COutputLogger
   /** Resets all stats. By default (deep_clear=false), all section names are
    * remembered (not freed) so the cost of creating upon the first next call
    * is avoided.
-   *
-   * \note By design, calling this method is the only one which is not thread
-   * safe. It's not made thread-safe to save the performance cost. Please,
-   * ensure that you call `clear()` only while there are no other threads
-   * registering annotations in the object.
    */
   void clear(bool deep_clear = false);
 

--- a/modules/mrpt_system/include/mrpt/system/CTimeLogger.h
+++ b/modules/mrpt_system/include/mrpt/system/CTimeLogger.h
@@ -120,6 +120,10 @@ class CTimeLogger : public mrpt::system::COutputLogger
   void do_enter(const std::string_view& func_name) noexcept;
   double do_leave(const std::string_view& func_name) noexcept;
 
+  /** Updates the min/mean/max/history stats of a single, already-resolved
+   * section. Locks only that section's mutex (not the container). */
+  void updateStat(TCallData& d, double value, bool is_time) noexcept;
+
   /** Returns a consistent copy of all recorded sections (name + stats), taken
    * while holding the container and per-section locks. Used by the report/save
    * methods so they can format the results without iterating the live container
@@ -219,7 +223,7 @@ class CTimeLogger : public mrpt::system::COutputLogger
   /** Start of a named section \sa enter */
   void enter(const std::string_view& func_name) noexcept
   {
-    if (m_enabled)
+    if (m_enabled.load(std::memory_order_relaxed))
     {
       do_enter(func_name);
     }
@@ -228,7 +232,7 @@ class CTimeLogger : public mrpt::system::COutputLogger
    * disabled. \sa enter */
   double leave(const std::string_view& func_name) noexcept
   {
-    return m_enabled ? do_leave(func_name) : 0;
+    return m_enabled.load(std::memory_order_relaxed) ? do_leave(func_name) : 0;
   }
   /** Return the mean execution time of the given "section", or 0 if it hasn't
    * ever been called "enter" with that section name */
@@ -279,9 +283,11 @@ struct CTimeLoggerEntry
   void stop();  //!< for correct use, see docs for CTimeLoggerEntry
 
  private:
-  // Note we cannot store the string_view since we have no guarantees of the
-  // life-time of the provided string buffer.
-  const std::string m_section_name;
+  // The target section is resolved once at construction (while the caller's
+  // string buffer is still alive), so stop() needs neither a stored name nor a
+  // second hash lookup. Null if the logger was disabled at construction or the
+  // section could not be allocated (hash-table overflow).
+  CTimeLogger::TCallData* m_data = nullptr;
   double m_entry = 0;
   bool stopped_{false};
 };

--- a/modules/mrpt_system/src/CTimeLogger.cpp
+++ b/modules/mrpt_system/src/CTimeLogger.cpp
@@ -323,7 +323,7 @@ void CTimeLogger::dumpAllStats(size_t column_width) const
 
 void CTimeLogger::do_enter(const std::string_view& func_name) noexcept
 {
-  TCallData* d_ptr = m_data.find_or_alloc(std::string(func_name));
+  TCallData* d_ptr = m_data.find_or_alloc(func_name);
   if (!d_ptr)
   {
     std::cerr << "[CTimeLogger::do_enter] Warning: skipping due to hash "
@@ -341,7 +341,7 @@ double CTimeLogger::do_leave(const std::string_view& func_name) noexcept
 {
   const double tim = m_tictac.Tac();
 
-  TCallData* d_ptr = m_data.find_or_alloc(std::string(func_name));
+  TCallData* d_ptr = m_data.find_or_alloc(func_name);
   if (!d_ptr)
   {
     std::cerr << "[CTimeLogger::do_enter] Warning: skipping due to hash "
@@ -383,21 +383,8 @@ double CTimeLogger::do_leave(const std::string_view& func_name) noexcept
   return 0;  // This shouldn't happen!
 }
 
-void CTimeLogger::registerUserMeasure(
-    const std::string_view& event_name, const double value, const bool is_time) noexcept
+void CTimeLogger::updateStat(TCallData& d, double value, bool is_time) noexcept
 {
-  if (!m_enabled)
-  {
-    return;
-  }
-  TCallData* d_ptr = m_data.find_or_alloc(std::string(event_name));
-  if (!d_ptr)
-  {
-    std::cerr << "[CTimeLogger::do_enter] Warning: skipping due to hash "
-                 "collision.\n";
-    return;
-  }
-  auto& d = *d_ptr;
   auto lck = mrpt::lockHelper(d.mtx);
 
   d.has_time_units = is_time;
@@ -425,6 +412,23 @@ void CTimeLogger::registerUserMeasure(
   }
 }
 
+void CTimeLogger::registerUserMeasure(
+    const std::string_view& event_name, const double value, const bool is_time) noexcept
+{
+  if (!m_enabled.load(std::memory_order_relaxed))
+  {
+    return;
+  }
+  TCallData* d_ptr = m_data.find_or_alloc(event_name);
+  if (!d_ptr)
+  {
+    std::cerr << "[CTimeLogger::registerUserMeasure] Warning: skipping due to "
+                 "hash collision.\n";
+    return;
+  }
+  updateStat(*d_ptr, value, is_time);
+}
+
 double CTimeLogger::getMeanTime(const std::string& name) const
 {
   TDataMap::const_iterator it = m_data.find(name);
@@ -449,9 +453,16 @@ double CTimeLogger::getLastTime(const std::string& name) const
 
 CTimeLoggerEntry::CTimeLoggerEntry(
     const CTimeLogger& logger, const std::string_view& section_name) :
-    m_logger(const_cast<CTimeLogger&>(logger)), m_section_name(section_name)
+    m_logger(const_cast<CTimeLogger&>(logger))
 {
-  m_entry = logger.m_tictac.Tac();
+  // Resolve the section now, while the caller's string buffer is still alive,
+  // so stop() needs neither a stored name nor a second hash lookup.
+  if (m_logger.m_enabled.load(std::memory_order_relaxed))
+  {
+    m_data = m_logger.m_data.find_or_alloc(section_name);
+  }
+  // Start timing last, so the lookup cost is not counted in the section time.
+  m_entry = m_logger.m_tictac.Tac();
 }
 void CTimeLoggerEntry::stop()
 {
@@ -459,11 +470,13 @@ void CTimeLoggerEntry::stop()
   {
     return;
   }
-  const double leave = m_logger.m_tictac.Tac();
-  const double dt = leave - m_entry;
-
-  m_logger.registerUserMeasure(m_section_name, dt, true);
   stopped_ = true;
+  if (!m_data)
+  {
+    return;  // disabled at construction, or hash-table overflow
+  }
+  const double dt = m_logger.m_tictac.Tac() - m_entry;
+  m_logger.updateStat(*m_data, dt, true);
 }
 
 CTimeLoggerEntry::~CTimeLoggerEntry()

--- a/modules/mrpt_system/src/CTimeLogger.cpp
+++ b/modules/mrpt_system/src/CTimeLogger.cpp
@@ -90,13 +90,25 @@ void CTimeLogger::clear(bool deep_clear)
   }
   else
   {
-    for (auto& e : m_data)
-    {
-      e.second.mtx.lock();
-      e.second.mtx.unlock();
-      e.second = TCallData();
-    }
+    m_data.visitAllEntries(
+        [](TDataMap::value_type& e)
+        {
+          auto lck = mrpt::lockHelper(e.second.mtx);
+          e.second = TCallData();
+        });
   }
+}
+
+std::vector<std::pair<std::string, CTimeLogger::TCallData>> CTimeLogger::getSectionsSnapshot() const
+{
+  std::vector<std::pair<std::string, TCallData>> out;
+  m_data.visitAllEntries(
+      [&out](const TDataMap::value_type& e)
+      {
+        auto lck = mrpt::lockHelper(e.second.mtx);
+        out.emplace_back(e.first, e.second);
+      });
+  return out;
 }
 
 std::string aux_format_string_multilines(const std::string& s, size_t len)
@@ -117,17 +129,15 @@ std::string aux_format_string_multilines(const std::string& s, size_t len)
 void CTimeLogger::getStats(std::map<std::string, TCallStats>& out_stats) const
 {
   out_stats.clear();
-  for (const auto& e : m_data)
+  for (const auto& [name, d] : getSectionsSnapshot())
   {
-    auto lck = mrpt::lockHelper(e.second.mtx);
-
-    TCallStats& cs = out_stats[std::string(e.first)];
-    cs.min_t = e.second.min_t;
-    cs.max_t = e.second.max_t;
-    cs.total_t = e.second.mean_t;
-    cs.mean_t = e.second.n_calls ? e.second.mean_t / static_cast<double>(e.second.n_calls) : 0;
-    cs.n_calls = e.second.n_calls;
-    cs.last_t = e.second.last_t;
+    TCallStats& cs = out_stats[name];
+    cs.min_t = d.min_t;
+    cs.max_t = d.max_t;
+    cs.total_t = d.mean_t;
+    cs.mean_t = d.n_calls ? d.mean_t / static_cast<double>(d.n_calls) : 0;
+    cs.n_calls = d.n_calls;
+    cs.last_t = d.last_t;
   }
 }
 
@@ -163,11 +173,11 @@ std::string CTimeLogger::getStatsAsText(size_t column_width) const
   stats_text += bottom_header + "\n"s;
 
   // for all the timed sections: sort by inserting into a std::map
-  using NameAndCallData = std::map<std::string_view, TCallData>;
+  using NameAndCallData = std::map<std::string, TCallData>;
   NameAndCallData stat_strs;
-  for (const auto& i : m_data)
+  for (auto& [name, d] : getSectionsSnapshot())
   {
-    stat_strs[i.first] = i.second;
+    stat_strs[name] = std::move(d);
   }
 
   // format tree-like patterns like:
@@ -185,8 +195,6 @@ std::string CTimeLogger::getStatsAsText(size_t column_width) const
   std::string last_parent;
   for (const auto& i : stat_strs)
   {
-    auto lck = mrpt::lockHelper(i.second.mtx);
-
     string line = string(i.first);  // make a copy
 
     const auto dot_pos = line.find(".");
@@ -228,10 +236,8 @@ void CTimeLogger::saveToCSVFile(const std::string& csv_file) const
   std::string s;
   s += "FUNCTION, #CALLS, LAST.T, MIN.T, MEAN.T, MAX.T, TOTAL.T [, "
        "WHOLE_HISTORY]\n";
-  for (const auto& i : m_data)
+  for (const auto& i : getSectionsSnapshot())
   {
-    auto lck = mrpt::lockHelper(i.second.mtx);
-
     s += mrpt::format(
         "\"%.*s\",%7u,%e,%e,%e,%e,%e", static_cast<int>(i.first.size()), i.first.data(),
         static_cast<unsigned int>(i.second.n_calls), i.second.last_t, i.second.min_t,
@@ -269,10 +275,8 @@ void CTimeLogger::saveToMFile(const std::string& file) const
   std::string s_maxs = "s.max=["s;
   std::string s_means = "s.mean=["s;
 
-  for (const auto& i : m_data)
+  for (const auto& i : getSectionsSnapshot())
   {
-    auto lck = mrpt::lockHelper(i.second.mtx);
-
     s_names += "'"s + i.first + "',"s;
     s_counts += std::to_string(i.second.n_calls) + ","s;
     s_mins += mrpt::format("%e,", i.second.min_t);

--- a/modules/mrpt_system/tests/CTimeLogger_unittest.cpp
+++ b/modules/mrpt_system/tests/CTimeLogger_unittest.cpp
@@ -201,6 +201,51 @@ TEST(CTimeLogger, concurrentDumpWhileLogging)
   tl.clear(true);  // to silent console output upon dtor
 }
 
+// The RAII helper resolves its section once at construction and updates it at
+// destruction via a cached pointer (no second lookup, no stored name).
+TEST(CTimeLogger, scopedEntryRecords)
+{
+  mrpt::system::CTimeLogger tl;
+  {
+    mrpt::system::CTimeLoggerEntry tle(tl, "scoped");
+    std::this_thread::sleep_for(std::chrono::milliseconds(10));
+  }
+  EXPECT_GT(tl.getLastTime("scoped"), 5e-3);
+
+  // Explicit stop() must not double-count on later destruction:
+  {
+    mrpt::system::CTimeLoggerEntry tle(tl, "scoped2");
+    std::this_thread::sleep_for(std::chrono::milliseconds(10));
+    tle.stop();
+    tle.stop();  // no-op
+  }
+  std::map<std::string, mrpt::system::CTimeLogger::TCallStats> stats;
+  tl.getStats(stats);
+  EXPECT_EQ(stats["scoped2"].n_calls, 1U);
+
+  // Many scoped entries reusing the same section name (the hot path): all
+  // recorded under a single section.
+  for (int i = 0; i < 50; i++)
+  {
+    mrpt::system::CTimeLoggerEntry tle(tl, "loop");
+  }
+  tl.getStats(stats);
+  EXPECT_EQ(stats["loop"].n_calls, 50U);
+
+  tl.clear(true);  // to silent console output upon dtor
+}
+
+// A logger disabled at construction of the RAII entry records nothing.
+TEST(CTimeLogger, scopedEntryDisabled)
+{
+  mrpt::system::CTimeLogger tl(false /*disabled*/);
+  {
+    mrpt::system::CTimeLoggerEntry tle(tl, "nope");
+  }
+  EXPECT_EQ(tl.getLastTime("nope"), 0);
+  tl.clear(true);  // to silent console output upon dtor
+}
+
 // clear(false) must also be safe against concurrent logging.
 TEST(CTimeLogger, concurrentClearWhileLogging)
 {

--- a/modules/mrpt_system/tests/CTimeLogger_unittest.cpp
+++ b/modules/mrpt_system/tests/CTimeLogger_unittest.cpp
@@ -13,11 +13,17 @@
 */
 
 #include <gtest/gtest.h>
+#include <mrpt/core/format.h>
 #include <mrpt/system/CTimeLogger.h>
+#include <mrpt/system/filesystem.h>
 
+#include <atomic>
 #include <chrono>
+#include <map>
 #include <mutex>
+#include <string>
 #include <thread>
+#include <vector>
 
 namespace
 {
@@ -136,4 +142,96 @@ TEST(CTimeLogger, multithread)
   const std::string s = tl.getStatsAsText();
   tl.clear(true);  // to silent console output upon dtor
   EXPECT_EQ(std::count(s.begin(), s.end(), '\n'), 9U);
+}
+
+// Reporting/saving must be safe to call from one thread while other threads
+// keep logging (including registering brand-new sections). Before the fix, the
+// report methods iterated the live container without synchronization against
+// the writers, which is a data race (crash under TSan/ASan).
+TEST(CTimeLogger, concurrentDumpWhileLogging)
+{
+  mrpt::system::CTimeLogger tl;
+  tl.enableKeepWholeHistory(true);
+
+  std::atomic_bool stop{false};
+  std::vector<std::thread> ths;
+
+  // Writers: each thread keeps allocating/updating a growing set of sections.
+  for (int t = 0; t < 8; t++)
+  {
+    ths.emplace_back(
+        [t, &tl, &stop]()
+        {
+          int i = 0;
+          while (!stop)
+          {
+            const std::string name = mrpt::format("thread%d_sec%d", t, (i++) % 40);
+            tl.enter(name);
+            tl.leave(name);
+          }
+        });
+  }
+
+  // Readers: hammer all the report/save paths concurrently with the writers.
+  const std::string csv = mrpt::system::getTempFileName();
+  for (int r = 0; r < 3; r++)
+  {
+    ths.emplace_back(
+        [&tl, &csv, &stop]()
+        {
+          while (!stop)
+          {
+            (void)tl.getStatsAsText();
+            std::map<std::string, mrpt::system::CTimeLogger::TCallStats> stats;
+            tl.getStats(stats);
+            tl.saveToCSVFile(csv);
+          }
+        });
+  }
+
+  std::this_thread::sleep_for(std::chrono::milliseconds(300));
+  stop = true;
+  for (auto& th : ths)
+  {
+    th.join();
+  }
+
+  // If we got here without crashing/deadlocking, the test passed. Sanity check:
+  EXPECT_FALSE(tl.getStatsAsText().empty());
+  tl.clear(true);  // to silent console output upon dtor
+}
+
+// clear(false) must also be safe against concurrent logging.
+TEST(CTimeLogger, concurrentClearWhileLogging)
+{
+  mrpt::system::CTimeLogger tl;
+  std::atomic_bool stop{false};
+  std::vector<std::thread> ths;
+
+  for (int t = 0; t < 6; t++)
+  {
+    ths.emplace_back(
+        [t, &tl, &stop]()
+        {
+          int i = 0;
+          while (!stop)
+          {
+            const std::string name = mrpt::format("t%d_s%d", t, (i++) % 20);
+            tl.enter(name);
+            tl.leave(name);
+          }
+        });
+  }
+
+  for (int k = 0; k < 200; k++)
+  {
+    tl.clear(false);
+    std::this_thread::sleep_for(std::chrono::milliseconds(1));
+  }
+  stop = true;
+  for (auto& th : ths)
+  {
+    th.join();
+  }
+  tl.clear(true);  // to silent console output upon dtor
 }


### PR DESCRIPTION
## Summary

Two-commit change to `CTimeLogger` / `ts_hash_map`, motivated by a thread-safety analysis of the profiler's use of `mrpt::containers::ts_hash_map`.

### Commit 1 — thread-safety fix (`fix:`)

The fast path (`enter()`/`leave()` for *different* section names from different threads) was already safe, thanks to `ts_hash_map`'s fixed `std::array` backing (stable element addresses) and the per-section `std::mutex`. But the **report/save methods were not**:

`getStats`, `getStatsAsText`, `saveToCSVFile`, `saveToMFile` and `clear(false)` iterated the live container with a range-for. `ts_hash_map::iterator`'s increment is not internally synchronized, and a first-time `find_or_alloc()` writes each entry's `used`/`first` under the *container* mutex while those readers held only the *per-entry* mutex — disjoint locks, so no mutual exclusion. Reading a section's `std::string` name mid-write can crash, not just misreport (e.g. the global profiler dumping at shutdown while worker threads still log via `MRPT_START/END`).

- `ts_hash_map`: add `visitAllEntries()`, a visitor traversal that holds the container mutex, safe against concurrent `find_or_alloc()`.
- `CTimeLogger`: take a locked, consistent snapshot of all sections and format/serialize from that, instead of iterating the container live. `clear(false)` resets entries under the same lock (now thread-safe too).
- `m_enabled` is now `std::atomic<bool>` (was a plain-bool data race vs. `enable()`/`disable()`); copy/move special members hand-written accordingly.

### Commit 2 — minimize `enter()`/`leave()` overhead (`perf:`)

The correctness fixes are all on the cold (report/clear) path, so they add **no** steady-state hot-path cost. This commit then trims the hot path itself, without any public API change:

- **Allocation-free lookup**: new `find_or_alloc(std::string_view)` heterogeneous overload — `enter()`/`leave()`/`registerUserMeasure()` no longer build a temporary `std::string` per call; a `std::string` is allocated only when a *new* section is first inserted.
- **Cheaper lock**: `recursive_mutex` → plain `std::mutex`, taken exactly once per op via a shared `find_or_alloc_unlocked()` core (`operator[]` no longer double-locks).
- **`CTimeLoggerEntry` (the recommended multi-thread path)**: resolves its section once at construction and caches the pointer, so `stop()` updates stats directly — no stored name, no second hash, no container lock. Both per-entry `std::string` allocations are gone.
- `enter()`/`leave()` read `m_enabled` with a relaxed atomic load.

Net for a scoped entry: from *2 heap allocations + 2 hash lookups + a recursive-mutex round-trip* down to *1 hash lookup at construction (0 allocations after first use) + a single plain-mutex update at stop()*.

Note: `CTimeLoggerEntry` now decides whether to record based on `isEnabled()` at **construction** time (it resolves the section then) rather than at `stop()` time. A logger disabled when the scope opens records nothing for that scope.

## Tests

- `ts_hash_map`: `visitAllEntries` (const + non-const).
- `CTimeLogger`: `concurrentDumpWhileLogging` and `concurrentClearWhileLogging` stress tests (would race/crash before commit 1), plus `scopedEntryRecords` / `scopedEntryDisabled` for the reworked RAII path.
- Full `mrpt_containers` (97) and `mrpt_system` (33) suites pass; downstream `mrpt_graphs`/`mrpt_opengl` (which use `enter/leave` and `CTimeLoggerEntry`) build cleanly.

`ts_hash_map` is used only by `CTimeLogger`, so the container changes are low-risk.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added thread-safe traversal of hash map entries, with both read-only inspection and in-place updates.
  - Added allocation-free `std::string_view` lookup support for the timing logger’s internal key handling.

- **Improvements**
  - Enhanced hash map synchronization to reduce unnecessary locking and improve safety under contention.
  - Strengthened concurrent behavior of the timing logger during recording, stats generation, clearing, and CSV/M-file export.
  - Reduced temporary allocations during timing capture for better runtime performance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->