### PR TITLE
test(mrpt_nav, mrpt_kinematics): raise coverage to 90%/97% and fix 10 bugs found on the way

### DIFF
--- a/agents.md
+++ b/agents.md
@@ -201,7 +201,9 @@ files needed changes.
 A full rebuild of all 33 `modules/*` packages was done with coverage
 instrumentation, followed by a full `colcon test` run (all tests passed) and a
 `gcovr` line/branch report. **Goal: 90% line coverage per module.** Current
-overall (2026-07-06): **51.3% lines / 38.1% branches** — well short of goal.
+overall (2026-08-28, deduplicated the same way as
+`scripts/coverage_module_report.py`): **68.5% lines / 48.8% branches**
+— still short of goal, dominated by the hardware/GUI modules below.
 Per-module rows below are still the 2026-07-03 baseline except where a row is
 tagged with a newer date (e.g. `mrpt_math`, `mrpt_graphs`, after their
 unit-test passes).
@@ -292,14 +294,12 @@ and accurate path — pick two.
 | mrpt_gui | 22/4621 | 0.5% | 0.2% |
 | mrpt_hwdrivers | 913/6592 | 13.9% | 9.7% |
 | mrpt_comms | 237/1013 | 23.4% | 11.2% |
-| mrpt_kinematics | 184/482 | 38.2% | 17.9% |
 | mrpt_graphslam | 257/611 | 42.1% | 37.3% |
 | mrpt_opengl | 2035/4234 | 48.1% | 30.1% |
 | mrpt_system | 1012/1900 | 53.3% | 39.6% |
 | mrpt_io | 726/1292 | 56.2% | 39.9% |
 | mrpt_libapps_cli | 1130/1910 | 59.2% | 38.0% |
 | mrpt_libapps_gui | 952/1567 | 60.8% | 42.6% |
-| mrpt_nav | 3928/6234 | 63.0% | 45.3% |
 | mrpt_slam | 2778/4299 | 64.6% | 43.7% |
 | mrpt_viz (2026-08-02) | 6449/9426 | 68.4% | 50.1% |
 | mrpt_rtti | 126/176 | 71.6% | 73.5% |
@@ -308,6 +308,7 @@ and accurate path — pick two.
 | mrpt_math (2026-07-05) | 6914/8070 | 85.7% | 57.5% |
 | mrpt_core | 541/628 | 86.1% | 64.8% |
 | mrpt_obs (2026-07-10) | 4631/5324 | 87.0% | 56.1% |
+| mrpt_nav (2026-08-28)¶ | 4524/5026 | 90.0% | 69.3% |
 | mrpt_img (2026-07-10)† | 2255/2495 | 90.4% | 69.2% |
 | mrpt_graphs (2026-07-06) | 1022/1111 | 92.0% | 76.7% |
 | mrpt_poses | 6263/6787 | 92.3% | 59.8% |
@@ -315,6 +316,7 @@ and accurate path — pick two.
 | mrpt_expr | 93/100 | 93.0% | 60.2% |
 | mrpt_random | 160/167 | 95.8% | 85.1% |
 | mrpt_bayes (2026-07-09) | 1036/1078 | 96.1% | 77.4% |
+| mrpt_kinematics (2026-08-28)¶ | 426/440 | 96.8% | 83.5% |
 | mrpt_config (2026-07-09) | 531/548 | 96.9% | 82.3% |
 | mrpt_tfest (2026-07-07) | 633/652 | 97.1% | 73.3% |
 | mrpt_topography (2026-07-10) | 373/375 | 99.5% | 91.2% |
@@ -551,6 +553,81 @@ test), `opengl_fonts.h` (0%, embedded glyph bitmap data), and
 `CSetOfTexturedTriangles.cpp` (2.1%, needs a rendering-based test since its
 logic is mostly buffer-upload bookkeping).
 
+¶ `mrpt_nav` was raised from 63.0%/45.3% (2026-07-03 baseline) to
+90.0%/69.3% on 2026-08-28, together with `mrpt_kinematics`
+(38.2%/17.9% → 96.8%/83.5%), which had **no C++ unit tests at all** —
+only a python-bindings smoke test, so its `CMakeLists.txt` had no
+`LIB_UNIT_TEST_SOURCES` list at all and one had to be added. New test files:
+`mrpt_kinematics/tests/{CVehicleVelCmd,CVehicleSimul,CKinematicChain}_unittest.cpp`
+and `mrpt_nav/tests/{TWaypoint,PTG_variants,CAbstractNavigator,nav_misc,
+planners_and_logs,holonomic_config,rnav_variants,nav_interfaces}_unittest.cpp`.
+`CPTG_DiffDrive_CC`/`_CS`/`_CCS` had never been instantiated by any test
+(~2% each) and `impl_renderMoveTree.h` was at 0%.
+
+Real bugs found and fixed along the way: (1) `CVehicleVelCmd`'s copy
+constructor delegated to `operator=()`, which dispatches pure virtual methods
+while the derived object is still under construction — copy-constructing *any*
+velocity command aborted the process; (2)
+`CAbstractNavigator::internal_onStartNewNavigation()` cleared the cached pose
+history but left `m_last_curPoseVelUpdate_robot_time` untouched, so the
+`updateCurrentPoseAndSpeeds()` call right after it was skipped by its 20 ms
+minimum-period throttle and the following `ASSERT_(!m_latestPoses.empty())`
+threw on the first navigation step of *every* waypoint mission and *every*
+relative-target navigation; (3) `performNavigationStepNavigating()` ended with
+`m_navigationState = prevState;`, undoing the transitions it had just decided,
+so neither an exception nor `doEmergencyStop()` could ever leave the navigator
+in `NAV_ERROR` (the assignment was meant for `m_lastNavigationState`, and it
+was also what masked bug (2)); (4)
+`CWaypointsNavigator::checkHasReachedTarget()` dereferenced a possibly-null
+waypoint pointer via `(wp == nullptr && ...) || (wp->reached)`; (5)
+`CParameterizedTrajectoryGenerator::Alpha2index()` discarded `wrapToPi()`'s
+return value, clamping out-of-range directions to the first/last path instead
+of wrapping; (6) `CMultiObjectiveMotionOptimizerBase::decide()` returned `-1`
+from a `std::optional<size_t>` function on a formula compile error — an
+*engaged* optional holding `SIZE_MAX`, indexed out of bounds by the caller;
+(7) its `clear()` kept the variable table, so the next `decide()` threw
+"Expression name already exists as an input variable"; (8) `CLogFileRecord`'s
+legacy (pre-v15) deserialization wrote velocity components into the wrong
+slots; (9) `CReactiveNavigationSystem3D::saveConfigFile()` never called the
+`CAbstractPTGBasedReactive` implementation, so a saved 3D config was an
+unloadable stub; (10) `PlannerSimple2D::computePath()`'s endpoint bounds check
+read `!(originInside || !targetInside)`, which only flagged
+origin-outside-*and*-target-inside and let an out-of-grid target fall through
+into the search.
+
+Gotchas for future passes on these modules:
+
+* `mrpt_nav`'s `LIB_UNIT_TEST_SOURCES` is an explicit list (like `mrpt_maps`',
+  unlike glob-based modules): a new `*_unittest.cpp` silently never runs until
+  it is registered there.
+* `rnav_unittest.cpp`'s helper `return`s silently when the shared
+  `navigation-ptgs/*.ini` files are missing *and* swallows every exception, so
+  it can pass while testing nothing. New reactive-navigation tests build their
+  configuration with `mrpt::config::CConfigFileMemory` instead.
+* Reactive navigation tests must advance the robot's **navigation time**
+  (`CRobot2NavInterface::getNavigationTime()`), not only the wall/simulated
+  clock: `updateCurrentPoseAndSpeeds()` throttles to one query per 20 ms of
+  robot time, and a mock returning a constant leaves the pose cache empty.
+* `CHolonomicFullEval::navigate()` asserts `ni.clearance != nullptr`;
+  `CHolonomicVFF`/`CHolonomicND` ignore that field.
+* `CPTG_DiffDrive_*` need a polygonal robot shape in the config
+  (`shape_x0`/`shape_y0`/...) or `initialize()` throws "Robot shape was not
+  defined"; `CPTG_Holo_Blend` takes `robot_radius` instead and rejects a
+  polygonal one. `setRefDistance()` throws on a collision-grid PTG once
+  initialized.
+* With a `CPTG_Holo_Blend`, a waypoint left at `TWaypoint`'s default
+  `speed_ratio = 1.0` yields no viable movement at all and the mission times
+  out; `rnav_variants_unittest.cpp` sets an explicit `0.05`. Not investigated
+  further.
+* `CWaypointsNavigator::m_last_alignment_cmd` is set in the constructor and
+  never updated when an alignment command is issued, so the "give the
+  alignment some time to finish" wait actually measures time since the
+  navigator was constructed. Left as-is: fixing it adds a real dwell at every
+  waypoint with a heading.
+* `CVehicleSimulVirtualBase::setCurrentOdometricPose()` is templated but does
+  not accept a `mrpt::poses::CPose2D` (there is no `TPose2D` constructor from
+  it); pass `.asTPose()`.
+
 ### Weak areas, grouped by root cause
 
 1. **Hardware drivers — `mrpt_hwdrivers` (13.9%), most of `mrpt_comms` (23.4%)**:
@@ -586,6 +663,7 @@ logic is mostly buffer-upload bookkeping).
 5. **Biggest single-file impact (most uncovered lines, worth prioritizing for
    raw percentage gains)**:
    `mrpt_maps/src/maps/COccupancyGridMap2D_io.cpp` (85, 56.0%),
+   `mrpt_nav/src/reactive/CAbstractPTGBasedReactive.cpp` (123, 82.1%),
    `mrpt_maps/src/maps/COccupancyGridMap2D_simulate.cpp` (49, 53.3%).
    (`mrpt_viz/src/CPolyhedron.cpp`, formerly the single biggest uncovered file
    in the whole repo at 1420 uncovered lines, cleared this bucket as of

--- a/modules/mrpt_kinematics/CMakeLists.txt
+++ b/modules/mrpt_kinematics/CMakeLists.txt
@@ -26,6 +26,12 @@ set(LIB_SOURCES
   src/CVehicleSimul_DiffDriven.cpp
 )
 
+set(LIB_UNIT_TEST_SOURCES
+  tests/CKinematicChain_unittest.cpp
+  tests/CVehicleSimul_unittest.cpp
+  tests/CVehicleVelCmd_unittest.cpp
+)
+
 set(LIB_PUBLIC_HEADERS
   include/mrpt/kinematics/CVehicleSimul_Holo.h
   include/mrpt/kinematics/CVehicleSimul_DiffDriven.h
@@ -41,6 +47,7 @@ set(LIB_PUBLIC_HEADERS
 mrpt_add_library(
   TARGET ${PROJECT_NAME}
   SOURCES ${LIB_SOURCES} ${LIB_PUBLIC_HEADERS}
+  UNIT_TEST_SOURCES ${LIB_UNIT_TEST_SOURCES}
   PUBLIC_LINK_LIBRARIES
     mrpt::mrpt_viz
 #  PRIVATE_LINK_LIBRARIES

--- a/modules/mrpt_kinematics/include/mrpt/kinematics/CKinematicChain.h
+++ b/modules/mrpt_kinematics/include/mrpt/kinematics/CKinematicChain.h
@@ -178,11 +178,11 @@ class CKinematicChain : public mrpt::serialization::CSerializable
   void update3DObject(std::vector<mrpt::poses::CPose3D>* out_all_poses = nullptr) const;
 
   /** Go thru all the links of the chain and compute the global pose of each
-   * link. The "ground" link pose "pose0" defaults to the origin of
-   * coordinates,
-   * but anything else can be passed as the optional argument.
+   * link, starting at the pose set with setOriginPose().
    * The returned vector has N+1 elements (N=number of links), since [0]
    * contains the base frame, [1] the pose after the first link, and so on.
+   * \note `pose0` is currently ignored; use setOriginPose() to relocate the
+   * whole chain.
    */
   void recomputeAllPoses(
       std::vector<mrpt::poses::CPose3D>& poses,

--- a/modules/mrpt_kinematics/src/CKinematicChain.cpp
+++ b/modules/mrpt_kinematics/src/CKinematicChain.cpp
@@ -84,9 +84,8 @@ void CKinematicChain::serializeFrom(mrpt::serialization::CArchive& in, uint8_t v
   };
 }
 
-/** Go thru all the links of the chain and compute the global pose of each link.
- * The "ground" link pose "pose0" defaults to the origin of coordinates,
- * but anything else can be passed as the optional argument. */
+/** Go thru all the links of the chain and compute the global pose of each link,
+ * starting at the pose set with setOriginPose(). See header docs. */
 void CKinematicChain::recomputeAllPoses(
     std::vector<mrpt::poses::CPose3D>& poses,
     [[maybe_unused]] const mrpt::poses::CPose3D& pose0) const

--- a/modules/mrpt_kinematics/src/CVehicleVelCmd.cpp
+++ b/modules/mrpt_kinematics/src/CVehicleVelCmd.cpp
@@ -20,7 +20,10 @@ using namespace mrpt::kinematics;
 IMPLEMENTS_VIRTUAL_SERIALIZABLE(CVehicleVelCmd, CSerializable, mrpt::kinematics)
 
 CVehicleVelCmd::CVehicleVelCmd() = default;
-CVehicleVelCmd::CVehicleVelCmd(const CVehicleVelCmd& other) { *this = other; }
+// Note: defaulted on purpose. The base class holds no data, and delegating to
+// operator=() here would dispatch virtual calls while the derived object is
+// still under construction.
+CVehicleVelCmd::CVehicleVelCmd(const CVehicleVelCmd& other) = default;
 CVehicleVelCmd::~CVehicleVelCmd() = default;
 std::string mrpt::kinematics::CVehicleVelCmd::asString() const
 {

--- a/modules/mrpt_kinematics/tests/CKinematicChain_unittest.cpp
+++ b/modules/mrpt_kinematics/tests/CKinematicChain_unittest.cpp
@@ -1,0 +1,255 @@
+/*                    _
+                     | |    Mobile Robot Programming Toolkit (MRPT)
+ _ __ ___  _ __ _ __ | |_
+| '_ ` _ \| '__| '_ \| __|          https://www.mrpt.org/
+| | | | | | |  | |_) | |_
+|_| |_| |_|_|  | .__/ \__|     https://github.com/MRPT/mrpt/
+               | |
+               |_|
+
+ Copyright (c) 2005-2026, Individual contributors, see AUTHORS file
+ See: https://www.mrpt.org/Authors - All rights reserved.
+ SPDX-License-Identifier: BSD-3-Clause
+*/
+
+#include <gtest/gtest.h>
+#include <mrpt/io/CMemoryStream.h>
+#include <mrpt/kinematics/CKinematicChain.h>
+#include <mrpt/math/CVectorDynamic.h>
+#include <mrpt/serialization/CArchive.h>
+#include <mrpt/viz/CSetOfObjects.h>
+
+#include <vector>
+
+using namespace mrpt::kinematics;
+
+namespace
+{
+/** A 2-link planar arm: both links revolute, of length `a`, in the XY plane. */
+CKinematicChain make_planar_arm(double a = 1.0)
+{
+  CKinematicChain c;
+  c.addLink(.0 /*theta*/, .0 /*d*/, a /*a*/, .0 /*alpha*/, false /*revolute*/);
+  c.addLink(.0, .0, a, .0, false);
+  return c;
+}
+}  // namespace
+
+TEST(CKinematicChain, default_constructed_is_empty)
+{
+  CKinematicChain c;
+  EXPECT_EQ(c.size(), 0U);
+  EXPECT_EQ(c.getOriginPose(), mrpt::poses::CPose3D());
+
+  std::vector<mrpt::poses::CPose3D> poses;
+  c.recomputeAllPoses(poses);
+  EXPECT_EQ(poses.size(), 1U);  // just the base frame
+}
+
+TEST(CKinematicChain, add_get_and_remove_links)
+{
+  CKinematicChain c;
+  c.addLink(0.1, 0.2, 0.3, 0.4, false);
+  c.addLink(1.1, 1.2, 1.3, 1.4, true);
+  ASSERT_EQ(c.size(), 2U);
+
+  const auto& l0 = c.getLink(0);
+  EXPECT_NEAR(l0.theta, 0.1, 1e-12);
+  EXPECT_NEAR(l0.d, 0.2, 1e-12);
+  EXPECT_NEAR(l0.a, 0.3, 1e-12);
+  EXPECT_NEAR(l0.alpha, 0.4, 1e-12);
+  EXPECT_FALSE(l0.is_prismatic);
+  EXPECT_TRUE(c.getLink(1).is_prismatic);
+
+  c.getLinkRef(0).theta = 0.9;
+  EXPECT_NEAR(c.getLink(0).theta, 0.9, 1e-12);
+
+  EXPECT_ANY_THROW(c.getLink(2));
+  EXPECT_ANY_THROW(c.getLinkRef(2));
+  EXPECT_ANY_THROW(c.removeLink(2));
+
+  c.removeLink(0);
+  ASSERT_EQ(c.size(), 1U);
+  EXPECT_NEAR(c.getLink(0).theta, 1.1, 1e-12);
+
+  c.clear();
+  EXPECT_EQ(c.size(), 0U);
+}
+
+TEST(CKinematicChain, configuration_get_and_set)
+{
+  CKinematicChain c;
+  c.addLink(0.5, .0, 1.0, .0, false);  // revolute: q is `theta`
+  c.addLink(.0, 0.7, 1.0, .0, true);   // prismatic: q is `d`
+
+  std::vector<double> q;
+  c.getConfiguration(q);
+  ASSERT_EQ(q.size(), 2U);
+  EXPECT_NEAR(q[0], 0.5, 1e-12);
+  EXPECT_NEAR(q[1], 0.7, 1e-12);
+
+  c.setConfiguration(std::vector<double>{1.5, 2.5});
+  EXPECT_NEAR(c.getLink(0).theta, 1.5, 1e-12);
+  EXPECT_NEAR(c.getLink(1).d, 2.5, 1e-12);
+  // The "unused" DOF of each link must be left untouched:
+  EXPECT_NEAR(c.getLink(0).d, .0, 1e-12);
+  EXPECT_NEAR(c.getLink(1).theta, .0, 1e-12);
+
+  EXPECT_ANY_THROW(c.setConfiguration(std::vector<double>{1.0}));
+}
+
+TEST(CKinematicChain, configuration_works_with_mrpt_vectors)
+{
+  CKinematicChain c = make_planar_arm();
+
+  mrpt::math::CVectorDouble q;
+  c.getConfiguration(q);
+  ASSERT_EQ(q.size(), 2);
+
+  q[0] = 0.25;
+  q[1] = -0.25;
+  c.setConfiguration(q);
+  EXPECT_NEAR(c.getLink(0).theta, 0.25, 1e-12);
+  EXPECT_NEAR(c.getLink(1).theta, -0.25, 1e-12);
+}
+
+TEST(CKinematicChain, forward_kinematics_of_a_stretched_planar_arm)
+{
+  const double a = 1.0;
+  CKinematicChain c = make_planar_arm(a);
+
+  std::vector<mrpt::poses::CPose3D> poses;
+  c.recomputeAllPoses(poses);
+  ASSERT_EQ(poses.size(), 3U);
+
+  EXPECT_NEAR(poses[0].x(), .0, 1e-9);
+  EXPECT_NEAR(poses[1].x(), a, 1e-9);
+  EXPECT_NEAR(poses[2].x(), 2 * a, 1e-9);
+  EXPECT_NEAR(poses[2].y(), .0, 1e-9);
+  EXPECT_NEAR(poses[2].z(), .0, 1e-9);
+}
+
+TEST(CKinematicChain, forward_kinematics_of_a_folded_planar_arm)
+{
+  const double a = 1.0;
+  CKinematicChain c = make_planar_arm(a);
+  c.setConfiguration(std::vector<double>{.0, M_PI * 0.5});
+
+  std::vector<mrpt::poses::CPose3D> poses;
+  c.recomputeAllPoses(poses);
+  ASSERT_EQ(poses.size(), 3U);
+
+  // 2nd link turns +90deg, so the tip ends at (1,1,0):
+  EXPECT_NEAR(poses[2].x(), a, 1e-9);
+  EXPECT_NEAR(poses[2].y(), a, 1e-9);
+  EXPECT_NEAR(poses[2].z(), .0, 1e-9);
+}
+
+TEST(CKinematicChain, prismatic_link_translates_along_z)
+{
+  CKinematicChain c;
+  c.addLink(.0, 0.5 /*d*/, .0, .0, true);
+
+  std::vector<mrpt::poses::CPose3D> poses;
+  c.recomputeAllPoses(poses);
+  ASSERT_EQ(poses.size(), 2U);
+  EXPECT_NEAR(poses[1].z(), 0.5, 1e-9);
+
+  c.setConfiguration(std::vector<double>{1.5});
+  c.recomputeAllPoses(poses);
+  EXPECT_NEAR(poses[1].z(), 1.5, 1e-9);
+}
+
+TEST(CKinematicChain, origin_pose_offsets_the_whole_chain)
+{
+  CKinematicChain c = make_planar_arm();
+  const mrpt::poses::CPose3D org(10, 20, 30, .0, .0, .0);
+  c.setOriginPose(org);
+  EXPECT_EQ(c.getOriginPose(), org);
+
+  std::vector<mrpt::poses::CPose3D> poses;
+  c.recomputeAllPoses(poses);
+  ASSERT_EQ(poses.size(), 3U);
+  EXPECT_NEAR(poses[0].x(), 10.0, 1e-9);
+  EXPECT_NEAR(poses[2].x(), 12.0, 1e-9);
+  EXPECT_NEAR(poses[2].y(), 20.0, 1e-9);
+  EXPECT_NEAR(poses[2].z(), 30.0, 1e-9);
+}
+
+TEST(CKinematicChain, serialization_roundtrip)
+{
+  CKinematicChain c = make_planar_arm(0.75);
+  c.getLinkRef(1).is_prismatic = true;
+  c.setOriginPose(mrpt::poses::CPose3D(1, 2, 3, 0.1, 0.2, 0.3));
+
+  mrpt::io::CMemoryStream buf;
+  auto arch = mrpt::serialization::archiveFrom(buf);
+  arch << c;
+  buf.Seek(0);
+
+  CKinematicChain c2;
+  arch >> c2;
+
+  ASSERT_EQ(c2.size(), c.size());
+  for (size_t i = 0; i < c.size(); i++)
+  {
+    EXPECT_NEAR(c2.getLink(i).theta, c.getLink(i).theta, 1e-12);
+    EXPECT_NEAR(c2.getLink(i).d, c.getLink(i).d, 1e-12);
+    EXPECT_NEAR(c2.getLink(i).a, c.getLink(i).a, 1e-12);
+    EXPECT_NEAR(c2.getLink(i).alpha, c.getLink(i).alpha, 1e-12);
+    EXPECT_EQ(c2.getLink(i).is_prismatic, c.getLink(i).is_prismatic);
+  }
+  EXPECT_NEAR(c2.getOriginPose().x(), 1.0, 1e-9);
+  EXPECT_NEAR(c2.getOriginPose().yaw(), 0.1, 1e-9);
+}
+
+TEST(CKinematicChain, visualization_objects_are_built_and_updated)
+{
+  CKinematicChain c = make_planar_arm();
+  c.addLink(.0, 0.5, .0, .0, true);  // a prismatic link too
+
+  auto gl = mrpt::viz::CSetOfObjects::Create();
+  std::vector<mrpt::poses::CPose3D> poses;
+  c.getAs3DObject(gl, &poses);
+
+  EXPECT_EQ(poses.size(), c.size() + 1);
+  EXPECT_EQ(gl->size(), c.size() + 1);
+
+  // Moving the arm and refreshing must not throw nor change the object count:
+  const size_t nObjs = gl->size();
+  c.setConfiguration(std::vector<double>{0.3, -0.3, 1.0});
+  EXPECT_NO_THROW(c.update3DObject(&poses));
+  EXPECT_EQ(gl->size(), nObjs);
+  EXPECT_EQ(poses.size(), c.size() + 1);
+}
+
+TEST(CKinematicChain, getAs3DObject_requires_a_non_null_object)
+{
+  CKinematicChain c = make_planar_arm();
+  mrpt::viz::CSetOfObjects::Ptr gl;  // null
+  EXPECT_ANY_THROW(c.getAs3DObject(gl));
+}
+
+TEST(CKinematicChain, update3DObject_without_prior_getAs3DObject_throws)
+{
+  CKinematicChain c = make_planar_arm();
+  EXPECT_ANY_THROW(c.update3DObject());
+}
+
+TEST(TKinematicLink, stream_operators_roundtrip)
+{
+  TKinematicLink l(0.1, 0.2, 0.3, 0.4, true);
+
+  mrpt::io::CMemoryStream buf;
+  auto arch = mrpt::serialization::archiveFrom(buf);
+  arch << l;
+  buf.Seek(0);
+
+  TKinematicLink l2;
+  arch >> l2;
+  EXPECT_NEAR(l2.theta, 0.1, 1e-12);
+  EXPECT_NEAR(l2.d, 0.2, 1e-12);
+  EXPECT_NEAR(l2.a, 0.3, 1e-12);
+  EXPECT_NEAR(l2.alpha, 0.4, 1e-12);
+  EXPECT_TRUE(l2.is_prismatic);
+}

--- a/modules/mrpt_kinematics/tests/CVehicleSimul_unittest.cpp
+++ b/modules/mrpt_kinematics/tests/CVehicleSimul_unittest.cpp
@@ -1,0 +1,312 @@
+/*                    _
+                     | |    Mobile Robot Programming Toolkit (MRPT)
+ _ __ ___  _ __ _ __ | |_
+| '_ ` _ \| '__| '_ \| __|          https://www.mrpt.org/
+| | | | | | |  | |_) | |_
+|_| |_| |_|_|  | .__/ \__|     https://github.com/MRPT/mrpt/
+               | |
+               |_|
+
+ Copyright (c) 2005-2026, Individual contributors, see AUTHORS file
+ See: https://www.mrpt.org/Authors - All rights reserved.
+ SPDX-License-Identifier: BSD-3-Clause
+*/
+
+#include <gtest/gtest.h>
+#include <mrpt/kinematics/CVehicleSimul_DiffDriven.h>
+#include <mrpt/kinematics/CVehicleSimul_Holo.h>
+#include <mrpt/random.h>
+
+#include <cmath>
+
+using namespace mrpt::kinematics;
+
+// ---------------------------------------------------------------------------
+//  CVehicleSimul_DiffDriven
+// ---------------------------------------------------------------------------
+TEST(CVehicleSimul_DiffDriven, initial_state_is_zero)
+{
+  CVehicleSimul_DiffDriven sim;
+  EXPECT_EQ(sim.getTime(), .0);
+  EXPECT_EQ(sim.getCurrentGTPose().x, .0);
+  EXPECT_EQ(sim.getCurrentGTPose().y, .0);
+  EXPECT_EQ(sim.getCurrentGTPose().phi, .0);
+  EXPECT_EQ(sim.getCurrentOdometricPose().x, .0);
+  EXPECT_EQ(sim.getCurrentGTVel().vx, .0);
+  EXPECT_EQ(sim.getV(), .0);
+  EXPECT_EQ(sim.getW(), .0);
+}
+
+TEST(CVehicleSimul_DiffDriven, straight_motion_advances_along_x)
+{
+  CVehicleSimul_DiffDriven sim;
+  sim.movementCommand(1.0 /*m/s*/, .0);
+  sim.simulateOneTimeStep(2.0 /*s*/);
+
+  EXPECT_NEAR(sim.getCurrentGTPose().x, 2.0, 0.05);
+  EXPECT_NEAR(sim.getCurrentGTPose().y, .0, 1e-6);
+  EXPECT_NEAR(sim.getCurrentGTPose().phi, .0, 1e-6);
+  EXPECT_NEAR(sim.getTime(), 2.0, 0.01);
+
+  // Without odometry errors, GT and odometry must match:
+  EXPECT_NEAR(sim.getCurrentOdometricPose().x, sim.getCurrentGTPose().x, 1e-9);
+  EXPECT_NEAR(sim.getCurrentOdometricPose().y, sim.getCurrentGTPose().y, 1e-9);
+}
+
+TEST(CVehicleSimul_DiffDriven, pure_rotation_changes_heading_only)
+{
+  CVehicleSimul_DiffDriven sim;
+  sim.movementCommand(.0, 0.5 /*rad/s*/);
+  sim.simulateOneTimeStep(2.0);
+
+  EXPECT_NEAR(sim.getCurrentGTPose().phi, 1.0, 0.02);
+  EXPECT_NEAR(sim.getCurrentGTPose().x, .0, 1e-6);
+  EXPECT_NEAR(sim.getCurrentGTPose().y, .0, 1e-6);
+}
+
+TEST(CVehicleSimul_DiffDriven, sendVelCmd_matches_movementCommand)
+{
+  CVehicleSimul_DiffDriven sim;
+  CVehicleVelCmd_DiffDriven cmd;
+  cmd.lin_vel = 0.5;
+  cmd.ang_vel = .0;
+  sim.sendVelCmd(cmd);
+  sim.simulateOneTimeStep(1.0);
+  EXPECT_NEAR(sim.getCurrentGTPose().x, 0.5, 0.05);
+}
+
+TEST(CVehicleSimul_DiffDriven, sendVelCmd_rejects_wrong_kinematic_class)
+{
+  CVehicleSimul_DiffDriven sim;
+  CVehicleVelCmd_Holo wrongCmd;
+  EXPECT_ANY_THROW(sim.sendVelCmd(wrongCmd));
+}
+
+TEST(CVehicleSimul_DiffDriven, getVelCmdType_returns_diffdriven_cmd)
+{
+  CVehicleSimul_DiffDriven sim;
+  auto c = sim.getVelCmdType();
+  ASSERT_TRUE(c);
+  EXPECT_EQ(c->getVelCmdLength(), 2U);
+  EXPECT_NE(dynamic_cast<CVehicleVelCmd_DiffDriven*>(c.get()), nullptr);
+}
+
+TEST(CVehicleSimul_DiffDriven, teleport_and_odometry_override)
+{
+  CVehicleSimul_DiffDriven sim;
+  sim.setCurrentGTPose(mrpt::math::TPose2D(1, 2, 0.3));
+  EXPECT_NEAR(sim.getCurrentGTPose().x, 1.0, 1e-12);
+  EXPECT_NEAR(sim.getCurrentGTPose().y, 2.0, 1e-12);
+  EXPECT_NEAR(sim.getCurrentGTPose().phi, 0.3, 1e-12);
+
+  sim.setCurrentOdometricPose(mrpt::math::TPose2D(4, 5, 0.6));
+  EXPECT_NEAR(sim.getCurrentOdometricPose().x, 4.0, 1e-12);
+  EXPECT_NEAR(sim.getCurrentOdometricPose().phi, 0.6, 1e-12);
+}
+
+TEST(CVehicleSimul_DiffDriven, local_vs_global_velocities)
+{
+  CVehicleSimul_DiffDriven sim;
+  sim.setCurrentGTPose(mrpt::math::TPose2D(0, 0, M_PI * 0.5));
+  sim.setCurrentOdometricPose(mrpt::math::TPose2D(0, 0, M_PI * 0.5));
+  sim.movementCommand(1.0, .0);
+  sim.simulateOneTimeStep(0.5);
+
+  // Moving "forward" while heading +90deg => global velocity is along +y:
+  const auto vGlobal = sim.getCurrentGTVel();
+  EXPECT_NEAR(vGlobal.vx, .0, 1e-6);
+  EXPECT_NEAR(vGlobal.vy, 1.0, 1e-6);
+
+  // ... but in the robot local frame it is purely along +x:
+  const auto vLocal = sim.getCurrentGTVelLocal();
+  EXPECT_NEAR(vLocal.vx, 1.0, 1e-6);
+  EXPECT_NEAR(vLocal.vy, .0, 1e-6);
+
+  const auto vOdoLocal = sim.getCurrentOdometricVelLocal();
+  EXPECT_NEAR(vOdoLocal.vx, 1.0, 1e-6);
+  EXPECT_NEAR(vOdoLocal.vy, .0, 1e-6);
+}
+
+TEST(CVehicleSimul_DiffDriven, resetStatus_and_resetTime)
+{
+  CVehicleSimul_DiffDriven sim;
+  sim.movementCommand(1.0, 0.5);
+  sim.simulateOneTimeStep(1.0);
+  ASSERT_GT(sim.getTime(), 0.5);
+
+  sim.resetStatus();
+  EXPECT_EQ(sim.getCurrentGTPose().x, .0);
+  EXPECT_EQ(sim.getCurrentGTPose().phi, .0);
+  EXPECT_EQ(sim.getCurrentOdometricPose().x, .0);
+  EXPECT_EQ(sim.getCurrentGTVel().vx, .0);
+  EXPECT_EQ(sim.getV(), .0);
+  EXPECT_EQ(sim.getW(), .0);
+  // resetStatus() does not touch the simulation clock:
+  EXPECT_GT(sim.getTime(), 0.5);
+
+  sim.resetTime();
+  EXPECT_EQ(sim.getTime(), .0);
+}
+
+TEST(CVehicleSimul_DiffDriven, setV_setW_are_overwritten_by_control_step)
+{
+  CVehicleSimul_DiffDriven sim;
+  sim.setV(0.5);
+  sim.setW(0.1);
+  EXPECT_NEAR(sim.getV(), 0.5, 1e-12);
+  EXPECT_NEAR(sim.getW(), 0.1, 1e-12);
+
+  // No command was issued, so the low-level controller drives them to zero:
+  sim.simulateOneTimeStep(0.1);
+  EXPECT_NEAR(sim.getV(), .0, 1e-12);
+  EXPECT_NEAR(sim.getW(), .0, 1e-12);
+}
+
+TEST(CVehicleSimul_DiffDriven, first_order_delay_model_ramps_up_speed)
+{
+  CVehicleSimul_DiffDriven sim;
+  sim.setDelayModelParams(1.0 /*TAU*/, 0.2 /*DELAY*/);
+  sim.movementCommand(1.0, .0);
+
+  // During the pure delay the robot must not have moved yet:
+  sim.simulateOneTimeStep(0.1);
+  EXPECT_NEAR(sim.getV(), .0, 1e-6);
+
+  // After a while it approaches, but does not reach, the commanded speed:
+  sim.simulateOneTimeStep(0.5);
+  EXPECT_GT(sim.getV(), .0);
+  EXPECT_LT(sim.getV(), 1.0);
+
+  // ... and after several time constants it is nearly there:
+  sim.simulateOneTimeStep(5.0);
+  EXPECT_NEAR(sim.getV(), 1.0, 0.02);
+}
+
+TEST(CVehicleSimul_DiffDriven, odometry_errors_make_gt_and_odometry_diverge)
+{
+  mrpt::random::getRandomGenerator().randomize(1234);
+
+  CVehicleSimul_DiffDriven sim;
+  sim.setOdometryErrors(true, 0.05, 0.02, 0.05, 0.02, 0.05, 0.02);
+  sim.movementCommand(1.0, .0);
+  sim.simulateOneTimeStep(3.0);
+
+  const double gt_x = sim.getCurrentGTPose().x;
+  const double odo_x = sim.getCurrentOdometricPose().x;
+  EXPECT_GT(gt_x, .0);
+  EXPECT_GT(odo_x, .0);
+  EXPECT_GT(std::abs(gt_x - odo_x), 1e-3);
+
+  // Disabling them again makes both evolve identically from now on:
+  sim.setOdometryErrors(false);
+  const double gt_x0 = sim.getCurrentGTPose().x;
+  const double odo_x0 = sim.getCurrentOdometricPose().x;
+  sim.simulateOneTimeStep(1.0);
+  EXPECT_NEAR(
+      sim.getCurrentGTPose().x - gt_x0, sim.getCurrentOdometricPose().x - odo_x0, 1e-9);
+}
+
+// ---------------------------------------------------------------------------
+//  CVehicleSimul_Holo
+// ---------------------------------------------------------------------------
+TEST(CVehicleSimul_Holo, initial_state_is_zero)
+{
+  CVehicleSimul_Holo sim;
+  EXPECT_EQ(sim.getTime(), .0);
+  EXPECT_EQ(sim.getCurrentGTPose().x, .0);
+  EXPECT_EQ(sim.getCurrentGTVel().vx, .0);
+}
+
+TEST(CVehicleSimul_Holo, getVelCmdType_returns_holo_cmd)
+{
+  CVehicleSimul_Holo sim;
+  auto c = sim.getVelCmdType();
+  ASSERT_TRUE(c);
+  EXPECT_EQ(c->getVelCmdLength(), 4U);
+  EXPECT_NE(dynamic_cast<CVehicleVelCmd_Holo*>(c.get()), nullptr);
+}
+
+TEST(CVehicleSimul_Holo, vel_ramp_reaches_commanded_velocity)
+{
+  CVehicleSimul_Holo sim;
+  sim.sendVelRampCmd(1.0 /*vel*/, .0 /*dir*/, 0.5 /*ramp_time*/, .0 /*rot_speed*/);
+
+  // Half-way through the ramp, speed is in between:
+  sim.simulateOneTimeStep(0.25);
+  EXPECT_GT(sim.getCurrentOdometricVel().vx, 0.2);
+  EXPECT_LT(sim.getCurrentOdometricVel().vx, 0.8);
+
+  // Once the ramp is over, the target velocity is held:
+  sim.simulateOneTimeStep(1.0);
+  EXPECT_NEAR(sim.getCurrentOdometricVel().vx, 1.0, 1e-6);
+  EXPECT_NEAR(sim.getCurrentOdometricVel().vy, .0, 1e-6);
+  EXPECT_GT(sim.getCurrentGTPose().x, 0.5);
+}
+
+TEST(CVehicleSimul_Holo, motion_direction_is_honored)
+{
+  CVehicleSimul_Holo sim;
+  sim.sendVelRampCmd(1.0, M_PI * 0.5 /*dir: +90deg*/, 0.2, .0);
+  sim.simulateOneTimeStep(1.0);
+  EXPECT_NEAR(sim.getCurrentOdometricVel().vx, .0, 1e-6);
+  EXPECT_NEAR(sim.getCurrentOdometricVel().vy, 1.0, 1e-6);
+  EXPECT_GT(sim.getCurrentGTPose().y, 0.5);
+}
+
+TEST(CVehicleSimul_Holo, rotates_until_aligned_with_motion_direction)
+{
+  CVehicleSimul_Holo sim;
+  sim.sendVelRampCmd(0.1, M_PI * 0.5 /*dir*/, 0.2, 1.0 /*rot_speed*/);
+  sim.simulateOneTimeStep(5.0);
+
+  // The heading converges to the commanded direction, and rotation stops:
+  EXPECT_NEAR(sim.getCurrentOdometricPose().phi, M_PI * 0.5, mrpt::DEG2RAD(2.0));
+  EXPECT_NEAR(sim.getCurrentOdometricVel().omega, .0, 1e-9);
+}
+
+TEST(CVehicleSimul_Holo, rotation_direction_follows_shortest_angle)
+{
+  CVehicleSimul_Holo sim;
+  // Target heading at -90 deg: the robot must rotate clockwise (omega<0):
+  sim.sendVelRampCmd(0.1, -M_PI * 0.5, 0.2, 1.0);
+  sim.simulateOneTimeStep(0.3);
+  EXPECT_LT(sim.getCurrentOdometricVel().omega, .0);
+}
+
+TEST(CVehicleSimul_Holo, sendVelRampCmd_requires_positive_ramp_time)
+{
+  CVehicleSimul_Holo sim;
+  EXPECT_ANY_THROW(sim.sendVelRampCmd(1.0, .0, .0 /*ramp_time*/, .0));
+}
+
+TEST(CVehicleSimul_Holo, sendVelCmd_dispatches_to_ramp_command)
+{
+  CVehicleSimul_Holo sim;
+  CVehicleVelCmd_Holo cmd(1.0, .0, 0.3, .0);
+  sim.sendVelCmd(cmd);
+  sim.simulateOneTimeStep(1.0);
+  EXPECT_NEAR(sim.getCurrentOdometricVel().vx, 1.0, 1e-6);
+}
+
+TEST(CVehicleSimul_Holo, sendVelCmd_rejects_wrong_kinematic_class)
+{
+  CVehicleSimul_Holo sim;
+  CVehicleVelCmd_DiffDriven wrongCmd;
+  EXPECT_ANY_THROW(sim.sendVelCmd(wrongCmd));
+}
+
+TEST(CVehicleSimul_Holo, resetStatus_clears_pending_ramp_command)
+{
+  CVehicleSimul_Holo sim;
+  sim.sendVelRampCmd(1.0, .0, 0.2, .0);
+  sim.simulateOneTimeStep(1.0);
+  ASSERT_GT(sim.getCurrentGTPose().x, 0.1);
+
+  sim.resetStatus();
+  EXPECT_EQ(sim.getCurrentGTPose().x, .0);
+  EXPECT_EQ(sim.getCurrentOdometricVel().vx, .0);
+
+  // With the command cleared, the robot stays put:
+  sim.simulateOneTimeStep(1.0);
+  EXPECT_NEAR(sim.getCurrentGTPose().x, .0, 1e-12);
+}

--- a/modules/mrpt_kinematics/tests/CVehicleSimul_unittest.cpp
+++ b/modules/mrpt_kinematics/tests/CVehicleSimul_unittest.cpp
@@ -202,8 +202,7 @@ TEST(CVehicleSimul_DiffDriven, odometry_errors_make_gt_and_odometry_diverge)
   const double gt_x0 = sim.getCurrentGTPose().x;
   const double odo_x0 = sim.getCurrentOdometricPose().x;
   sim.simulateOneTimeStep(1.0);
-  EXPECT_NEAR(
-      sim.getCurrentGTPose().x - gt_x0, sim.getCurrentOdometricPose().x - odo_x0, 1e-9);
+  EXPECT_NEAR(sim.getCurrentGTPose().x - gt_x0, sim.getCurrentOdometricPose().x - odo_x0, 1e-9);
 }
 
 // ---------------------------------------------------------------------------

--- a/modules/mrpt_kinematics/tests/CVehicleVelCmd_unittest.cpp
+++ b/modules/mrpt_kinematics/tests/CVehicleVelCmd_unittest.cpp
@@ -1,0 +1,345 @@
+/*                    _
+                     | |    Mobile Robot Programming Toolkit (MRPT)
+ _ __ ___  _ __ _ __ | |_
+| '_ ` _ \| '__| '_ \| __|          https://www.mrpt.org/
+| | | | | | |  | |_) | |_
+|_| |_| |_|_|  | .__/ \__|     https://github.com/MRPT/mrpt/
+               | |
+               |_|
+
+ Copyright (c) 2005-2026, Individual contributors, see AUTHORS file
+ See: https://www.mrpt.org/Authors - All rights reserved.
+ SPDX-License-Identifier: BSD-3-Clause
+*/
+
+#include <gtest/gtest.h>
+#include <mrpt/config/CConfigFileMemory.h>
+#include <mrpt/io/CMemoryStream.h>
+#include <mrpt/kinematics/CVehicleVelCmd_DiffDriven.h>
+#include <mrpt/kinematics/CVehicleVelCmd_Holo.h>
+#include <mrpt/serialization/CArchive.h>
+
+using namespace mrpt::kinematics;
+
+// ---------------------------------------------------------------------------
+//  CVehicleVelCmd_DiffDriven
+// ---------------------------------------------------------------------------
+TEST(CVehicleVelCmd_DiffDriven, component_accessors)
+{
+  CVehicleVelCmd_DiffDriven c;
+  EXPECT_EQ(c.getVelCmdLength(), 2U);
+  EXPECT_EQ(c.getVelCmdDescription(0), "lin_vel");
+  EXPECT_EQ(c.getVelCmdDescription(1), "ang_vel");
+  EXPECT_ANY_THROW(c.getVelCmdDescription(2));
+
+  c.setVelCmdElement(0, 1.5);
+  c.setVelCmdElement(1, -0.25);
+  EXPECT_NEAR(c.getVelCmdElement(0), 1.5, 1e-12);
+  EXPECT_NEAR(c.getVelCmdElement(1), -0.25, 1e-12);
+  EXPECT_NEAR(c.lin_vel, 1.5, 1e-12);
+  EXPECT_NEAR(c.ang_vel, -0.25, 1e-12);
+
+  EXPECT_ANY_THROW(c.getVelCmdElement(2));
+  EXPECT_ANY_THROW(c.setVelCmdElement(2, 0.0));
+}
+
+TEST(CVehicleVelCmd_DiffDriven, stop_detection)
+{
+  CVehicleVelCmd_DiffDriven c;
+  EXPECT_TRUE(c.isStopCmd());  // default-constructed is (0,0)
+
+  c.lin_vel = 0.5;
+  EXPECT_FALSE(c.isStopCmd());
+  c.lin_vel = .0;
+  c.ang_vel = 0.5;
+  EXPECT_FALSE(c.isStopCmd());
+
+  c.setToStop();
+  EXPECT_TRUE(c.isStopCmd());
+  EXPECT_EQ(c.lin_vel, .0);
+  EXPECT_EQ(c.ang_vel, .0);
+}
+
+TEST(CVehicleVelCmd_DiffDriven, asString_mentions_components)
+{
+  CVehicleVelCmd_DiffDriven c;
+  c.lin_vel = 0.7;
+  c.ang_vel = 0.3;
+  const std::string s = c.asString();
+  EXPECT_NE(s.find("lin_vel"), std::string::npos);
+  EXPECT_NE(s.find("ang_vel"), std::string::npos);
+}
+
+TEST(CVehicleVelCmd_DiffDriven, cmdVel_scale_scales_both_components)
+{
+  CVehicleVelCmd_DiffDriven c;
+  c.lin_vel = 1.0;
+  c.ang_vel = -2.0;
+  c.cmdVel_scale(0.5);
+  EXPECT_NEAR(c.lin_vel, 0.5, 1e-12);
+  EXPECT_NEAR(c.ang_vel, -1.0, 1e-12);
+}
+
+TEST(CVehicleVelCmd_DiffDriven, cmdVel_limits_no_clipping_needed)
+{
+  CVehicleVelCmd_DiffDriven prev;  // (0,0)
+  CVehicleVelCmd_DiffDriven c;
+  c.lin_vel = 0.5;
+  c.ang_vel = 0.1;
+
+  CVehicleVelCmd::TVelCmdParams p;
+  p.robotMax_V_mps = 1.0;
+  p.robotMax_W_radps = 1.0;
+
+  // beta=1 => no blending with the previous command:
+  const double scale = c.cmdVel_limits(prev, 1.0, p);
+  EXPECT_NEAR(scale, 1.0, 1e-12);
+  EXPECT_NEAR(c.lin_vel, 0.5, 1e-12);
+  EXPECT_NEAR(c.ang_vel, 0.1, 1e-12);
+}
+
+TEST(CVehicleVelCmd_DiffDriven, cmdVel_limits_clips_linear_speed)
+{
+  CVehicleVelCmd_DiffDriven prev;
+  CVehicleVelCmd_DiffDriven c;
+  c.lin_vel = 4.0;
+  c.ang_vel = 0.4;
+
+  CVehicleVelCmd::TVelCmdParams p;
+  p.robotMax_V_mps = 1.0;
+  p.robotMax_W_radps = 10.0;
+
+  const double scale = c.cmdVel_limits(prev, 1.0, p);
+  EXPECT_LE(std::abs(c.lin_vel), p.robotMax_V_mps + 1e-9);
+  EXPECT_GT(scale, 0.0);
+  EXPECT_LT(scale, 1.0);
+  // The path curvature (w/v ratio) must be preserved while clipping:
+  EXPECT_NEAR(c.ang_vel / c.lin_vel, 0.4 / 4.0, 1e-9);
+}
+
+TEST(CVehicleVelCmd_DiffDriven, cmdVel_limits_clips_angular_speed)
+{
+  CVehicleVelCmd_DiffDriven prev;
+  CVehicleVelCmd_DiffDriven c;
+  c.lin_vel = 0.5;
+  c.ang_vel = 5.0;
+
+  CVehicleVelCmd::TVelCmdParams p;
+  p.robotMax_V_mps = 10.0;
+  p.robotMax_W_radps = 1.0;
+
+  const double scale = c.cmdVel_limits(prev, 1.0, p);
+  EXPECT_LE(std::abs(c.ang_vel), p.robotMax_W_radps + 1e-9);
+  EXPECT_LT(scale, 1.0);
+}
+
+TEST(CVehicleVelCmd_DiffDriven, cmdVel_limits_blends_pure_rotation)
+{
+  CVehicleVelCmd_DiffDriven prev;
+  prev.lin_vel = .0;
+  prev.ang_vel = 1.0;
+
+  CVehicleVelCmd_DiffDriven c;
+  c.lin_vel = .0;  // below the 0.01 threshold => "nearly pure rotation"
+  c.ang_vel = .0;
+
+  CVehicleVelCmd::TVelCmdParams p;
+  p.robotMax_V_mps = 1.0;
+  p.robotMax_W_radps = 2.0;
+
+  c.cmdVel_limits(prev, 0.25, p);
+  // 0.25*0 + 0.75*1.0
+  EXPECT_NEAR(c.ang_vel, 0.75, 1e-9);
+}
+
+TEST(CVehicleVelCmd_DiffDriven, cmdVel_limits_requires_valid_limits)
+{
+  CVehicleVelCmd_DiffDriven prev, c;
+  c.lin_vel = 0.5;
+  CVehicleVelCmd::TVelCmdParams p;  // both limits left at -1 (unset)
+  EXPECT_ANY_THROW(c.cmdVel_limits(prev, 1.0, p));
+}
+
+TEST(CVehicleVelCmd_DiffDriven, cmdVel_limits_rejects_foreign_prev_cmd)
+{
+  CVehicleVelCmd_Holo prev;
+  CVehicleVelCmd_DiffDriven c;
+  c.lin_vel = 0.5;
+
+  CVehicleVelCmd::TVelCmdParams p;
+  p.robotMax_V_mps = 1.0;
+  p.robotMax_W_radps = 1.0;
+  EXPECT_ANY_THROW(c.cmdVel_limits(prev, 1.0, p));
+}
+
+TEST(CVehicleVelCmd_DiffDriven, serialization_roundtrip)
+{
+  CVehicleVelCmd_DiffDriven c;
+  c.lin_vel = 0.33;
+  c.ang_vel = -0.77;
+
+  mrpt::io::CMemoryStream buf;
+  auto arch = mrpt::serialization::archiveFrom(buf);
+  arch << c;
+  buf.Seek(0);
+
+  CVehicleVelCmd_DiffDriven c2;
+  arch >> c2;
+  EXPECT_NEAR(c2.lin_vel, c.lin_vel, 1e-12);
+  EXPECT_NEAR(c2.ang_vel, c.ang_vel, 1e-12);
+}
+
+// ---------------------------------------------------------------------------
+//  CVehicleVelCmd_Holo
+// ---------------------------------------------------------------------------
+TEST(CVehicleVelCmd_Holo, component_accessors)
+{
+  CVehicleVelCmd_Holo c(1.0, 0.5, 0.8, 0.2);
+  EXPECT_EQ(c.getVelCmdLength(), 4U);
+  EXPECT_EQ(c.getVelCmdDescription(0), "vel");
+  EXPECT_EQ(c.getVelCmdDescription(1), "dir_local");
+  EXPECT_EQ(c.getVelCmdDescription(2), "ramp_time");
+  EXPECT_EQ(c.getVelCmdDescription(3), "rot_speed");
+  EXPECT_ANY_THROW(c.getVelCmdDescription(4));
+
+  EXPECT_NEAR(c.getVelCmdElement(0), 1.0, 1e-12);
+  EXPECT_NEAR(c.getVelCmdElement(1), 0.5, 1e-12);
+  EXPECT_NEAR(c.getVelCmdElement(2), 0.8, 1e-12);
+  EXPECT_NEAR(c.getVelCmdElement(3), 0.2, 1e-12);
+  EXPECT_ANY_THROW(c.getVelCmdElement(4));
+
+  for (int i = 0; i < 4; i++)
+  {
+    c.setVelCmdElement(i, 0.1 * (i + 1));
+  }
+  EXPECT_NEAR(c.vel, 0.1, 1e-12);
+  EXPECT_NEAR(c.dir_local, 0.2, 1e-12);
+  EXPECT_NEAR(c.ramp_time, 0.3, 1e-12);
+  EXPECT_NEAR(c.rot_speed, 0.4, 1e-12);
+  EXPECT_ANY_THROW(c.setVelCmdElement(4, 0.0));
+}
+
+TEST(CVehicleVelCmd_Holo, stop_detection)
+{
+  CVehicleVelCmd_Holo c(1.0, 0.5, 0.8, 0.2);
+  EXPECT_FALSE(c.isStopCmd());
+  c.setToStop();
+  EXPECT_TRUE(c.isStopCmd());
+  EXPECT_EQ(c.vel, .0);
+  EXPECT_EQ(c.dir_local, .0);
+  EXPECT_EQ(c.ramp_time, .0);
+  EXPECT_EQ(c.rot_speed, .0);
+}
+
+TEST(CVehicleVelCmd_Holo, cmdVel_scale_only_affects_linear_speed)
+{
+  CVehicleVelCmd_Holo c(1.0, 0.5, 0.8, 0.2);
+  c.cmdVel_scale(0.5);
+  EXPECT_NEAR(c.vel, 0.5, 1e-12);
+  // A holonomic path is invariant to the rotation speed:
+  EXPECT_NEAR(c.rot_speed, 0.2, 1e-12);
+  EXPECT_NEAR(c.ramp_time, 0.8, 1e-12);
+}
+
+TEST(CVehicleVelCmd_Holo, cmdVel_limits_scales_down_over_max_speed)
+{
+  CVehicleVelCmd_Holo prev;
+  CVehicleVelCmd_Holo c(2.0, 0.0, 0.8, 1.0);
+
+  CVehicleVelCmd::TVelCmdParams p;
+  p.robotMax_V_mps = 1.0;
+
+  const double f = c.cmdVel_limits(prev, 1.0, p);
+  EXPECT_NEAR(f, 0.5, 1e-12);
+  EXPECT_NEAR(c.vel, 1.0, 1e-12);
+  EXPECT_NEAR(c.rot_speed, 0.5, 1e-12);
+  EXPECT_NEAR(c.ramp_time, 0.8, 1e-12);  // left unchanged
+}
+
+TEST(CVehicleVelCmd_Holo, cmdVel_limits_below_max_is_a_noop)
+{
+  CVehicleVelCmd_Holo prev;
+  CVehicleVelCmd_Holo c(0.4, 0.0, 0.8, 1.0);
+
+  CVehicleVelCmd::TVelCmdParams p;
+  p.robotMax_V_mps = 1.0;
+
+  EXPECT_NEAR(c.cmdVel_limits(prev, 1.0, p), 1.0, 1e-12);
+  EXPECT_NEAR(c.vel, 0.4, 1e-12);
+  EXPECT_NEAR(c.rot_speed, 1.0, 1e-12);
+}
+
+TEST(CVehicleVelCmd_Holo, cmdVel_limits_requires_valid_max_speed)
+{
+  CVehicleVelCmd_Holo prev;
+  CVehicleVelCmd_Holo c(0.4, 0.0, 0.8, 1.0);
+  CVehicleVelCmd::TVelCmdParams p;  // robotMax_V_mps left at -1
+  EXPECT_ANY_THROW(c.cmdVel_limits(prev, 1.0, p));
+}
+
+TEST(CVehicleVelCmd_Holo, serialization_roundtrip)
+{
+  CVehicleVelCmd_Holo c(1.25, -0.5, 0.9, 0.15);
+
+  mrpt::io::CMemoryStream buf;
+  auto arch = mrpt::serialization::archiveFrom(buf);
+  arch << c;
+  buf.Seek(0);
+
+  CVehicleVelCmd_Holo c2;
+  arch >> c2;
+  EXPECT_NEAR(c2.vel, c.vel, 1e-12);
+  EXPECT_NEAR(c2.dir_local, c.dir_local, 1e-12);
+  EXPECT_NEAR(c2.ramp_time, c.ramp_time, 1e-12);
+  EXPECT_NEAR(c2.rot_speed, c.rot_speed, 1e-12);
+}
+
+// ---------------------------------------------------------------------------
+//  Base class: copy semantics and TVelCmdParams
+// ---------------------------------------------------------------------------
+TEST(CVehicleVelCmd, copy_and_assign)
+{
+  CVehicleVelCmd_DiffDriven a;
+  a.lin_vel = 1.0;
+  a.ang_vel = 2.0;
+
+  CVehicleVelCmd_DiffDriven b(a);
+  EXPECT_NEAR(b.lin_vel, 1.0, 1e-12);
+
+  CVehicleVelCmd_DiffDriven c;
+  c = a;
+  EXPECT_NEAR(c.ang_vel, 2.0, 1e-12);
+
+  // Assignment through the abstract base class reference:
+  CVehicleVelCmd& base_c = c;
+  CVehicleVelCmd& base_a = a;
+  base_c = base_a;
+  EXPECT_NEAR(c.lin_vel, 1.0, 1e-12);
+}
+
+TEST(TVelCmdParams, config_file_roundtrip)
+{
+  CVehicleVelCmd::TVelCmdParams p;
+  p.robotMax_V_mps = 1.5;
+  p.robotMax_W_radps = 0.75;
+  p.robotMinCurvRadius = 0.3;
+
+  mrpt::config::CConfigFileMemory cfg;
+  p.saveToConfigFile(cfg, "S");
+
+  CVehicleVelCmd::TVelCmdParams q;
+  q.loadConfigFile(cfg, "S");
+
+  EXPECT_NEAR(q.robotMax_V_mps, 1.5, 1e-9);
+  // deg <-> rad conversion through the text config file loses some precision:
+  EXPECT_NEAR(q.robotMax_W_radps, 0.75, 1e-6);
+  EXPECT_NEAR(q.robotMinCurvRadius, 0.3, 1e-9);
+}
+
+TEST(TVelCmdParams, defaults_are_unset)
+{
+  CVehicleVelCmd::TVelCmdParams p;
+  EXPECT_LT(p.robotMax_V_mps, .0);
+  EXPECT_LT(p.robotMax_W_radps, .0);
+  EXPECT_LT(p.robotMinCurvRadius, .0);
+}

--- a/modules/mrpt_nav/CMakeLists.txt
+++ b/modules/mrpt_nav/CMakeLists.txt
@@ -70,6 +70,8 @@ set(LIB_UNIT_TEST_SOURCES
   tests/TWaypoint_unittest.cpp
   tests/PTG_variants_unittest.cpp
   tests/CAbstractNavigator_unittest.cpp
+  tests/nav_misc_unittest.cpp
+  tests/planners_and_logs_unittest.cpp
 )
 
 set(LIB_PUBLIC_HEADERS

--- a/modules/mrpt_nav/CMakeLists.txt
+++ b/modules/mrpt_nav/CMakeLists.txt
@@ -72,6 +72,8 @@ set(LIB_UNIT_TEST_SOURCES
   tests/CAbstractNavigator_unittest.cpp
   tests/nav_misc_unittest.cpp
   tests/planners_and_logs_unittest.cpp
+  tests/holonomic_config_unittest.cpp
+  tests/rnav_variants_unittest.cpp
 )
 
 set(LIB_PUBLIC_HEADERS

--- a/modules/mrpt_nav/CMakeLists.txt
+++ b/modules/mrpt_nav/CMakeLists.txt
@@ -67,6 +67,9 @@ set(LIB_UNIT_TEST_SOURCES
   tests/holonomic_unittest.cpp
   tests/rnav_unittest.cpp
   tests/waypoints_and_rrt_unittest.cpp
+  tests/TWaypoint_unittest.cpp
+  tests/PTG_variants_unittest.cpp
+  tests/CAbstractNavigator_unittest.cpp
 )
 
 set(LIB_PUBLIC_HEADERS

--- a/modules/mrpt_nav/CMakeLists.txt
+++ b/modules/mrpt_nav/CMakeLists.txt
@@ -74,6 +74,7 @@ set(LIB_UNIT_TEST_SOURCES
   tests/planners_and_logs_unittest.cpp
   tests/holonomic_config_unittest.cpp
   tests/rnav_variants_unittest.cpp
+  tests/nav_interfaces_unittest.cpp
 )
 
 set(LIB_PUBLIC_HEADERS

--- a/modules/mrpt_nav/src/planners/PlannerSimple2D.cpp
+++ b/modules/mrpt_nav/src/planners/PlannerSimple2D.cpp
@@ -309,10 +309,12 @@ void PlannerSimple2D::computePath(
   const TPoint2D target = TPoint2D(target_.asTPose());
 
   // Check that origin and target fall inside the grid:
-  if (!((origin.x > theMap.getXMin() && origin.x < theMap.getXMax() &&
-         origin.y > theMap.getYMin() && origin.y < theMap.getYMax()) ||
-        !(target.x > theMap.getXMin() && target.x < theMap.getXMax() &&
-          target.y > theMap.getYMin() && target.y < theMap.getYMax())))
+  const auto isInsideGrid = [&theMap](const TPoint2D& p)
+  {
+    return p.x > theMap.getXMin() && p.x < theMap.getXMax() && p.y > theMap.getYMin() &&
+           p.y < theMap.getYMax();
+  };
+  if (!isInsideGrid(origin) || !isInsideGrid(target))
   {
     notFound = true;
     return;

--- a/modules/mrpt_nav/src/reactive/CAbstractNavigator.cpp
+++ b/modules/mrpt_nav/src/reactive/CAbstractNavigator.cpp
@@ -471,6 +471,10 @@ void CAbstractNavigator::internal_onStartNewNavigation()
   m_robot.startWatchdog(1000);  // Watchdog = 1 seg
   m_latestPoses.clear();        // Clear cache of last poses.
   m_latestOdomPoses.clear();
+  // Force the next updateCurrentPoseAndSpeeds() to actually query the robot:
+  // the caches just emptied above must be refilled even if the last query was
+  // more recent than the minimum inter-query period.
+  m_last_curPoseVelUpdate_robot_time = -1e9;
   onStartNewNavigation();
 }
 
@@ -639,7 +643,10 @@ void CAbstractNavigator::performNavigationStepNavigating(bool call_virtual_nav_m
     MRPT_LOG_ERROR("[CAbstractNavigator::navigationStep] Untyped exception!");
     if (m_rethrow_exceptions) throw;
   }
-  m_navigationState = prevState;
+  // Note: only the "previous state" bookkeeping is updated here. Overwriting
+  // m_navigationState would silently undo the transitions decided above (e.g.
+  // an emergency stop switching to NAV_ERROR).
+  m_lastNavigationState = prevState;
 }
 
 bool CAbstractNavigator::checkCollisionWithLatestObstacles(

--- a/modules/mrpt_nav/src/reactive/CLogFileRecord.cpp
+++ b/modules/mrpt_nav/src/reactive/CLogFileRecord.cpp
@@ -352,7 +352,7 @@ void CLogFileRecord::serializeFrom(mrpt::serialization::CArchive& in, uint8_t ve
           else
             cmd_vel = std::make_shared<mrpt::kinematics::CVehicleVelCmd_Holo>();
           for (size_t k = 0; k < cmd_vel->getVelCmdLength(); k++)
-            cmd_vel->setVelCmdElement(i, vel[k]);
+            cmd_vel->setVelCmdElement(static_cast<int>(k), vel[k]);
         }
       }
       else
@@ -361,7 +361,7 @@ void CLogFileRecord::serializeFrom(mrpt::serialization::CArchive& in, uint8_t ve
         in >> v >> w;
         cmd_vel = std::make_shared<mrpt::kinematics::CVehicleVelCmd_DiffDriven>();
         cmd_vel->setVelCmdElement(0, v);
-        cmd_vel->setVelCmdElement(0, w);
+        cmd_vel->setVelCmdElement(1, w);
       }
 
       if (version >= 15 && ptg_index_NOP < 0) in >> cmd_vel_original;

--- a/modules/mrpt_nav/src/reactive/CMultiObjectiveMotionOptimizerBase.cpp
+++ b/modules/mrpt_nav/src/reactive/CMultiObjectiveMotionOptimizerBase.cpp
@@ -63,7 +63,9 @@ std::optional<size_t> CMultiObjectiveMotionOptimizerBase::decide(
         }
         catch (std::exception&)
         {
-          m_score_exprs.clear();
+          // Drop *all* cached expression state: score names already registered
+          // as variables would make the next decide() throw.
+          this->clear();
           return std::nullopt;  // no good motion in this case
         }
 
@@ -101,7 +103,7 @@ std::optional<size_t> CMultiObjectiveMotionOptimizerBase::decide(
         }
         catch (std::exception&)
         {
-          m_movement_assert_exprs.clear();
+          this->clear();
           return std::nullopt;  // no good motion in this case
         }
       }

--- a/modules/mrpt_nav/src/reactive/CMultiObjectiveMotionOptimizerBase.cpp
+++ b/modules/mrpt_nav/src/reactive/CMultiObjectiveMotionOptimizerBase.cpp
@@ -64,7 +64,7 @@ std::optional<size_t> CMultiObjectiveMotionOptimizerBase::decide(
         catch (std::exception&)
         {
           m_score_exprs.clear();
-          return -1;  // no good motion in this case
+          return std::nullopt;  // no good motion in this case
         }
 
         // Register formulas also as variables, usable by the assert()
@@ -102,7 +102,7 @@ std::optional<size_t> CMultiObjectiveMotionOptimizerBase::decide(
         catch (std::exception&)
         {
           m_movement_assert_exprs.clear();
-          return -1;  // no good motion in this case
+          return std::nullopt;  // no good motion in this case
         }
       }
     }
@@ -214,7 +214,12 @@ std::optional<size_t> CMultiObjectiveMotionOptimizerBase::decide(
   return impl_decide(movs, extra_info);
 }
 
-void CMultiObjectiveMotionOptimizerBase::clear() { m_score_exprs.clear(); }
+void CMultiObjectiveMotionOptimizerBase::clear()
+{
+  m_score_exprs.clear();
+  m_movement_assert_exprs.clear();
+  m_expr_vars.clear();
+}
 CMultiObjectiveMotionOptimizerBase::Ptr CMultiObjectiveMotionOptimizerBase::Factory(
     const std::string& className) noexcept
 {

--- a/modules/mrpt_nav/src/reactive/CReactiveNavigationSystem3D.cpp
+++ b/modules/mrpt_nav/src/reactive/CReactiveNavigationSystem3D.cpp
@@ -62,6 +62,8 @@ void CReactiveNavigationSystem3D::changeRobotShape(TRobotShape robotShape)
 
 void CReactiveNavigationSystem3D::saveConfigFile(mrpt::config::CConfigFileBase& c) const
 {
+  CAbstractPTGBasedReactive::saveConfigFile(c);
+
   const std::string s = "CReactiveNavigationSystem3D";
 
   unsigned int HEIGHT_LEVELS = static_cast<unsigned int>(m_robotShape.size());

--- a/modules/mrpt_nav/src/reactive/CWaypointsNavigator.cpp
+++ b/modules/mrpt_nav/src/reactive/CWaypointsNavigator.cpp
@@ -560,8 +560,8 @@ bool CWaypointsNavigator::checkHasReachedTarget(const double targetDist) const
           wps.waypoint_index_current_goal < static_cast<int>(wps.waypoints.size()))
              ? &wps.waypoints[wps.waypoint_index_current_goal]
              : nullptr;
-    ret = (wp == nullptr && targetDist <= m_navigationParams->target.targetAllowedDistance) ||
-          (wp->reached);
+    ret = (wp == nullptr) ? (targetDist <= m_navigationParams->target.targetAllowedDistance)
+                          : wp->reached;
   }
   else
   {

--- a/modules/mrpt_nav/src/tpspace/CParameterizedTrajectoryGenerator.cpp
+++ b/modules/mrpt_nav/src/tpspace/CParameterizedTrajectoryGenerator.cpp
@@ -225,7 +225,7 @@ double CParameterizedTrajectoryGenerator::index2alpha(uint16_t k) const
 
 uint16_t CParameterizedTrajectoryGenerator::Alpha2index(double alpha, const unsigned int num_paths)
 {
-  mrpt::math::wrapToPi(alpha);
+  mrpt::math::wrapToPiInPlace(alpha);
   int k = mrpt::round(0.5 * (num_paths * (1.0 + alpha / M_PI) - 1.0));
   if (k < 0) k = 0;
   if (k >= static_cast<int>(num_paths)) k = num_paths - 1;

--- a/modules/mrpt_nav/tests/CAbstractNavigator_unittest.cpp
+++ b/modules/mrpt_nav/tests/CAbstractNavigator_unittest.cpp
@@ -144,10 +144,7 @@ struct TestNavigator : public CWaypointsNavigator
     m_navProfiler.enable(false);
   }
 
-  bool impl_waypoint_is_reachable(const mrpt::math::TPoint2D&) const override
-  {
-    return reachable;
-  }
+  bool impl_waypoint_is_reachable(const mrpt::math::TPoint2D&) const override { return reachable; }
   using CWaypointsNavigator::waypoints_isAligning;
   void performNavigationStep() override
   {
@@ -414,8 +411,7 @@ TEST(CAbstractNavigator, exceptions_in_the_nav_step_raise_a_nav_error)
 
   EXPECT_EQ(nav.getCurrentState(), CAbstractNavigator::TState::NAV_ERROR);
   EXPECT_EQ(nav.getErrorReason().error_code, CAbstractNavigator::TErrorCode::OTHER);
-  EXPECT_NE(
-      nav.getErrorReason().error_msg.find("synthetic navigation failure"), std::string::npos);
+  EXPECT_NE(nav.getErrorReason().error_msg.find("synthetic navigation failure"), std::string::npos);
 
   // The next step reports the error to the robot interface and stops it:
   nav.navigationStep();

--- a/modules/mrpt_nav/tests/CAbstractNavigator_unittest.cpp
+++ b/modules/mrpt_nav/tests/CAbstractNavigator_unittest.cpp
@@ -23,6 +23,7 @@
 #include <mrpt/maps/CSimplePointsMap.h>
 #include <mrpt/nav/reactive/CWaypointsNavigator.h>
 
+#include <chrono>
 #include <stdexcept>
 
 using namespace mrpt::nav;
@@ -480,16 +481,25 @@ TEST(CAbstractNavigator, not_approaching_the_target_times_out)
 {
   MockRobotIF robot;
   TestNavigator nav(robot);
-  nav.params_abstract_navigator.alarm_seems_not_approaching_target_timeout = 0.0;
+  nav.params_abstract_navigator.alarm_seems_not_approaching_target_timeout = 2.0;
+
+  // The alarm compares wall-clock timestamps, so drive it from the simulated
+  // clock: a plain "0 s timeout" would depend on the platform clock
+  // resolution being fine enough for two consecutive now() calls to differ.
+  const auto savedClock = mrpt::Clock::getActiveClock();
+  mrpt::Clock::setSimulatedTime(mrpt::Clock::now());
+  mrpt::Clock::setActiveClock(mrpt::Clock::Simulated);
 
   auto np = make_target(10.0, 0.0, 0.1);
   nav.navigate(&np);
 
   // The robot never moves, so the "not approaching" alarm must fire:
-  for (int i = 0; i < 5 && nav.getCurrentState() == CAbstractNavigator::TState::NAVIGATING; i++)
+  for (int i = 0; i < 10 && nav.getCurrentState() == CAbstractNavigator::TState::NAVIGATING; i++)
   {
     nav.step();
+    mrpt::Clock::setSimulatedTime(mrpt::Clock::now() + std::chrono::milliseconds(500));
   }
+  mrpt::Clock::setActiveClock(savedClock);
 
   EXPECT_EQ(nav.getCurrentState(), CAbstractNavigator::TState::NAV_ERROR);
   EXPECT_EQ(nav.getErrorReason().error_code, CAbstractNavigator::TErrorCode::CANNOT_REACH_TARGET);
@@ -730,12 +740,20 @@ TEST(CWaypointsNavigator, waypoints_with_a_heading_align_before_being_reached)
   seq.waypoints.emplace_back(1.0, 0.0, 0.4, true, mrpt::DEG2RAD(90.0));
   nav.navigateWaypoints(seq);
 
+  // The alignment settling window is measured against the wall clock; freeze
+  // a simulated one so the outcome does not depend on how fast the loop below
+  // happens to run.
+  const auto savedClock = mrpt::Clock::getActiveClock();
+  mrpt::Clock::setSimulatedTime(mrpt::Clock::now());
+  mrpt::Clock::setActiveClock(mrpt::Clock::Simulated);
+
   // Drive the robot right onto the waypoint, but with the wrong heading:
   for (int i = 0; i < 10; i++)
   {
     nav.step();
     nav.teleportTowardsTarget(0.5);
   }
+  mrpt::Clock::setActiveClock(savedClock);
 
   // The robot is at the waypoint but not aligned: the navigator requests an
   // in-place rotation instead of declaring the waypoint reached.

--- a/modules/mrpt_nav/tests/CAbstractNavigator_unittest.cpp
+++ b/modules/mrpt_nav/tests/CAbstractNavigator_unittest.cpp
@@ -1,0 +1,779 @@
+/*                    _
+                     | |    Mobile Robot Programming Toolkit (MRPT)
+ _ __ ___  _ __ _ __ | |_
+| '_ ` _ \| '__| '_ \| __|          https://www.mrpt.org/
+| | | | | | |  | |_) | |_
+|_| |_| |_|_|  | .__/ \__|     https://github.com/MRPT/mrpt/
+               | |
+               |_|
+
+ Copyright (c) 2005-2026, Individual contributors, see AUTHORS file
+ See: https://www.mrpt.org/Authors - All rights reserved.
+ SPDX-License-Identifier: BSD-3-Clause
+*/
+
+/** Unit tests for the navigation state machine implemented by
+ *  CAbstractNavigator, and for the waypoint-sequence layer on top of it
+ *  (CWaypointsNavigator), driven by a mock robot interface.
+ */
+
+#include <gtest/gtest.h>
+#include <mrpt/config/CConfigFileMemory.h>
+#include <mrpt/kinematics/CVehicleVelCmd_DiffDriven.h>
+#include <mrpt/maps/CSimplePointsMap.h>
+#include <mrpt/nav/reactive/CWaypointsNavigator.h>
+
+#include <stdexcept>
+
+using namespace mrpt::nav;
+
+namespace
+{
+/** A robot interface that records every callback invoked by the navigator. */
+struct MockRobotIF : public CRobot2NavInterface
+{
+  mrpt::math::TPose2D pose{0, 0, 0};
+  bool poseIsAvailable = true;
+  bool changeSpeedsSucceeds = true;
+  double navTime = 0;
+
+  int nChangeSpeeds = 0;
+  int nChangeSpeedsNOP = 0;
+  int nStop = 0;
+  int nStartWatchdog = 0;
+  int nStopWatchdog = 0;
+  int nNavStart = 0;
+  int nNavEnd = 0;
+  int nNavEndDueToError = 0;
+  int nWaypointReached = 0;
+  int nWaypointSkipped = 0;
+  int nNewWaypointTarget = 0;
+  int nWaySeemsBlocked = 0;
+  int nCannotGetCloser = 0;
+
+  /** If set, getAlignCmd() returns it (i.e. this robot supports in-place
+   * rotations). */
+  bool supportsAlignCmd = false;
+
+  std::optional<CurrentPoseAndSpeeds> getCurrentPoseAndSpeeds() override
+  {
+    if (!poseIsAvailable) return std::nullopt;
+    CurrentPoseAndSpeeds ret;
+    ret.pose = pose;
+    ret.velGlobal = mrpt::math::TTwist2D(0, 0, 0);
+    ret.timestamp = mrpt::Clock::now();
+    ret.odometry = pose;
+    return ret;
+  }
+  bool changeSpeeds(const mrpt::kinematics::CVehicleVelCmd&) override
+  {
+    nChangeSpeeds++;
+    return changeSpeedsSucceeds;
+  }
+  bool changeSpeedsNOP() override
+  {
+    nChangeSpeedsNOP++;
+    return true;
+  }
+  bool stop(StopType) override
+  {
+    nStop++;
+    return true;
+  }
+  mrpt::kinematics::CVehicleVelCmd::Ptr getEmergencyStopCmd() override
+  {
+    return std::make_shared<mrpt::kinematics::CVehicleVelCmd_DiffDriven>();
+  }
+  mrpt::kinematics::CVehicleVelCmd::Ptr getStopCmd() override
+  {
+    return std::make_shared<mrpt::kinematics::CVehicleVelCmd_DiffDriven>();
+  }
+  mrpt::kinematics::CVehicleVelCmd::Ptr getAlignCmd(const double) override
+  {
+    if (!supportsAlignCmd) return {};
+    return std::make_shared<mrpt::kinematics::CVehicleVelCmd_DiffDriven>();
+  }
+  bool senseObstacles(mrpt::maps::CSimplePointsMap& obs, mrpt::system::TTimeStamp& ts) override
+  {
+    obs.clear();
+    ts = mrpt::Clock::now();
+    return true;
+  }
+  bool startWatchdog(float) override
+  {
+    nStartWatchdog++;
+    return true;
+  }
+  bool stopWatchdog() override
+  {
+    nStopWatchdog++;
+    return true;
+  }
+  void sendNavigationStartEvent() override { nNavStart++; }
+  void sendNavigationEndEvent() override { nNavEnd++; }
+  void sendNavigationEndDueToErrorEvent() override { nNavEndDueToError++; }
+  void sendWaypointReachedEvent(int, bool reached_nSkipped) override
+  {
+    if (reached_nSkipped)
+      nWaypointReached++;
+    else
+      nWaypointSkipped++;
+  }
+  void sendNewWaypointTargetEvent(int) override { nNewWaypointTarget++; }
+  void sendWaySeemsBlockedEvent() override { nWaySeemsBlocked++; }
+  void sendCannotGetCloserToBlockedTargetEvent() override { nCannotGetCloser++; }
+
+  double getNavigationTime() override { return navTime; }
+  void resetNavigationTimer() override { navTime = 0; }
+};
+
+/** Minimal concrete navigator: the robot is "teleported" to the target at a
+ *  configurable speed so navigation actually converges. */
+struct TestNavigator : public CWaypointsNavigator
+{
+  MockRobotIF& m_mock;
+  bool reachable = true;
+  bool throwOnStep = false;
+  bool emergencyStopOnStep = false;
+  bool targetIsColliding = false;
+  int nPerformNavigationStep = 0;
+
+  TestNavigator(MockRobotIF& r) : CWaypointsNavigator(r), m_mock(r)
+  {
+    this->setMinLoggingLevel(mrpt::system::LVL_ERROR);
+    m_navProfiler.enable(false);
+  }
+
+  bool impl_waypoint_is_reachable(const mrpt::math::TPoint2D&) const override
+  {
+    return reachable;
+  }
+  using CWaypointsNavigator::waypoints_isAligning;
+  void performNavigationStep() override
+  {
+    nPerformNavigationStep++;
+    if (throwOnStep) throw std::runtime_error("synthetic navigation failure");
+    if (emergencyStopOnStep) this->doEmergencyStop("synthetic emergency stop");
+  }
+  bool checkCollisionWithLatestObstacles(const mrpt::math::TPose2D&) const override
+  {
+    return targetIsColliding;
+  }
+  void loadConfigFile(const mrpt::config::CConfigFileBase& c) override
+  {
+    CWaypointsNavigator::loadConfigFile(c);
+  }
+  void saveConfigFile(mrpt::config::CConfigFileBase& c) const override
+  {
+    CWaypointsNavigator::saveConfigFile(c);
+  }
+  void initialize() override {}
+
+  /** Advances the robot's navigation clock and runs one navigation cycle. */
+  void step(double dt = 0.5)
+  {
+    m_mock.navTime += dt;
+    this->navigationStep();
+  }
+
+  /** Move the robot straight towards the current target. */
+  void teleportTowardsTarget(double step)
+  {
+    if (!m_navigationParams) return;
+    const auto trg = mrpt::math::TPoint2D(m_navigationParams->target.target_coords);
+    auto d = trg - mrpt::math::TPoint2D(m_mock.pose);
+    const double n = d.norm();
+    if (n < step)
+      m_mock.pose = mrpt::math::TPose2D(trg.x, trg.y, m_mock.pose.phi);
+    else
+    {
+      d *= step / n;
+      m_mock.pose.x += d.x;
+      m_mock.pose.y += d.y;
+    }
+  }
+};
+
+CAbstractNavigator::TNavigationParams make_target(double x, double y, double allowedDist = 0.5)
+{
+  CAbstractNavigator::TNavigationParams np;
+  np.target.target_coords = mrpt::math::TPose2D(x, y, 0);
+  np.target.targetAllowedDistance = static_cast<float>(allowedDist);
+  return np;
+}
+}  // namespace
+
+// ---------------------------------------------------------------------------
+//  TargetInfo / TNavigationParams value semantics
+// ---------------------------------------------------------------------------
+TEST(CAbstractNavigator, target_info_defaults_and_text)
+{
+  CAbstractNavigator::TargetInfo ti;
+  EXPECT_EQ(ti.target_frame_id, "map");
+  EXPECT_FALSE(ti.targetIsRelative);
+  EXPECT_FALSE(ti.targetIsIntermediaryWaypoint);
+
+  const std::string s = ti.getAsText();
+  EXPECT_NE(s.find("target_coords"), std::string::npos);
+  EXPECT_NE(s.find("targetAllowedDistance"), std::string::npos);
+  EXPECT_NE(s.find("targetIsRelative = NO"), std::string::npos);
+}
+
+TEST(CAbstractNavigator, target_info_equality)
+{
+  CAbstractNavigator::TargetInfo a, b;
+  EXPECT_TRUE(a == b);
+  EXPECT_FALSE(a != b);
+
+  b.target_coords = mrpt::math::TPose2D(1, 2, 3);
+  EXPECT_TRUE(a != b);
+
+  b = a;
+  b.targetAllowedDistance = 9.0f;
+  EXPECT_TRUE(a != b);
+
+  b = a;
+  b.targetIsRelative = true;
+  EXPECT_TRUE(a != b);
+
+  b = a;
+  b.target_frame_id = "odom";
+  EXPECT_TRUE(a != b);
+
+  b = a;
+  b.targetIsIntermediaryWaypoint = true;
+  EXPECT_TRUE(a != b);
+
+  b = a;
+  b.targetDesiredRelSpeed = 0.9;
+  EXPECT_TRUE(a != b);
+}
+
+TEST(CAbstractNavigator, nav_params_equality_is_type_aware)
+{
+  CAbstractNavigator::TNavigationParams a, b;
+  EXPECT_TRUE(a == b);
+
+  b.target.target_coords = mrpt::math::TPose2D(1, 0, 0);
+  EXPECT_FALSE(a == b);
+
+  // Different dynamic types are never equal:
+  CWaypointsNavigator::TNavigationParamsWaypoints c;
+  EXPECT_FALSE(a == c);
+
+  EXPECT_NE(a.getAsText().find("Single target"), std::string::npos);
+
+  auto cloned = a.clone();
+  ASSERT_TRUE(cloned);
+  EXPECT_TRUE(a == *cloned);
+}
+
+TEST(CWaypointsNavigator, waypoints_nav_params_text_and_equality)
+{
+  CWaypointsNavigator::TNavigationParamsWaypoints a, b;
+  EXPECT_TRUE(a == b);
+
+  CAbstractNavigator::TargetInfo ti;
+  ti.target_coords = mrpt::math::TPose2D(1, 2, 0);
+  b.multiple_targets.push_back(ti);
+  EXPECT_FALSE(a == b);
+  EXPECT_NE(b.getAsText().find("multiple_targets"), std::string::npos);
+
+  auto cloned = b.clone();
+  ASSERT_TRUE(cloned);
+  EXPECT_TRUE(b == *cloned);
+}
+
+// ---------------------------------------------------------------------------
+//  State machine
+// ---------------------------------------------------------------------------
+TEST(CAbstractNavigator, state_machine_idle_navigating_suspended)
+{
+  MockRobotIF robot;
+  TestNavigator nav(robot);
+
+  EXPECT_EQ(nav.getCurrentState(), CAbstractNavigator::TState::IDLE);
+
+  auto np = make_target(10, 0);
+  nav.navigate(&np);
+  EXPECT_EQ(nav.getCurrentState(), CAbstractNavigator::TState::NAVIGATING);
+
+  nav.navigationStep();
+  EXPECT_EQ(nav.getCurrentState(), CAbstractNavigator::TState::NAVIGATING);
+  EXPECT_EQ(robot.nStartWatchdog, 1);
+  EXPECT_EQ(robot.nNavStart, 1);
+  EXPECT_GT(nav.nPerformNavigationStep, 0);
+
+  nav.suspend();
+  EXPECT_EQ(nav.getCurrentState(), CAbstractNavigator::TState::SUSPENDED);
+  const int stopsAfterSuspend = robot.nStop;
+  EXPECT_GT(stopsAfterSuspend, 0);
+
+  // While suspended, no navigation step is run:
+  const int nStepsBefore = nav.nPerformNavigationStep;
+  nav.navigationStep();
+  EXPECT_EQ(nav.nPerformNavigationStep, nStepsBefore);
+  EXPECT_EQ(robot.nStopWatchdog, 1);
+
+  nav.resume();
+  EXPECT_EQ(nav.getCurrentState(), CAbstractNavigator::TState::NAVIGATING);
+
+  nav.cancel();
+  EXPECT_EQ(nav.getCurrentState(), CAbstractNavigator::TState::IDLE);
+}
+
+TEST(CAbstractNavigator, resume_and_suspend_are_noops_in_other_states)
+{
+  MockRobotIF robot;
+  TestNavigator nav(robot);
+
+  nav.resume();  // not suspended
+  EXPECT_EQ(nav.getCurrentState(), CAbstractNavigator::TState::IDLE);
+
+  nav.suspend();  // not navigating
+  EXPECT_EQ(nav.getCurrentState(), CAbstractNavigator::TState::IDLE);
+
+  nav.resetNavError();  // not in error
+  EXPECT_EQ(nav.getCurrentState(), CAbstractNavigator::TState::IDLE);
+}
+
+TEST(CAbstractNavigator, reaching_the_target_ends_the_navigation)
+{
+  MockRobotIF robot;
+  TestNavigator nav(robot);
+
+  auto np = make_target(1.0, 0.0, 0.5);
+  nav.navigate(&np);
+
+  for (int i = 0; i < 20 && nav.getCurrentState() != CAbstractNavigator::TState::IDLE; i++)
+  {
+    nav.step();
+    nav.teleportTowardsTarget(0.3);
+  }
+
+  EXPECT_EQ(nav.getCurrentState(), CAbstractNavigator::TState::IDLE);
+  EXPECT_EQ(robot.nNavEnd, 1);
+}
+
+TEST(CAbstractNavigator, relative_targets_are_converted_to_absolute)
+{
+  MockRobotIF robot;
+  robot.pose = mrpt::math::TPose2D(10, 20, .0);
+  TestNavigator nav(robot);
+
+  auto np = make_target(1.0, 2.0);
+  np.target.targetIsRelative = true;
+  nav.navigate(&np);
+
+  nav.navigationStep();
+  EXPECT_EQ(nav.getCurrentState(), CAbstractNavigator::TState::NAVIGATING);
+}
+
+TEST(CAbstractNavigator, navigate_rejects_null_or_out_of_range_params)
+{
+  MockRobotIF robot;
+  TestNavigator nav(robot);
+
+  EXPECT_ANY_THROW(nav.navigate(nullptr));
+
+  auto np = make_target(1, 0);
+  np.target.targetDesiredRelSpeed = 5.0;  // out of [0,1]
+  EXPECT_ANY_THROW(nav.navigate(&np));
+}
+
+TEST(CAbstractNavigator, unavailable_robot_pose_raises_a_nav_error)
+{
+  MockRobotIF robot;
+  TestNavigator nav(robot);
+
+  auto np = make_target(10, 0);
+  nav.navigate(&np);
+
+  robot.poseIsAvailable = false;
+  nav.navigationStep();
+
+  EXPECT_EQ(nav.getCurrentState(), CAbstractNavigator::TState::NAV_ERROR);
+  EXPECT_EQ(nav.getErrorReason().error_code, CAbstractNavigator::TErrorCode::EMERGENCY_STOP);
+  EXPECT_FALSE(nav.getErrorReason().error_msg.empty());
+
+  // Only resetNavError() gets us out of it:
+  nav.resetNavError();
+  EXPECT_EQ(nav.getCurrentState(), CAbstractNavigator::TState::IDLE);
+  EXPECT_EQ(nav.getErrorReason().error_code, CAbstractNavigator::TErrorCode::NONE);
+}
+
+TEST(CAbstractNavigator, exceptions_in_the_nav_step_raise_a_nav_error)
+{
+  MockRobotIF robot;
+  TestNavigator nav(robot);
+
+  auto np = make_target(10, 0);
+  nav.navigate(&np);
+  nav.throwOnStep = true;
+  nav.navigationStep();
+
+  EXPECT_EQ(nav.getCurrentState(), CAbstractNavigator::TState::NAV_ERROR);
+  EXPECT_EQ(nav.getErrorReason().error_code, CAbstractNavigator::TErrorCode::OTHER);
+  EXPECT_NE(
+      nav.getErrorReason().error_msg.find("synthetic navigation failure"), std::string::npos);
+
+  // The next step reports the error to the robot interface and stops it:
+  nav.navigationStep();
+  EXPECT_EQ(robot.nNavEndDueToError, 1);
+}
+
+TEST(CAbstractNavigator, exceptions_can_be_rethrown_to_the_caller)
+{
+  MockRobotIF robot;
+  TestNavigator nav(robot);
+
+  EXPECT_FALSE(nav.isRethrowNavExceptionsEnabled());
+  nav.enableRethrowNavExceptions(true);
+  EXPECT_TRUE(nav.isRethrowNavExceptionsEnabled());
+
+  auto np = make_target(10, 0);
+  nav.navigate(&np);
+  nav.throwOnStep = true;
+  EXPECT_ANY_THROW(nav.navigationStep());
+  EXPECT_EQ(nav.getCurrentState(), CAbstractNavigator::TState::NAV_ERROR);
+}
+
+TEST(CAbstractNavigator, emergency_stop_latches_the_error_state)
+{
+  MockRobotIF robot;
+  TestNavigator nav(robot);
+
+  auto np = make_target(10, 0);
+  nav.navigate(&np);
+  nav.emergencyStopOnStep = true;
+  nav.navigationStep();
+
+  EXPECT_EQ(nav.getCurrentState(), CAbstractNavigator::TState::NAV_ERROR);
+  EXPECT_EQ(nav.getErrorReason().error_code, CAbstractNavigator::TErrorCode::EMERGENCY_STOP);
+  EXPECT_NE(nav.getErrorReason().error_msg.find("synthetic emergency stop"), std::string::npos);
+}
+
+TEST(CAbstractNavigator, a_blocked_target_raises_the_corresponding_event)
+{
+  MockRobotIF robot;
+  TestNavigator nav(robot);
+  nav.params_abstract_navigator.dist_check_target_is_blocked = 5.0;
+  nav.params_abstract_navigator.hysteresis_check_target_is_blocked = 2;
+
+  auto np = make_target(1.0, 0.0, 0.1 /*never reached*/);
+  nav.navigate(&np);
+  nav.targetIsColliding = true;
+
+  for (int i = 0; i < 4; i++)
+  {
+    nav.step();
+  }
+  EXPECT_GT(robot.nCannotGetCloser, 0);
+
+  // Once the obstacle is gone the hysteresis counter is reset:
+  const int n0 = robot.nCannotGetCloser;
+  nav.targetIsColliding = false;
+  for (int i = 0; i < 4; i++)
+  {
+    nav.step();
+  }
+  EXPECT_EQ(robot.nCannotGetCloser, n0);
+}
+
+TEST(CAbstractNavigator, not_approaching_the_target_times_out)
+{
+  MockRobotIF robot;
+  TestNavigator nav(robot);
+  nav.params_abstract_navigator.alarm_seems_not_approaching_target_timeout = 0.0;
+
+  auto np = make_target(10.0, 0.0, 0.1);
+  nav.navigate(&np);
+
+  // The robot never moves, so the "not approaching" alarm must fire:
+  for (int i = 0; i < 5 && nav.getCurrentState() == CAbstractNavigator::TState::NAVIGATING; i++)
+  {
+    nav.step();
+  }
+
+  EXPECT_EQ(nav.getCurrentState(), CAbstractNavigator::TState::NAV_ERROR);
+  EXPECT_EQ(nav.getErrorReason().error_code, CAbstractNavigator::TErrorCode::CANNOT_REACH_TARGET);
+  EXPECT_GT(robot.nWaySeemsBlocked, 0);
+}
+
+TEST(CAbstractNavigator, end_of_nav_event_distance_is_configurable)
+{
+  MockRobotIF robot;
+  TestNavigator nav(robot);
+  // Send the "navigation end" event well before the target is reached:
+  nav.params_abstract_navigator.dist_to_target_for_sending_event = 3.0;
+
+  auto np = make_target(1.0, 0.0, 0.2);
+  nav.navigate(&np);
+  nav.navigationStep();
+
+  EXPECT_EQ(robot.nNavEnd, 1);
+}
+
+TEST(CAbstractNavigator, config_file_roundtrip)
+{
+  MockRobotIF robot;
+  TestNavigator nav(robot);
+
+  nav.params_abstract_navigator.dist_to_target_for_sending_event = 1.25;
+  nav.params_abstract_navigator.alarm_seems_not_approaching_target_timeout = 12.5;
+  nav.params_abstract_navigator.dist_check_target_is_blocked = 3.5;
+  nav.params_abstract_navigator.hysteresis_check_target_is_blocked = 7;
+  nav.params_waypoints_navigator.max_distance_to_allow_skip_waypoint = 4.5;
+  nav.params_waypoints_navigator.min_timesteps_confirm_skip_waypoints = 3;
+  nav.params_waypoints_navigator.multitarget_look_ahead = 2;
+  nav.params_waypoints_navigator.minimum_target_approach_per_step = 0.05;
+
+  mrpt::config::CConfigFileMemory cfg;
+  nav.saveConfigFile(cfg);
+
+  MockRobotIF robot2;
+  TestNavigator nav2(robot2);
+  nav2.loadConfigFile(cfg);
+
+  EXPECT_NEAR(nav2.params_abstract_navigator.dist_to_target_for_sending_event, 1.25, 1e-9);
+  EXPECT_NEAR(
+      nav2.params_abstract_navigator.alarm_seems_not_approaching_target_timeout, 12.5, 1e-9);
+  EXPECT_NEAR(nav2.params_abstract_navigator.dist_check_target_is_blocked, 3.5, 1e-9);
+  EXPECT_EQ(nav2.params_abstract_navigator.hysteresis_check_target_is_blocked, 7);
+  EXPECT_NEAR(nav2.params_waypoints_navigator.max_distance_to_allow_skip_waypoint, 4.5, 1e-9);
+  EXPECT_EQ(nav2.params_waypoints_navigator.min_timesteps_confirm_skip_waypoints, 3);
+  EXPECT_EQ(nav2.params_waypoints_navigator.multitarget_look_ahead, 2);
+  EXPECT_NEAR(nav2.params_waypoints_navigator.minimum_target_approach_per_step, 0.05, 1e-9);
+}
+
+TEST(CAbstractNavigator, frame_transformer_is_stored)
+{
+  MockRobotIF robot;
+  TestNavigator nav(robot);
+  EXPECT_TRUE(nav.getFrameTF().expired());
+
+  auto tf = std::make_shared<mrpt::poses::FrameTransformer<2>>();
+  nav.setFrameTF(tf);
+  EXPECT_FALSE(nav.getFrameTF().expired());
+}
+
+// ---------------------------------------------------------------------------
+//  Waypoint sequences
+// ---------------------------------------------------------------------------
+TEST(CWaypointsNavigator, navigates_through_a_whole_sequence)
+{
+  MockRobotIF robot;
+  TestNavigator nav(robot);
+  nav.reachable = false;  // disable the skip policy: follow them one by one
+
+  TWaypointSequence seq;
+  seq.waypoints.emplace_back(1.0, 0.0, 0.4);
+  seq.waypoints.emplace_back(2.0, 0.0, 0.4);
+  seq.waypoints.emplace_back(3.0, 0.0, 0.4);
+  nav.navigateWaypoints(seq);
+
+  for (int i = 0; i < 100 && !nav.getWaypointNavStatus().final_goal_reached; i++)
+  {
+    nav.step();
+    nav.teleportTowardsTarget(0.25);
+  }
+
+  const auto st = nav.getWaypointNavStatus();
+  EXPECT_TRUE(st.final_goal_reached);
+  EXPECT_EQ(st.waypoint_index_current_goal, 2);
+  for (const auto& wp : st.waypoints)
+  {
+    EXPECT_TRUE(wp.reached);
+    EXPECT_FALSE(wp.skipped);
+    EXPECT_NE(wp.timestamp_reach, INVALID_TIMESTAMP);
+  }
+  EXPECT_GE(robot.nWaypointReached, 3);
+  EXPECT_GE(robot.nNewWaypointTarget, 3);
+  EXPECT_EQ(robot.nNavEnd, 1);
+}
+
+TEST(CWaypointsNavigator, skips_reachable_intermediary_waypoints)
+{
+  MockRobotIF robot;
+  TestNavigator nav(robot);
+  nav.reachable = true;  // every waypoint looks directly reachable
+  nav.params_waypoints_navigator.min_timesteps_confirm_skip_waypoints = 0;
+
+  TWaypointSequence seq;
+  seq.waypoints.emplace_back(1.0, 0.0, 0.4);
+  seq.waypoints.emplace_back(2.0, 0.0, 0.4);
+  seq.waypoints.emplace_back(3.0, 0.0, 0.4);
+  nav.navigateWaypoints(seq);
+
+  // The first cycle only activates waypoint #0; the skip policy runs from the
+  // second one on:
+  nav.step();
+  nav.step();
+
+  const auto st = nav.getWaypointNavStatus();
+  // It jumped straight to the last waypoint, marking the others as skipped:
+  EXPECT_EQ(st.waypoint_index_current_goal, 2);
+  EXPECT_TRUE(st.waypoints[0].skipped);
+  EXPECT_TRUE(st.waypoints[0].reached);
+  EXPECT_TRUE(st.waypoints[1].skipped);
+  EXPECT_FALSE(st.waypoints[2].reached);
+  EXPECT_EQ(robot.nWaypointSkipped, 2);
+}
+
+TEST(CWaypointsNavigator, non_skippable_waypoints_are_honored)
+{
+  MockRobotIF robot;
+  TestNavigator nav(robot);
+  nav.reachable = true;
+  nav.params_waypoints_navigator.min_timesteps_confirm_skip_waypoints = 0;
+
+  TWaypointSequence seq;
+  seq.waypoints.emplace_back(1.0, 0.0, 0.4, false /*allow_skip*/);
+  seq.waypoints.emplace_back(2.0, 0.0, 0.4);
+  nav.navigateWaypoints(seq);
+
+  nav.navigationStep();
+
+  const auto st = nav.getWaypointNavStatus();
+  EXPECT_EQ(st.waypoint_index_current_goal, 0);
+  EXPECT_FALSE(st.waypoints[0].skipped);
+}
+
+TEST(CWaypointsNavigator, far_away_waypoints_are_not_skipped_to)
+{
+  MockRobotIF robot;
+  TestNavigator nav(robot);
+  nav.reachable = true;
+  nav.params_waypoints_navigator.min_timesteps_confirm_skip_waypoints = 0;
+  nav.params_waypoints_navigator.max_distance_to_allow_skip_waypoint = 1.5;
+
+  TWaypointSequence seq;
+  seq.waypoints.emplace_back(1.0, 0.0, 0.4);
+  seq.waypoints.emplace_back(50.0, 0.0, 0.4);  // beyond the look-ahead radius
+  nav.navigateWaypoints(seq);
+
+  nav.navigationStep();
+
+  const auto st = nav.getWaypointNavStatus();
+  EXPECT_EQ(st.waypoint_index_current_goal, 0);
+}
+
+TEST(CWaypointsNavigator, multitarget_look_ahead_forwards_extra_targets)
+{
+  MockRobotIF robot;
+  TestNavigator nav(robot);
+  nav.reachable = false;
+  nav.params_waypoints_navigator.multitarget_look_ahead = 2;
+
+  TWaypointSequence seq;
+  seq.waypoints.emplace_back(1.0, 0.0, 0.4);
+  seq.waypoints.emplace_back(2.0, 0.0, 0.4);
+  seq.waypoints.emplace_back(3.0, 0.0, 0.4);
+  nav.navigateWaypoints(seq);
+
+  nav.navigationStep();
+  EXPECT_EQ(nav.getCurrentState(), CAbstractNavigator::TState::NAVIGATING);
+  EXPECT_EQ(robot.nNewWaypointTarget, 1);
+}
+
+TEST(CWaypointsNavigator, empty_waypoint_sequences_are_rejected)
+{
+  MockRobotIF robot;
+  TestNavigator nav(robot);
+  TWaypointSequence seq;
+  EXPECT_ANY_THROW(nav.navigateWaypoints(seq));
+
+  // ... and so are incompletely-filled waypoints:
+  seq.waypoints.emplace_back();
+  EXPECT_ANY_THROW(nav.navigateWaypoints(seq));
+}
+
+TEST(CWaypointsNavigator, cancel_clears_the_waypoint_status)
+{
+  MockRobotIF robot;
+  TestNavigator nav(robot);
+
+  TWaypointSequence seq;
+  seq.waypoints.emplace_back(1.0, 0.0, 0.4);
+  nav.navigateWaypoints(seq);
+  ASSERT_EQ(nav.getWaypointNavStatus().waypoints.size(), 1U);
+
+  nav.cancel();
+  EXPECT_TRUE(nav.getWaypointNavStatus().waypoints.empty());
+  EXPECT_EQ(nav.getWaypointNavStatus().timestamp_nav_started, INVALID_TIMESTAMP);
+  EXPECT_EQ(nav.getCurrentState(), CAbstractNavigator::TState::IDLE);
+}
+
+TEST(CWaypointsNavigator, waypoints_emptied_mid_navigation_do_not_crash)
+{
+  MockRobotIF robot;
+  TestNavigator nav(robot);
+
+  TWaypointSequence seq;
+  seq.waypoints.emplace_back(10.0, 0.0, 0.4);
+  nav.navigateWaypoints(seq);
+  nav.navigationStep();
+
+  // A user of the access guard may legitimately empty the list:
+  {
+    auto guard = nav.getWaypointsAccessGuard();
+    guard.waypoints().waypoints.clear();
+  }
+
+  EXPECT_NO_THROW(nav.navigationStep());
+}
+
+TEST(CWaypointsNavigator, waypoints_with_a_heading_align_before_being_reached)
+{
+  MockRobotIF robot;
+  robot.supportsAlignCmd = true;
+  TestNavigator nav(robot);
+  nav.reachable = false;
+
+  TWaypointSequence seq;
+  seq.waypoints.emplace_back(1.0, 0.0, 0.4, true, mrpt::DEG2RAD(90.0));
+  nav.navigateWaypoints(seq);
+
+  // Drive the robot right onto the waypoint, but with the wrong heading:
+  for (int i = 0; i < 10; i++)
+  {
+    nav.step();
+    nav.teleportTowardsTarget(0.5);
+  }
+
+  // The robot is at the waypoint but not aligned: the navigator requests an
+  // in-place rotation instead of declaring the waypoint reached.
+  EXPECT_TRUE(nav.waypoints_isAligning());
+  EXPECT_FALSE(nav.getWaypointNavStatus().final_goal_reached);
+  EXPECT_GT(robot.nChangeSpeeds, 0);
+}
+
+TEST(CWaypointsNavigator, headed_waypoints_are_reached_when_alignment_is_unsupported)
+{
+  MockRobotIF robot;
+  robot.supportsAlignCmd = false;  // this robot cannot rotate in place
+  TestNavigator nav(robot);
+  nav.reachable = false;
+
+  TWaypointSequence seq;
+  seq.waypoints.emplace_back(1.0, 0.0, 0.4, true, mrpt::DEG2RAD(90.0));
+  nav.navigateWaypoints(seq);
+
+  for (int i = 0; i < 30 && !nav.getWaypointNavStatus().final_goal_reached; i++)
+  {
+    nav.step();
+    nav.teleportTowardsTarget(0.5);
+  }
+  EXPECT_TRUE(nav.getWaypointNavStatus().final_goal_reached);
+}
+
+TEST(CWaypointsNavigator, isRelativePointReachable_forwards_to_the_implementation)
+{
+  MockRobotIF robot;
+  TestNavigator nav(robot);
+
+  nav.reachable = true;
+  EXPECT_TRUE(nav.isRelativePointReachable(mrpt::math::TPoint2D(1, 0)));
+  nav.reachable = false;
+  EXPECT_FALSE(nav.isRelativePointReachable(mrpt::math::TPoint2D(1, 0)));
+}

--- a/modules/mrpt_nav/tests/PTG_variants_unittest.cpp
+++ b/modules/mrpt_nav/tests/PTG_variants_unittest.cpp
@@ -33,6 +33,7 @@
 #include <mrpt/system/filesystem.h>
 #include <mrpt/viz/CSetOfLines.h>
 
+#include <fstream>
 #include <memory>
 
 using namespace mrpt::nav;
@@ -283,14 +284,11 @@ TEST(PTGBase, collision_behavior_is_settable)
   const auto saved = CParameterizedTrajectoryGenerator::getCollisionBehavior();
 
   CParameterizedTrajectoryGenerator::setCollisionBehavior(PTGCollisionBehavior::STOP);
-  EXPECT_EQ(
-      CParameterizedTrajectoryGenerator::getCollisionBehavior(), PTGCollisionBehavior::STOP);
+  EXPECT_EQ(CParameterizedTrajectoryGenerator::getCollisionBehavior(), PTGCollisionBehavior::STOP);
 
-  CParameterizedTrajectoryGenerator::setCollisionBehavior(
-      PTGCollisionBehavior::BACK_AWAY);
+  CParameterizedTrajectoryGenerator::setCollisionBehavior(PTGCollisionBehavior::BACK_AWAY);
   EXPECT_EQ(
-      CParameterizedTrajectoryGenerator::getCollisionBehavior(),
-      PTGCollisionBehavior::BACK_AWAY);
+      CParameterizedTrajectoryGenerator::getCollisionBehavior(), PTGCollisionBehavior::BACK_AWAY);
 
   CParameterizedTrajectoryGenerator::setCollisionBehavior(saved);
 }
@@ -307,8 +305,7 @@ TEST(PTGBase, debugDumpInFiles_writes_the_trajectory_tables)
 {
   auto ptg = make_diffdrive_ptg("CPTG_DiffDrive_C");
 
-  const std::string sDir =
-      mrpt::system::getTempFileName() + std::string("_ptg_dump");
+  const std::string sDir = mrpt::system::getTempFileName() + std::string("_ptg_dump");
   const auto saved = CParameterizedTrajectoryGenerator::getOutputDebugPathPrefix();
   CParameterizedTrajectoryGenerator::setOutputDebugPathPrefix(sDir);
 
@@ -433,11 +430,12 @@ TEST(PTGBase, factory_accepts_legacy_numeric_names)
 
   // MRPT <1.5.0 named the PTG classes by a single digit:
   const std::pair<const char*, const char*> legacy[] = {
-      {"1", "CPTG_DiffDrive_C"},
+      {"1",     "CPTG_DiffDrive_C"},
       {"2", "CPTG_DiffDrive_alpha"},
-      {"3", "CPTG_DiffDrive_CCS"},
-      {"4", "CPTG_DiffDrive_CC"},
-      {"5", "CPTG_DiffDrive_CS"}};
+      {"3",   "CPTG_DiffDrive_CCS"},
+      {"4",    "CPTG_DiffDrive_CC"},
+      {"5",    "CPTG_DiffDrive_CS"}
+  };
 
   for (const auto& [digit, className] : legacy)
   {
@@ -578,4 +576,89 @@ TEST(PTGHoloBlend, relative_priority_depends_on_target_speed)
   const auto prio = ptg->evalPathRelativePriority(0, 1.0);
   EXPECT_TRUE(std::isfinite(prio));
   EXPECT_GT(prio, .0);
+}
+
+// ---------------------------------------------------------------------------
+//  Collision-grid cache files and per-path queries
+// ---------------------------------------------------------------------------
+TEST(PTGVariants, collision_grid_is_cached_to_and_reloaded_from_a_file)
+{
+  const std::string cacheFil = mrpt::system::getTempFileName() + std::string("_ptg_cache.dat.gz");
+
+  mrpt::config::CConfigFileMemory cfg;
+  fill_diffdrive_cfg(cfg, "PTG");
+
+  // 1st run: the grid is built from scratch and dumped to the cache file.
+  auto ptg1 = CParameterizedTrajectoryGenerator::CreatePTG("CPTG_DiffDrive_C", cfg, "PTG", "");
+  ptg1->initialize(cacheFil, false /*verbose*/);
+  ASSERT_TRUE(mrpt::system::fileExists(cacheFil));
+
+  // 2nd run: the very same grid is now read back from the cache.
+  auto ptg2 = CParameterizedTrajectoryGenerator::CreatePTG("CPTG_DiffDrive_C", cfg, "PTG", "");
+  ptg2->initialize(cacheFil, false);
+  EXPECT_TRUE(ptg2->isInitialized());
+
+  std::vector<double> obs1, obs2;
+  ptg1->initTPObstacles(obs1);
+  ptg2->initTPObstacles(obs2);
+  ptg1->updateTPObstacle(1.0, 0.3, obs1);
+  ptg2->updateTPObstacle(1.0, 0.3, obs2);
+  EXPECT_EQ(obs1, obs2);
+
+  // A corrupt/foreign cache file is detected and the grid rebuilt instead:
+  {
+    std::ofstream f(cacheFil, std::ios::binary | std::ios::trunc);
+    f << "not a collision grid";
+  }
+  auto ptg3 = CParameterizedTrajectoryGenerator::CreatePTG("CPTG_DiffDrive_C", cfg, "PTG", "");
+  EXPECT_NO_THROW(ptg3->initialize(cacheFil, false));
+  EXPECT_TRUE(ptg3->isInitialized());
+
+  mrpt::system::deleteFile(cacheFil);
+}
+
+TEST(PTGVariants, per_path_tp_obstacle_updates_match_the_full_update)
+{
+  auto ptg = make_diffdrive_ptg("CPTG_DiffDrive_C");
+
+  std::vector<double> all;
+  ptg->initTPObstacles(all);
+  ptg->updateTPObstacle(1.0, 0.2, all);
+
+  for (uint16_t k = 0; k < ptg->getPathCount(); k++)
+  {
+    double single = .0;
+    ptg->initTPObstacleSingle(k, single);
+    ptg->updateTPObstacleSingle(1.0, 0.2, k, single);
+    EXPECT_NEAR(single, all[k], 1e-9) << "k=" << k;
+  }
+}
+
+TEST(PTGVariants, points_beyond_the_reference_distance_map_outside_the_unit_range)
+{
+  for (const auto* name : diffdrive_ptg_names)
+  {
+    auto ptg = make_diffdrive_ptg(name);
+    // These PTGs answer with the nearest precomputed path, so the way to tell
+    // an unreachable point apart is its normalized distance being >1:
+    const double farAway = 10 * ptg->getRefDistance();
+    if (const auto inv = ptg->inverseMap_WS2TP(farAway, farAway))
+    {
+      EXPECT_GT(inv->second, 1.0) << name;
+    }
+  }
+}
+
+TEST(PTGVariants, getPathStepForDist_beyond_the_path_end_fails)
+{
+  auto ptg = make_diffdrive_ptg("CPTG_DiffDrive_C");
+  uint32_t step = 0;
+  EXPECT_FALSE(ptg->getPathStepForDist(0, 1e6 /*way beyond refDistance*/, step));
+}
+
+TEST(PTGVariants, deinitialized_ptgs_reject_path_queries)
+{
+  auto ptg = make_diffdrive_ptg("CPTG_DiffDrive_C");
+  ptg->deinitialize();
+  EXPECT_ANY_THROW(ptg->getPathStepCount(0));
 }

--- a/modules/mrpt_nav/tests/PTG_variants_unittest.cpp
+++ b/modules/mrpt_nav/tests/PTG_variants_unittest.cpp
@@ -1,0 +1,581 @@
+/*                    _
+                     | |    Mobile Robot Programming Toolkit (MRPT)
+ _ __ ___  _ __ _ __ | |_
+| '_ ` _ \| '__| '_ \| __|          https://www.mrpt.org/
+| | | | | | |  | |_) | |_
+|_| |_| |_|_|  | .__/ \__|     https://github.com/MRPT/mrpt/
+               | |
+               |_|
+
+ Copyright (c) 2005-2026, Individual contributors, see AUTHORS file
+ See: https://www.mrpt.org/Authors - All rights reserved.
+ SPDX-License-Identifier: BSD-3-Clause
+*/
+
+/** Coverage for the whole family of PTG classes: the ones not exercised by
+ *  `PTGs_unittest.cpp` (which only instantiates a subset from a config file),
+ *  plus the shared services of the CParameterizedTrajectoryGenerator base:
+ *  config file and stream (de)serialization, TP-space index mapping,
+ *  visualization, clearance diagrams and the robot-shape mixins.
+ */
+
+#include <gtest/gtest.h>
+#include <mrpt/config/CConfigFileMemory.h>
+#include <mrpt/io/CMemoryStream.h>
+#include <mrpt/nav/holonomic/ClearanceDiagram.h>
+#include <mrpt/nav/tpspace/CPTG_DiffDrive_C.h>
+#include <mrpt/nav/tpspace/CPTG_DiffDrive_CC.h>
+#include <mrpt/nav/tpspace/CPTG_DiffDrive_CCS.h>
+#include <mrpt/nav/tpspace/CPTG_DiffDrive_CS.h>
+#include <mrpt/nav/tpspace/CPTG_DiffDrive_alpha.h>
+#include <mrpt/nav/tpspace/CPTG_Holo_Blend.h>
+#include <mrpt/serialization/CArchive.h>
+#include <mrpt/system/filesystem.h>
+#include <mrpt/viz/CSetOfLines.h>
+
+#include <memory>
+
+using namespace mrpt::nav;
+
+namespace
+{
+/** Config with the keys shared by every CPTG_DiffDrive_CollisionGridBased
+ *  derived class. A small refDistance/num_paths keeps the collision grid
+ *  build time low. */
+void fill_diffdrive_cfg(mrpt::config::CConfigFileMemory& cfg, const std::string& s)
+{
+  cfg.write(s, "num_paths", 21);
+  cfg.write(s, "refDistance", 2.0);
+  cfg.write(s, "resolution", 0.25);
+  cfg.write(s, "v_max_mps", 1.0);
+  cfg.write(s, "w_max_dps", 60.0);
+  cfg.write(s, "K", 1.0);
+  cfg.write(s, "cte_a0v_deg", 57.0);
+  cfg.write(s, "cte_a0w_deg", 57.0);
+  // A small square robot shape:
+  cfg.write(s, "shape_x0", -0.2);
+  cfg.write(s, "shape_y0", 0.2);
+  cfg.write(s, "shape_x1", 0.2);
+  cfg.write(s, "shape_y1", 0.2);
+  cfg.write(s, "shape_x2", 0.2);
+  cfg.write(s, "shape_y2", -0.2);
+  cfg.write(s, "shape_x3", -0.2);
+  cfg.write(s, "shape_y3", -0.2);
+}
+
+void fill_holo_cfg(mrpt::config::CConfigFileMemory& cfg, const std::string& s)
+{
+  cfg.write(s, "num_paths", 21);
+  cfg.write(s, "refDistance", 3.0);
+  cfg.write(s, "T_ramp_max", 0.8);
+  cfg.write(s, "v_max_mps", 1.0);
+  cfg.write(s, "w_max_dps", 60.0);
+  cfg.write(s, "robot_radius", 0.35);
+}
+
+/** All the collision-grid-based PTG class names, i.e. those whose paths are
+ *  precomputed into a look-up table. */
+const char* const diffdrive_ptg_names[] = {
+    "CPTG_DiffDrive_C", "CPTG_DiffDrive_alpha", "CPTG_DiffDrive_CC", "CPTG_DiffDrive_CCS",
+    "CPTG_DiffDrive_CS"};
+
+CParameterizedTrajectoryGenerator::Ptr make_diffdrive_ptg(const std::string& className)
+{
+  mrpt::config::CConfigFileMemory cfg;
+  fill_diffdrive_cfg(cfg, "PTG");
+  auto ptg = CParameterizedTrajectoryGenerator::CreatePTG(className, cfg, "PTG", "");
+  ptg->initialize(std::string(), false /*verbose*/);
+  return ptg;
+}
+}  // namespace
+
+// ---------------------------------------------------------------------------
+//  Every PTG flavor: factory + initialize + basic invariants
+// ---------------------------------------------------------------------------
+TEST(PTGVariants, all_diffdrive_flavors_initialize)
+{
+  for (const auto* name : diffdrive_ptg_names)
+  {
+    auto ptg = make_diffdrive_ptg(name);
+    ASSERT_TRUE(ptg) << name;
+    EXPECT_TRUE(ptg->isInitialized()) << name;
+    EXPECT_EQ(ptg->getPathCount(), 21U) << name;
+    EXPECT_EQ(ptg->getAlphaValuesCount(), ptg->getPathCount()) << name;
+    EXPECT_NEAR(ptg->getRefDistance(), 2.0, 1e-9) << name;
+    EXPECT_FALSE(ptg->getDescription().empty()) << name;
+    EXPECT_GT(ptg->getMaxRobotRadius(), .0) << name;
+    EXPECT_GT(ptg->getMaxLinVel(), .0) << name;
+    EXPECT_GT(ptg->getMaxAngVel(), .0) << name;
+
+    // Every path must have at least one step, and step<->distance must be
+    // monotonically consistent:
+    for (uint16_t k = 0; k < ptg->getPathCount(); k++)
+    {
+      const size_t nSteps = ptg->getPathStepCount(k);
+      ASSERT_GT(nSteps, 0U) << name << " k=" << k;
+      EXPECT_GE(ptg->getPathDist(k, 0), .0) << name;
+      EXPECT_GE(ptg->getPathDist(k, static_cast<uint32_t>(nSteps - 1)), ptg->getPathDist(k, 0))
+          << name;
+    }
+
+    ptg->deinitialize();
+    EXPECT_FALSE(ptg->isInitialized()) << name;
+  }
+}
+
+TEST(PTGVariants, diffdrive_config_file_roundtrip)
+{
+  for (const auto* name : diffdrive_ptg_names)
+  {
+    auto ptg = make_diffdrive_ptg(name);
+
+    mrpt::config::CConfigFileMemory cfg2;
+    ptg->saveToConfigFile(cfg2, "OUT");
+
+    auto ptg2 = CParameterizedTrajectoryGenerator::CreatePTG(name, cfg2, "OUT", "");
+    ASSERT_TRUE(ptg2) << name;
+    EXPECT_EQ(ptg2->getPathCount(), ptg->getPathCount()) << name;
+    EXPECT_NEAR(ptg2->getRefDistance(), ptg->getRefDistance(), 1e-9) << name;
+    EXPECT_EQ(ptg2->getDescription(), ptg->getDescription()) << name;
+  }
+}
+
+TEST(PTGVariants, diffdrive_serialization_roundtrip)
+{
+  for (const auto* name : diffdrive_ptg_names)
+  {
+    auto ptg = make_diffdrive_ptg(name);
+
+    mrpt::io::CMemoryStream buf;
+    auto arch = mrpt::serialization::archiveFrom(buf);
+    arch << *ptg;
+    buf.Seek(0);
+
+    mrpt::serialization::CSerializable::Ptr obj;
+    arch >> obj;
+    auto ptg2 = std::dynamic_pointer_cast<CParameterizedTrajectoryGenerator>(obj);
+    ASSERT_TRUE(ptg2) << name;
+    EXPECT_EQ(ptg2->getPathCount(), ptg->getPathCount()) << name;
+    EXPECT_NEAR(ptg2->getRefDistance(), ptg->getRefDistance(), 1e-9) << name;
+    EXPECT_EQ(ptg2->getDescription(), ptg->getDescription()) << name;
+    // Deserialization leaves the PTG un-initialized (no LUT yet):
+    EXPECT_FALSE(ptg2->isInitialized()) << name;
+  }
+}
+
+TEST(PTGVariants, diffdrive_default_params_are_usable)
+{
+  for (const auto* name : diffdrive_ptg_names)
+  {
+    mrpt::config::CConfigFileMemory cfg;
+    fill_diffdrive_cfg(cfg, "PTG");
+    auto ptg = CParameterizedTrajectoryGenerator::CreatePTG(name, cfg, "PTG", "");
+    ASSERT_TRUE(ptg);
+
+    ptg->loadDefaultParams();
+    EXPECT_GT(ptg->getPathCount(), 0U) << name;
+    EXPECT_GT(ptg->getRefDistance(), .0) << name;
+  }
+}
+
+TEST(PTGVariants, diffdrive_render_path_and_shape)
+{
+  auto ptg = make_diffdrive_ptg("CPTG_DiffDrive_C");
+
+  mrpt::viz::CSetOfLines gl;
+  ptg->renderPathAsSimpleLine(0, gl, 0.10 /*decimate*/, -1.0 /*whole path*/);
+  EXPECT_GT(gl.size(), 0U);
+
+  // Truncating the path yields no more segments than the full path:
+  mrpt::viz::CSetOfLines gl2;
+  ptg->renderPathAsSimpleLine(0, gl2, 0.10, 0.5 /*max_path_distance*/);
+  EXPECT_LE(gl2.size(), gl.size());
+
+  mrpt::viz::CSetOfLines glShape;
+  ptg->add_robotShape_to_setOfLines(glShape, mrpt::poses::CPose2D(1, 2, 0.5));
+  EXPECT_GT(glShape.size(), 0U);
+}
+
+TEST(PTGVariants, diffdrive_tp_obstacles_and_inverse_map)
+{
+  auto ptg = make_diffdrive_ptg("CPTG_DiffDrive_C");
+
+  std::vector<double> tp_obs;
+  ptg->initTPObstacles(tp_obs);
+  ASSERT_EQ(tp_obs.size(), ptg->getPathCount());
+  for (const double d : tp_obs)
+  {
+    EXPECT_NEAR(d, ptg->getRefDistance(), 1e-9);
+  }
+
+  double tp_obs_k = .0;
+  ptg->initTPObstacleSingle(0, tp_obs_k);
+  EXPECT_NEAR(tp_obs_k, ptg->getRefDistance(), 1e-9);
+
+  // An obstacle right ahead must shorten at least one TP-obstacle entry:
+  const auto tp_obs_org = tp_obs;
+  ptg->updateTPObstacle(1.0, .0, tp_obs);
+  EXPECT_NE(tp_obs, tp_obs_org);
+
+  // A point reachable by the PTG must be invertible into (k,d):
+  const auto inv = ptg->inverseMap_WS2TP(1.0, 0.05);
+  EXPECT_TRUE(inv.has_value());
+  EXPECT_TRUE(ptg->PTG_IsIntoDomain(1.0, 0.05));
+}
+
+TEST(PTGVariants, diffdrive_vel_cmds)
+{
+  auto ptg = make_diffdrive_ptg("CPTG_DiffDrive_C");
+
+  auto emptyCmd = ptg->getSupportedKinematicVelocityCommand();
+  ASSERT_TRUE(emptyCmd);
+  EXPECT_EQ(emptyCmd->getVelCmdLength(), 2U);
+
+  auto cmd = ptg->directionToMotionCommand(ptg->getPathCount() / 2);
+  ASSERT_TRUE(cmd);
+  EXPECT_EQ(cmd->getVelCmdLength(), emptyCmd->getVelCmdLength());
+}
+
+// ---------------------------------------------------------------------------
+//  Base class services
+// ---------------------------------------------------------------------------
+TEST(PTGBase, alpha_index_roundtrip)
+{
+  const unsigned int N = 64;
+  for (uint16_t k = 0; k < N; k++)
+  {
+    const double a = CParameterizedTrajectoryGenerator::Index2alpha(k, N);
+    EXPECT_GE(a, -M_PI);
+    EXPECT_LE(a, M_PI);
+    EXPECT_EQ(CParameterizedTrajectoryGenerator::Alpha2index(a, N), k);
+  }
+  EXPECT_ANY_THROW(CParameterizedTrajectoryGenerator::Index2alpha(N, N));
+}
+
+TEST(PTGBase, alpha2index_covers_the_whole_circle)
+{
+  const unsigned int N = 32;
+  EXPECT_EQ(CParameterizedTrajectoryGenerator::Alpha2index(-M_PI, N), 0);
+  EXPECT_EQ(CParameterizedTrajectoryGenerator::Alpha2index(M_PI - 1e-9, N), N - 1);
+  EXPECT_EQ(CParameterizedTrajectoryGenerator::Alpha2index(.0, N), N / 2);
+}
+
+TEST(PTGBase, alpha2index_wraps_angles_outside_the_pi_range)
+{
+  const unsigned int N = 32;
+  const double a = 0.25 * M_PI;
+  const uint16_t k = CParameterizedTrajectoryGenerator::Alpha2index(a, N);
+  // Adding a full turn must not change the resulting path index:
+  EXPECT_EQ(CParameterizedTrajectoryGenerator::Alpha2index(a + 2 * M_PI, N), k);
+  EXPECT_EQ(CParameterizedTrajectoryGenerator::Alpha2index(a - 2 * M_PI, N), k);
+}
+
+TEST(PTGBase, instance_alpha_index_helpers_use_the_path_count)
+{
+  auto ptg = make_diffdrive_ptg("CPTG_DiffDrive_C");
+  const uint16_t k = 7;
+  const double a = ptg->index2alpha(k);
+  EXPECT_EQ(ptg->alpha2index(a), k);
+}
+
+TEST(PTGBase, collision_behavior_is_settable)
+{
+  const auto saved = CParameterizedTrajectoryGenerator::getCollisionBehavior();
+
+  CParameterizedTrajectoryGenerator::setCollisionBehavior(PTGCollisionBehavior::STOP);
+  EXPECT_EQ(
+      CParameterizedTrajectoryGenerator::getCollisionBehavior(), PTGCollisionBehavior::STOP);
+
+  CParameterizedTrajectoryGenerator::setCollisionBehavior(
+      PTGCollisionBehavior::BACK_AWAY);
+  EXPECT_EQ(
+      CParameterizedTrajectoryGenerator::getCollisionBehavior(),
+      PTGCollisionBehavior::BACK_AWAY);
+
+  CParameterizedTrajectoryGenerator::setCollisionBehavior(saved);
+}
+
+TEST(PTGBase, output_debug_path_prefix_is_settable)
+{
+  const auto saved = CParameterizedTrajectoryGenerator::getOutputDebugPathPrefix();
+  CParameterizedTrajectoryGenerator::setOutputDebugPathPrefix("./some_dir");
+  EXPECT_EQ(CParameterizedTrajectoryGenerator::getOutputDebugPathPrefix(), "./some_dir");
+  CParameterizedTrajectoryGenerator::setOutputDebugPathPrefix(saved);
+}
+
+TEST(PTGBase, debugDumpInFiles_writes_the_trajectory_tables)
+{
+  auto ptg = make_diffdrive_ptg("CPTG_DiffDrive_C");
+
+  const std::string sDir =
+      mrpt::system::getTempFileName() + std::string("_ptg_dump");
+  const auto saved = CParameterizedTrajectoryGenerator::getOutputDebugPathPrefix();
+  CParameterizedTrajectoryGenerator::setOutputDebugPathPrefix(sDir);
+
+  EXPECT_TRUE(ptg->debugDumpInFiles("UnitTest"));
+  EXPECT_TRUE(mrpt::system::fileExists(sDir + "/PTGs/PTGUnitTest_x.txt"));
+  EXPECT_TRUE(mrpt::system::fileExists(sDir + "/PTGs/PTGUnitTest_y.txt"));
+  EXPECT_TRUE(mrpt::system::fileExists(sDir + "/PTGs/PTGUnitTest_phi.txt"));
+  EXPECT_TRUE(mrpt::system::fileExists(sDir + "/PTGs/PTGUnitTest_d.txt"));
+
+  CParameterizedTrajectoryGenerator::setOutputDebugPathPrefix(saved);
+  mrpt::system::deleteFilesInDirectory(sDir + "/PTGs", true);
+}
+
+TEST(PTGBase, nav_dynamic_state_comparison_and_stream)
+{
+  CParameterizedTrajectoryGenerator::TNavDynamicState a, b;
+  EXPECT_TRUE(a == b);
+  EXPECT_FALSE(a != b);
+
+  b.curVelLocal = mrpt::math::TTwist2D(1.0, .0, .0);
+  EXPECT_TRUE(a != b);
+
+  b.relTarget = mrpt::math::TPose2D(1, 2, 0.3);
+  b.targetRelSpeed = 0.5;
+
+  mrpt::io::CMemoryStream buf;
+  auto arch = mrpt::serialization::archiveFrom(buf);
+  b.writeToStream(arch);
+  buf.Seek(0);
+
+  CParameterizedTrajectoryGenerator::TNavDynamicState c;
+  c.readFromStream(arch);
+  EXPECT_TRUE(c == b);
+}
+
+TEST(PTGBase, updateNavDynamicState_is_forwarded_to_the_ptg)
+{
+  auto ptg = make_diffdrive_ptg("CPTG_DiffDrive_C");
+
+  CParameterizedTrajectoryGenerator::TNavDynamicState st;
+  st.curVelLocal = mrpt::math::TTwist2D(0.5, .0, .0);
+  st.relTarget = mrpt::math::TPose2D(2, 0, 0);
+  st.targetRelSpeed = 0.0;
+
+  ptg->updateNavDynamicState(st);
+  EXPECT_TRUE(ptg->getCurrentNavDynamicState() == st);
+
+  // Re-applying the same state is a no-op, and `force_update` re-applies it:
+  ptg->updateNavDynamicState(st);
+  ptg->updateNavDynamicState(st, true /*force_update*/);
+  EXPECT_TRUE(ptg->getCurrentNavDynamicState() == st);
+}
+
+TEST(PTGBase, score_priority_and_clearance_resolution_setters)
+{
+  auto ptg = make_diffdrive_ptg("CPTG_DiffDrive_C");
+
+  ptg->setScorePriorty(0.25);
+  EXPECT_NEAR(ptg->getScorePriority(), 0.25, 1e-12);
+
+  ptg->setClearanceStepCount(7);
+  EXPECT_EQ(ptg->getClearanceStepCount(), 7U);
+  ptg->setClearanceDecimatedPaths(5);
+  EXPECT_EQ(ptg->getClearanceDecimatedPaths(), 5U);
+}
+
+TEST(PTGBase, setRefDistance_is_rejected_by_grid_based_ptgs_once_initialized)
+{
+  // The collision grid is built for a fixed reference distance:
+  auto ptg = make_diffdrive_ptg("CPTG_DiffDrive_C");
+  EXPECT_ANY_THROW(ptg->setRefDistance(5.0));
+
+  mrpt::config::CConfigFileMemory cfg;
+  fill_holo_cfg(cfg, "PTG");
+  auto holo = CParameterizedTrajectoryGenerator::CreatePTG("CPTG_Holo_Blend", cfg, "PTG", "");
+  holo->setRefDistance(5.0);
+  EXPECT_NEAR(holo->getRefDistance(), 5.0, 1e-9);
+}
+
+TEST(PTGBase, clearance_diagram_is_filled_from_obstacles)
+{
+  auto ptg = make_diffdrive_ptg("CPTG_DiffDrive_C");
+
+  ClearanceDiagram cd;
+  ptg->initClearanceDiagram(cd);
+  EXPECT_FALSE(cd.empty());
+  EXPECT_EQ(cd.get_actual_num_paths(), ptg->getPathCount());
+
+  ptg->updateClearance(2.0, 1.0, cd);
+  ptg->updateClearance(-2.0, -1.0, cd);
+
+  std::vector<double> tp_obs;
+  ptg->initTPObstacles(tp_obs);
+  ptg->updateClearancePost(cd, tp_obs);
+
+  // Clearance values must be finite and non-negative:
+  for (uint16_t k = 0; k < ptg->getPathCount(); k++)
+  {
+    const double c = cd.getClearance(k, 0.5, false /*integrate_over_path*/);
+    EXPECT_TRUE(std::isfinite(c)) << "k=" << k;
+    EXPECT_GE(c, .0) << "k=" << k;
+  }
+}
+
+TEST(PTGBase, getPathTwist_is_consistent_with_the_path)
+{
+  auto ptg = make_diffdrive_ptg("CPTG_DiffDrive_C");
+
+  const uint16_t k = ptg->getPathCount() / 2;
+  ASSERT_GT(ptg->getPathStepCount(k), 2U);
+
+  const auto tw = ptg->getPathTwist(k, 1);
+  EXPECT_TRUE(std::isfinite(tw.vx));
+  EXPECT_TRUE(std::isfinite(tw.vy));
+  EXPECT_TRUE(std::isfinite(tw.omega));
+}
+
+TEST(PTGBase, factory_accepts_legacy_numeric_names)
+{
+  mrpt::config::CConfigFileMemory cfg;
+  fill_diffdrive_cfg(cfg, "PTG");
+
+  // MRPT <1.5.0 named the PTG classes by a single digit:
+  const std::pair<const char*, const char*> legacy[] = {
+      {"1", "CPTG_DiffDrive_C"},
+      {"2", "CPTG_DiffDrive_alpha"},
+      {"3", "CPTG_DiffDrive_CCS"},
+      {"4", "CPTG_DiffDrive_CC"},
+      {"5", "CPTG_DiffDrive_CS"}};
+
+  for (const auto& [digit, className] : legacy)
+  {
+    auto ptg = CParameterizedTrajectoryGenerator::CreatePTG(digit, cfg, "PTG", "");
+    ASSERT_TRUE(ptg) << digit;
+    auto ref = CParameterizedTrajectoryGenerator::CreatePTG(className, cfg, "PTG", "");
+    EXPECT_EQ(ptg->GetRuntimeClass(), ref->GetRuntimeClass()) << digit;
+  }
+}
+
+TEST(PTGBase, factory_rejects_unknown_class_names)
+{
+  mrpt::config::CConfigFileMemory cfg;
+  fill_diffdrive_cfg(cfg, "PTG");
+  EXPECT_ANY_THROW(
+      CParameterizedTrajectoryGenerator::CreatePTG("NotAPTGClassName", cfg, "PTG", ""));
+  // A registered class that is not a PTG:
+  EXPECT_ANY_THROW(
+      CParameterizedTrajectoryGenerator::CreatePTG("mrpt::poses::CPose3D", cfg, "PTG", ""));
+}
+
+TEST(PTGBase, factory_honors_the_key_prefix)
+{
+  mrpt::config::CConfigFileMemory cfg;
+  fill_diffdrive_cfg(cfg, "S");
+
+  // With the same section but a prefix that matches no key, loading fails:
+  EXPECT_ANY_THROW(
+      CParameterizedTrajectoryGenerator::CreatePTG("CPTG_DiffDrive_C", cfg, "S", "PTG0_"));
+}
+
+// ---------------------------------------------------------------------------
+//  Robot shape mixins
+// ---------------------------------------------------------------------------
+TEST(PTGRobotShape, polygonal_shape_queries)
+{
+  auto ptg = std::make_shared<CPTG_DiffDrive_C>();
+
+  mrpt::math::CPolygon poly;
+  poly.add_vertex(-0.5, 0.5);
+  poly.add_vertex(0.5, 0.5);
+  poly.add_vertex(0.5, -0.5);
+  poly.add_vertex(-0.5, -0.5);
+  ptg->setRobotShape(poly);
+
+  EXPECT_EQ(ptg->getRobotShape().size(), 4U);
+  EXPECT_NEAR(ptg->getMaxRobotRadius(), std::sqrt(0.5), 1e-9);
+
+  EXPECT_TRUE(ptg->isPointInsideRobotShape(.0, .0));
+  EXPECT_FALSE(ptg->isPointInsideRobotShape(10.0, .0));
+
+  // Inside the shape there is no clearance at all:
+  EXPECT_NEAR(ptg->evalClearanceToRobotShape(.0, .0), .0, 1e-12);
+  // Far away, clearance grows with the distance:
+  EXPECT_GT(ptg->evalClearanceToRobotShape(10.0, .0), ptg->evalClearanceToRobotShape(5.0, .0));
+  // Just outside the shape a minimum "fake" clearance is enforced:
+  EXPECT_GT(ptg->evalClearanceToRobotShape(0.55, .0), .0);
+
+  // Degenerate shapes are rejected:
+  mrpt::math::CPolygon tooFew;
+  tooFew.add_vertex(0, 0);
+  tooFew.add_vertex(1, 0);
+  EXPECT_ANY_THROW(ptg->setRobotShape(tooFew));
+}
+
+TEST(PTGRobotShape, circular_shape_queries)
+{
+  auto ptg = std::make_shared<CPTG_Holo_Blend>();
+  ptg->setRobotShapeRadius(0.5);
+  EXPECT_NEAR(ptg->getRobotShapeRadius(), 0.5, 1e-12);
+  EXPECT_NEAR(ptg->getMaxRobotRadius(), 0.5, 1e-12);
+
+  EXPECT_TRUE(ptg->isPointInsideRobotShape(0.1, .0));
+  EXPECT_FALSE(ptg->isPointInsideRobotShape(1.0, .0));
+
+  EXPECT_NEAR(ptg->evalClearanceToRobotShape(1.5, .0), 1.0, 1e-9);
+
+  mrpt::viz::CSetOfLines gl;
+  ptg->add_robotShape_to_setOfLines(gl, mrpt::poses::CPose2D(0, 0, 0));
+  EXPECT_GT(gl.size(), 0U);
+}
+
+// ---------------------------------------------------------------------------
+//  CPTG_Holo_Blend specifics
+// ---------------------------------------------------------------------------
+TEST(PTGHoloBlend, initialize_and_basic_queries)
+{
+  mrpt::config::CConfigFileMemory cfg;
+  fill_holo_cfg(cfg, "PTG");
+
+  auto ptg = CParameterizedTrajectoryGenerator::CreatePTG("CPTG_Holo_Blend", cfg, "PTG", "");
+  ASSERT_TRUE(ptg);
+  ptg->initialize(std::string(), false);
+
+  EXPECT_TRUE(ptg->isInitialized());
+  EXPECT_EQ(ptg->getPathCount(), 21U);
+  EXPECT_TRUE(ptg->supportVelCmdNOP());
+  EXPECT_GT(ptg->getPathStepDuration(), .0);
+  EXPECT_GT(ptg->maxTimeInVelCmdNOP(0), .0);
+
+  auto cmd = ptg->getSupportedKinematicVelocityCommand();
+  ASSERT_TRUE(cmd);
+  EXPECT_EQ(cmd->getVelCmdLength(), 4U);
+}
+
+TEST(PTGHoloBlend, config_file_and_serialization_roundtrip)
+{
+  mrpt::config::CConfigFileMemory cfg;
+  fill_holo_cfg(cfg, "PTG");
+  auto ptg = CParameterizedTrajectoryGenerator::CreatePTG("CPTG_Holo_Blend", cfg, "PTG", "");
+  ptg->initialize(std::string(), false);
+
+  mrpt::config::CConfigFileMemory cfg2;
+  ptg->saveToConfigFile(cfg2, "OUT");
+  auto ptgB = CParameterizedTrajectoryGenerator::CreatePTG("CPTG_Holo_Blend", cfg2, "OUT", "");
+  ASSERT_TRUE(ptgB);
+  EXPECT_EQ(ptgB->getDescription(), ptg->getDescription());
+
+  mrpt::io::CMemoryStream buf;
+  auto arch = mrpt::serialization::archiveFrom(buf);
+  arch << *ptg;
+  buf.Seek(0);
+  mrpt::serialization::CSerializable::Ptr obj;
+  arch >> obj;
+  auto ptgC = std::dynamic_pointer_cast<CParameterizedTrajectoryGenerator>(obj);
+  ASSERT_TRUE(ptgC);
+  EXPECT_EQ(ptgC->getPathCount(), ptg->getPathCount());
+  EXPECT_EQ(ptgC->getDescription(), ptg->getDescription());
+}
+
+TEST(PTGHoloBlend, relative_priority_depends_on_target_speed)
+{
+  mrpt::config::CConfigFileMemory cfg;
+  fill_holo_cfg(cfg, "PTG");
+  auto ptg = CParameterizedTrajectoryGenerator::CreatePTG("CPTG_Holo_Blend", cfg, "PTG", "");
+  ptg->initialize(std::string(), false);
+
+  const auto prio = ptg->evalPathRelativePriority(0, 1.0);
+  EXPECT_TRUE(std::isfinite(prio));
+  EXPECT_GT(prio, .0);
+}

--- a/modules/mrpt_nav/tests/TWaypoint_unittest.cpp
+++ b/modules/mrpt_nav/tests/TWaypoint_unittest.cpp
@@ -1,0 +1,186 @@
+/*                    _
+                     | |    Mobile Robot Programming Toolkit (MRPT)
+ _ __ ___  _ __ _ __ | |_
+| '_ ` _ \| '__| '_ \| __|          https://www.mrpt.org/
+| | | | | | |  | |_) | |_
+|_| |_| |_|_|  | .__/ \__|     https://github.com/MRPT/mrpt/
+               | |
+               |_|
+
+ Copyright (c) 2005-2026, Individual contributors, see AUTHORS file
+ See: https://www.mrpt.org/Authors - All rights reserved.
+ SPDX-License-Identifier: BSD-3-Clause
+*/
+
+#include <gtest/gtest.h>
+#include <mrpt/config/CConfigFileMemory.h>
+#include <mrpt/nav/reactive/TWaypoint.h>
+#include <mrpt/viz/CSetOfObjects.h>
+
+using namespace mrpt::nav;
+
+TEST(TWaypoint, getAsText_reports_unset_fields)
+{
+  TWaypoint wp;  // nothing set
+  const std::string s = wp.getAsText();
+  EXPECT_NE(s.find("Coordinates not set"), std::string::npos);
+  EXPECT_NE(s.find("allowed_distance not set"), std::string::npos);
+  EXPECT_NE(s.find("heading: any"), std::string::npos);
+}
+
+TEST(TWaypoint, getAsText_reports_set_fields)
+{
+  TWaypoint wp(1.0, 2.0, 0.5, false, mrpt::DEG2RAD(90.0), 0.25);
+  const std::string s = wp.getAsText();
+  EXPECT_NE(s.find("target="), std::string::npos);
+  EXPECT_NE(s.find("phi="), std::string::npos);
+  EXPECT_NE(s.find("allowed_dist="), std::string::npos);
+  EXPECT_NE(s.find("allow_skip: NO"), std::string::npos);
+  EXPECT_NE(s.find("speed_ratio"), std::string::npos);
+}
+
+TEST(TWaypoint, invalid_heading_sentinel_is_treated_as_unset)
+{
+  // Backwards-compatibility: the old "no heading" sentinel value:
+  TWaypoint wp(1.0, 2.0, 0.5, true, static_cast<double>(TWaypoint::INVALID_NUM));
+  EXPECT_FALSE(wp.target_heading.has_value());
+}
+
+TEST(TWaypoint, is_invalid_if_only_some_fields_are_set)
+{
+  TWaypoint wp;
+  wp.target = mrpt::math::TPoint2D(1, 2);
+  EXPECT_FALSE(wp.isValid());  // allowed_distance still unset
+
+  wp.allowed_distance = 0.5;
+  EXPECT_TRUE(wp.isValid());
+
+  wp.target.y = TWaypoint::INVALID_NUM;
+  EXPECT_FALSE(wp.isValid());
+}
+
+TEST(TWaypointSequence, config_file_roundtrip)
+{
+  TWaypointSequence seq;
+  seq.waypoints.emplace_back(1.0, 2.0, 0.5, true, mrpt::DEG2RAD(45.0), 0.75);
+  seq.waypoints.emplace_back(3.0, 4.0, 0.6, false);
+  seq.waypoints.back().target_frame_id = "odom";
+
+  mrpt::config::CConfigFileMemory cfg;
+  seq.save(cfg, "WPS");
+
+  TWaypointSequence seq2;
+  seq2.load(cfg, "WPS");
+
+  ASSERT_EQ(seq2.waypoints.size(), 2U);
+
+  EXPECT_NEAR(seq2.waypoints[0].target.x, 1.0, 1e-9);
+  EXPECT_NEAR(seq2.waypoints[0].target.y, 2.0, 1e-9);
+  EXPECT_NEAR(seq2.waypoints[0].allowed_distance, 0.5, 1e-9);
+  EXPECT_TRUE(seq2.waypoints[0].allow_skip);
+  ASSERT_TRUE(seq2.waypoints[0].target_heading.has_value());
+  // the config file stores a rounded decimal representation:
+  EXPECT_NEAR(*seq2.waypoints[0].target_heading, mrpt::DEG2RAD(45.0), 1e-6);
+  EXPECT_NEAR(seq2.waypoints[0].speed_ratio, 0.75, 1e-9);
+
+  EXPECT_FALSE(seq2.waypoints[1].allow_skip);
+  EXPECT_FALSE(seq2.waypoints[1].target_heading.has_value());
+  EXPECT_EQ(seq2.waypoints[1].target_frame_id, "odom");
+  EXPECT_NEAR(seq2.waypoints[1].speed_ratio, 1.0, 1e-9);
+}
+
+TEST(TWaypointSequence, load_of_an_empty_section_throws)
+{
+  mrpt::config::CConfigFileMemory cfg;
+  TWaypointSequence seq;
+  EXPECT_ANY_THROW(seq.load(cfg, "DoesNotExist"));
+}
+
+TEST(TWaypointSequence, load_clears_previous_contents)
+{
+  mrpt::config::CConfigFileMemory cfg;
+  cfg.write("WPS", "waypoint_count", 0);
+
+  TWaypointSequence seq;
+  seq.waypoints.emplace_back(1.0, 2.0, 0.5);
+  seq.load(cfg, "WPS");
+  EXPECT_TRUE(seq.waypoints.empty());
+}
+
+TEST(TWaypointSequence, opengl_visualization_has_one_object_per_waypoint)
+{
+  TWaypointSequence seq;
+  seq.waypoints.emplace_back(1.0, 2.0, 0.5);                             // no heading
+  seq.waypoints.emplace_back(3.0, 4.0, 0.5, false, mrpt::DEG2RAD(90.0));  // + heading arrow
+
+  auto gl = mrpt::viz::CSetOfObjects::Create();
+  seq.getAsOpenglVisualization(*gl);
+  // 2 disks + 1 heading arrow:
+  EXPECT_EQ(gl->size(), 3U);
+
+  // Rendering again must clear the previous contents, not accumulate:
+  seq.getAsOpenglVisualization(*gl);
+  EXPECT_EQ(gl->size(), 3U);
+
+  // Labels can be turned off:
+  TWaypointsRenderingParams p;
+  p.show_labels = false;
+  seq.getAsOpenglVisualization(*gl, p);
+  EXPECT_EQ(gl->size(), 3U);
+}
+
+TEST(TWaypointStatus, getAsText_includes_reached_flag)
+{
+  TWaypointStatus ws;
+  ws = TWaypoint(1.0, 2.0, 0.5);
+  EXPECT_NE(ws.getAsText().find("reached=NO"), std::string::npos);
+  ws.reached = true;
+  EXPECT_NE(ws.getAsText().find("reached=YES"), std::string::npos);
+}
+
+TEST(TWaypointStatusSequence, getAsText_summarizes_progress)
+{
+  TWaypointStatusSequence seq;
+  seq.waypoints.resize(2);
+  seq.waypoints[0] = TWaypoint(1.0, 2.0, 0.5);
+  seq.waypoints[1] = TWaypoint(3.0, 4.0, 0.5);
+  seq.waypoints[0].reached = true;
+  seq.waypoint_index_current_goal = 1;
+
+  const std::string s = seq.getAsText();
+  EXPECT_NE(s.find("Status for 2 waypoints"), std::string::npos);
+  EXPECT_NE(s.find("final_goal_reached:NO"), std::string::npos);
+  EXPECT_NE(s.find("waypoint_index_current_goal=1"), std::string::npos);
+
+  seq.final_goal_reached = true;
+  EXPECT_NE(seq.getAsText().find("final_goal_reached:YES"), std::string::npos);
+}
+
+TEST(TWaypointStatusSequence, opengl_visualization_colors_by_status)
+{
+  TWaypointStatusSequence seq;
+  seq.waypoints.resize(3);
+  seq.waypoints[0] = TWaypoint(1.0, 0.0, 0.5);
+  seq.waypoints[1] = TWaypoint(2.0, 0.0, 0.5, false);
+  seq.waypoints[2] = TWaypoint(3.0, 0.0, 0.5, true, mrpt::DEG2RAD(90.0));
+  seq.waypoints[0].reached = true;
+  seq.waypoint_index_current_goal = 1;
+
+  auto gl = mrpt::viz::CSetOfObjects::Create();
+  seq.getAsOpenglVisualization(*gl);
+  // 3 disks + 1 heading arrow:
+  EXPECT_EQ(gl->size(), 4U);
+
+  TWaypointsRenderingParams p;
+  p.show_labels = false;
+  seq.getAsOpenglVisualization(*gl, p);
+  EXPECT_EQ(gl->size(), 4U);
+}
+
+TEST(TWaypointsRenderingParams, defaults_are_sane)
+{
+  TWaypointsRenderingParams p;
+  EXPECT_GT(p.outer_radius, p.inner_radius);
+  EXPECT_GT(p.heading_arrow_len, .0);
+  EXPECT_TRUE(p.show_labels);
+}

--- a/modules/mrpt_nav/tests/TWaypoint_unittest.cpp
+++ b/modules/mrpt_nav/tests/TWaypoint_unittest.cpp
@@ -110,7 +110,7 @@ TEST(TWaypointSequence, load_clears_previous_contents)
 TEST(TWaypointSequence, opengl_visualization_has_one_object_per_waypoint)
 {
   TWaypointSequence seq;
-  seq.waypoints.emplace_back(1.0, 2.0, 0.5);                             // no heading
+  seq.waypoints.emplace_back(1.0, 2.0, 0.5);                              // no heading
   seq.waypoints.emplace_back(3.0, 4.0, 0.5, false, mrpt::DEG2RAD(90.0));  // + heading arrow
 
   auto gl = mrpt::viz::CSetOfObjects::Create();

--- a/modules/mrpt_nav/tests/holonomic_config_unittest.cpp
+++ b/modules/mrpt_nav/tests/holonomic_config_unittest.cpp
@@ -1,0 +1,361 @@
+/*                    _
+                     | |    Mobile Robot Programming Toolkit (MRPT)
+ _ __ ___  _ __ _ __ | |_
+| '_ ` _ \| '__| '_ \| __|          https://www.mrpt.org/
+| | | | | | |  | |_) | |_
+|_| |_| |_|_|  | .__/ \__|     https://github.com/MRPT/mrpt/
+               | |
+               |_|
+
+ Copyright (c) 2005-2026, Individual contributors, see AUTHORS file
+ See: https://www.mrpt.org/Authors - All rights reserved.
+ SPDX-License-Identifier: BSD-3-Clause
+*/
+
+/** Configuration, factory, serialization and log-record coverage for the
+ *  holonomic navigation methods, complementing the behavioral tests in
+ *  holonomic_unittest.cpp.
+ */
+
+#include <gtest/gtest.h>
+#include <mrpt/config/CConfigFileMemory.h>
+#include <mrpt/io/CMemoryStream.h>
+#include <mrpt/nav/holonomic/CHolonomicFullEval.h>
+#include <mrpt/nav/holonomic/CHolonomicND.h>
+#include <mrpt/nav/holonomic/CHolonomicVFF.h>
+#include <mrpt/nav/holonomic/ClearanceDiagram.h>
+#include <mrpt/serialization/CArchive.h>
+
+using namespace mrpt::nav;
+using CHRM = CAbstractHolonomicReactiveMethod;
+
+namespace
+{
+CHRM::NavInput make_nav_input(size_t nDirs, double targetX, double targetY)
+{
+  CHRM::NavInput ni;
+  ni.obstacles.assign(nDirs, 1.0);
+  ni.maxObstacleDist = 1.0;
+  ni.maxRobotSpeed = 1.0;
+  ni.targets.emplace_back(targetX, targetY, .0);
+  return ni;
+}
+
+/** CHolonomicFullEval requires a clearance diagram; the other methods ignore
+ *  it. Kept alive by the caller for the duration of navigate(). */
+ClearanceDiagram make_clearance(size_t nDirs)
+{
+  ClearanceDiagram cd;
+  cd.resize(nDirs, std::min<size_t>(nDirs, 10));
+  for (size_t k = 0; k < cd.get_decimated_num_paths(); k++)
+  {
+    cd.get_path_clearance_decimated(k)[1.0] = 1.0;
+  }
+  return cd;
+}
+}  // namespace
+
+// ---------------------------------------------------------------------------
+//  Factory
+// ---------------------------------------------------------------------------
+TEST(HolonomicMethods, factory_creates_the_three_known_methods)
+{
+  for (const char* name : {"CHolonomicVFF", "CHolonomicND", "CHolonomicFullEval"})
+  {
+    auto m = CHRM::Factory(name);
+    ASSERT_TRUE(m) << name;
+    EXPECT_EQ(m->getConfigFileSectionName(), name);
+  }
+}
+
+TEST(HolonomicMethods, factory_rejects_unknown_and_unrelated_classes)
+{
+  EXPECT_FALSE(CHRM::Factory("NoSuchHolonomicMethod"));
+  EXPECT_FALSE(CHRM::Factory("mrpt::poses::CPose3D"));
+}
+
+TEST(HolonomicMethods, config_section_name_is_settable)
+{
+  CHolonomicVFF m;
+  EXPECT_EQ(m.getConfigFileSectionName(), "CHolonomicVFF");
+  m.setConfigFileSectionName("MySection");
+  EXPECT_EQ(m.getConfigFileSectionName(), "MySection");
+}
+
+TEST(HolonomicMethods, associated_ptg_is_stored)
+{
+  CHolonomicVFF m;
+  EXPECT_EQ(m.getAssociatedPTG(), nullptr);
+  // A non-owning observer pointer; nullptr round-trips fine:
+  m.setAssociatedPTG(nullptr);
+  EXPECT_EQ(m.getAssociatedPTG(), nullptr);
+}
+
+// ---------------------------------------------------------------------------
+//  CHolonomicVFF
+// ---------------------------------------------------------------------------
+TEST(CHolonomicVFF, config_file_roundtrip)
+{
+  CHolonomicVFF a;
+  a.options.TARGET_SLOW_APPROACHING_DISTANCE = 0.25;
+  a.options.TARGET_ATTRACTIVE_FORCE = 42.0;
+
+  mrpt::config::CConfigFileMemory cfg;
+  a.saveConfigFile(cfg);
+
+  CHolonomicVFF b;
+  b.initialize(cfg);
+  EXPECT_NEAR(b.options.TARGET_SLOW_APPROACHING_DISTANCE, 0.25, 1e-9);
+  EXPECT_NEAR(b.options.TARGET_ATTRACTIVE_FORCE, 42.0, 1e-9);
+
+  EXPECT_NEAR(b.getTargetApproachSlowDownDistance(), 0.25, 1e-9);
+  b.setTargetApproachSlowDownDistance(0.9);
+  EXPECT_NEAR(b.options.TARGET_SLOW_APPROACHING_DISTANCE, 0.9, 1e-9);
+}
+
+TEST(CHolonomicVFF, serialization_roundtrip)
+{
+  CHolonomicVFF a;
+  a.options.TARGET_ATTRACTIVE_FORCE = 33.0;
+
+  mrpt::io::CMemoryStream buf;
+  auto arch = mrpt::serialization::archiveFrom(buf);
+  arch << a;
+  buf.Seek(0);
+
+  CHolonomicVFF b;
+  arch >> b;
+  EXPECT_NEAR(b.options.TARGET_ATTRACTIVE_FORCE, 33.0, 1e-9);
+}
+
+TEST(CHolonomicVFF, produces_a_log_record)
+{
+  CHolonomicVFF m;
+  auto ni = make_nav_input(50, 0.5, .0);
+  const auto no = m.navigate(ni);
+  EXPECT_TRUE(no.logRecord);
+  EXPECT_EQ(no.logRecord->getDirectionScores(), nullptr);
+}
+
+// ---------------------------------------------------------------------------
+//  CHolonomicND
+// ---------------------------------------------------------------------------
+TEST(CHolonomicND, config_file_roundtrip)
+{
+  CHolonomicND a;
+  a.options.TOO_CLOSE_OBSTACLE = 0.2;
+  a.options.WIDE_GAP_SIZE_PERCENT = 0.3;
+  a.options.RISK_EVALUATION_SECTORS_PERCENT = 0.2;
+  a.options.RISK_EVALUATION_DISTANCE = 0.5;
+  a.options.MAX_SECTOR_DIST_FOR_D2_PERCENT = 0.35;
+  a.options.TARGET_SLOW_APPROACHING_DISTANCE = 0.7;
+  a.options.factorWeights = {1.0, 2.0, 3.0, 4.0};
+
+  mrpt::config::CConfigFileMemory cfg;
+  a.saveConfigFile(cfg);
+
+  CHolonomicND b;
+  b.initialize(cfg);
+  EXPECT_NEAR(b.options.TOO_CLOSE_OBSTACLE, 0.2, 1e-9);
+  EXPECT_NEAR(b.options.WIDE_GAP_SIZE_PERCENT, 0.3, 1e-9);
+  EXPECT_NEAR(b.options.RISK_EVALUATION_DISTANCE, 0.5, 1e-9);
+  EXPECT_NEAR(b.options.TARGET_SLOW_APPROACHING_DISTANCE, 0.7, 1e-9);
+  ASSERT_EQ(b.options.factorWeights.size(), 4U);
+  EXPECT_NEAR(b.options.factorWeights[2], 3.0, 1e-9);
+}
+
+TEST(CHolonomicND, serialization_roundtrip)
+{
+  CHolonomicND a;
+  a.options.RISK_EVALUATION_DISTANCE = 0.77;
+
+  mrpt::io::CMemoryStream buf;
+  auto arch = mrpt::serialization::archiveFrom(buf);
+  arch << a;
+  buf.Seek(0);
+
+  CHolonomicND b;
+  arch >> b;
+  EXPECT_NEAR(b.options.RISK_EVALUATION_DISTANCE, 0.77, 1e-9);
+}
+
+TEST(CHolonomicND, log_record_reports_the_selected_gap)
+{
+  CHolonomicND m;
+  auto ni = make_nav_input(60, 0.5, .0);
+  // A blocked sector forces the method to pick a gap:
+  for (size_t i = 25; i < 35; i++) ni.obstacles[i] = 0.05;
+
+  const auto no = m.navigate(ni);
+  ASSERT_TRUE(no.logRecord);
+  auto* nd = dynamic_cast<CLogFileRecord_ND*>(no.logRecord.get());
+  ASSERT_NE(nd, nullptr);
+
+  mrpt::io::CMemoryStream buf;
+  auto arch = mrpt::serialization::archiveFrom(buf);
+  arch << *nd;
+  buf.Seek(0);
+  CLogFileRecord_ND nd2;
+  arch >> nd2;
+  EXPECT_EQ(nd2.gaps_ini.size(), nd->gaps_ini.size());
+}
+
+// ---------------------------------------------------------------------------
+//  CHolonomicFullEval
+// ---------------------------------------------------------------------------
+TEST(CHolonomicFullEval, config_file_roundtrip)
+{
+  CHolonomicFullEval a;
+  a.options.TOO_CLOSE_OBSTACLE = 0.2;
+  a.options.TARGET_SLOW_APPROACHING_DISTANCE = 0.5;
+  a.options.OBSTACLE_SLOW_DOWN_DISTANCE = 0.25;
+  a.options.HYSTERESIS_SECTOR_COUNT = 7;
+  a.options.LOG_SCORE_MATRIX = true;
+  a.options.clearance_threshold_ratio = 0.11;
+  a.options.gap_width_ratio_threshold = 0.22;
+
+  mrpt::config::CConfigFileMemory cfg;
+  a.saveConfigFile(cfg);
+
+  CHolonomicFullEval b;
+  b.initialize(cfg);
+  EXPECT_NEAR(b.options.TOO_CLOSE_OBSTACLE, 0.2, 1e-9);
+  EXPECT_NEAR(b.options.OBSTACLE_SLOW_DOWN_DISTANCE, 0.25, 1e-9);
+  EXPECT_NEAR(b.options.HYSTERESIS_SECTOR_COUNT, 7, 1e-9);
+  EXPECT_TRUE(b.options.LOG_SCORE_MATRIX);
+  EXPECT_NEAR(b.options.clearance_threshold_ratio, 0.11, 1e-9);
+  EXPECT_NEAR(b.options.gap_width_ratio_threshold, 0.22, 1e-9);
+  EXPECT_EQ(b.options.factorWeights.size(), a.options.factorWeights.size());
+  EXPECT_EQ(b.options.PHASE_FACTORS.size(), a.options.PHASE_FACTORS.size());
+}
+
+TEST(CHolonomicFullEval, config_load_validates_the_phase_definitions)
+{
+  CHolonomicFullEval a;
+  mrpt::config::CConfigFileMemory cfg;
+  a.saveConfigFile(cfg);
+
+  // Declare more phases than the ones actually described:
+  cfg.write("CHolonomicFullEval", "PHASE_COUNT", 99);
+  CHolonomicFullEval b;
+  EXPECT_ANY_THROW(b.initialize(cfg));
+}
+
+TEST(CHolonomicFullEval, serialization_roundtrip)
+{
+  CHolonomicFullEval a;
+  a.options.TOO_CLOSE_OBSTACLE = 0.33;
+  a.options.clearance_threshold_ratio = 0.44;
+  a.options.gap_width_ratio_threshold = 0.55;
+
+  mrpt::io::CMemoryStream buf;
+  auto arch = mrpt::serialization::archiveFrom(buf);
+  arch << a;
+  buf.Seek(0);
+
+  CHolonomicFullEval b;
+  arch >> b;
+  EXPECT_NEAR(b.options.TOO_CLOSE_OBSTACLE, 0.33, 1e-9);
+  EXPECT_NEAR(b.options.clearance_threshold_ratio, 0.44, 1e-9);
+  EXPECT_NEAR(b.options.gap_width_ratio_threshold, 0.55, 1e-9);
+}
+
+TEST(CHolonomicFullEval, score_matrix_is_logged_when_enabled)
+{
+  CHolonomicFullEval m;
+  m.options.LOG_SCORE_MATRIX = true;
+
+  auto ni = make_nav_input(40, 0.5, .0);
+  const auto cd = make_clearance(40);
+  ni.clearance = &cd;
+  const auto no = m.navigate(ni);
+  ASSERT_TRUE(no.logRecord);
+  auto* fe = dynamic_cast<CLogFileRecord_FullEval*>(no.logRecord.get());
+  ASSERT_NE(fe, nullptr);
+  const auto* scores = fe->getDirectionScores();
+  ASSERT_NE(scores, nullptr);
+  EXPECT_GT(scores->rows(), 0);
+
+  mrpt::io::CMemoryStream buf;
+  auto arch = mrpt::serialization::archiveFrom(buf);
+  arch << *fe;
+  buf.Seek(0);
+  CLogFileRecord_FullEval fe2;
+  arch >> fe2;
+  EXPECT_EQ(fe2.selectedSector, fe->selectedSector);
+}
+
+TEST(CHolonomicFullEval, no_score_matrix_when_disabled)
+{
+  auto ni = make_nav_input(40, 0.5, .0);
+  const auto cd = make_clearance(40);
+  ni.clearance = &cd;
+
+  const auto scoreMatrixSize = [&](bool enableLogging)
+  {
+    CHolonomicFullEval m;
+    m.options.LOG_SCORE_MATRIX = enableLogging;
+    const auto no = m.navigate(ni);
+    auto* fe = dynamic_cast<CLogFileRecord_FullEval*>(no.logRecord.get());
+    return fe ? fe->dirs_scores.size() : 0U;
+  };
+
+  // The score matrix is only copied into the log record on demand:
+  EXPECT_LT(scoreMatrixSize(false), scoreMatrixSize(true));
+}
+
+TEST(CHolonomicFullEval, target_approach_slowdown_can_be_disabled)
+{
+  CHolonomicFullEval m;
+  m.options.TARGET_SLOW_APPROACHING_DISTANCE = 5.0;  // always "close"
+
+  auto ni = make_nav_input(40, 0.2, .0);  // target very near
+  const auto cd = make_clearance(40);
+  ni.clearance = &cd;
+  const auto slowNo = m.navigate(ni);
+
+  m.enableApproachTargetSlowDown(false);
+  const auto fastNo = m.navigate(ni);
+
+  EXPECT_GE(fastNo.desiredSpeed, slowNo.desiredSpeed);
+}
+
+TEST(CHolonomicFullEval, all_directions_blocked_yields_a_stop)
+{
+  CHolonomicFullEval m;
+  auto ni = make_nav_input(40, 1.0, .0);
+  const auto cd = make_clearance(40);
+  ni.clearance = &cd;
+  for (auto& o : ni.obstacles) o = 0.01;  // everything too close
+
+  const auto no = m.navigate(ni);
+  EXPECT_NEAR(no.desiredSpeed, .0, 1e-9);
+}
+
+TEST(CHolonomicND, all_directions_blocked_yields_a_stop)
+{
+  CHolonomicND m;
+  auto ni = make_nav_input(40, 1.0, .0);
+  for (auto& o : ni.obstacles) o = 0.01;
+
+  const auto no = m.navigate(ni);
+  EXPECT_NEAR(no.desiredSpeed, .0, 1e-9);
+}
+
+TEST(HolonomicMethods, multiple_targets_are_accepted)
+{
+  for (const char* name : {"CHolonomicVFF", "CHolonomicND", "CHolonomicFullEval"})
+  {
+    auto m = CHRM::Factory(name);
+    ASSERT_TRUE(m) << name;
+
+    auto ni = make_nav_input(40, 0.5, .0);
+    const auto cd = make_clearance(40);
+    ni.clearance = &cd;
+    ni.targets.emplace_back(0.8, 0.2, .0);  // a second, higher-priority target
+
+    const auto no = m->navigate(ni);
+    EXPECT_GE(no.desiredSpeed, .0) << name;
+    EXPECT_LE(no.desiredSpeed, ni.maxRobotSpeed + 1e-6) << name;
+  }
+}

--- a/modules/mrpt_nav/tests/nav_interfaces_unittest.cpp
+++ b/modules/mrpt_nav/tests/nav_interfaces_unittest.cpp
@@ -1,0 +1,462 @@
+/*                    _
+                     | |    Mobile Robot Programming Toolkit (MRPT)
+ _ __ ___  _ __ _ __ | |_
+| '_ ` _ \| '__| '_ \| __|          https://www.mrpt.org/
+| | | | | | |  | |_) | |_
+|_| |_| |_|_|  | .__/ \__|     https://github.com/MRPT/mrpt/
+               | |
+               |_|
+
+ Copyright (c) 2005-2026, Individual contributors, see AUTHORS file
+ See: https://www.mrpt.org/Authors - All rights reserved.
+ SPDX-License-Identifier: BSD-3-Clause
+*/
+
+/** Coverage for the ready-made robot interfaces backed by the kinematic
+ *  simulators, the pre-programmed velocity-sequence navigator, and the
+ *  3D (multi-height) reactive navigation system.
+ */
+
+#include <gtest/gtest.h>
+#include <mrpt/config/CConfigFileMemory.h>
+#include <mrpt/kinematics/CVehicleSimul_DiffDriven.h>
+#include <mrpt/kinematics/CVehicleSimul_Holo.h>
+#include <mrpt/nav/reactive/CNavigatorManualSequence.h>
+#include <mrpt/nav/reactive/CReactiveNavigationSystem3D.h>
+#include <mrpt/nav/reactive/CRobot2NavInterfaceForSimulator.h>
+
+#include <string>
+
+using namespace mrpt::nav;
+
+// ---------------------------------------------------------------------------
+//  CRobot2NavInterfaceForSimulator_{Holo,DiffDriven}
+// ---------------------------------------------------------------------------
+namespace
+{
+struct HoloIF : public CRobot2NavInterfaceForSimulator_Holo
+{
+  using CRobot2NavInterfaceForSimulator_Holo::CRobot2NavInterfaceForSimulator_Holo;
+  bool senseObstacles(mrpt::maps::CSimplePointsMap& o, mrpt::system::TTimeStamp& ts) override
+  {
+    o.clear();
+    ts = mrpt::Clock::now();
+    return true;
+  }
+};
+
+struct DiffIF : public CRobot2NavInterfaceForSimulator_DiffDriven
+{
+  using CRobot2NavInterfaceForSimulator_DiffDriven::CRobot2NavInterfaceForSimulator_DiffDriven;
+  bool senseObstacles(mrpt::maps::CSimplePointsMap& o, mrpt::system::TTimeStamp& ts) override
+  {
+    o.clear();
+    ts = mrpt::Clock::now();
+    return true;
+  }
+};
+}  // namespace
+
+TEST(RobotIFForSimulator, holo_interface_drives_the_simulator)
+{
+  mrpt::kinematics::CVehicleSimul_Holo simul;
+  HoloIF robot(simul);
+  robot.setMinLoggingLevel(mrpt::system::LVL_ERROR);
+
+  const auto ps = robot.getCurrentPoseAndSpeeds();
+  ASSERT_TRUE(ps);
+  EXPECT_NEAR(ps->pose.x, .0, 1e-12);
+
+  mrpt::kinematics::CVehicleVelCmd_Holo cmd(1.0, .0, 0.3, .0);
+  EXPECT_TRUE(robot.changeSpeeds(cmd));
+  simul.simulateOneTimeStep(1.0);
+  EXPECT_GT(simul.getCurrentGTPose().x, 0.1);
+
+  // Normal and emergency stops differ only in the ramp time:
+  auto stopCmd = robot.getStopCmd();
+  auto emergCmd = robot.getEmergencyStopCmd();
+  ASSERT_TRUE(stopCmd);
+  ASSERT_TRUE(emergCmd);
+  EXPECT_TRUE(stopCmd->isStopCmd());
+  EXPECT_TRUE(emergCmd->isStopCmd());
+  EXPECT_GT(stopCmd->getVelCmdElement(2), emergCmd->getVelCmdElement(2));
+
+  EXPECT_TRUE(robot.stop(StopType::Normal));
+  EXPECT_TRUE(robot.stop(StopType::Emergency));
+
+  // Aligning: the commanded rotation speed follows the sign of the error:
+  auto alignL = robot.getAlignCmd(+1.0);
+  auto alignR = robot.getAlignCmd(-1.0);
+  ASSERT_TRUE(alignL);
+  ASSERT_TRUE(alignR);
+  EXPECT_GT(alignL->getVelCmdElement(3), .0);
+  EXPECT_LT(alignR->getVelCmdElement(3), .0);
+
+  // The navigation clock follows simulated, not wall-clock, time:
+  robot.resetNavigationTimer();
+  EXPECT_NEAR(robot.getNavigationTime(), .0, 1e-9);
+  simul.simulateOneTimeStep(0.5);
+  EXPECT_NEAR(robot.getNavigationTime(), 0.5, 0.01);
+}
+
+TEST(RobotIFForSimulator, diffdriven_interface_drives_the_simulator)
+{
+  mrpt::kinematics::CVehicleSimul_DiffDriven simul;
+  DiffIF robot(simul);
+  robot.setMinLoggingLevel(mrpt::system::LVL_ERROR);
+
+  const auto ps = robot.getCurrentPoseAndSpeeds();
+  ASSERT_TRUE(ps);
+
+  mrpt::kinematics::CVehicleVelCmd_DiffDriven cmd;
+  cmd.lin_vel = 1.0;
+  cmd.ang_vel = .0;
+  EXPECT_TRUE(robot.changeSpeeds(cmd));
+  simul.simulateOneTimeStep(1.0);
+  EXPECT_GT(simul.getCurrentGTPose().x, 0.5);
+
+  auto stopCmd = robot.getStopCmd();
+  ASSERT_TRUE(stopCmd);
+  EXPECT_TRUE(stopCmd->isStopCmd());
+  auto emergCmd = robot.getEmergencyStopCmd();
+  ASSERT_TRUE(emergCmd);
+  EXPECT_TRUE(emergCmd->isStopCmd());
+
+  // The stop command is forwarded to the simulator, which ramps down to zero:
+  EXPECT_TRUE(robot.stop(StopType::Normal));
+  simul.simulateOneTimeStep(0.5);
+  EXPECT_NEAR(simul.getV(), .0, 1e-9);
+
+  robot.resetNavigationTimer();
+  EXPECT_NEAR(robot.getNavigationTime(), .0, 1e-9);
+  simul.simulateOneTimeStep(0.25);
+  EXPECT_NEAR(robot.getNavigationTime(), 0.25, 0.01);
+}
+
+// ---------------------------------------------------------------------------
+//  CNavigatorManualSequence
+// ---------------------------------------------------------------------------
+namespace
+{
+struct RecordingRobotIF : public CRobot2NavInterfaceForSimulator_DiffDriven
+{
+  int nChangeSpeeds = 0;
+  int nStop = 0;
+  bool changeSpeedsSucceeds = true;
+  double navTime = 0;
+
+  using CRobot2NavInterfaceForSimulator_DiffDriven::CRobot2NavInterfaceForSimulator_DiffDriven;
+
+  bool senseObstacles(mrpt::maps::CSimplePointsMap& o, mrpt::system::TTimeStamp& ts) override
+  {
+    o.clear();
+    ts = mrpt::Clock::now();
+    return true;
+  }
+  bool changeSpeeds(const mrpt::kinematics::CVehicleVelCmd& c) override
+  {
+    nChangeSpeeds++;
+    if (!changeSpeedsSucceeds) return false;
+    return CRobot2NavInterfaceForSimulator_DiffDriven::changeSpeeds(c);
+  }
+  bool stop(StopType t) override
+  {
+    nStop++;
+    return CRobot2NavInterfaceForSimulator_DiffDriven::stop(t);
+  }
+  double getNavigationTime() override { return navTime; }
+  void resetNavigationTimer() override { navTime = 0; }
+};
+
+std::string manual_sequence_cfg()
+{
+  return "[CNavigatorManualSequence]\n"
+         // t  lin_vel  ang_vel   (2 components => differential-driven)
+         "cmd1 = 0.0 0.5 0.0\n"
+         "cmd2 = 1.0 0.0 0.3\n";
+}
+}  // namespace
+
+TEST(CNavigatorManualSequence, executes_the_programmed_sequence_in_order)
+{
+  mrpt::kinematics::CVehicleSimul_DiffDriven simul;
+  RecordingRobotIF robot(simul);
+  robot.setMinLoggingLevel(mrpt::system::LVL_ERROR);
+
+  CNavigatorManualSequence nav(robot);
+  nav.setMinLoggingLevel(mrpt::system::LVL_ERROR);
+
+  mrpt::config::CConfigFileMemory cfg(manual_sequence_cfg());
+  nav.loadConfigFile(cfg);
+  ASSERT_EQ(nav.programmed_orders.size(), 2U);
+
+  nav.initialize();
+
+  // t=0: the first command fires:
+  robot.navTime = 0.0;
+  nav.navigationStep();
+  EXPECT_EQ(robot.nChangeSpeeds, 1);
+  EXPECT_EQ(nav.programmed_orders.size(), 1U);
+
+  // still before t=1: nothing new:
+  robot.navTime = 0.5;
+  nav.navigationStep();
+  EXPECT_EQ(robot.nChangeSpeeds, 1);
+
+  // t>=1: the second command fires and the queue empties:
+  robot.navTime = 1.5;
+  nav.navigationStep();
+  EXPECT_EQ(robot.nChangeSpeeds, 2);
+  EXPECT_TRUE(nav.programmed_orders.empty());
+
+  // Once empty, further steps are no-ops:
+  nav.navigationStep();
+  EXPECT_EQ(robot.nChangeSpeeds, 2);
+}
+
+TEST(CNavigatorManualSequence, a_rejected_command_triggers_an_emergency_stop)
+{
+  mrpt::kinematics::CVehicleSimul_DiffDriven simul;
+  RecordingRobotIF robot(simul);
+  robot.setMinLoggingLevel(mrpt::system::LVL_ERROR);
+  robot.changeSpeedsSucceeds = false;
+
+  CNavigatorManualSequence nav(robot);
+  nav.setMinLoggingLevel(mrpt::system::LVL_ERROR);
+
+  mrpt::config::CConfigFileMemory cfg(manual_sequence_cfg());
+  nav.loadConfigFile(cfg);
+  nav.initialize();
+
+  robot.navTime = 0.0;
+  nav.navigationStep();
+  EXPECT_GT(robot.nStop, 0);
+  // The failed command is kept at the head of the queue:
+  EXPECT_EQ(nav.programmed_orders.size(), 2U);
+}
+
+TEST(CNavigatorManualSequence, holonomic_commands_are_recognized_by_arity)
+{
+  mrpt::kinematics::CVehicleSimul_DiffDriven simul;
+  RecordingRobotIF robot(simul);
+  CNavigatorManualSequence nav(robot);
+  nav.setMinLoggingLevel(mrpt::system::LVL_ERROR);
+
+  mrpt::config::CConfigFileMemory cfg(
+      std::string{"[CNavigatorManualSequence]\n"
+                  // 4 components => holonomic
+                  "cmd1 = 0.0 1.0 0.2 0.5 0.1\n"});
+  nav.loadConfigFile(cfg);
+  ASSERT_EQ(nav.programmed_orders.size(), 1U);
+  EXPECT_EQ(nav.programmed_orders.begin()->second.cmd_vel->getVelCmdLength(), 4U);
+}
+
+TEST(CNavigatorManualSequence, malformed_sequences_are_rejected)
+{
+  mrpt::kinematics::CVehicleSimul_DiffDriven simul;
+  RecordingRobotIF robot(simul);
+  CNavigatorManualSequence nav(robot);
+  nav.setMinLoggingLevel(mrpt::system::LVL_ERROR);
+
+  {  // too few tokens
+    mrpt::config::CConfigFileMemory cfg(
+        std::string{"[CNavigatorManualSequence]\n"
+                    "cmd1 = 0.0 0.5\n"});
+    EXPECT_ANY_THROW(nav.loadConfigFile(cfg));
+  }
+  {  // 3 velocity components: neither 2 nor 4
+    mrpt::config::CConfigFileMemory cfg(
+        std::string{"[CNavigatorManualSequence]\n"
+                    "cmd1 = 0.0 0.5 0.1 0.2\n"});
+    EXPECT_ANY_THROW(nav.loadConfigFile(cfg));
+  }
+}
+
+TEST(CNavigatorManualSequence, initialize_requires_a_non_empty_sequence)
+{
+  mrpt::kinematics::CVehicleSimul_DiffDriven simul;
+  RecordingRobotIF robot(simul);
+  CNavigatorManualSequence nav(robot);
+  nav.setMinLoggingLevel(mrpt::system::LVL_ERROR);
+  EXPECT_ANY_THROW(nav.initialize());
+}
+
+TEST(CNavigatorManualSequence, saveConfigFile_is_a_no_op)
+{
+  mrpt::kinematics::CVehicleSimul_DiffDriven simul;
+  RecordingRobotIF robot(simul);
+  CNavigatorManualSequence nav(robot);
+
+  mrpt::config::CConfigFileMemory cfg;
+  EXPECT_NO_THROW(nav.saveConfigFile(cfg));
+}
+
+// ---------------------------------------------------------------------------
+//  CReactiveNavigationSystem3D
+// ---------------------------------------------------------------------------
+namespace
+{
+/** Same shape as the 2D config used in rnav_variants_unittest.cpp, plus the
+ *  multi-height-level robot description this class requires. */
+std::string rnav3d_config()
+{
+  std::string s;
+  s += "[CAbstractNavigator]\n";
+  s += "dist_to_target_for_sending_event = 0\n";
+  s += "alarm_seems_not_approaching_target_timeout = 30\n";
+  s += "dist_check_target_is_blocked = 0.5\n";
+  s += "hysteresis_check_target_is_blocked = 3\n";
+  s += "enable_time_profiler = false\n";
+
+  s += "[CWaypointsNavigator]\n";
+  s += "max_distance_to_allow_skip_waypoint = -1\n";
+  s += "min_timesteps_confirm_skip_waypoints = 1\n";
+  s += "waypoint_angle_tolerance = 5.0\n";
+  s += "multitarget_look_ahead = 0\n";
+  s += "minimum_target_approach_per_step = 0.02\n";
+
+  s += "[CAbstractPTGBasedReactive]\n";
+  s += "robotMax_V_mps = 1.0\n";
+  s += "robotMax_W_degps = 60.0\n";
+  s += "holonomic_method = CHolonomicVFF\n";
+  s += "motion_decider_method = CMultiObjMotionOpt_Scalarization\n";
+  s += "ref_distance = 4.0\n";
+  s += "speedfilter_tau = 0.0\n";
+  s += "secure_distance_start = 0.05\n";
+  s += "secure_distance_end = 0.15\n";
+  s += "use_delays_model = false\n";
+  s += "max_distance_predicted_actual_path = 0.15\n";
+  s += "min_normalized_free_space_for_ptg_continuation = 0.2\n";
+  s += "enable_obstacle_filtering = true\n";
+  s += "evaluate_clearance = false\n";
+
+  s += "[CPointCloudFilterByDistance]\n";
+  s += "min_dist = 0.1\n";
+  s += "angle_tolerance = 5.0\n";
+  s += "too_old_seconds = 1.0\n";
+  s += "previous_keyframes = 1\n";
+  s += "max_deletion_ratio = 0.4\n";
+
+  s += "[CHolonomicVFF]\n";
+  s += "TARGET_SLOW_APPROACHING_DISTANCE = 0.10\n";
+  s += "TARGET_ATTRACTIVE_FORCE = 20.0\n";
+
+  s += "[CMultiObjectiveMotionOptimizerBase]\n";
+  s += "score1_name = collision_free_distance_score\n";
+  s += "score1_formula = collision_free_distance\n";
+  s += "score2_name = euclidean_nearness\n";
+  s += "score2_formula = 1/(1+dist_eucl_min^2)\n";
+  s += "scores_to_normalize = \n";
+
+  s += "[CMultiObjMotionOpt_Scalarization]\n";
+  s += "scalar_score_formula = 0.5*collision_free_distance_score + 8.0*euclidean_nearness\n";
+
+  // Two vertical sections of the robot body:
+  s += "[CReactiveNavigationSystem3D]\n";
+  s += "HEIGHT_LEVELS = 2\n";
+  s += "LEVEL1_HEIGHT = 0.4\n";
+  s += "LEVEL1_VECTORX = -0.2 0.2 0.2 -0.2\n";
+  s += "LEVEL1_VECTORY = 0.2 0.2 -0.2 -0.2\n";
+  s += "LEVEL2_HEIGHT = 0.6\n";
+  s += "LEVEL2_VECTORX = -0.15 0.15 0.15 -0.15\n";
+  s += "LEVEL2_VECTORY = 0.15 0.15 -0.15 -0.15\n";
+  s += "PTG_COUNT = 1\n";
+  s += "PTG1_Type = CPTG_DiffDrive_C\n";
+  s += "PTG1_resolution = 0.10\n";
+  s += "PTG1_refDistance = 4.0\n";
+  s += "PTG1_num_paths = 31\n";
+  s += "PTG1_v_max_mps = 1.0\n";
+  s += "PTG1_w_max_dps = 60\n";
+  s += "PTG1_K = 1.0\n";
+  s += "PTG1_score_priority = 1.0\n";
+  return s;
+}
+}  // namespace
+
+TEST(CReactiveNavigationSystem3D, in_memory_config_run)
+{
+  mrpt::kinematics::CVehicleSimul_DiffDriven simul;
+  DiffIF robot(simul);
+  robot.setMinLoggingLevel(mrpt::system::LVL_ERROR);
+
+  auto nav = std::make_unique<CReactiveNavigationSystem3D>(robot, false /*no console output*/);
+  nav->setMinLoggingLevel(mrpt::system::LVL_ERROR);
+  nav->enableTimeLog(false);
+
+  mrpt::config::CConfigFileMemory cfg(rnav3d_config());
+  nav->loadConfigFile(cfg);
+  nav->initialize();
+
+  EXPECT_EQ(nav->getPTG_count(), 1U);
+  ASSERT_NE(nav->getPTG(0), nullptr);
+  const auto* constNav = nav.get();
+  EXPECT_NE(constNav->getPTG(0), nullptr);
+
+  // The parameters survive a save/load round-trip:
+  mrpt::config::CConfigFileMemory out;
+  nav->saveConfigFile(out);
+  EXPECT_TRUE(out.sectionExists("CAbstractPTGBasedReactive"));
+
+  CAbstractNavigator::TNavigationParams np;
+  np.target.target_coords = mrpt::math::TPose2D(2.0, .0, .0);
+  np.target.targetAllowedDistance = 0.4f;
+  nav->navigate(&np);
+
+  const auto savedClock = mrpt::Clock::getActiveClock();
+  mrpt::Clock::setSimulatedTime(mrpt::Clock::now());
+  mrpt::Clock::setActiveClock(mrpt::Clock::Simulated);
+
+  const auto dt = std::chrono::milliseconds(200);
+  for (unsigned int i = 0; i < 60; i++)
+  {
+    nav->navigationStep();
+    if (nav->getCurrentState() == CAbstractNavigator::TState::IDLE) break;
+    simul.simulateOneTimeStep(0.2);
+    mrpt::Clock::setSimulatedTime(mrpt::Clock::now() + dt);
+  }
+  mrpt::Clock::setActiveClock(savedClock);
+
+  using mrpt::system::CTimeLogger;
+  const_cast<CTimeLogger&>(nav->getTimeLogger()).clear(true);
+  const_cast<CTimeLogger&>(nav->getDelaysTimeLogger()).clear(true);
+
+  EXPECT_LT(
+      (mrpt::math::TPoint2D(simul.getCurrentGTPose()) - mrpt::math::TPoint2D(2.0, .0)).norm(), 0.6);
+}
+
+TEST(CReactiveNavigationSystem3D, robot_shape_can_be_redefined)
+{
+  mrpt::kinematics::CVehicleSimul_DiffDriven simul;
+  DiffIF robot(simul);
+  CReactiveNavigationSystem3D nav(robot, false);
+  nav.setMinLoggingLevel(mrpt::system::LVL_ERROR);
+  nav.enableTimeLog(false);
+
+  mrpt::config::CConfigFileMemory cfg(rnav3d_config());
+  nav.loadConfigFile(cfg);
+  nav.initialize();
+
+  TRobotShape shape;
+  shape.resize(2);
+  for (size_t lvl = 0; lvl < 2; lvl++)
+  {
+    auto& poly = shape.polygon(lvl);
+    poly.add_vertex(-0.25, 0.25);
+    poly.add_vertex(0.25, 0.25);
+    poly.add_vertex(0.25, -0.25);
+    poly.add_vertex(-0.25, -0.25);
+    shape.setHeight(lvl, 0.4 + 0.2 * lvl);
+    shape.setRadius(lvl, 0.35);
+  }
+  EXPECT_NO_THROW(nav.changeRobotShape(shape));
+  EXPECT_EQ(shape.getHeights().size(), 2U);
+  EXPECT_NEAR(shape.getRadius(0), 0.35, 1e-9);
+  EXPECT_NEAR(shape.getHeight(1), 0.6, 1e-9);
+
+  // A degenerate level polygon is rejected:
+  TRobotShape bad;
+  bad.resize(1);
+  bad.polygon(0).add_vertex(0, 0);
+  bad.polygon(0).add_vertex(1, 0);
+  EXPECT_ANY_THROW(nav.changeRobotShape(bad));
+}

--- a/modules/mrpt_nav/tests/nav_misc_unittest.cpp
+++ b/modules/mrpt_nav/tests/nav_misc_unittest.cpp
@@ -22,7 +22,9 @@
 #include <mrpt/config/CConfigFileMemory.h>
 #include <mrpt/io/CMemoryStream.h>
 #include <mrpt/kinematics/CVehicleVelCmd_DiffDriven.h>
+#include <mrpt/nav/holonomic/CHolonomicVFF.h>
 #include <mrpt/nav/holonomic/ClearanceDiagram.h>
+#include <mrpt/nav/planners/PlannerSimple2D.h>
 #include <mrpt/nav/planners/nav_plan_geometry_utils.h>
 #include <mrpt/nav/reactive/CMultiObjMotionOpt_Scalarization.h>
 #include <mrpt/nav/reactive/CRobot2NavInterface.h>
@@ -739,4 +741,64 @@ TEST(MultiObjOpt, an_invalid_scalar_formula_throws)
   std::vector<TCandidateMovementPTG> movs{make_candidate(1.0, 1.0)};
   CMultiObjectiveMotionOptimizerBase::TResultInfo info;
   EXPECT_ANY_THROW((void)opt.decide(movs, info));
+}
+
+// ---------------------------------------------------------------------------
+//  A few remaining corners
+// ---------------------------------------------------------------------------
+TEST(CHolonomicVFF, log_record_serialization_roundtrip)
+{
+  mrpt::io::CMemoryStream buf;
+  auto arch = mrpt::serialization::archiveFrom(buf);
+
+  CLogFileRecord_VFF rec;
+  arch << rec;
+  buf.Seek(0);
+
+  CLogFileRecord_VFF rec2;
+  EXPECT_NO_THROW(arch >> rec2);
+}
+
+TEST(PlannerSimple2D, out_of_grid_endpoints_are_reported_as_not_found)
+{
+  mrpt::maps::COccupancyGridMap2D grid;
+  grid.setSize(-5.0f, 5.0f, -5.0f, 5.0f, 0.10f);
+  grid.fill(0.6f);
+
+  PlannerSimple2D planner;
+  planner.robotRadius = 0.15f;
+
+  const mrpt::poses::CPose2D inside(0, 0, 0), outside(100, 100, 0);
+  std::deque<mrpt::math::TPoint2D> path;
+  bool notFound = false;
+
+  planner.computePath(grid, outside, inside, path, notFound);
+  EXPECT_TRUE(notFound);
+
+  notFound = false;
+  planner.computePath(grid, inside, outside, path, notFound);
+  EXPECT_TRUE(notFound);
+
+  notFound = false;
+  planner.computePath(grid, outside, outside, path, notFound);
+  EXPECT_TRUE(notFound);
+}
+
+TEST(PlannerSimple2D, origin_and_target_in_the_same_cell)
+{
+  mrpt::maps::COccupancyGridMap2D grid;
+  grid.setSize(-5.0f, 5.0f, -5.0f, 5.0f, 0.10f);
+  grid.fill(0.6f);
+
+  PlannerSimple2D planner;
+  std::deque<mrpt::math::TPoint2D> path;
+  bool notFound = true;
+
+  planner.computePath(
+      grid, mrpt::poses::CPose2D(0.01, 0.01, 0), mrpt::poses::CPose2D(0.02, 0.02, 0), path,
+      notFound);
+
+  EXPECT_FALSE(notFound);
+  ASSERT_EQ(path.size(), 1U);
+  EXPECT_NEAR(path.front().x, 0.02, 1e-9);
 }

--- a/modules/mrpt_nav/tests/nav_misc_unittest.cpp
+++ b/modules/mrpt_nav/tests/nav_misc_unittest.cpp
@@ -678,6 +678,28 @@ TEST(MultiObjOpt, a_score_formula_that_cannot_be_compiled_yields_no_decision)
   EXPECT_FALSE(best.has_value());
 }
 
+TEST(MultiObjOpt, a_failed_compilation_leaves_no_stale_state_behind)
+{
+  CMultiObjMotionOpt_Scalarization opt;
+  opt.parameters.formula_score.clear();
+  // The first score compiles, the second does not: the names registered while
+  // compiling the first must not survive into the next decide().
+  opt.parameters.formula_score["aaa_ok"] = "collision_free_distance";
+  opt.parameters.formula_score["zzz_bad"] = "***not valid***";
+  opt.parameters.scores_to_normalize.clear();
+  opt.parameters.scalar_score_formula = "aaa_ok";
+
+  std::vector<TCandidateMovementPTG> movs{make_candidate(1.0, 1.0)};
+
+  CMultiObjectiveMotionOptimizerBase::TResultInfo info;
+  EXPECT_FALSE(opt.decide(movs, info).has_value());
+
+  // Repairing the formula must make the optimizer usable again:
+  opt.parameters.formula_score["zzz_bad"] = "clearance";
+  CMultiObjectiveMotionOptimizerBase::TResultInfo info2;
+  EXPECT_TRUE(opt.decide(movs, info2).has_value());
+}
+
 TEST(MultiObjOpt, a_movement_assert_that_cannot_be_compiled_yields_no_decision)
 {
   CMultiObjMotionOpt_Scalarization opt;

--- a/modules/mrpt_nav/tests/nav_misc_unittest.cpp
+++ b/modules/mrpt_nav/tests/nav_misc_unittest.cpp
@@ -1,0 +1,742 @@
+/*                    _
+                     | |    Mobile Robot Programming Toolkit (MRPT)
+ _ __ ___  _ __ _ __ | |_
+| '_ ` _ \| '__| '_ \| __|          https://www.mrpt.org/
+| | | | | | |  | |_) | |_
+|_| |_| |_|_|  | .__/ \__|     https://github.com/MRPT/mrpt/
+               | |
+               |_|
+
+ Copyright (c) 2005-2026, Individual contributors, see AUTHORS file
+ See: https://www.mrpt.org/Authors - All rights reserved.
+ SPDX-License-Identifier: BSD-3-Clause
+*/
+
+/** Unit tests for the smaller pieces of mrpt_nav: the clearance diagram,
+ *  the geometric collision helpers, the default CRobot2NavInterface
+ *  implementations, the navigation logger, the velocity filter and the
+ *  multi-objective motion optimizers.
+ */
+
+#include <gtest/gtest.h>
+#include <mrpt/config/CConfigFileMemory.h>
+#include <mrpt/io/CMemoryStream.h>
+#include <mrpt/kinematics/CVehicleVelCmd_DiffDriven.h>
+#include <mrpt/nav/holonomic/ClearanceDiagram.h>
+#include <mrpt/nav/planners/nav_plan_geometry_utils.h>
+#include <mrpt/nav/reactive/CMultiObjMotionOpt_Scalarization.h>
+#include <mrpt/nav/reactive/CRobot2NavInterface.h>
+#include <mrpt/nav/reactive/NavigationLogger.h>
+#include <mrpt/nav/reactive/VelocityFilter.h>
+#include <mrpt/nav/tpspace/CPTG_DiffDrive_C.h>
+#include <mrpt/serialization/CArchive.h>
+#include <mrpt/system/filesystem.h>
+#include <mrpt/viz/CMesh.h>
+
+#include <cmath>
+#include <fstream>
+
+using namespace mrpt::nav;
+
+// ---------------------------------------------------------------------------
+//  ClearanceDiagram
+// ---------------------------------------------------------------------------
+namespace
+{
+ClearanceDiagram make_clearance_diagram(size_t nPaths = 20, size_t nDecim = 5)
+{
+  ClearanceDiagram cd;
+  cd.resize(nPaths, nDecim);
+  for (size_t k = 0; k < nDecim; k++)
+  {
+    auto& m = cd.get_path_clearance_decimated(k);
+    m[0.25] = 0.5;
+    m[0.50] = 0.4;
+    m[1.00] = 0.3;
+  }
+  return cd;
+}
+}  // namespace
+
+TEST(ClearanceDiagram, resize_maps_between_real_and_decimated_indices)
+{
+  auto cd = make_clearance_diagram(21, 6);
+  EXPECT_EQ(cd.get_actual_num_paths(), 21U);
+  EXPECT_EQ(cd.get_decimated_num_paths(), 6U);
+
+  EXPECT_EQ(cd.real_k_to_decimated_k(0), 0U);
+  EXPECT_EQ(cd.real_k_to_decimated_k(20), 5U);
+  EXPECT_EQ(cd.decimated_k_to_real_k(0), 0U);
+  EXPECT_EQ(cd.decimated_k_to_real_k(5), 20U);
+
+  // Out-of-range indices are rejected:
+  EXPECT_ANY_THROW(cd.real_k_to_decimated_k(1000));
+  EXPECT_ANY_THROW(cd.decimated_k_to_real_k(1000));
+}
+
+TEST(ClearanceDiagram, index_mapping_needs_a_non_empty_diagram)
+{
+  ClearanceDiagram cd;
+  EXPECT_TRUE(cd.empty());
+  EXPECT_ANY_THROW(cd.real_k_to_decimated_k(0));
+  EXPECT_ANY_THROW(cd.decimated_k_to_real_k(0));
+}
+
+TEST(ClearanceDiagram, resize_to_zero_decimated_paths_clears_it)
+{
+  auto cd = make_clearance_diagram();
+  ASSERT_FALSE(cd.empty());
+  cd.resize(10, 0);
+  EXPECT_TRUE(cd.empty());
+  EXPECT_EQ(cd.get_actual_num_paths(), 0U);
+}
+
+TEST(ClearanceDiagram, resize_rejects_more_decimated_than_actual_paths)
+{
+  ClearanceDiagram cd;
+  EXPECT_ANY_THROW(cd.resize(4, 8));
+}
+
+TEST(ClearanceDiagram, getClearance_of_an_empty_diagram_is_zero)
+{
+  ClearanceDiagram cd;
+  EXPECT_EQ(cd.getClearance(0, 1.0, false), .0);
+  EXPECT_EQ(cd.getClearance(0, 1.0, true), .0);
+}
+
+TEST(ClearanceDiagram, getClearance_averages_or_integrates_over_the_path)
+{
+  auto cd = make_clearance_diagram();
+
+  // Averaged over the path up to (and including) the first sample past the
+  // query distance:
+  const double avg = cd.getClearance(0, 0.5, false /*integrate_over_path*/);
+  EXPECT_NEAR(avg, (0.5 + 0.4 + 0.3) / 3, 1e-9);
+
+  // "integrate_over_path" keeps only the last visited sample:
+  const double last = cd.getClearance(0, 0.5, true);
+  EXPECT_NEAR(last, 0.3, 1e-9);
+
+  // A query beyond every stored sample averages them all:
+  EXPECT_NEAR(cd.getClearance(0, 100.0, false), (0.5 + 0.4 + 0.3) / 3, 1e-9);
+
+  EXPECT_ANY_THROW(cd.getClearance(1000, 0.5, false));
+}
+
+TEST(ClearanceDiagram, path_clearance_accessors)
+{
+  auto cd = make_clearance_diagram(20, 5);
+  const auto& constCd = cd;
+
+  EXPECT_EQ(cd.get_path_clearance(0).size(), 3U);
+  EXPECT_EQ(constCd.get_path_clearance(0).size(), 3U);
+  EXPECT_EQ(constCd.get_path_clearance_decimated(0).size(), 3U);
+
+  cd.get_path_clearance(0)[2.0] = 0.2;
+  EXPECT_EQ(constCd.get_path_clearance(0).size(), 4U);
+}
+
+TEST(ClearanceDiagram, serialization_roundtrip)
+{
+  auto cd = make_clearance_diagram(20, 5);
+
+  mrpt::io::CMemoryStream buf;
+  auto arch = mrpt::serialization::archiveFrom(buf);
+  cd.writeToStream(arch);
+  buf.Seek(0);
+
+  ClearanceDiagram cd2;
+  cd2.readFromStream(arch);
+
+  EXPECT_EQ(cd2.get_actual_num_paths(), cd.get_actual_num_paths());
+  EXPECT_EQ(cd2.get_decimated_num_paths(), cd.get_decimated_num_paths());
+  EXPECT_NEAR(cd2.getClearance(0, 1.0, false), cd.getClearance(0, 1.0, false), 1e-12);
+}
+
+TEST(ClearanceDiagram, clear_resets_everything)
+{
+  auto cd = make_clearance_diagram();
+  cd.clear();
+  EXPECT_TRUE(cd.empty());
+  EXPECT_EQ(cd.get_actual_num_paths(), 0U);
+  EXPECT_EQ(cd.get_decimated_num_paths(), 0U);
+}
+
+TEST(ClearanceDiagram, renderAs3DObject_fills_a_mesh)
+{
+  auto cd = make_clearance_diagram();
+
+  mrpt::viz::CMesh mesh;
+  cd.renderAs3DObject(mesh, -1.0, 1.0, -1.0, 1.0, 0.25, false);
+  EXPECT_GT(mesh.getxMax(), mesh.getxMin());
+
+  // An empty diagram renders nothing, but must not throw:
+  ClearanceDiagram empty;
+  mrpt::viz::CMesh mesh2;
+  EXPECT_NO_THROW(empty.renderAs3DObject(mesh2, -1.0, 1.0, -1.0, 1.0, 0.25, true));
+
+  // Degenerate rendering bounds are rejected:
+  EXPECT_ANY_THROW(cd.renderAs3DObject(mesh, -1.0, 1.0, -1.0, 1.0, .0 /*cell_res*/, false));
+  EXPECT_ANY_THROW(cd.renderAs3DObject(mesh, 1.0, -1.0, -1.0, 1.0, 0.25, false));
+  EXPECT_ANY_THROW(cd.renderAs3DObject(mesh, -1.0, 1.0, 1.0, -1.0, 0.25, false));
+}
+
+// ---------------------------------------------------------------------------
+//  nav_plan_geometry_utils
+// ---------------------------------------------------------------------------
+TEST(NavGeomUtils, straight_segment_hits_an_obstacle_ahead)
+{
+  double d = .0;
+  // Robot of radius 0.5 moving along +x; obstacle at (2,0):
+  EXPECT_TRUE(collision_free_dist_segment_circ_robot({0, 0}, {5, 0}, 0.5, {2, 0}, d));
+  EXPECT_NEAR(d, 1.5, 1e-9);
+}
+
+TEST(NavGeomUtils, straight_segment_misses_a_lateral_obstacle)
+{
+  double d = .0;
+  EXPECT_FALSE(collision_free_dist_segment_circ_robot({0, 0}, {5, 0}, 0.5, {2, 3}, d));
+  EXPECT_LT(d, .0);
+}
+
+TEST(NavGeomUtils, straight_segment_ignores_obstacles_behind_and_beyond)
+{
+  double d = .0;
+  // Behind the start point:
+  EXPECT_FALSE(collision_free_dist_segment_circ_robot({0, 0}, {5, 0}, 0.5, {-3, 0}, d));
+  // Beyond the segment end:
+  EXPECT_FALSE(collision_free_dist_segment_circ_robot({0, 0}, {1, 0}, 0.5, {9, 0}, d));
+}
+
+TEST(NavGeomUtils, straight_segment_requires_a_non_degenerate_segment)
+{
+  double d = .0;
+  EXPECT_ANY_THROW(collision_free_dist_segment_circ_robot({0, 0}, {0, 0}, 0.5, {2, 0}, d));
+}
+
+TEST(NavGeomUtils, arc_path_hits_an_obstacle_on_the_arc)
+{
+  // Arc turning left with radius 2 m: the trajectory passes through (2,2).
+  double d = .0;
+  const bool hit = collision_free_dist_arc_circ_robot(2.0, 0.5, {2.0, 2.0}, d);
+  ASSERT_TRUE(hit);
+  EXPECT_GT(d, .0);
+  // A quarter of the circle is pi/2*R ~= 3.14 m; the collision happens a bit
+  // earlier because of the robot radius:
+  EXPECT_LT(d, 2.0 * M_PI / 2);
+}
+
+TEST(NavGeomUtils, arc_path_misses_a_far_away_obstacle)
+{
+  double d = .0;
+  EXPECT_FALSE(collision_free_dist_arc_circ_robot(2.0, 0.5, {50.0, 50.0}, d));
+  EXPECT_LT(d, .0);
+}
+
+TEST(NavGeomUtils, arc_path_misses_an_obstacle_inside_the_turning_circle)
+{
+  double d = .0;
+  // The center of the turning circle is at (0,2): an obstacle right there is
+  // never touched by the arc.
+  EXPECT_FALSE(collision_free_dist_arc_circ_robot(2.0, 0.1, {0.0, 2.0}, d));
+}
+
+TEST(NavGeomUtils, arc_path_works_for_right_turns_too)
+{
+  double d = .0;
+  const bool hit = collision_free_dist_arc_circ_robot(-2.0, 0.5, {2.0, -2.0}, d);
+  ASSERT_TRUE(hit);
+  EXPECT_GT(d, .0);
+}
+
+TEST(NavGeomUtils, arc_path_requires_a_non_degenerate_radius)
+{
+  double d = .0;
+  EXPECT_ANY_THROW(collision_free_dist_arc_circ_robot(.0, 0.5, {2.0, 2.0}, d));
+}
+
+// ---------------------------------------------------------------------------
+//  CRobot2NavInterface default implementations
+// ---------------------------------------------------------------------------
+namespace
+{
+/** Implements only the pure virtual methods, leaving every optional callback
+ *  at its base-class default. */
+struct BareRobotIF : public CRobot2NavInterface
+{
+  std::optional<CurrentPoseAndSpeeds> getCurrentPoseAndSpeeds() override
+  {
+    return CurrentPoseAndSpeeds();
+  }
+  bool changeSpeeds(const mrpt::kinematics::CVehicleVelCmd&) override { return true; }
+  bool stop(StopType) override { return true; }
+  mrpt::kinematics::CVehicleVelCmd::Ptr getEmergencyStopCmd() override
+  {
+    return std::make_shared<mrpt::kinematics::CVehicleVelCmd_DiffDriven>();
+  }
+  mrpt::kinematics::CVehicleVelCmd::Ptr getStopCmd() override
+  {
+    return std::make_shared<mrpt::kinematics::CVehicleVelCmd_DiffDriven>();
+  }
+  bool senseObstacles(mrpt::maps::CSimplePointsMap& obs, mrpt::system::TTimeStamp& ts) override
+  {
+    obs.clear();
+    ts = mrpt::Clock::now();
+    return true;
+  }
+};
+}  // namespace
+
+TEST(CRobot2NavInterface, default_callbacks_are_harmless_no_ops)
+{
+  BareRobotIF r;
+  r.setMinLoggingLevel(mrpt::system::LVL_ERROR);
+
+  EXPECT_TRUE(r.changeSpeedsNOP());
+  EXPECT_TRUE(r.startWatchdog(1000.f));
+  EXPECT_TRUE(r.stopWatchdog());
+  EXPECT_FALSE(r.getAlignCmd(1.0));  // in-place rotations unsupported
+
+  EXPECT_NO_THROW(r.sendNavigationStartEvent());
+  EXPECT_NO_THROW(r.sendNavigationEndEvent());
+  EXPECT_NO_THROW(r.sendWaypointReachedEvent(0, true));
+  EXPECT_NO_THROW(r.sendWaypointReachedEvent(0, false));
+  EXPECT_NO_THROW(r.sendNewWaypointTargetEvent(1));
+  EXPECT_NO_THROW(r.sendNavigationEndDueToErrorEvent());
+  EXPECT_NO_THROW(r.sendWaySeemsBlockedEvent());
+  EXPECT_NO_THROW(r.sendApparentCollisionEvent());
+  EXPECT_NO_THROW(r.sendCannotGetCloserToBlockedTargetEvent());
+}
+
+TEST(CRobot2NavInterface, navigation_timer_starts_from_zero)
+{
+  BareRobotIF r;
+  r.resetNavigationTimer();
+  const double t = r.getNavigationTime();
+  EXPECT_GE(t, .0);
+  EXPECT_LT(t, 5.0);
+}
+
+// ---------------------------------------------------------------------------
+//  NavigationLogger
+// ---------------------------------------------------------------------------
+TEST(NavigationLogger, log_directory_accessors)
+{
+  NavigationLogger lg;
+  EXPECT_FALSE(lg.getLogFileDirectory().empty());
+
+  lg.setLogFileDirectory("./some/dir");
+  EXPECT_EQ(lg.getLogFileDirectory(), "./some/dir");
+}
+
+TEST(NavigationLogger, keeping_records_in_memory)
+{
+  NavigationLogger lg;
+  EXPECT_FALSE(lg.shouldFillLogRecord());
+
+  lg.enableKeepLogRecords(true);
+  EXPECT_TRUE(lg.shouldFillLogRecord());
+
+  CLogFileRecord rec;
+  rec.nSelectedPTG = 3;
+  rec.robotPoseLocalization = mrpt::math::TPose2D(1, 2, 0.3);
+
+  mrpt::system::CTimeLogger tl(false);
+  lg.writeLogRecord(rec, tl);
+
+  CLogFileRecord out;
+  lg.getLastLogRecord(out);
+  EXPECT_EQ(out.nSelectedPTG, 3);
+  EXPECT_NEAR(out.robotPoseLocalization.x, 1.0, 1e-9);
+
+  lg.enableKeepLogRecords(false);
+  EXPECT_FALSE(lg.shouldFillLogRecord());
+}
+
+TEST(NavigationLogger, writes_and_closes_a_log_file)
+{
+  const std::string dir = mrpt::system::getTempFileName() + std::string("_navlog");
+
+  NavigationLogger lg;
+  EXPECT_FALSE(lg.isNewLogFile());
+  EXPECT_EQ(lg.getLogStream(), nullptr);
+
+  lg.enableLogFile(true, dir, nullptr);
+  ASSERT_NE(lg.getLogStream(), nullptr);
+  EXPECT_TRUE(lg.shouldFillLogRecord());
+  EXPECT_TRUE(lg.isNewLogFile());
+
+  lg.markLogFileIntroduced();
+  EXPECT_FALSE(lg.isNewLogFile());
+
+  CLogFileRecord rec;
+  mrpt::system::CTimeLogger tl(false);
+  lg.writeLogRecord(rec, tl);
+
+  // Enabling twice is a no-op:
+  auto* prevStream = lg.getLogStream();
+  lg.enableLogFile(true, dir, nullptr);
+  EXPECT_EQ(lg.getLogStream(), prevStream);
+
+  EXPECT_TRUE(mrpt::system::fileExists(dir + "/log_000.reactivenavlog"));
+
+  lg.enableLogFile(false, dir, nullptr);
+  EXPECT_EQ(lg.getLogStream(), nullptr);
+
+  // Disabling twice is also a no-op:
+  EXPECT_NO_THROW(lg.enableLogFile(false, dir, nullptr));
+
+  lg.close();
+  EXPECT_EQ(lg.getLogStream(), nullptr);
+
+  mrpt::system::deleteFilesInDirectory(dir, true);
+}
+
+TEST(NavigationLogger, an_unusable_log_directory_is_reported_not_thrown)
+{
+  NavigationLogger lg;
+  // A path that cannot be created (a component of it is an existing file):
+  const std::string fil = mrpt::system::getTempFileName();
+  {
+    std::ofstream f(fil);
+    f << "x";
+  }
+  EXPECT_NO_THROW(lg.enableLogFile(true, fil + "/sub", nullptr));
+  EXPECT_EQ(lg.getLogStream(), nullptr);
+  mrpt::system::deleteFile(fil);
+}
+
+// ---------------------------------------------------------------------------
+//  VelocityFilter
+// ---------------------------------------------------------------------------
+namespace
+{
+CParameterizedTrajectoryGenerator::Ptr make_test_ptg()
+{
+  mrpt::config::CConfigFileMemory cfg;
+  cfg.write("PTG", "num_paths", 21);
+  cfg.write("PTG", "refDistance", 2.0);
+  cfg.write("PTG", "resolution", 0.25);
+  cfg.write("PTG", "v_max_mps", 1.0);
+  cfg.write("PTG", "w_max_dps", 60.0);
+  cfg.write("PTG", "K", 1.0);
+  cfg.write("PTG", "shape_x0", -0.2);
+  cfg.write("PTG", "shape_y0", 0.2);
+  cfg.write("PTG", "shape_x1", 0.2);
+  cfg.write("PTG", "shape_y1", 0.2);
+  cfg.write("PTG", "shape_x2", 0.2);
+  cfg.write("PTG", "shape_y2", -0.2);
+  cfg.write("PTG", "shape_x3", -0.2);
+  cfg.write("PTG", "shape_y3", -0.2);
+  auto ptg = CParameterizedTrajectoryGenerator::CreatePTG("CPTG_DiffDrive_C", cfg, "PTG", "");
+  ptg->initialize(std::string(), false);
+  return ptg;
+}
+}  // namespace
+
+TEST(VelocityFilter, zero_speed_produces_a_stop_command)
+{
+  VelocityFilter vf;
+  mrpt::system::CTimeLogger tl(false);
+
+  TCandidateMovementPTG mov;
+  auto ptgTmp = make_test_ptg();
+  mov.PTG = ptgTmp.get();
+  mov.speed = .0;
+  mov.direction = .0;
+
+  mrpt::kinematics::CVehicleVelCmd::Ptr cmd;
+  mrpt::kinematics::CVehicleVelCmd::TVelCmdParams params;
+  params.robotMax_V_mps = 1.0;
+  params.robotMax_W_radps = 1.0;
+
+  const double scale = vf.generateVelCmd(mov, cmd, .0, params, 0.1, tl);
+  ASSERT_TRUE(cmd);
+  EXPECT_TRUE(cmd->isStopCmd());
+  EXPECT_NEAR(scale, 1.0, 1e-12);
+}
+
+TEST(VelocityFilter, non_zero_speed_scales_and_remembers_the_last_command)
+{
+  VelocityFilter vf;
+  mrpt::system::CTimeLogger tl(false);
+  auto ptg = make_test_ptg();
+
+  TCandidateMovementPTG mov;
+  mov.PTG = ptg.get();
+  mov.speed = 0.5;
+  mov.direction = .0;
+
+  mrpt::kinematics::CVehicleVelCmd::Ptr cmd;
+  mrpt::kinematics::CVehicleVelCmd::TVelCmdParams params;
+  params.robotMax_V_mps = 1.0;
+  params.robotMax_W_radps = 1.0;
+
+  EXPECT_FALSE(vf.getLastVelCmd());
+  const double scale = vf.generateVelCmd(mov, cmd, .0, params, 0.1, tl);
+  ASSERT_TRUE(cmd);
+  EXPECT_GT(scale, .0);
+  EXPECT_LE(scale, 1.0);
+  EXPECT_FALSE(cmd->isStopCmd());
+  EXPECT_TRUE(vf.getLastVelCmd());
+
+  vf.resetLastVelCmd();
+  EXPECT_FALSE(vf.getLastVelCmd());
+}
+
+TEST(VelocityFilter, slowdown_movements_are_not_rescaled)
+{
+  VelocityFilter vf;
+  mrpt::system::CTimeLogger tl(false);
+  auto ptg = make_test_ptg();
+
+  TCandidateMovementPTG mov;
+  mov.PTG = ptg.get();
+  mov.speed = 0.5;
+  mov.direction = .0;
+  mov.props["is_slowdown"] = 1.0;
+
+  mrpt::kinematics::CVehicleVelCmd::Ptr cmd;
+  mrpt::kinematics::CVehicleVelCmd::TVelCmdParams params;
+  params.robotMax_V_mps = 1.0;
+  params.robotMax_W_radps = 1.0;
+
+  const double scale = vf.generateVelCmd(mov, cmd, .0, params, 0.1, tl);
+  ASSERT_TRUE(cmd);
+  EXPECT_NEAR(scale, 1.0, 1e-12);
+}
+
+// ---------------------------------------------------------------------------
+//  Multi-objective motion optimizers
+// ---------------------------------------------------------------------------
+namespace
+{
+TCandidateMovementPTG make_candidate(double speed, double collision_free_distance)
+{
+  TCandidateMovementPTG m;
+  m.speed = speed;
+  m.direction = .0;
+  m.props["collision_free_distance"] = collision_free_distance;
+  m.props["hysteresis"] = 0.0;
+  m.props["clearance"] = 1.0;
+  m.props["dist_eucl_final"] = 1.0;
+  m.props["target_k"] = 0.0;
+  m.props["move_k"] = 0.0;
+  m.props["num_paths"] = 100.0;
+  m.props["ref_dist"] = 10.0;
+  return m;
+}
+}  // namespace
+
+TEST(MultiObjOpt, factory_creates_known_optimizers_only)
+{
+  auto opt = CMultiObjectiveMotionOptimizerBase::Factory("CMultiObjMotionOpt_Scalarization");
+  EXPECT_TRUE(opt);
+  EXPECT_FALSE(CMultiObjectiveMotionOptimizerBase::Factory("NoSuchOptimizerClass"));
+  // A registered class that is not a motion optimizer:
+  EXPECT_FALSE(CMultiObjectiveMotionOptimizerBase::Factory("mrpt::poses::CPose3D"));
+}
+
+TEST(MultiObjOpt, default_params_define_the_standard_scores)
+{
+  CMultiObjectiveMotionOptimizerBase::TParamsBase p;
+  EXPECT_FALSE(p.formula_score.empty());
+  EXPECT_NE(p.formula_score.find("collision_free_distance"), p.formula_score.end());
+  EXPECT_NE(p.formula_score.find("hysteresis"), p.formula_score.end());
+  EXPECT_EQ(p.scores_to_normalize.size(), 1U);
+  EXPECT_EQ(p.scores_to_normalize[0], "clearance");
+}
+
+TEST(MultiObjOpt, params_config_file_roundtrip)
+{
+  CMultiObjMotionOpt_Scalarization opt;
+  opt.parameters.formula_score.clear();
+  opt.parameters.formula_score["s1"] = "collision_free_distance";
+  opt.parameters.formula_score["s2"] = "clearance";
+  opt.parameters.movement_assert.emplace_back("collision_free_distance>0.1");
+  opt.parameters.scores_to_normalize = {"s2"};
+  opt.parameters.scalar_score_formula = "s1+s2";
+
+  mrpt::config::CConfigFileMemory cfg;
+  opt.saveConfigFile(cfg);
+
+  CMultiObjMotionOpt_Scalarization opt2;
+  opt2.loadConfigFile(cfg);
+
+  EXPECT_EQ(opt2.parameters.formula_score.size(), 2U);
+  EXPECT_EQ(opt2.parameters.formula_score["s1"], "collision_free_distance");
+  ASSERT_EQ(opt2.parameters.movement_assert.size(), 1U);
+  EXPECT_EQ(opt2.parameters.movement_assert[0], "collision_free_distance>0.1");
+  ASSERT_EQ(opt2.parameters.scores_to_normalize.size(), 1U);
+  EXPECT_EQ(opt2.parameters.scores_to_normalize[0], "s2");
+  EXPECT_EQ(opt2.parameters.scalar_score_formula, "s1+s2");
+}
+
+TEST(MultiObjOpt, params_load_rejects_incomplete_score_definitions)
+{
+  {
+    mrpt::config::CConfigFileMemory cfg;
+    cfg.write("S", "dummy", "");  // section exists, but no scores at all
+    CMultiObjectiveMotionOptimizerBase::TParamsBase p;
+    EXPECT_ANY_THROW(p.loadFromConfigFile(cfg, "S"));
+  }
+  {
+    mrpt::config::CConfigFileMemory cfg;
+    cfg.write("S", "score1_name", "a");  // name without formula
+    CMultiObjectiveMotionOptimizerBase::TParamsBase p;
+    EXPECT_ANY_THROW(p.loadFromConfigFile(cfg, "S"));
+  }
+}
+
+TEST(MultiObjOpt, movement_asserts_veto_candidates)
+{
+  CMultiObjMotionOpt_Scalarization opt;
+  opt.parameters.formula_score.clear();
+  opt.parameters.formula_score["s"] = "collision_free_distance";
+  opt.parameters.scores_to_normalize.clear();
+  opt.parameters.movement_assert.emplace_back("collision_free_distance>0.5");
+  opt.parameters.scalar_score_formula = "s";
+
+  std::vector<TCandidateMovementPTG> movs{
+      make_candidate(1.0, 0.2 /*vetoed*/), make_candidate(1.0, 0.9 /*accepted*/)};
+
+  CMultiObjectiveMotionOptimizerBase::TResultInfo info;
+  const auto best = opt.decide(movs, info);
+  ASSERT_TRUE(best.has_value());
+  EXPECT_EQ(*best, 1U);
+  EXPECT_FALSE(info.log_entries.empty());
+}
+
+TEST(MultiObjOpt, scores_are_normalized_when_requested)
+{
+  CMultiObjMotionOpt_Scalarization opt;
+  opt.parameters.formula_score.clear();
+  opt.parameters.formula_score["s"] = "collision_free_distance";
+  opt.parameters.scores_to_normalize = {"s"};
+  opt.parameters.scalar_score_formula = "s";
+
+  std::vector<TCandidateMovementPTG> movs{make_candidate(1.0, 0.5), make_candidate(1.0, 2.0)};
+
+  CMultiObjectiveMotionOptimizerBase::TResultInfo info;
+  const auto best = opt.decide(movs, info);
+  ASSERT_TRUE(best.has_value());
+  EXPECT_EQ(*best, 1U);
+  // The maximum score is normalized to exactly 1.0:
+  EXPECT_NEAR(info.score_values[1]["s"], 1.0, 1e-9);
+  EXPECT_NEAR(info.score_values[0]["s"], 0.25, 1e-9);
+}
+
+TEST(MultiObjOpt, all_zero_scores_are_normalized_to_one)
+{
+  CMultiObjMotionOpt_Scalarization opt;
+  opt.parameters.formula_score.clear();
+  opt.parameters.formula_score["s"] = "collision_free_distance";
+  opt.parameters.scores_to_normalize = {"s"};
+  opt.parameters.scalar_score_formula = "s";
+
+  std::vector<TCandidateMovementPTG> movs{make_candidate(1.0, .0), make_candidate(1.0, .0)};
+
+  CMultiObjectiveMotionOptimizerBase::TResultInfo info;
+  const auto best = opt.decide(movs, info);
+  ASSERT_TRUE(best.has_value());
+  EXPECT_NEAR(info.score_values[0]["s"], 1.0, 1e-9);
+  EXPECT_NEAR(info.score_values[1]["s"], 1.0, 1e-9);
+}
+
+TEST(MultiObjOpt, invalid_candidates_score_zero)
+{
+  CMultiObjMotionOpt_Scalarization opt;
+  opt.parameters.formula_score.clear();
+  opt.parameters.formula_score["s"] = "collision_free_distance";
+  opt.parameters.scores_to_normalize.clear();
+  opt.parameters.scalar_score_formula = "s";
+
+  std::vector<TCandidateMovementPTG> movs{
+      make_candidate(-1.0 /*inviable*/, 5.0), make_candidate(1.0, 1.0)};
+
+  CMultiObjectiveMotionOptimizerBase::TResultInfo info;
+  const auto best = opt.decide(movs, info);
+  ASSERT_TRUE(best.has_value());
+  EXPECT_EQ(*best, 1U);
+  EXPECT_NEAR(info.score_values[0]["s"], .0, 1e-12);
+}
+
+TEST(MultiObjOpt, a_score_formula_that_cannot_be_compiled_yields_no_decision)
+{
+  CMultiObjMotionOpt_Scalarization opt;
+  opt.parameters.formula_score.clear();
+  opt.parameters.formula_score["s"] = "this is ***not*** a valid expression";
+  opt.parameters.scores_to_normalize.clear();
+  opt.parameters.scalar_score_formula = "s";
+
+  std::vector<TCandidateMovementPTG> movs{make_candidate(1.0, 1.0)};
+
+  CMultiObjectiveMotionOptimizerBase::TResultInfo info;
+  const auto best = opt.decide(movs, info);
+  EXPECT_FALSE(best.has_value());
+}
+
+TEST(MultiObjOpt, a_movement_assert_that_cannot_be_compiled_yields_no_decision)
+{
+  CMultiObjMotionOpt_Scalarization opt;
+  opt.parameters.formula_score.clear();
+  opt.parameters.formula_score["s"] = "collision_free_distance";
+  opt.parameters.scores_to_normalize.clear();
+  opt.parameters.movement_assert.emplace_back("***not valid***");
+  opt.parameters.scalar_score_formula = "s";
+
+  std::vector<TCandidateMovementPTG> movs{make_candidate(1.0, 1.0)};
+
+  CMultiObjectiveMotionOptimizerBase::TResultInfo info;
+  const auto best = opt.decide(movs, info);
+  EXPECT_FALSE(best.has_value());
+}
+
+TEST(MultiObjOpt, a_score_name_clashing_with_an_input_variable_is_rejected)
+{
+  CMultiObjMotionOpt_Scalarization opt;
+  opt.parameters.formula_score.clear();
+  // "hysteresis" is one of the per-candidate input variables:
+  opt.parameters.formula_score["hysteresis"] = "collision_free_distance";
+  opt.parameters.scores_to_normalize.clear();
+  opt.parameters.scalar_score_formula = "hysteresis";
+
+  std::vector<TCandidateMovementPTG> movs{make_candidate(1.0, 1.0)};
+
+  CMultiObjectiveMotionOptimizerBase::TResultInfo info;
+  EXPECT_ANY_THROW((void)opt.decide(movs, info));
+}
+
+TEST(MultiObjOpt, clear_forces_the_formulas_to_be_recompiled)
+{
+  CMultiObjMotionOpt_Scalarization opt;
+  opt.parameters.formula_score.clear();
+  opt.parameters.formula_score["s"] = "collision_free_distance";
+  opt.parameters.scores_to_normalize.clear();
+  opt.parameters.scalar_score_formula = "s";
+
+  std::vector<TCandidateMovementPTG> movs{make_candidate(1.0, 1.0)};
+  CMultiObjectiveMotionOptimizerBase::TResultInfo info;
+  ASSERT_TRUE(opt.decide(movs, info).has_value());
+
+  opt.parameters.scalar_score_formula = "2*s";
+  opt.clear();
+
+  CMultiObjectiveMotionOptimizerBase::TResultInfo info2;
+  const auto best = opt.decide(movs, info2);
+  ASSERT_TRUE(best.has_value());
+  EXPECT_NEAR(info2.final_evaluation[0], 2 * info.final_evaluation[0], 1e-9);
+}
+
+TEST(MultiObjOpt, an_invalid_scalar_formula_throws)
+{
+  CMultiObjMotionOpt_Scalarization opt;
+  opt.parameters.formula_score.clear();
+  opt.parameters.formula_score["s"] = "collision_free_distance";
+  opt.parameters.scores_to_normalize.clear();
+  opt.parameters.scalar_score_formula = "***nope***";
+
+  std::vector<TCandidateMovementPTG> movs{make_candidate(1.0, 1.0)};
+  CMultiObjectiveMotionOptimizerBase::TResultInfo info;
+  EXPECT_ANY_THROW((void)opt.decide(movs, info));
+}

--- a/modules/mrpt_nav/tests/planners_and_logs_unittest.cpp
+++ b/modules/mrpt_nav/tests/planners_and_logs_unittest.cpp
@@ -1,0 +1,393 @@
+/*                    _
+                     | |    Mobile Robot Programming Toolkit (MRPT)
+ _ __ ___  _ __ _ __ | |_
+| '_ ` _ \| '__| '_ \| __|          https://www.mrpt.org/
+| | | | | | |  | |_) | |_
+|_| |_| |_|_|  | .__/ \__|     https://github.com/MRPT/mrpt/
+               | |
+               |_|
+
+ Copyright (c) 2005-2026, Individual contributors, see AUTHORS file
+ See: https://www.mrpt.org/Authors - All rights reserved.
+ SPDX-License-Identifier: BSD-3-Clause
+*/
+
+/** Path-planner coverage beyond the "does it find a solution" tests: the
+ *  RRT move-tree 3D rendering, planner configuration variants, and a full
+ *  round-trip of the (heavily populated) reactive-navigation log record.
+ */
+
+#include <gtest/gtest.h>
+#include <mrpt/config/CConfigFileMemory.h>
+#include <mrpt/io/CMemoryStream.h>
+#include <mrpt/kinematics/CVehicleVelCmd_DiffDriven.h>
+#include <mrpt/nav/holonomic/CHolonomicFullEval.h>
+#include <mrpt/nav/planners/PlannerRRT_SE2_TPS.h>
+#include <mrpt/nav/planners/PlannerSimple2D.h>
+#include <mrpt/nav/reactive/CLogFileRecord.h>
+#include <mrpt/nav/tpspace/CPTG_DiffDrive_C.h>
+#include <mrpt/serialization/CArchive.h>
+#include <mrpt/viz/Scene.h>
+
+using namespace mrpt::nav;
+
+namespace
+{
+const char* const kRRTCfgCircular =
+    "[PTG_CONFIG]\n"
+    "robot_shape_circular_radius = 0.3\n"
+    "PTG_COUNT = 1\n"
+    "PTG0_Type = CPTG_Holo_Blend\n"
+    "PTG0_refDistance = 4.0\n"
+    "PTG0_num_paths = 21\n"
+    "PTG0_v_max_mps = 1.0\n"
+    "PTG0_w_max_dps = 90\n"
+    "PTG0_T_ramp_max = 0.9\n";
+
+/** Same, but with an explicit polygonal robot shape (MATLAB matrix syntax). */
+const char* const kRRTCfgPolygonal =
+    "[PTG_CONFIG]\n"
+    "robot_shape = [-0.2 0.2 0.2 -0.2; -0.1 -0.1 0.1 0.1]\n"
+    "PTG_COUNT = 1\n"
+    "PTG0_Type = CPTG_DiffDrive_C\n"
+    "PTG0_refDistance = 3.0\n"
+    "PTG0_resolution = 0.25\n"
+    "PTG0_num_paths = 21\n"
+    "PTG0_v_max_mps = 1.0\n"
+    "PTG0_w_max_dps = 90\n"
+    "PTG0_K = 1.0\n";
+
+void setup_planner(PlannerRRT_SE2_TPS& planner, const char* cfgText)
+{
+  mrpt::config::CConfigFileMemory cfg(std::string{cfgText});
+  planner.loadConfig(cfg);
+  planner.end_criteria.maxComputationTime = 1.0;
+  planner.end_criteria.acceptedDistToTarget = 0.4;
+  planner.params.ptg_verbose = false;
+  planner.params.ptg_cache_files_directory = "/tmp";
+  planner.initialize();
+}
+
+PlannerRRT_SE2_TPS::TPlannerInput make_planner_input()
+{
+  PlannerRRT_SE2_TPS::TPlannerInput pi;
+  pi.start_pose = mrpt::math::TPose2D(0, 0, 0);
+  pi.goal_pose = mrpt::math::TPose2D(2.0, 0.5, 0);
+  pi.world_bbox_min = mrpt::math::TPose2D(-5, -5, -M_PI);
+  pi.world_bbox_max = mrpt::math::TPose2D(5, 5, M_PI);
+  return pi;
+}
+}  // namespace
+
+// ---------------------------------------------------------------------------
+//  PlannerRRT_SE2_TPS
+// ---------------------------------------------------------------------------
+TEST(PlannerRRTSE2TPS, loads_a_polygonal_robot_shape)
+{
+  PlannerRRT_SE2_TPS planner;
+  ASSERT_NO_THROW(setup_planner(planner, kRRTCfgPolygonal));
+  EXPECT_EQ(planner.params.robot_shape.size(), 4U);
+  EXPECT_EQ(planner.getPTGs().size(), 1U);
+}
+
+TEST(PlannerRRTSE2TPS, rejects_a_malformed_robot_shape)
+{
+  PlannerRRT_SE2_TPS planner;
+  mrpt::config::CConfigFileMemory cfg(std::string{
+      "[PTG_CONFIG]\n"
+      "robot_shape = not a matlab matrix\n"
+      "PTG_COUNT = 0\n"});
+  EXPECT_ANY_THROW(planner.loadConfig(cfg));
+}
+
+TEST(PlannerRRTSE2TPS, solve_before_initialize_is_rejected)
+{
+  PlannerRRT_SE2_TPS planner;
+  auto pi = make_planner_input();
+  PlannerRRT_SE2_TPS::TPlannerResult result;
+  EXPECT_ANY_THROW(planner.solve(pi, result));
+}
+
+TEST(PlannerRRTSE2TPS, obstacles_are_taken_into_account)
+{
+  PlannerRRT_SE2_TPS planner;
+  setup_planner(planner, kRRTCfgCircular);
+
+  auto pi = make_planner_input();
+  // A wall of obstacles right between start and goal:
+  for (double y = -2.0; y <= 2.0; y += 0.05)
+  {
+    pi.obstacles_points.insertPoint(1.0, y, .0);
+  }
+
+  PlannerRRT_SE2_TPS::TPlannerResult result;
+  EXPECT_NO_THROW(planner.solve(pi, result));
+  // Whatever the outcome, the tree must have been grown from the root:
+  EXPECT_GT(result.move_tree.getAllNodes().size(), 0U);
+  EXPECT_GT(result.computation_time, .0);
+}
+
+TEST(PlannerRRTSE2TPS, renders_the_move_tree_into_a_3d_scene)
+{
+  PlannerRRT_SE2_TPS planner;
+  setup_planner(planner, kRRTCfgCircular);
+
+  auto pi = make_planner_input();
+  pi.obstacles_points.insertPoint(1.0, 1.0, .0);
+  pi.obstacles_points.insertPoint(1.0, -1.0, .0);
+
+  PlannerRRT_SE2_TPS::TPlannerResult result;
+  planner.solve(pi, result);
+
+  mrpt::viz::Scene scene;
+  PlannerRRT_SE2_TPS::TRenderPlannedPathOptions opts;
+  opts.highlight_path_to_node_id = result.best_goal_node_id;
+  opts.highlight_last_added_edge = true;
+  opts.ground_xy_grid_frequency = 1.0;
+  opts.log_msg = "unit test";
+
+  const mrpt::poses::CPose2D xRand(1, 1, 0), xNearest(0.5, 0.5, 0), newState(1.5, 0.5, 0);
+  opts.x_rand_pose = &xRand;
+  opts.x_nearest_pose = &xNearest;
+  opts.new_state = &newState;
+  opts.local_obs_from_nearest_pose = &pi.obstacles_points;
+
+  planner.renderMoveTree(scene, pi, result, opts);
+  EXPECT_GT(scene.getViewport()->size(), 0U);
+}
+
+TEST(PlannerRRTSE2TPS, rendering_options_can_be_switched_off)
+{
+  PlannerRRT_SE2_TPS planner;
+  setup_planner(planner, kRRTCfgPolygonal);
+
+  auto pi = make_planner_input();
+  PlannerRRT_SE2_TPS::TPlannerResult result;
+  planner.solve(pi, result);
+
+  mrpt::viz::Scene scene;
+  PlannerRRT_SE2_TPS::TRenderPlannedPathOptions opts;
+  opts.draw_obstacles = false;
+  opts.ground_xy_grid_frequency = 0;  // disabled
+  opts.draw_shape_decimation = 3;
+  opts.xyzcorners_scale = 0.5;
+
+  EXPECT_NO_THROW(planner.renderMoveTree(scene, pi, result, opts));
+  EXPECT_GT(scene.getViewport()->size(), 0U);
+}
+
+TEST(PlannerRRTSE2TPS, an_unsolved_tree_still_renders)
+{
+  PlannerRRT_SE2_TPS planner;
+  setup_planner(planner, kRRTCfgCircular);
+
+  auto pi = make_planner_input();
+  PlannerRRT_SE2_TPS::TPlannerResult emptyResult;  // never solved
+
+  mrpt::viz::Scene scene;
+  PlannerRRT_SE2_TPS::TRenderPlannedPathOptions opts;
+  EXPECT_NO_THROW(planner.renderMoveTree(scene, pi, emptyResult, opts));
+}
+
+TEST(PlannerRRTSE2TPS, profiler_is_accessible)
+{
+  PlannerRRT_SE2_TPS planner;
+  EXPECT_NO_THROW(planner.getProfiler().clear(true));
+}
+
+// ---------------------------------------------------------------------------
+//  PlannerSimple2D
+// ---------------------------------------------------------------------------
+TEST(PlannerSimple2D, unreachable_goal_yields_an_empty_path)
+{
+  mrpt::maps::COccupancyGridMap2D grid;
+  grid.setSize(-5.0f, 5.0f, -5.0f, 5.0f, 0.10f);
+  grid.fill(0.6f);
+
+  // A wall fully splitting the map in two:
+  for (float y = -5.0f; y <= 5.0f; y += 0.05f)
+  {
+    grid.setPos(0.0f, y, 0.0f);
+  }
+
+  PlannerSimple2D planner;
+  planner.robotRadius = 0.15f;
+
+  std::deque<mrpt::math::TPoint2D> path;
+  bool notFound = false;
+  planner.computePath(
+      grid, mrpt::poses::CPose2D(-2, 0, 0), mrpt::poses::CPose2D(2, 0, 0), path, notFound, 20.0f);
+
+  EXPECT_TRUE(notFound);
+  EXPECT_TRUE(path.empty());
+}
+
+TEST(PlannerSimple2D, path_is_found_in_an_open_map)
+{
+  mrpt::maps::COccupancyGridMap2D grid;
+  grid.setSize(-5.0f, 5.0f, -5.0f, 5.0f, 0.10f);
+  grid.fill(0.6f);
+
+  PlannerSimple2D planner;
+  planner.robotRadius = 0.15f;
+
+  std::deque<mrpt::math::TPoint2D> path;
+  bool notFound = true;
+  planner.computePath(
+      grid, mrpt::poses::CPose2D(-2, 0, 0), mrpt::poses::CPose2D(2, 0, 0), path, notFound, -1.0f);
+
+  EXPECT_FALSE(notFound);
+  EXPECT_GT(path.size(), 1U);
+  EXPECT_NEAR(path.back().x, 2.0, 0.5);
+  EXPECT_NEAR(path.back().y, 0.0, 0.5);
+}
+
+// ---------------------------------------------------------------------------
+//  CLogFileRecord
+// ---------------------------------------------------------------------------
+TEST(CLogFileRecord, fully_populated_record_survives_a_roundtrip)
+{
+  // A PTG to embed in the record (as the navigator does for the first entry
+  // of every log file):
+  mrpt::config::CConfigFileMemory ptgCfg;
+  ptgCfg.write("PTG", "num_paths", 21);
+  ptgCfg.write("PTG", "refDistance", 2.0);
+  ptgCfg.write("PTG", "resolution", 0.25);
+  ptgCfg.write("PTG", "v_max_mps", 1.0);
+  ptgCfg.write("PTG", "w_max_dps", 60.0);
+  ptgCfg.write("PTG", "K", 1.0);
+  ptgCfg.write("PTG", "shape_x0", -0.2);
+  ptgCfg.write("PTG", "shape_y0", 0.2);
+  ptgCfg.write("PTG", "shape_x1", 0.2);
+  ptgCfg.write("PTG", "shape_y1", 0.2);
+  ptgCfg.write("PTG", "shape_x2", 0.2);
+  ptgCfg.write("PTG", "shape_y2", -0.2);
+  auto ptg = CParameterizedTrajectoryGenerator::CreatePTG("CPTG_DiffDrive_C", ptgCfg, "PTG", "");
+
+  CLogFileRecord rec;
+  rec.nPTGs = 1;
+  rec.infoPerPTG.resize(1);
+  {
+    auto& ipp = rec.infoPerPTG[0];
+    ipp.PTG_desc = "a PTG";
+    ipp.TP_Obstacles.resize(4);
+    ipp.TP_Obstacles.fill(1.5f);
+    ipp.TP_Targets.emplace_back(1.0, 2.0, 0.3);
+    ipp.TP_Robot = mrpt::math::TPoint2D(0.1, 0.2);
+    ipp.timeForTPObsTransformation = 0.01;
+    ipp.timeForHolonomicMethod = 0.02;
+    ipp.desiredDirection = 0.3;
+    ipp.desiredSpeed = 0.4;
+    ipp.evaluation = 0.5;
+    ipp.evalFactors["clearance"] = 0.6;
+    ipp.HLFR = std::make_shared<CLogFileRecord_FullEval>();
+    ipp.ptg = ptg;
+    ipp.clearance.resize(21, 4);
+    ipp.clearance.get_path_clearance_decimated(0)[0.5] = 0.7;
+    ipp.dynState.curVelLocal = mrpt::math::TTwist2D(0.5, 0, 0);
+    ipp.lastDynState.relTarget = mrpt::math::TPose2D(1, 1, 0);
+  }
+  rec.nSelectedPTG = 0;
+  rec.values["executionTime"] = 0.05;
+  rec.timestamps["tim_start_iteration"] = mrpt::Clock::now();
+  rec.additional_debug_msgs["msg"] = "hello";
+  rec.WS_Obstacles.insertPoint(1, 2, 0);
+  rec.WS_Obstacles_original.insertPoint(1, 2, 0);
+  rec.robotPoseLocalization = mrpt::math::TPose2D(1, 2, 0.3);
+  rec.robotPoseOdometry = mrpt::math::TPose2D(1.1, 2.1, 0.31);
+  rec.relPoseSense = mrpt::math::TPose2D(0.01, 0, 0);
+  rec.relPoseVelCmd = mrpt::math::TPose2D(0.02, 0, 0);
+  rec.WS_targets_relative.emplace_back(3.0, 4.0, 0.0);
+  {
+    auto c = std::make_shared<mrpt::kinematics::CVehicleVelCmd_DiffDriven>();
+    c->lin_vel = 0.5;
+    c->ang_vel = 0.1;
+    rec.cmd_vel = c;
+    rec.cmd_vel_original = c;
+  }
+  rec.cur_vel = mrpt::math::TTwist2D(0.5, 0, 0.1);
+  rec.cur_vel_local = mrpt::math::TTwist2D(0.5, 0, 0.1);
+  rec.robotShape_x.resize(3);
+  rec.robotShape_y.resize(3);
+  rec.robotShape_radius = 0.35;
+  rec.ptg_index_NOP = -1;  // not a "NOP cmdvel" step: cmd_vel is stored
+  rec.rel_cur_pose_wrt_last_vel_cmd_NOP = mrpt::math::TPose2D(0.1, 0, 0);
+  rec.rel_pose_PTG_origin_wrt_sense_NOP = mrpt::math::TPose2D(0.2, 0, 0);
+  rec.visuals.push_back(mrpt::viz::CSetOfObjects::Create());
+
+  mrpt::io::CMemoryStream buf;
+  auto arch = mrpt::serialization::archiveFrom(buf);
+  arch << rec;
+  buf.Seek(0);
+
+  CLogFileRecord rec2;
+  arch >> rec2;
+
+  EXPECT_EQ(rec2.nPTGs, rec.nPTGs);
+  ASSERT_EQ(rec2.infoPerPTG.size(), 1U);
+  EXPECT_EQ(rec2.infoPerPTG[0].PTG_desc, "a PTG");
+  EXPECT_EQ(rec2.infoPerPTG[0].TP_Obstacles.size(), 4);
+  ASSERT_EQ(rec2.infoPerPTG[0].TP_Targets.size(), 1U);
+  EXPECT_NEAR(rec2.infoPerPTG[0].TP_Targets[0].x, 1.0, 1e-6);
+  EXPECT_NEAR(rec2.infoPerPTG[0].desiredDirection, 0.3, 1e-9);
+  EXPECT_NEAR(rec2.infoPerPTG[0].evalFactors.at("clearance"), 0.6, 1e-9);
+  EXPECT_TRUE(rec2.infoPerPTG[0].HLFR);
+  EXPECT_TRUE(rec2.infoPerPTG[0].ptg);
+  EXPECT_EQ(rec2.infoPerPTG[0].clearance.get_actual_num_paths(), 21U);
+  EXPECT_EQ(rec2.nSelectedPTG, 0);
+  EXPECT_NEAR(rec2.values.at("executionTime"), 0.05, 1e-9);
+  EXPECT_EQ(rec2.additional_debug_msgs.at("msg"), "hello");
+  EXPECT_EQ(rec2.WS_Obstacles.size(), 1U);
+  EXPECT_NEAR(rec2.robotPoseLocalization.x, 1.0, 1e-9);
+  ASSERT_EQ(rec2.WS_targets_relative.size(), 1U);
+  EXPECT_NEAR(rec2.WS_targets_relative[0].x, 3.0, 1e-9);
+  ASSERT_TRUE(rec2.cmd_vel);
+  EXPECT_NEAR(rec2.cmd_vel->getVelCmdElement(0), 0.5, 1e-9);
+  EXPECT_NEAR(rec2.robotShape_radius, 0.35, 1e-9);
+  EXPECT_EQ(rec2.ptg_index_NOP, -1);
+  EXPECT_EQ(rec2.visuals.size(), 1U);
+}
+
+TEST(CLogFileRecord, nop_cmdvel_records_store_the_ptg_continuation_fields)
+{
+  CLogFileRecord rec;
+  rec.nPTGs = 0;
+  // In "NOP cmdvel" steps no new command is sent; the PTG-continuation
+  // bookkeeping is stored instead.
+  rec.ptg_index_NOP = 1;
+  rec.ptg_last_k_NOP = 7;
+  rec.rel_cur_pose_wrt_last_vel_cmd_NOP = mrpt::math::TPose2D(0.1, 0.2, 0.3);
+  rec.rel_pose_PTG_origin_wrt_sense_NOP = mrpt::math::TPose2D(0.4, 0.5, 0.6);
+
+  mrpt::io::CMemoryStream buf;
+  auto arch = mrpt::serialization::archiveFrom(buf);
+  arch << rec;
+  buf.Seek(0);
+
+  CLogFileRecord rec2;
+  arch >> rec2;
+
+  EXPECT_EQ(rec2.ptg_index_NOP, 1);
+  EXPECT_EQ(rec2.ptg_last_k_NOP, 7);
+  EXPECT_NEAR(rec2.rel_cur_pose_wrt_last_vel_cmd_NOP.x, 0.1, 1e-9);
+  EXPECT_NEAR(rec2.rel_pose_PTG_origin_wrt_sense_NOP.y, 0.5, 1e-9);
+  EXPECT_FALSE(rec2.cmd_vel);
+}
+
+TEST(CLogFileRecord, record_without_a_cmd_vel_roundtrips)
+{
+  CLogFileRecord rec;
+  rec.nPTGs = 0;
+  rec.ptg_index_NOP = -1;  // NOP mode disabled: the NOP fields are skipped
+
+  mrpt::io::CMemoryStream buf;
+  auto arch = mrpt::serialization::archiveFrom(buf);
+  arch << rec;
+  buf.Seek(0);
+
+  CLogFileRecord rec2;
+  arch >> rec2;
+  EXPECT_EQ(rec2.nPTGs, 0U);
+  EXPECT_FALSE(rec2.cmd_vel);
+  EXPECT_EQ(rec2.ptg_index_NOP, -1);
+}

--- a/modules/mrpt_nav/tests/planners_and_logs_unittest.cpp
+++ b/modules/mrpt_nav/tests/planners_and_logs_unittest.cpp
@@ -27,6 +27,7 @@
 #include <mrpt/nav/reactive/CLogFileRecord.h>
 #include <mrpt/nav/tpspace/CPTG_DiffDrive_C.h>
 #include <mrpt/serialization/CArchive.h>
+#include <mrpt/system/filesystem.h>
 #include <mrpt/viz/Scene.h>
 
 using namespace mrpt::nav;
@@ -64,7 +65,8 @@ void setup_planner(PlannerRRT_SE2_TPS& planner, const char* cfgText)
   planner.end_criteria.maxComputationTime = 1.0;
   planner.end_criteria.acceptedDistToTarget = 0.4;
   planner.params.ptg_verbose = false;
-  planner.params.ptg_cache_files_directory = "/tmp";
+  planner.params.ptg_cache_files_directory =
+      mrpt::system::extractFileDirectory(mrpt::system::getTempFileName());
   planner.initialize();
 }
 

--- a/modules/mrpt_nav/tests/planners_and_logs_unittest.cpp
+++ b/modules/mrpt_nav/tests/planners_and_logs_unittest.cpp
@@ -93,10 +93,10 @@ TEST(PlannerRRTSE2TPS, loads_a_polygonal_robot_shape)
 TEST(PlannerRRTSE2TPS, rejects_a_malformed_robot_shape)
 {
   PlannerRRT_SE2_TPS planner;
-  mrpt::config::CConfigFileMemory cfg(std::string{
-      "[PTG_CONFIG]\n"
-      "robot_shape = not a matlab matrix\n"
-      "PTG_COUNT = 0\n"});
+  mrpt::config::CConfigFileMemory cfg(
+      std::string{"[PTG_CONFIG]\n"
+                  "robot_shape = not a matlab matrix\n"
+                  "PTG_COUNT = 0\n"});
   EXPECT_ANY_THROW(planner.loadConfig(cfg));
 }
 

--- a/modules/mrpt_nav/tests/rnav_variants_unittest.cpp
+++ b/modules/mrpt_nav/tests/rnav_variants_unittest.cpp
@@ -1,0 +1,413 @@
+/*                    _
+                     | |    Mobile Robot Programming Toolkit (MRPT)
+ _ __ ___  _ __ _ __ | |_
+| '_ ` _ \| '__| '_ \| __|          https://www.mrpt.org/
+| | | | | | |  | |_) | |_
+|_| |_| |_|_|  | .__/ \__|     https://github.com/MRPT/mrpt/
+               | |
+               |_|
+
+ Copyright (c) 2005-2026, Individual contributors, see AUTHORS file
+ See: https://www.mrpt.org/Authors - All rights reserved.
+ SPDX-License-Identifier: BSD-3-Clause
+*/
+
+/** Reactive navigation runs driven by fully in-memory configurations, so they
+ *  do not depend on the shared config files. They exercise the optional
+ *  features of CAbstractPTGBasedReactive that the default configuration used
+ *  by rnav_unittest.cpp leaves switched off: the delays model, clearance
+ *  evaluation, velocity filtering, "NOP cmdvel" PTG continuation, obstacle
+ *  filtering, log records and the visualization helpers.
+ */
+
+#include <gtest/gtest.h>
+#include <mrpt/config/CConfigFileMemory.h>
+#include <mrpt/kinematics/CVehicleSimul_Holo.h>
+#include <mrpt/nav/reactive/CReactiveNavigationSystem.h>
+#include <mrpt/nav/reactive/CRobot2NavInterfaceForSimulator.h>
+#include <mrpt/system/filesystem.h>
+
+#include <string>
+
+using namespace mrpt::nav;
+
+namespace
+{
+/** A holonomic simulated robot that reports a fixed set of obstacles. */
+struct HoloSimRobot : public CRobot2NavInterfaceForSimulator_Holo
+{
+  std::vector<mrpt::math::TPoint2D> obstacles;
+  bool senseSucceeds = true;
+
+  HoloSimRobot(mrpt::kinematics::CVehicleSimul_Holo& sim) :
+      CRobot2NavInterfaceForSimulator_Holo(sim)
+  {
+    this->setMinLoggingLevel(mrpt::system::LVL_ERROR);
+  }
+
+  void sendNavigationStartEvent() override {}
+  void sendNavigationEndEvent() override {}
+
+  bool senseObstacles(
+      mrpt::maps::CSimplePointsMap& obs, mrpt::system::TTimeStamp& timestamp) override
+  {
+    obs.clear();
+    timestamp = mrpt::Clock::now();
+    if (!senseSucceeds) return false;
+    for (const auto& p : obstacles) obs.insertPoint(p.x, p.y, 0.0);
+    return true;
+  }
+};
+
+/** Builds an in-memory reactive-navigation config. `holoPTG` selects a
+ *  CPTG_Holo_Blend (which supports "NOP cmdvel" PTG continuation) instead of
+ *  the differential-drive default. */
+std::string make_rnav_config(
+    bool useDelaysModel, bool evaluateClearance, double speedFilterTau, bool obstacleFiltering)
+{
+  std::string s;
+  s += "[CAbstractNavigator]\n";
+  s += "dist_to_target_for_sending_event = 0\n";
+  s += "alarm_seems_not_approaching_target_timeout = 30\n";
+  s += "dist_check_target_is_blocked = 0.5\n";
+  s += "hysteresis_check_target_is_blocked = 3\n";
+  s += "enable_time_profiler = false\n";
+
+  s += "[CWaypointsNavigator]\n";
+  s += "max_distance_to_allow_skip_waypoint = -1\n";
+  s += "min_timesteps_confirm_skip_waypoints = 1\n";
+  s += "waypoint_angle_tolerance = 5.0\n";
+  s += "multitarget_look_ahead = 0\n";
+  s += "minimum_target_approach_per_step = 0.02\n";
+
+  s += "[CAbstractPTGBasedReactive]\n";
+  s += "robotMax_V_mps = 1.0\n";
+  s += "robotMax_W_degps = 60.0\n";
+  s += "holonomic_method = CHolonomicVFF\n";
+  s += "motion_decider_method = CMultiObjMotionOpt_Scalarization\n";
+  s += "ref_distance = 4.0\n";
+  s += "speedfilter_tau = " + std::to_string(speedFilterTau) + "\n";
+  s += "secure_distance_start = 0.05\n";
+  s += "secure_distance_end = 0.15\n";
+  s += std::string("use_delays_model = ") + (useDelaysModel ? "true" : "false") + "\n";
+  s += "max_distance_predicted_actual_path = 0.15\n";
+  s += "min_normalized_free_space_for_ptg_continuation = 0.2\n";
+  s += std::string("enable_obstacle_filtering = ") + (obstacleFiltering ? "true" : "false") + "\n";
+  s += std::string("evaluate_clearance = ") + (evaluateClearance ? "true" : "false") + "\n";
+
+  s += "[CPointCloudFilterByDistance]\n";
+  s += "min_dist = 0.1\n";
+  s += "angle_tolerance = 5.0\n";
+  s += "too_old_seconds = 1.0\n";
+  s += "previous_keyframes = 1\n";
+  s += "max_deletion_ratio = 0.4\n";
+
+  s += "[CHolonomicVFF]\n";
+  s += "TARGET_SLOW_APPROACHING_DISTANCE = 0.10\n";
+  s += "TARGET_ATTRACTIVE_FORCE = 20.0\n";
+
+  s += "[CHolonomicND]\n";
+  s += "WIDE_GAP_SIZE_PERCENT = 0.25\n";
+  s += "MAX_SECTOR_DIST_FOR_D2_PERCENT = 0.25\n";
+  s += "RISK_EVALUATION_SECTORS_PERCENT = 0.10\n";
+  s += "RISK_EVALUATION_DISTANCE = 0.4\n";
+  s += "TOO_CLOSE_OBSTACLE = 0.15\n";
+  s += "TARGET_SLOW_APPROACHING_DISTANCE = 0.6\n";
+  s += "factorWeights = 1.00 0.50 2.00 0.40\n";
+
+  s += "[CMultiObjectiveMotionOptimizerBase]\n";
+  s += "score1_name = collision_free_distance_score\n";
+  s += "score1_formula = collision_free_distance\n";
+  s += "score2_name = euclidean_nearness\n";
+  s += "score2_formula = 1/(1+dist_eucl_min^2)\n";
+  s += "scores_to_normalize = \n";
+
+  s += "[CMultiObjMotionOpt_Scalarization]\n";
+  s += "scalar_score_formula = 0.5*collision_free_distance_score + 8.0*euclidean_nearness\n";
+
+  s += "[CReactiveNavigationSystem]\n";
+  s += "min_obstacles_height = 0.0\n";
+  s += "max_obstacles_height = 10.0\n";
+  s += "PTG_COUNT = 1\n";
+  s += "PTG0_Type = CPTG_Holo_Blend\n";
+  s += "PTG0_refDistance = 4.0\n";
+  s += "PTG0_num_paths = 31\n";
+  s += "PTG0_v_max_mps = 1.0\n";
+  s += "PTG0_w_max_dps = 60\n";
+  s += "PTG0_T_ramp_max = 0.8\n";
+  s += "PTG0_score_priority = 1.0\n";
+  s += "RobotModel_circular_shape_radius = 0.3\n";
+  return s;
+}
+
+struct RNavFixture
+{
+  mrpt::kinematics::CVehicleSimul_Holo simul;
+  HoloSimRobot robot{simul};
+  std::unique_ptr<CReactiveNavigationSystem> nav;
+
+  void build(const std::string& cfgText)
+  {
+    nav = std::make_unique<CReactiveNavigationSystem>(robot, false /*no console output*/);
+    nav->enableTimeLog(false);
+    nav->setMinLoggingLevel(mrpt::system::LVL_ERROR);
+
+    mrpt::config::CConfigFileMemory cfg(cfgText);
+    nav->loadConfigFile(cfg);
+    nav->initialize();
+  }
+
+  /** Runs the navigation loop under a simulated clock. */
+  void run(const mrpt::math::TPoint2D& target, unsigned int maxIters = 60)
+  {
+    CAbstractNavigator::TNavigationParams np;
+    np.target.target_coords = mrpt::math::TPose2D(target.x, target.y, .0);
+    np.target.targetAllowedDistance = 0.4f;
+    nav->navigate(&np);
+
+    const auto savedClock = mrpt::Clock::getActiveClock();
+    mrpt::Clock::setSimulatedTime(mrpt::Clock::now());
+    mrpt::Clock::setActiveClock(mrpt::Clock::Simulated);
+
+    const auto dt = std::chrono::milliseconds(200);
+    for (unsigned int i = 0; i < maxIters; i++)
+    {
+      nav->navigationStep();
+      if (nav->getCurrentState() == CAbstractNavigator::TState::IDLE) break;
+      simul.simulateOneTimeStep(0.2);
+      mrpt::Clock::setSimulatedTime(mrpt::Clock::now() + dt);
+    }
+    mrpt::Clock::setActiveClock(savedClock);
+
+    using mrpt::system::CTimeLogger;
+    const_cast<CTimeLogger&>(nav->getTimeLogger()).clear(true);
+    const_cast<CTimeLogger&>(nav->getDelaysTimeLogger()).clear(true);
+  }
+
+  double distToTarget(const mrpt::math::TPoint2D& target) const
+  {
+    return (mrpt::math::TPoint2D(simul.getCurrentGTPose()) - target).norm();
+  }
+};
+}  // namespace
+
+TEST(RNavVariants, plain_run_reaches_the_target)
+{
+  RNavFixture f;
+  f.build(make_rnav_config(false, false, .0, true));
+  EXPECT_EQ(f.nav->getPTG_count(), 1U);
+  ASSERT_NE(f.nav->getPTG(0), nullptr);
+  EXPECT_TRUE(f.nav->getPTG(0)->supportVelCmdNOP());
+
+  const mrpt::math::TPoint2D trg(2.0, 0.5);
+  f.run(trg);
+  EXPECT_LT(f.distToTarget(trg), 0.5);
+  EXPECT_EQ(f.nav->getCurrentState(), CAbstractNavigator::TState::IDLE);
+}
+
+TEST(RNavVariants, delays_model_run)
+{
+  RNavFixture f;
+  f.build(make_rnav_config(true /*use_delays_model*/, false, .0, true));
+
+  const mrpt::math::TPoint2D trg(2.0, .0);
+  f.run(trg);
+  EXPECT_LT(f.distToTarget(trg), 0.6);
+}
+
+TEST(RNavVariants, clearance_evaluation_run)
+{
+  RNavFixture f;
+  f.build(make_rnav_config(false, true /*evaluate_clearance*/, .0, true));
+  f.robot.obstacles = {{1.0, 1.0}, {1.0, -1.0}, {1.5, 1.2}};
+
+  const mrpt::math::TPoint2D trg(2.0, .0);
+  f.run(trg);
+  EXPECT_LT(f.distToTarget(trg), 0.6);
+}
+
+TEST(RNavVariants, velocity_filtering_run)
+{
+  RNavFixture f;
+  f.build(make_rnav_config(false, false, 0.2 /*speedfilter_tau*/, true));
+
+  const mrpt::math::TPoint2D trg(2.0, .0);
+  f.run(trg);
+  EXPECT_LT(f.distToTarget(trg), 0.6);
+}
+
+TEST(RNavVariants, obstacle_filtering_disabled_run)
+{
+  RNavFixture f;
+  f.build(make_rnav_config(false, false, .0, false /*enable_obstacle_filtering*/));
+  f.robot.obstacles = {{1.0, 1.0}, {1.0, -1.0}};
+
+  const mrpt::math::TPoint2D trg(2.0, .0);
+  f.run(trg);
+  EXPECT_LT(f.distToTarget(trg), 0.6);
+}
+
+TEST(RNavVariants, log_records_are_kept_and_written)
+{
+  RNavFixture f;
+  f.build(make_rnav_config(false, false, .0, true));
+
+  const std::string dir = mrpt::system::getTempFileName() + std::string("_rnavlog");
+  f.nav->setLogFileDirectory(dir);
+  f.nav->enableLogFile(true);
+  f.nav->enableKeepLogRecords(true);
+
+  const mrpt::math::TPoint2D trg(2.0, .0);
+  f.run(trg, 15);
+
+  CLogFileRecord rec;
+  f.nav->getLastLogRecord(rec);
+  EXPECT_GT(rec.nPTGs, 0U);
+  EXPECT_FALSE(rec.infoPerPTG.empty());
+  EXPECT_FALSE(rec.values.empty());
+
+  f.nav->enableLogFile(false);
+  EXPECT_TRUE(mrpt::system::fileExists(dir + "/log_000.reactivenavlog"));
+  mrpt::system::deleteFilesInDirectory(dir, true);
+}
+
+TEST(RNavVariants, waypoint_navigation_run)
+{
+  RNavFixture f;
+  f.build(make_rnav_config(false, false, .0, true));
+  f.robot.obstacles = {{1.0, 1.0}, {1.0, -1.0}};
+
+  TWaypointSequence seq;
+  // Note the explicit `speed_ratio`: with the default (1.0, i.e. "arrive at
+  // full speed") this holonomic-PTG setup finds no viable movement at all.
+  seq.waypoints.emplace_back(1.0, .0, 0.4, true, std::nullopt, 0.05 /*speed_ratio*/);
+  seq.waypoints.emplace_back(2.0, .0, 0.4, true, std::nullopt, 0.05);
+  f.nav->navigateWaypoints(seq);
+
+  const auto savedClock = mrpt::Clock::getActiveClock();
+  mrpt::Clock::setSimulatedTime(mrpt::Clock::now());
+  mrpt::Clock::setActiveClock(mrpt::Clock::Simulated);
+
+  const auto dt = std::chrono::milliseconds(200);
+  for (unsigned int i = 0; i < 200; i++)
+  {
+    f.nav->navigationStep();
+    if (f.nav->getWaypointNavStatus().final_goal_reached) break;
+    f.simul.simulateOneTimeStep(0.2);
+    mrpt::Clock::setSimulatedTime(mrpt::Clock::now() + dt);
+  }
+  mrpt::Clock::setActiveClock(savedClock);
+
+  using mrpt::system::CTimeLogger;
+  const_cast<CTimeLogger&>(f.nav->getTimeLogger()).clear(true);
+  const_cast<CTimeLogger&>(f.nav->getDelaysTimeLogger()).clear(true);
+
+  EXPECT_TRUE(f.nav->getWaypointNavStatus().final_goal_reached)
+      << f.nav->getWaypointNavStatus().getAsText();
+}
+
+TEST(RNavVariants, restricting_the_usable_ptgs)
+{
+  RNavFixture f;
+  f.build(make_rnav_config(false, false, .0, true));
+
+  CAbstractPTGBasedReactive::TNavigationParamsPTG np;
+  np.target.target_coords = mrpt::math::TPose2D(2.0, .0, .0);
+  np.target.targetAllowedDistance = 0.4f;
+  np.restrict_PTG_indices.push_back(0);
+
+  EXPECT_NE(np.getAsText().find("restrict_PTG_indices"), std::string::npos);
+
+  auto cloned = np.clone();
+  ASSERT_TRUE(cloned);
+  EXPECT_TRUE(np == *cloned);
+
+  CAbstractPTGBasedReactive::TNavigationParamsPTG other;
+  EXPECT_FALSE(np == other);
+
+  f.nav->navigate(&np);
+  EXPECT_NO_THROW(f.nav->navigationStep());
+}
+
+TEST(RNavVariants, a_failing_obstacle_sensor_stops_the_robot)
+{
+  RNavFixture f;
+  f.build(make_rnav_config(false, false, .0, true));
+  f.robot.senseSucceeds = false;
+
+  CAbstractNavigator::TNavigationParams np;
+  np.target.target_coords = mrpt::math::TPose2D(2.0, .0, .0);
+  np.target.targetAllowedDistance = 0.4f;
+  f.nav->navigate(&np);
+  f.nav->navigationStep();
+
+  EXPECT_EQ(f.nav->getCurrentState(), CAbstractNavigator::TState::NAV_ERROR);
+}
+
+TEST(RNavVariants, navigating_before_initialize_is_rejected)
+{
+  mrpt::kinematics::CVehicleSimul_Holo simul;
+  HoloSimRobot robot{simul};
+  CReactiveNavigationSystem nav(robot, false);
+  nav.setMinLoggingLevel(mrpt::system::LVL_ERROR);
+  nav.enableTimeLog(false);
+  nav.enableRethrowNavExceptions(true);
+
+  CAbstractNavigator::TNavigationParams np;
+  np.target.target_coords = mrpt::math::TPose2D(1, 0, 0);
+  nav.navigate(&np);
+  EXPECT_ANY_THROW(nav.navigationStep());
+}
+
+TEST(RNavVariants, holonomic_method_can_be_switched_at_runtime)
+{
+  RNavFixture f;
+  f.build(make_rnav_config(false, false, .0, true));
+
+  mrpt::config::CConfigFileMemory cfg(make_rnav_config(false, false, .0, true));
+  EXPECT_NO_THROW(f.nav->setHolonomicMethod("CHolonomicND", cfg));
+  EXPECT_NO_THROW(f.nav->setHolonomicMethod("CHolonomicVFF", cfg));
+  EXPECT_ANY_THROW(f.nav->setHolonomicMethod("NoSuchHolonomicMethod", cfg));
+}
+
+TEST(RNavVariants, config_file_roundtrip)
+{
+  RNavFixture f;
+  f.build(make_rnav_config(true, true, 0.3, false));
+
+  mrpt::config::CConfigFileMemory out;
+  f.nav->saveConfigFile(out);
+
+  EXPECT_TRUE(out.sectionExists("CAbstractPTGBasedReactive"));
+  EXPECT_NEAR(
+      out.read_double("CAbstractPTGBasedReactive", "speedfilter_tau", -1.0), 0.3, 1e-6);
+  EXPECT_TRUE(out.read_bool("CAbstractPTGBasedReactive", "use_delays_model", false));
+  EXPECT_TRUE(out.read_bool("CAbstractPTGBasedReactive", "evaluate_clearance", false));
+  EXPECT_FALSE(out.read_bool("CAbstractPTGBasedReactive", "enable_obstacle_filtering", true));
+}
+
+TEST(RNavVariants, target_approach_slowdown_distance_is_forwarded_to_the_holo_method)
+{
+  RNavFixture f;
+  f.build(make_rnav_config(false, false, .0, true));
+  EXPECT_NO_THROW(f.nav->setTargetApproachSlowDownDistance(0.55));
+}
+
+TEST(RNavVariants, changing_the_robot_shape_after_initialization)
+{
+  RNavFixture f;
+  f.build(make_rnav_config(false, false, .0, true));
+
+  mrpt::math::CPolygon shape;
+  shape.add_vertex(-0.2, 0.2);
+  shape.add_vertex(0.2, 0.2);
+  shape.add_vertex(0.2, -0.2);
+  shape.add_vertex(-0.2, -0.2);
+  EXPECT_NO_THROW(f.nav->changeRobotShape(shape));
+
+  // A degenerate shape is rejected:
+  mrpt::math::CPolygon tooFew;
+  tooFew.add_vertex(0, 0);
+  tooFew.add_vertex(1, 0);
+  EXPECT_ANY_THROW(f.nav->changeRobotShape(tooFew));
+}

--- a/modules/mrpt_nav/tests/rnav_variants_unittest.cpp
+++ b/modules/mrpt_nav/tests/rnav_variants_unittest.cpp
@@ -219,7 +219,11 @@ TEST(RNavVariants, clearance_evaluation_run)
 {
   RNavFixture f;
   f.build(make_rnav_config(false, true /*evaluate_clearance*/, .0, true));
-  f.robot.obstacles = {{1.0, 1.0}, {1.0, -1.0}, {1.5, 1.2}};
+  f.robot.obstacles = {
+      {1.0,  1.0},
+      {1.0, -1.0},
+      {1.5,  1.2}
+  };
 
   const mrpt::math::TPoint2D trg(2.0, .0);
   f.run(trg);
@@ -240,7 +244,10 @@ TEST(RNavVariants, obstacle_filtering_disabled_run)
 {
   RNavFixture f;
   f.build(make_rnav_config(false, false, .0, false /*enable_obstacle_filtering*/));
-  f.robot.obstacles = {{1.0, 1.0}, {1.0, -1.0}};
+  f.robot.obstacles = {
+      {1.0,  1.0},
+      {1.0, -1.0}
+  };
 
   const mrpt::math::TPoint2D trg(2.0, .0);
   f.run(trg);
@@ -275,7 +282,10 @@ TEST(RNavVariants, waypoint_navigation_run)
 {
   RNavFixture f;
   f.build(make_rnav_config(false, false, .0, true));
-  f.robot.obstacles = {{1.0, 1.0}, {1.0, -1.0}};
+  f.robot.obstacles = {
+      {1.0,  1.0},
+      {1.0, -1.0}
+  };
 
   TWaypointSequence seq;
   // Note the explicit `speed_ratio`: with the default (1.0, i.e. "arrive at
@@ -379,8 +389,7 @@ TEST(RNavVariants, config_file_roundtrip)
   f.nav->saveConfigFile(out);
 
   EXPECT_TRUE(out.sectionExists("CAbstractPTGBasedReactive"));
-  EXPECT_NEAR(
-      out.read_double("CAbstractPTGBasedReactive", "speedfilter_tau", -1.0), 0.3, 1e-6);
+  EXPECT_NEAR(out.read_double("CAbstractPTGBasedReactive", "speedfilter_tau", -1.0), 0.3, 1e-6);
   EXPECT_TRUE(out.read_bool("CAbstractPTGBasedReactive", "use_delays_model", false));
   EXPECT_TRUE(out.read_bool("CAbstractPTGBasedReactive", "evaluate_clearance", false));
   EXPECT_FALSE(out.read_bool("CAbstractPTGBasedReactive", "enable_obstacle_filtering", true));


### PR DESCRIPTION
## Summary

Raises unit-test coverage of the navigation stack, targeting the two largest
pure-logic blind spots left in the per-module table of `agents.md`:

| Module | Lines before | Lines after | Branches before | Branches after |
|---|---|---|---|---|
| `mrpt_nav` | 63.0% | **90.0%** | 45.3% | 69.3% |
| `mrpt_kinematics` | 38.2% | **96.8%** | 17.9% | 83.5% |

`mrpt_kinematics` had **no C++ unit tests at all** (only a Python bindings
smoke test); `mrpt_nav`'s were limited to a handful of reactive-navigation
integration runs plus a few data-structure checks.

Measured with the recipe documented in `agents.md` (whole-repo
`colcon build -DENABLE_COVERAGE=ON` + `colcon test` + `gcovr`, deduplicated
with `scripts/coverage_module_report.py`).

## New test files

**`mrpt_kinematics`** (new `UNIT_TEST_SOURCES` list — the module had none):
- `CVehicleVelCmd_unittest.cpp` — both kinematic models: component
  accessors and their out-of-range throws, stop detection, scaling,
  `cmdVel_limits()` clipping/blending, serialization, `TVelCmdParams`
  config round-trip.
- `CVehicleSimul_unittest.cpp` — differential-driven and holonomic
  simulators: straight/rotational motion, local vs. global velocities, the
  first-order delay model, odometry error injection, reset semantics, and
  the wrong-kinematic-class rejection paths.
- `CKinematicChain_unittest.cpp` — link management, DH forward kinematics
  (revolute and prismatic), origin pose, configuration vectors,
  serialization, and the 3D visualization helpers.

**`mrpt_nav`**:
- `PTG_variants_unittest.cpp` — the whole PTG family, including
  `CPTG_DiffDrive_CC` / `_CS` / `_CCS`, which no test had ever instantiated
  (~2% line coverage each), plus the shared base services: config and stream
  round-trips, TP-space index mapping, clearance diagrams, `debugDumpInFiles()`,
  path/robot-shape rendering, and the legacy numeric PTG names.
- `CAbstractNavigator_unittest.cpp` — the navigation state machine driven by
  a recording mock robot: every state transition, the error paths, the
  blocked-target and not-approaching alarms, and the waypoint-sequence layer
  (skip policy, non-skippable waypoints, look-ahead, heading alignment).
- `TWaypoint_unittest.cpp` — waypoint text/config/visualization round-trips.
- `nav_misc_unittest.cpp` — `ClearanceDiagram`, the arc-vs-circular-robot
  collision helper, the default `CRobot2NavInterface` callbacks,
  `NavigationLogger`, `VelocityFilter` and the multi-objective optimizers.
- `planners_and_logs_unittest.cpp` — the RRT move-tree 3D renderer
  (`impl_renderMoveTree.h`, previously 0%), planner configuration variants,
  and a fully-populated `CLogFileRecord` round-trip.
- `holonomic_config_unittest.cpp` — config/serialization/log-record coverage
  for `CHolonomicVFF` / `ND` / `FullEval`.
- `rnav_variants_unittest.cpp` — reactive-navigation runs from fully
  in-memory configs (so they cannot silently skip when the shared config
  files are absent), exercising the delays model, clearance evaluation,
  velocity filtering, disabled obstacle filtering, log-record keeping and
  file writing, and — via a `CPTG_Holo_Blend` — the "NOP cmdvel"
  PTG-continuation branches that the differential-drive PTGs cannot reach.

Both modules now meet the 90% line-coverage goal stated in `agents.md`.
294 new/extended test cases across 11 files; all 78 module test suites pass.

## Bugs found and fixed

1. **`CVehicleVelCmd` copy constructor called a pure virtual method.**
   It delegated to `operator=()`, which dispatches `getVelCmdLength()` /
   `setVelCmdElement()` while the derived object is still under
   construction. Copy-constructing *any* velocity command aborted the
   process (`pure virtual method called`). The base class holds no data, so
   the copy constructor is now `= default`.

2. **`CAbstractNavigator` threw on the first step of every waypoint mission
   and every relative-target navigation.**
   `internal_onStartNewNavigation()` cleared the cached pose history but left
   `m_last_curPoseVelUpdate_robot_time` untouched, so the
   `updateCurrentPoseAndSpeeds()` call right after it was skipped by its
   20 ms minimum-period throttle and the cache stayed empty; the following
   `ASSERT_(!m_latestPoses.empty())` then threw. The exception was swallowed
   (see the next item), so the symptom was a silently lost first navigation
   step.

3. **`NAV_ERROR` could never be reached.**
   `performNavigationStepNavigating()` ended with
   `m_navigationState = prevState;`, restoring the state it had on entry and
   undoing the transitions it had just decided — neither an exception nor
   `doEmergencyStop()` could leave the navigator in `NAV_ERROR`. The
   assignment was clearly meant for `m_lastNavigationState`, mirroring
   `navigationStep()` a few hundred lines above.

4. **Null-pointer dereference in `CWaypointsNavigator::checkHasReachedTarget()`.**
   `(wp == nullptr && targetDist <= allowed) || (wp->reached)` dereferences
   `wp` whenever it is null *and* the robot is farther than the allowed
   distance — reachable e.g. after emptying the list through
   `getWaypointsAccessGuard()`.

5. **`CParameterizedTrajectoryGenerator::Alpha2index()` discarded
   `wrapToPi()`'s result** (it returns by value), so directions outside
   `[-pi,pi]` were clamped to the first or last path instead of wrapping
   around.

6. **`CMultiObjectiveMotionOptimizerBase::decide()` returned `-1` from a
   function returning `std::optional<size_t>`** when a user score/assert
   formula failed to compile. That is an *engaged* optional holding
   `SIZE_MAX`, so instead of the documented "no valid candidate" the caller
   indexed the candidate vector out of bounds.

7. **`CMultiObjectiveMotionOptimizerBase::clear()` left the variable table
   behind**, so the next `decide()` threw *"Expression name already exists
   as an input variable"* — i.e. the documented way to re-apply changed
   parameters was unusable.

8. **`CLogFileRecord`'s legacy (pre-v15) deserialization wrote velocity
   command components into the wrong slots**: one loop indexed with the
   outer loop variable, and the oldest format wrote both `v` and `w` into
   element 0.

9. **`CReactiveNavigationSystem3D::saveConfigFile()` never called its parent.**
   Unlike its 2D sibling, and contrary to the documented contract
   ("derived classes must call the parent implementation"), so saving a 3D
   navigator's configuration produced a stub with only `HEIGHT_LEVELS` and
   `PTG_COUNT` that could not be loaded back.

10. **`PlannerSimple2D::computePath()`'s endpoint bounds check was inverted.**
    `!(originInside || !targetInside)` flags exactly one of the four cases,
    and the wrong one: it only reported `notFound` when the origin was outside
    *and* the target inside, letting an out-of-grid target (or both endpoints
    out of grid) fall through into the grid search.

## Observations left for a follow-up (not changed here)

- `CWaypointsNavigator::m_last_alignment_cmd` is set in the constructor and
  never updated when an alignment command is issued, so the
  "give the alignment some time to finish" wait actually measures time since
  the navigator was constructed. Fixing it would add a real dwell at every
  waypoint with a heading, which is a behavioral change better made
  deliberately.
- With a `CPTG_Holo_Blend`, a waypoint left at the default
  `speed_ratio = 1.0` produces no viable movement at all and the mission
  eventually times out; `rnav_variants_unittest.cpp` sets an explicit
  `0.05` and notes this in a comment.
- `CKinematicChain::recomputeAllPoses()` advertises a `pose0` argument that
  the implementation marks `[[maybe_unused]]` and ignores in favour of
  `setOriginPose()`. Documented as such here rather than changing behavior;
  removing the parameter would be an API break.
- `agents.md`'s coverage table, overall figure and notes are updated to match,
  including the gotchas hit while writing these tests (the explicit
  `LIB_UNIT_TEST_SOURCES` list, `rnav_unittest.cpp` silently skipping when the
  shared config files are absent, the navigation-time throttle in
  `updateCurrentPoseAndSpeeds()`, and the per-PTG robot-shape requirements).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved navigation state transitions, pose updates, waypoint handling, angle normalization, legacy log loading, and configuration clearing.
  - Corrected navigation configuration persistence and velocity-command copying.

- **Tests**
  - Added extensive coverage for kinematics, navigation, planners, trajectory generators, waypoints, reactive navigation, interfaces, logging, serialization, and configuration behavior.

- **Documentation**
  - Clarified how kinematic-chain origin poses are applied.

- **Chores**
  - Refreshed coverage metrics and module tracking information.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->