### PR TITLE
test(mrpt_core): regression test for Clock::toDouble unsigned wraparound

### DIFF
--- a/apps/mrpt_apps_cli/carmen2rawlog/carmen2rawlog_main.cpp
+++ b/apps/mrpt_apps_cli/carmen2rawlog/carmen2rawlog_main.cpp
@@ -36,6 +36,7 @@
 
 #include <CLI/CLI.hpp>
 #include <fstream>
+#include <iostream>
 #include <map>
 
 using namespace mrpt;

--- a/apps/mrpt_apps_cli/carmen2simplemap/carmen2simplemap_main.cpp
+++ b/apps/mrpt_apps_cli/carmen2simplemap/carmen2simplemap_main.cpp
@@ -39,6 +39,7 @@
 
 #include <CLI/CLI.hpp>
 #include <fstream>
+#include <iostream>
 
 using namespace mrpt;
 using namespace mrpt::poses;

--- a/apps/mrpt_apps_cli/gps2rawlog/gps2rawlog_main.cpp
+++ b/apps/mrpt_apps_cli/gps2rawlog/gps2rawlog_main.cpp
@@ -27,6 +27,7 @@
 #include <mrpt/system/os.h>
 
 #include <CLI/CLI.hpp>
+#include <iostream>
 
 using namespace mrpt;
 using namespace mrpt::hwdrivers;

--- a/modules/mrpt_core/src/Clock.cpp
+++ b/modules/mrpt_core/src/Clock.cpp
@@ -203,7 +203,17 @@ double mrpt::Clock::toDouble(const mrpt::Clock::time_point t) noexcept
     return .0;  // invalid time point
   }
 
-  return (static_cast<double>(t.time_since_epoch().count()) - 116444736e9) / 10000000.0;
+  // Offset between the 1601-01-01 epoch used by Clock::duration and the
+  // 1970-01-01 UNIX epoch, in 100-nanosecond ticks.
+  constexpr int64_t UNIX_EPOCH_OFFSET = INT64_C(116444736) * INT64_C(1000000000);
+
+  // Note: the subtraction below must be done in a floating-point (signed)
+  // domain. `t.time_since_epoch().count()` is a signed int64_t, so this is
+  // already the case here; do not change either operand to an unsigned type,
+  // or the result would wrap around for any t before 1970-01-01.
+  return (static_cast<double>(t.time_since_epoch().count()) -
+          static_cast<double>(UNIX_EPOCH_OFFSET)) /
+         10000000.0;
 }
 
 void mrpt::Clock::setActiveClock(Source s)

--- a/modules/mrpt_core/tests/Clock_unittest.cpp
+++ b/modules/mrpt_core/tests/Clock_unittest.cpp
@@ -137,6 +137,50 @@ TEST(clock, fromDouble_negativeAndNearEpoch)
   EXPECT_NEAR(mrpt::Clock::toDouble(tm1) - mrpt::Clock::toDouble(tm2), 1e-3, 1e-9);
 }
 
+TEST(clock, toDouble_preEpoch)
+{
+  // Regression test for an unsigned-wraparound bug: toDouble() used to
+  // compute `t.time_since_epoch().count() - UINT64_C(116444736) *
+  // UINT64_C(1000000000)` where both operands got promoted to uint64_t, even
+  // though `count()` is a *signed* int64_t. For any tick count before the
+  // 1970-01-01 UNIX epoch, the subtraction wrapped around and toDouble()
+  // returned ~+1.8e12 instead of a small negative number. This single-value
+  // check (as opposed to a difference of two toDouble() calls) is essential:
+  // a difference cancels the 2^64 wraparound and would pass even with the
+  // bug present.
+  const auto tm2ms = mrpt::Clock::fromDouble(-2e-3);
+  const double back = mrpt::Clock::toDouble(tm2ms);
+
+  EXPECT_NEAR(back, -2e-3, 1e-6);
+  EXPECT_LT(back, 0.0);
+  EXPECT_LT(std::abs(back), 1.0);  // must NOT be ~1.8e12
+}
+
+TEST(clock, toDouble_monotonicAcrossEpoch)
+{
+  // toDouble() must be strictly increasing across the 1601->1970 epoch
+  // boundary, i.e. no wraparound discontinuity for pre-epoch instants.
+  const double doubles[] = {-2e-3, -1e-3, 0.0, 1e-3, 1.0, 100.0};
+  double prev = mrpt::Clock::toDouble(mrpt::Clock::fromDouble(doubles[0]));
+  for (size_t i = 1; i < sizeof(doubles) / sizeof(doubles[0]); i++)
+  {
+    const double cur = mrpt::Clock::toDouble(mrpt::Clock::fromDouble(doubles[i]));
+    EXPECT_GT(cur, prev) << "i=" << i;
+    prev = cur;
+  }
+}
+
+TEST(clock, fromDouble_toDouble_roundtrip_negativeZeroPositive)
+{
+  // Round trip for negative, zero, and positive UNIX timestamps.
+  const double timestamps[] = {-100.0, -1.0, -1e-3, 0.0, 1e-3, 1.0, 100.0};
+  for (const double t : timestamps)
+  {
+    const double back = mrpt::Clock::toDouble(mrpt::Clock::fromDouble(t));
+    EXPECT_NEAR(back, t, 1e-6) << "t=" << t;
+  }
+}
+
 TEST(clock, simulatedTime)
 {
   const auto t0 = mrpt::Clock::now();


### PR DESCRIPTION
## Summary

`mrpt::Clock::toDouble()` on the 2.x maintenance line has a bug: it computes
the epoch subtraction with a `uint64_t` operand, which promotes the signed
`int64_t` tick count to unsigned and wraps around for any timestamp before
1970-01-01. See the companion fix on 2.x: #TBD (opening right after this PR).

**On `develop`, `toDouble()` is already correct.** It does the subtraction in
the floating-point domain:

```cpp
return (static_cast<double>(t.time_since_epoch().count()) - 116444736e9) / 10000000.0;
```

This double-precision subtraction never wraps, so no code change is needed
here. I verified this myself before touching anything (see the standalone
reproduction below) rather than "fixing" code that isn't broken.

What *is* missing on `develop` is a regression test that would catch this
class of bug. The existing `fromDouble_negativeAndNearEpoch` test (added by
b9e4174a, which fixed the sibling UB in `fromDouble()`) only checks a
*difference* of two `toDouble()` values:

```cpp
EXPECT_NEAR(mrpt::Clock::toDouble(tm1) - mrpt::Clock::toDouble(tm2), 1e-3, 1e-9);
```

A difference cancels a `2^64` wraparound, so this test passes whether or not
`toDouble()` itself is correct — it would not have caught the 2.x bug had it
been present here too.

## Changes

- `modules/mrpt_core/src/Clock.cpp`: no behavior change. Gave `toDouble()`
  the same named `UNIX_EPOCH_OFFSET` constant that `fromDouble()` already
  uses (added by b9e4174a), to make the epoch arithmetic self-documenting on
  both sides and keep the two functions easy to compare. The subtraction is
  still done as `double - double`, bit-identical to before (verified: a
  floating-point literal and `static_cast<double>` of the same integer value
  round to the same `double` under IEEE-754 round-to-nearest).
- `modules/mrpt_core/tests/Clock_unittest.cpp`: added
  - `toDouble_preEpoch`: a **single** pre-epoch `toDouble()` value, checked
    directly (not via a difference) — this is the test that would have
    caught the 2.x bug.
  - `toDouble_monotonicAcrossEpoch`: `toDouble()` must be strictly
    increasing across the 1601→1970 epoch boundary.
  - `fromDouble_toDouble_roundtrip_negativeZeroPositive`: round trip for
    negative, zero, and positive UNIX timestamps.

## Verification

Standalone `g++` reproduction of the exact `toDouble()` body used on
`develop` (floating-point subtraction) vs. the buggy unsigned-integer body
still present on 2.x, using the tick values from the bug report:

```
=== epoch - 2ms (ticks=116444735999980000) ===
  buggy : toDouble = 1844674407370.953125
  fixed : toDouble = -0.002000
=== epoch + 0.625s (ticks=116444736006250036) ===
  buggy : toDouble = 0.625004
  fixed : toDouble = 0.625003
=== difference (a - b), a=epoch-2ms, b=epoch+0.625s ===
  buggy : diff = 1844674407370.328125  (should be -0.627, wraps to ~ -1.8e12)
  fixed : diff = -0.627003  (expected -0.627)
=== post-epoch (t >= 1970) bit-identical check: PASS (identical for all t >= 1970 samples) ===
```

Confirms `develop`'s existing implementation is already correct, and that
the difference-based test alone would not distinguish buggy from fixed.

## Downstream report

`MOLAorg/mola_state_estimation#60` — `toDouble()`'s pre-epoch wraparound
(present on 2.x, not on develop) caused a spurious `-1.8e12 s` time
difference and an assertion failure that reset the state estimator on 22 of
22 KITTI runs, because `mola_lidar_odometry` backdates its first two fused
poses by 1-2 ms and KITTI's first scan is stamped `0.000000`.

Companion fix on the 2.x line (the branch that actually ships): see the PR
targeting `2.x` opened alongside this one.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected timestamp conversion for dates before 1970.
  * Preserved accurate ordering and round-trip behavior across the UNIX epoch, including small negative timestamps.

* **Tests**
  * Added regression coverage for negative, zero, and positive timestamp conversions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->