### PR TITLE
test(mrpt_serialization,mrpt_rtti): unit tests for the archive and RTTI cores

### DIFF
--- a/modules/mrpt_rtti/CMakeLists.txt
+++ b/modules/mrpt_rtti/CMakeLists.txt
@@ -24,6 +24,7 @@ set(LIB_SOURCES
 
 set(LIB_UNIT_TEST_SOURCES
   tests/rtti_unittest.cpp
+  tests/rtti_registry_unittest.cpp
 )
 
 set(LIB_PUBLIC_HEADERS

--- a/modules/mrpt_rtti/tests/rtti_registry_unittest.cpp
+++ b/modules/mrpt_rtti/tests/rtti_registry_unittest.cpp
@@ -1,0 +1,347 @@
+/*                    _
+                     | |    Mobile Robot Programming Toolkit (MRPT)
+ _ __ ___  _ __ _ __ | |_
+| '_ ` _ \| '__| '_ \| __|          https://www.mrpt.org/
+| | | | | | |  | |_) | |_
+|_| |_| |_|_|  | .__/ \__|     https://github.com/MRPT/mrpt/
+               | |
+               |_|
+
+ Copyright (c) 2005-2026, Individual contributors, see AUTHORS file
+ See: https://www.mrpt.org/Authors - All rights reserved.
+ SPDX-License-Identifier: BSD-3-Clause
+*/
+
+#include <gtest/gtest.h>
+#include <mrpt/rtti/CListOfClasses.h>
+#include <mrpt/rtti/CObject.h>
+
+#include <algorithm>
+#include <string>
+
+namespace RegNS
+{
+/** A virtual (non-instantiable) base, to exercise the DEFINE_VIRTUAL_MRPT_OBJECT
+ * path and the "no dynamic constructor" branch of createObject(). */
+class VirtBase : public mrpt::rtti::CObject
+{
+  DEFINE_VIRTUAL_MRPT_OBJECT(VirtBase, RegNS)
+};
+
+class Leaf : public VirtBase
+{
+ public:
+  int m_value{0};
+
+  Leaf() = default;
+  Leaf(int v) : m_value(v) {}
+  DEFINE_MRPT_OBJECT(Leaf, RegNS)
+};
+
+/** A class without a copy constructor, to exercise CopyCtor<false>::clone(). */
+class NonCopyable : public mrpt::rtti::CObject
+{
+ public:
+  NonCopyable() = default;
+  ~NonCopyable() override = default;
+  NonCopyable(const NonCopyable&) = delete;
+  NonCopyable& operator=(const NonCopyable&) = delete;
+  NonCopyable(NonCopyable&&) = default;
+  NonCopyable& operator=(NonCopyable&&) = default;
+  DEFINE_MRPT_OBJECT(NonCopyable, RegNS)
+};
+
+/** A bare CObject descendant, i.e. without the DEFINE_MRPT_OBJECT machinery. */
+class PlainObject : public mrpt::rtti::CObject
+{
+ public:
+  [[nodiscard]] mrpt::rtti::CObject* clone() const override { return new PlainObject(*this); }
+};
+
+}  // namespace RegNS
+
+IMPLEMENTS_VIRTUAL_MRPT_OBJECT(VirtBase, mrpt::rtti::CObject, RegNS)
+IMPLEMENTS_MRPT_OBJECT(Leaf, RegNS::VirtBase, RegNS)
+IMPLEMENTS_MRPT_OBJECT(NonCopyable, mrpt::rtti::CObject, RegNS)
+
+namespace
+{
+/** Registers this file's classes exactly once, whatever test runs first. */
+void registerTestClasses()
+{
+  static const bool done = []()
+  {
+    mrpt::rtti::registerClass(CLASS_ID_NAMESPACE(VirtBase, RegNS));
+    mrpt::rtti::registerClass(CLASS_ID_NAMESPACE(Leaf, RegNS));
+    mrpt::rtti::registerClass(CLASS_ID_NAMESPACE(NonCopyable, RegNS));
+    return true;
+  }();
+  (void)done;
+}
+
+bool listContains(
+    const std::vector<const mrpt::rtti::TRuntimeClassId*>& lst, const std::string& className)
+{
+  return std::any_of(
+      lst.begin(), lst.end(),
+      [&](const mrpt::rtti::TRuntimeClassId* id) { return className == id->className; });
+}
+}  // namespace
+
+TEST(rtti_registry, findRegisteredClass)
+{
+  registerTestClasses();
+
+  const auto* id = mrpt::rtti::findRegisteredClass("RegNS::Leaf");
+  ASSERT_NE(id, nullptr);
+  EXPECT_EQ(id, CLASS_ID(RegNS::Leaf));
+
+  // Unregistered names always yield nullptr:
+  EXPECT_EQ(mrpt::rtti::findRegisteredClass("RegNS::NotAClass"), nullptr);
+}
+
+TEST(rtti_registry, findRegisteredClassIgnoringNamespace)
+{
+  registerTestClasses();
+
+  // Datasets older than MRPT v2.0 stored class names without namespace, which
+  // is why the namespace-less lookup is enabled by default:
+  EXPECT_EQ(mrpt::rtti::findRegisteredClass("Leaf"), CLASS_ID(RegNS::Leaf));
+
+  // ...and can be disabled for strictly-namespaced streams:
+  EXPECT_EQ(mrpt::rtti::findRegisteredClass("Leaf", false), nullptr);
+
+  // A fully-qualified name must not depend on the fallback either:
+  EXPECT_EQ(mrpt::rtti::findRegisteredClass("RegNS::Leaf", false), CLASS_ID(RegNS::Leaf));
+}
+
+TEST(rtti_registry, registerClassCustomName)
+{
+  registerTestClasses();
+
+  mrpt::rtti::registerClassCustomName("AnAliasForLeaf", CLASS_ID(RegNS::Leaf));
+
+  EXPECT_EQ(mrpt::rtti::findRegisteredClass("AnAliasForLeaf"), CLASS_ID(RegNS::Leaf));
+
+  auto o = mrpt::rtti::classFactory("AnAliasForLeaf");
+  ASSERT_TRUE(o);
+  EXPECT_TRUE(IS_CLASS(*o, RegNS::Leaf));
+}
+
+TEST(rtti_registry, getAllRegisteredClasses)
+{
+  registerTestClasses();
+
+  const auto lst = mrpt::rtti::getAllRegisteredClasses();
+  EXPECT_FALSE(lst.empty());
+  EXPECT_TRUE(listContains(lst, "RegNS::Leaf"));
+  EXPECT_TRUE(listContains(lst, "RegNS::VirtBase"));
+}
+
+TEST(rtti_registry, getAllRegisteredClassesChildrenOf)
+{
+  registerTestClasses();
+
+  {
+    const auto lst = mrpt::rtti::getAllRegisteredClassesChildrenOf(CLASS_ID(RegNS::VirtBase));
+    EXPECT_TRUE(listContains(lst, "RegNS::Leaf"));
+    // The parent itself is never part of its own children list:
+    EXPECT_FALSE(listContains(lst, "RegNS::VirtBase"));
+    EXPECT_FALSE(listContains(lst, "RegNS::NonCopyable"));
+  }
+  {
+    // A leaf class has no children:
+    const auto lst = mrpt::rtti::getAllRegisteredClassesChildrenOf(CLASS_ID(RegNS::Leaf));
+    EXPECT_FALSE(listContains(lst, "RegNS::Leaf"));
+  }
+}
+
+TEST(rtti_registry, classFactoryUnknownName)
+{
+  EXPECT_EQ(mrpt::rtti::classFactory("RegNS::ThisDoesNotExist"), nullptr);
+}
+
+TEST(rtti_registry, createObjectOfVirtualClass)
+{
+  registerTestClasses();
+
+  // A DEFINE_VIRTUAL_MRPT_OBJECT class has no ptrCreateObject: creating it
+  // must fail gracefully with an empty pointer, not crash.
+  EXPECT_FALSE(CLASS_ID(RegNS::VirtBase)->createObject());
+  EXPECT_EQ(mrpt::rtti::classFactory("RegNS::VirtBase"), nullptr);
+}
+
+TEST(rtti_registry, derivedFromByName)
+{
+  registerTestClasses();
+
+  const auto* leaf = CLASS_ID(RegNS::Leaf);
+
+  EXPECT_TRUE(leaf->derivedFrom("RegNS::Leaf"));  // same class
+  EXPECT_TRUE(leaf->derivedFrom("RegNS::VirtBase"));
+  EXPECT_FALSE(leaf->derivedFrom("RegNS::NonCopyable"));
+
+  // A class not derived from the given one, walking up to the root:
+  EXPECT_FALSE(CLASS_ID(mrpt::rtti::CObject)->derivedFrom("RegNS::Leaf"));
+
+  // Unregistered base names are a programming error. Note that the root class
+  // mrpt::rtti::CObject is itself never registered, so it cannot be used as
+  // the argument of this by-name overload (use the TRuntimeClassId one):
+  EXPECT_ANY_THROW(leaf->derivedFrom("RegNS::ThisDoesNotExist"));
+  EXPECT_ANY_THROW(leaf->derivedFrom("mrpt::rtti::CObject"));
+}
+
+TEST(rtti_registry, derivedFromById)
+{
+  registerTestClasses();
+
+  const auto* leaf = CLASS_ID(RegNS::Leaf);
+
+  EXPECT_TRUE(leaf->derivedFrom(CLASS_ID(RegNS::Leaf)));
+  EXPECT_TRUE(leaf->derivedFrom(CLASS_ID(RegNS::VirtBase)));
+  EXPECT_TRUE(leaf->derivedFrom(CLASS_ID(mrpt::rtti::CObject)));
+  EXPECT_FALSE(leaf->derivedFrom(CLASS_ID(RegNS::NonCopyable)));
+
+  EXPECT_ANY_THROW(leaf->derivedFrom(static_cast<const mrpt::rtti::TRuntimeClassId*>(nullptr)));
+}
+
+TEST(rtti_registry, cloneAndDuplicateGetSmartPtr)
+{
+  RegNS::Leaf o(42);
+
+  {
+    auto p = std::unique_ptr<mrpt::rtti::CObject>(o.clone());
+    ASSERT_TRUE(p);
+    EXPECT_TRUE(IS_CLASS(*p, RegNS::Leaf));
+    EXPECT_EQ(dynamic_cast<RegNS::Leaf&>(*p).m_value, 42);
+  }
+  {
+    auto p = o.duplicateGetSmartPtr();
+    ASSERT_TRUE(p);
+    EXPECT_EQ(std::dynamic_pointer_cast<RegNS::Leaf>(p)->m_value, 42);
+  }
+}
+
+TEST(rtti_registry, cloneNonCopyableThrows)
+{
+  RegNS::NonCopyable o;
+  EXPECT_ANY_THROW(o.clone());
+}
+
+TEST(rtti_registry, ptrCastFromBaseToDerived)
+{
+  mrpt::rtti::CObject::Ptr base = RegNS::Leaf::Create(7);
+
+  auto derived = mrpt::ptr_cast<RegNS::Leaf>::from(base);
+  ASSERT_TRUE(derived);
+  EXPECT_EQ(derived->m_value, 7);
+
+  // A cast to an unrelated class yields an empty pointer:
+  EXPECT_FALSE(mrpt::ptr_cast<RegNS::NonCopyable>::from(base));
+}
+
+TEST(rtti_registry, getClassNameAndClassNameMember)
+{
+  EXPECT_EQ(std::string(RegNS::Leaf::className), "RegNS::Leaf");
+  EXPECT_EQ(std::string(RegNS::Leaf::getClassName().c_str()), "RegNS::Leaf");
+}
+
+TEST(rtti_registry, listOfClassesMultipleEntries)
+{
+  registerTestClasses();
+
+  mrpt::rtti::CListOfClasses l;
+  l.insert(CLASS_ID(RegNS::Leaf));
+  l.insert(CLASS_ID(RegNS::NonCopyable));
+
+  // asString() is ordered by the underlying std::set (pointer order), so only
+  // check that both names show up with the documented ", " separator:
+  const std::string s = l.asString();
+  EXPECT_NE(s.find("RegNS::Leaf"), std::string::npos);
+  EXPECT_NE(s.find("RegNS::NonCopyable"), std::string::npos);
+  EXPECT_NE(s.find(", "), std::string::npos);
+
+  // ...and that it round-trips through fromString():
+  mrpt::rtti::CListOfClasses l2;
+  l2.fromString(s);
+  EXPECT_EQ(l2.data, l.data);
+}
+
+TEST(rtti_registry, listOfClassesFromStringTrimsBlanks)
+{
+  registerTestClasses();
+
+  mrpt::rtti::CListOfClasses l;
+  l.fromString("  RegNS::Leaf ,\tRegNS::NonCopyable  ");
+
+  EXPECT_EQ(l.data.size(), 2U);
+  EXPECT_TRUE(l.contains(CLASS_ID(RegNS::Leaf)));
+  EXPECT_TRUE(l.contains(CLASS_ID(RegNS::NonCopyable)));
+}
+
+TEST(rtti_registry, listOfClassesFromStringClearsPreviousContents)
+{
+  registerTestClasses();
+
+  mrpt::rtti::CListOfClasses l;
+  l.insert(CLASS_ID(RegNS::NonCopyable));
+  l.fromString("RegNS::Leaf");
+
+  EXPECT_EQ(l.data.size(), 1U);
+  EXPECT_TRUE(l.contains(CLASS_ID(RegNS::Leaf)));
+  EXPECT_FALSE(l.contains(CLASS_ID(RegNS::NonCopyable)));
+}
+
+TEST(rtti_registry, listOfClassesEmptyAsString)
+{
+  mrpt::rtti::CListOfClasses l;
+  EXPECT_EQ(l.asString(), "");
+}
+
+TEST(rtti_registry, listOfClassesContainsDerivedFrom)
+{
+  registerTestClasses();
+
+  mrpt::rtti::CListOfClasses l;
+  l.insert(CLASS_ID(RegNS::Leaf));
+
+  EXPECT_TRUE(l.containsDerivedFrom(CLASS_ID(RegNS::VirtBase)));
+  EXPECT_FALSE(l.containsDerivedFrom(CLASS_ID(RegNS::NonCopyable)));
+}
+
+TEST(rtti_registry, registerClassWithNullArguments)
+{
+  // Both are misuses that must warn instead of crashing:
+  EXPECT_NO_THROW(mrpt::rtti::registerClass(nullptr));
+
+  const mrpt::rtti::TRuntimeClassId noName{};
+  EXPECT_NO_THROW(mrpt::rtti::registerClass(&noName));
+}
+
+TEST(rtti_registry, registerCustomNameTwiceWithDifferentClasses)
+{
+  registerTestClasses();
+
+  // The second registration warns and wins:
+  mrpt::rtti::registerClassCustomName("ADuplicatedAlias", CLASS_ID(RegNS::Leaf));
+  mrpt::rtti::registerClassCustomName("ADuplicatedAlias", CLASS_ID(RegNS::NonCopyable));
+
+  EXPECT_EQ(mrpt::rtti::findRegisteredClass("ADuplicatedAlias"), CLASS_ID(RegNS::NonCopyable));
+
+  // Re-registering the very same class is not a conflict:
+  EXPECT_NO_THROW(
+      mrpt::rtti::registerClassCustomName("ADuplicatedAlias", CLASS_ID(RegNS::NonCopyable)));
+}
+
+TEST(rtti_registry, plainCObjectDescendantRuntimeClass)
+{
+  // A class deriving from CObject without DEFINE_MRPT_OBJECT inherits the base
+  // implementation of GetRuntimeClass():
+  RegNS::PlainObject o;
+  EXPECT_EQ(o.GetRuntimeClass(), CLASS_ID(mrpt::rtti::CObject));
+  EXPECT_TRUE(IS_CLASS(o, mrpt::rtti::CObject));
+
+  auto p = o.duplicateGetSmartPtr();
+  ASSERT_TRUE(p);
+  EXPECT_EQ(p->GetRuntimeClass(), CLASS_ID(mrpt::rtti::CObject));
+}

--- a/modules/mrpt_serialization/CMakeLists.txt
+++ b/modules/mrpt_serialization/CMakeLists.txt
@@ -26,6 +26,14 @@ set(LIB_SOURCES
   src/CSchemeArchive.cpp
 )
 
+set(LIB_UNIT_TEST_SOURCES
+  tests/serialization_test_types.cpp
+  tests/CArchive_unittest.cpp
+  tests/CMessage_unittest.cpp
+  tests/CSchemeArchive_unittest.cpp
+  tests/stl_serialization_unittest.cpp
+)
+
 set(LIB_PUBLIC_HEADERS
   include/mrpt/serialization/metaprogramming_serialization.h
   include/mrpt/serialization/optional_serialization.h
@@ -47,6 +55,7 @@ set(LIB_PUBLIC_HEADERS
 mrpt_add_library(
   TARGET ${PROJECT_NAME}
   SOURCES ${LIB_SOURCES} ${LIB_PUBLIC_HEADERS}
+  UNIT_TEST_SOURCES ${LIB_UNIT_TEST_SOURCES}
   PUBLIC_LINK_LIBRARIES
     mrpt::mrpt_rtti
 #  PRIVATE_LINK_LIBRARIES
@@ -66,13 +75,14 @@ else()
 	set(tst_json_dep "")
 endif()
 
-# NOTE: unit tests for this module are in other modules downstream, like "mrpt_io" or "mrpt_poses".
+# NOTE: additional unit tests for this module also live in downstream modules
+# like "mrpt_io" or "mrpt_poses", where actual CStream implementations exist.
 
 if (tst_json_dep)
   target_link_libraries(${PROJECT_NAME} PRIVATE ${tst_json_dep})
 
   if (TARGET test_mrpt_serialization)
-    target_link_libraries(test_mrpt_serialization ${tst_json_dep})
+    target_link_libraries(test_mrpt_serialization PRIVATE ${tst_json_dep})
   endif()
 endif()
 

--- a/modules/mrpt_serialization/src/CArchive.cpp
+++ b/modules/mrpt_serialization/src/CArchive.cpp
@@ -413,7 +413,9 @@ void CArchive::internal_ReadObjectHeader(
       version = static_cast<uint8_t>(version_old);
     }
     else if (
-        strClassName != "nullptr" &&
+        // Neither of these two carries a version byte, see WriteObject() and
+        // operator<<(const std::monostate&):
+        strClassName != "nullptr" && strClassName != "std::monostate" &&
         sizeof(version) != ReadBuffer(reinterpret_cast<void*>(&version), sizeof(version)))
     {
       THROW_EXCEPTION("Cannot read object streaming version from stream!");
@@ -433,7 +435,7 @@ void CArchive::internal_ReadObjectHeader(
 
     THROW_EXCEPTION_FMT(
         "Exception while parsing typed object '%s' from %s.\nOriginal exception:\n%s",
-        getArchiveDescription().c_str(), readClassName, e.what());
+        readClassName, getArchiveDescription().c_str(), e.what());
   }
 }  // end method
 
@@ -558,8 +560,10 @@ void CArchive::sendMessage(const CMessage& msg)
   }
   else
   {
-    buf[nBytesTx++] = msg.content.size() & 0xff;         // lo
+    // Note the order: the frame carries the high byte first, as documented
+    // in sendMessage() and as expected by receiveMessage():
     buf[nBytesTx++] = (msg.content.size() >> 8) & 0xff;  // hi
+    buf[nBytesTx++] = msg.content.size() & 0xff;         // lo
   }
 
   if (!msg.content.empty())
@@ -606,68 +610,65 @@ bool CArchive::receiveMessage(CMessage& msg)
       nBytesToRx = expectedLen - nBytesInFrame;
     }  // end else
 
-    unsigned long nBytesRx = 0;
-    try
+    // Read the missing bytes, if any. Note that a frame with an empty payload
+    // is already complete at this point, and reading zero bytes would be
+    // mistaken for an end-of-stream condition below:
+    if (nBytesToRx != 0)
     {
-      nBytesRx = ReadBuffer(&buf[nBytesInFrame], nBytesToRx);
-    }
-    catch (const std::exception& e)
-    {
-      std::cerr << "Error reading from stream: " << e.what() << "\n";
-    }
+      unsigned long nBytesRx = 0;
+      try
+      {
+        nBytesRx = ReadBuffer(&buf[nBytesInFrame], nBytesToRx);
+      }
+      catch (const std::exception& e)
+      {
+        std::cerr << "Error reading from stream: " << e.what() << "\n";
+      }
 
-    // No more data! (read timeout is already included in the call to
-    // "Read")
-    if (!nBytesRx)
-    {
-      return false;
-    }
-
-    if (!nBytesInFrame && buf[0] != 0x69 && buf[0] != 0x79)
-    {
-      // Start flag is invalid:
-      if (!tries--)
+      // No more data! (read timeout is already included in the call to
+      // "Read")
+      if (!nBytesRx)
       {
         return false;
       }
-    }
-    else
-    {
-      // Is a new byte for the frame:
-      nBytesInFrame += nBytesRx;
 
-      if (nBytesInFrame == expectedLen)
+      if (!nBytesInFrame && buf[0] != 0x69 && buf[0] != 0x79)
       {
-        // Frame complete
-        // check for frame be ok:
-
-        // End flag?
-        if (buf[nBytesInFrame - 1] != 0x96)
+        // Start flag is invalid: drop the byte and re-sync, up to a few times.
+        if (!tries--)
         {
-          // Error in frame!
           return false;
         }
-
-        // copy out data:
-        msg.type = buf[1];
-        if (buf[0] == 0x69)
-        {
-          msg.content.resize(payload_len);
-          if (!msg.content.empty())
-          {
-            std::memcpy(msg.content.data(), &buf[3], payload_len);
-          }
-        }  // end if
-        if (buf[0] == 0x79)
-        {
-          msg.content.resize(payload_len);
-          if (!msg.content.empty())
-          {
-            std::memcpy(msg.content.data(), &buf[4], payload_len);
-          }
-        }  // end if
-        return true;
+        continue;
       }
+
+      // Is a new byte for the frame:
+      nBytesInFrame += nBytesRx;
+    }
+
+    if (expectedLen != 0 && nBytesInFrame == expectedLen)
+    {
+      // Frame complete
+      // check for frame be ok:
+
+      // End flag?
+      if (buf[nBytesInFrame - 1] != 0x96)
+      {
+        // Error in frame!
+        return false;
+      }
+
+      // copy out data:
+      msg.type = buf[1];
+      msg.content.resize(payload_len);
+      if (!msg.content.empty())
+      {
+        // The payload starts right after the header, whose size depends on
+        // whether the "tiny" (1-byte length) format is in use:
+        const std::size_t payloadOffset = (buf[0] == 0x69) ? 3 : 4;
+        std::memcpy(msg.content.data(), &buf[payloadOffset], payload_len);
+      }
+      return true;
     }
   }
   MRPT_END

--- a/modules/mrpt_serialization/src/CArchive.cpp
+++ b/modules/mrpt_serialization/src/CArchive.cpp
@@ -27,6 +27,9 @@ using namespace mrpt::serialization;
 
 const uint8_t SERIALIZATION_END_FLAG = 0x88;
 
+/** Largest payload describable by sendMessage()'s 16-bit length field. */
+constexpr std::size_t MAX_MESSAGE_PAYLOAD_LEN = 0xffff;
+
 size_t CArchive::ReadBuffer(void* Buffer, size_t Count)
 {
   ASSERT_(Buffer != nullptr);
@@ -544,6 +547,16 @@ CArchive& mrpt::serialization::operator>>(CArchive& s, std::vector<std::string>&
 void CArchive::sendMessage(const CMessage& msg)
 {
   MRPT_START
+
+  // The frame's length field is 16 bits wide, so anything longer cannot be
+  // described by the format at all: without this check the length would
+  // silently wrap around and, past ~64 KiB, the payload copy below would run
+  // past the end of the frame buffer.
+  ASSERTMSG_(
+      msg.content.size() <= MAX_MESSAGE_PAYLOAD_LEN,
+      mrpt::format(
+          "Message payload is too long (%zu bytes) for the frame format (max: %u bytes)",
+          msg.content.size(), static_cast<unsigned int>(MAX_MESSAGE_PAYLOAD_LEN)));
 
   std::array<uint8_t, 0x10100> buf{};
   std::size_t nBytesTx = 0;

--- a/modules/mrpt_serialization/tests/CArchive_unittest.cpp
+++ b/modules/mrpt_serialization/tests/CArchive_unittest.cpp
@@ -1,0 +1,647 @@
+/*                    _
+                     | |    Mobile Robot Programming Toolkit (MRPT)
+ _ __ ___  _ __ _ __ | |_
+| '_ ` _ \| '__| '_ \| __|          https://www.mrpt.org/
+| | | | | | |  | |_) | |_
+|_| |_| |_|_|  | .__/ \__|     https://github.com/MRPT/mrpt/
+               | |
+               |_|
+
+ Copyright (c) 2005-2026, Individual contributors, see AUTHORS file
+ See: https://www.mrpt.org/Authors - All rights reserved.
+ SPDX-License-Identifier: BSD-3-Clause
+*/
+
+#include <gtest/gtest.h>
+#include <mrpt/serialization/CArchive.h>
+#include <mrpt/serialization/CSerializable.h>
+#include <mrpt/serialization/aligned_serialization.h>
+#include <mrpt/serialization/archiveFrom_std_streams.h>
+#include <mrpt/serialization/archiveFrom_std_vector.h>
+
+#include <cstdint>
+#include <sstream>
+#include <string>
+#include <vector>
+
+#include "serialization_test_types.h"
+
+using mrpt::serialization::archiveFrom;
+using mrpt::serialization::CArchive;
+using mrpt::serialization::CExceptionEOF;
+using mrpt::serialization::CSerializable;
+
+namespace
+{
+/** Appends the MRPT object-header bytes for the given class name (new format,
+ * i.e. with the 0x80 marker in the length byte). */
+void appendNewFormatHeader(std::vector<uint8_t>& v, const std::string& className)
+{
+  v.push_back(static_cast<uint8_t>(className.size() | 0x80));
+  v.insert(v.end(), className.begin(), className.end());
+}
+}  // namespace
+
+TEST(CArchive, podRoundTrip)
+{
+  std::vector<uint8_t> v;
+  auto a = archiveFrom(v);
+
+  const bool bo = true;
+  const int8_t i8 = -8;
+  const uint8_t u8 = 8;
+  const int16_t i16 = -1600;
+  const uint16_t u16 = 1600;
+  const int32_t i32 = -320000;
+  const uint32_t u32 = 320000;
+  const int64_t i64 = -640000000000LL;
+  const uint64_t u64 = 640000000000ULL;
+  const float f = 1.5f;
+  const double d = -2.25;
+  const long double ld = 3.125L;
+
+  a << bo << i8 << u8 << i16 << u16 << i32 << u32 << i64 << u64 << f << d << ld;
+
+  bool r_bo = false;
+  int8_t r_i8 = 0;
+  uint8_t r_u8 = 0;
+  int16_t r_i16 = 0;
+  uint16_t r_u16 = 0;
+  int32_t r_i32 = 0;
+  uint32_t r_u32 = 0;
+  int64_t r_i64 = 0;
+  uint64_t r_u64 = 0;
+  float r_f = 0;
+  double r_d = 0;
+  long double r_ld = 0;
+
+  a >> r_bo >> r_i8 >> r_u8 >> r_i16 >> r_u16 >> r_i32 >> r_u32 >> r_i64 >> r_u64 >> r_f >> r_d >>
+      r_ld;
+
+  EXPECT_EQ(r_bo, bo);
+  EXPECT_EQ(r_i8, i8);
+  EXPECT_EQ(r_u8, u8);
+  EXPECT_EQ(r_i16, i16);
+  EXPECT_EQ(r_u16, u16);
+  EXPECT_EQ(r_i32, i32);
+  EXPECT_EQ(r_u32, u32);
+  EXPECT_EQ(r_i64, i64);
+  EXPECT_EQ(r_u64, u64);
+  EXPECT_EQ(r_f, f);
+  EXPECT_EQ(r_d, d);
+  EXPECT_EQ(r_ld, ld);
+}
+
+TEST(CArchive, stringRoundTrip)
+{
+  std::vector<uint8_t> v;
+  auto a = archiveFrom(v);
+
+  a << std::string("hello") << std::string();
+
+  std::string s1;
+  std::string s2 = "not empty";
+  a >> s1 >> s2;
+
+  EXPECT_EQ(s1, "hello");
+  EXPECT_TRUE(s2.empty());
+}
+
+TEST(CArchive, vectorBoolRoundTrip)
+{
+  std::vector<uint8_t> v;
+  auto a = archiveFrom(v);
+
+  const std::vector<bool> in = {true, false, true, true, false};
+  const std::vector<bool> empty;
+  a << in << empty;
+
+  std::vector<bool> out;
+  std::vector<bool> outEmpty = {true};
+  a >> out >> outEmpty;
+
+  EXPECT_EQ(out, in);
+  EXPECT_TRUE(outEmpty.empty());
+}
+
+template <typename T>
+void testNumericVectorRoundTrip(const std::vector<T>& in)
+{
+  std::vector<uint8_t> v;
+  auto a = archiveFrom(v);
+
+  const std::vector<T> empty;
+  a << in << empty;
+
+  std::vector<T> out;
+  std::vector<T> outEmpty = in;
+  a >> out >> outEmpty;
+
+  EXPECT_EQ(out, in);
+  EXPECT_TRUE(outEmpty.empty());
+}
+
+TEST(CArchive, numericVectorsRoundTrip)
+{
+  testNumericVectorRoundTrip<float>({1.0f, -2.5f, 3.75f});
+  testNumericVectorRoundTrip<double>({1.0, -2.5, 3.75});
+  testNumericVectorRoundTrip<int8_t>({1, -2, 3});
+  testNumericVectorRoundTrip<uint8_t>({1, 2, 3});
+  testNumericVectorRoundTrip<int16_t>({1, -2, 3});
+  testNumericVectorRoundTrip<uint16_t>({1, 2, 3});
+  testNumericVectorRoundTrip<int32_t>({1, -2, 3});
+  testNumericVectorRoundTrip<uint32_t>({1, 2, 3});
+  testNumericVectorRoundTrip<int64_t>({1, -2, 3});
+  testNumericVectorRoundTrip<size_t>({1, 2, 3});
+}
+
+TEST(CArchive, alignedVectorRoundTrip)
+{
+  std::vector<uint8_t> v;
+  auto a = archiveFrom(v);
+
+  mrpt::aligned_std_vector<float> in = {1.0f, -2.5f, 3.75f};
+  a << in;
+
+  mrpt::aligned_std_vector<float> out;
+  a >> out;
+
+  ASSERT_EQ(out.size(), in.size());
+  for (size_t i = 0; i < in.size(); i++)
+  {
+    EXPECT_EQ(out[i], in[i]);
+  }
+}
+
+TEST(CArchive, vectorOfStringsRoundTrip)
+{
+  std::vector<uint8_t> v;
+  auto a = archiveFrom(v);
+
+  const std::vector<std::string> in = {"one", "", "three"};
+  a << in;
+
+  std::vector<std::string> out;
+  a >> out;
+
+  EXPECT_EQ(out, in);
+}
+
+TEST(CArchive, clockTimePointRoundTrip)
+{
+  std::vector<uint8_t> v;
+  auto a = archiveFrom(v);
+
+  const auto in = mrpt::Clock::now();
+  a << in;
+
+  mrpt::Clock::time_point out;
+  a >> out;
+
+  EXPECT_EQ(out, in);
+}
+
+TEST(CArchive, readAsAndWriteAs)
+{
+  std::vector<uint8_t> v;
+  auto a = archiveFrom(v);
+
+  a.WriteAs<uint16_t>(1234);
+  a.WriteAs<int8_t>(-5);
+  a << static_cast<uint32_t>(77);
+
+  EXPECT_EQ(a.ReadAs<uint16_t>(), 1234);
+
+  int32_t widened = 0;
+  a.ReadAsAndCastTo<int8_t, int32_t>(widened);
+  EXPECT_EQ(widened, -5);
+
+  EXPECT_EQ(a.ReadPOD<uint32_t>(), 77U);
+}
+
+TEST(CArchive, macroReadPOD)
+{
+  std::vector<uint8_t> v;
+  auto a = archiveFrom(v);
+
+  a << static_cast<double>(3.5);
+
+  double d = 0;
+  MRPT_READ_POD(a, d);
+  EXPECT_EQ(d, 3.5);
+}
+
+TEST(CArchive, zeroLengthBufferOperations)
+{
+  std::vector<uint8_t> v;
+  auto a = archiveFrom(v);
+
+  // A zero-length request must be a no-op on an otherwise empty stream:
+  int dummy = 0;
+  EXPECT_EQ(a.ReadBuffer(&dummy, 0), 0U);
+  EXPECT_NO_THROW(a.WriteBuffer(&dummy, 0));
+  EXPECT_TRUE(v.empty());
+}
+
+TEST(CArchive, nullBufferThrows)
+{
+  std::vector<uint8_t> v;
+  auto a = archiveFrom(v);
+
+  EXPECT_ANY_THROW(a.ReadBuffer(nullptr, 1));
+  EXPECT_ANY_THROW(a.WriteBuffer(nullptr, 1));
+}
+
+TEST(CArchive, objectRoundTrip)
+{
+  SerTestNS::registerTestClasses();
+
+  std::vector<uint8_t> v;
+  auto a = archiveFrom(v);
+
+  auto obj = SerTestNS::Foo::Create();
+  obj->m_value = 0xDEADBEEF;
+  a << *obj;
+
+  auto read = a.ReadObject<SerTestNS::Foo>();
+  ASSERT_TRUE(read);
+  EXPECT_EQ(read->m_value, 0xDEADBEEFU);
+}
+
+TEST(CArchive, objectPtrRoundTrip)
+{
+  SerTestNS::registerTestClasses();
+
+  std::vector<uint8_t> v;
+  auto a = archiveFrom(v);
+
+  CSerializable::Ptr obj = SerTestNS::Foo::Create();
+  std::dynamic_pointer_cast<SerTestNS::Foo>(obj)->m_value = 7;
+  a << obj;
+
+  CSerializable::Ptr read;
+  a >> read;
+  ASSERT_TRUE(read);
+  EXPECT_EQ(std::dynamic_pointer_cast<SerTestNS::Foo>(read)->m_value, 7U);
+}
+
+TEST(CArchive, nullObjectRoundTrip)
+{
+  std::vector<uint8_t> v;
+  auto a = archiveFrom(v);
+
+  const CSerializable::Ptr nullObj;
+  a << nullObj;
+
+  CSerializable::Ptr read = SerTestNS::Foo::Create();
+  a >> read;
+  EXPECT_FALSE(read);
+}
+
+TEST(CArchive, readObjectIntoExistingObject)
+{
+  SerTestNS::registerTestClasses();
+
+  std::vector<uint8_t> v;
+  auto a = archiveFrom(v);
+
+  SerTestNS::Foo src;
+  src.m_value = 99;
+  a << src;
+
+  SerTestNS::Foo dst;
+  a >> dst;
+  EXPECT_EQ(dst.m_value, 99U);
+}
+
+TEST(CArchive, readObjectIntoExistingObjectOfWrongClassThrows)
+{
+  SerTestNS::registerTestClasses();
+
+  std::vector<uint8_t> v;
+  auto a = archiveFrom(v);
+
+  SerTestNS::Foo src;
+  a << src;
+
+  SerTestNS::Bar dst;
+  EXPECT_ANY_THROW(a >> dst);
+}
+
+TEST(CArchive, readObjectIntoExistingObjectOfUnregisteredClassThrows)
+{
+  std::vector<uint8_t> v;
+  appendNewFormatHeader(v, "SerTestNS::NotRegistered");
+  v.push_back(0);  // version
+
+  auto a = archiveFrom(v);
+
+  SerTestNS::Foo dst;
+  EXPECT_ANY_THROW(a >> dst);
+}
+
+TEST(CArchive, readObjectOfUnregisteredClassThrows)
+{
+  std::vector<uint8_t> v;
+  appendNewFormatHeader(v, "SerTestNS::NotRegistered");
+  v.push_back(0);  // version
+
+  auto a = archiveFrom(v);
+  EXPECT_ANY_THROW(a.ReadObject());
+}
+
+TEST(CArchive, readObjectWithCorruptedEndFlagThrows)
+{
+  SerTestNS::registerTestClasses();
+
+  std::vector<uint8_t> v;
+  {
+    auto a = archiveFrom(v);
+    SerTestNS::Foo src;
+    a << src;
+  }
+  ASSERT_FALSE(v.empty());
+  v.back() = 0x00;  // the end flag is the very last byte
+
+  auto a = archiveFrom(v);
+  EXPECT_ANY_THROW(a.ReadObject());
+}
+
+TEST(CArchive, readObjectWithTooLongClassNameThrows)
+{
+  std::vector<uint8_t> v;
+  // 127 is the largest length representable, and above the 120-char sanity
+  // limit that guards against corrupted streams:
+  v.push_back(static_cast<uint8_t>(127 | 0x80));
+  v.resize(v.size() + 127, 'x');
+
+  auto a = archiveFrom(v);
+  EXPECT_ANY_THROW(a.ReadObject());
+}
+
+TEST(CArchive, readObjectFromEmptyStreamThrowsEOF)
+{
+  std::vector<uint8_t> v;
+  auto a = archiveFrom(v);
+
+  EXPECT_THROW(a.ReadObject(), CExceptionEOF);
+}
+
+TEST(CArchive, readObjectTruncatedMidObjectThrowsPlainException)
+{
+  SerTestNS::registerTestClasses();
+
+  std::vector<uint8_t> v;
+  {
+    auto a = archiveFrom(v);
+    SerTestNS::Foo src;
+    a << src;
+  }
+  // Cut the stream in the middle of the payload: an EOF at a *wrong* place is
+  // reported as a plain exception, not as CExceptionEOF:
+  v.resize(v.size() - 3);
+
+  auto a = archiveFrom(v);
+  EXPECT_ANY_THROW(a.ReadObject());
+}
+
+TEST(CArchive, readObjectInPreMRPT055Format)
+{
+  SerTestNS::registerTestClasses();
+
+  // Streams older than MRPT 0.5.5 have no 0x80 marker in the class name length
+  // byte, are followed by three 0x00 padding bytes, store the version as an
+  // int32 and carry no end flag. The class name has no namespace either, which
+  // is why findRegisteredClass() falls back to a namespace-less lookup.
+  std::vector<uint8_t> v;
+  v.push_back(3);  // strlen("Foo"), no 0x80 marker
+  v.insert(v.end(), {0x00, 0x00, 0x00});
+  v.insert(v.end(), {'F', 'o', 'o'});
+  v.insert(v.end(), {0x00, 0x00, 0x00, 0x00});  // int32 version = 0
+  v.insert(v.end(), {0x2A, 0x00, 0x00, 0x00});  // uint32 payload = 42
+
+  auto a = archiveFrom(v);
+  auto obj = a.ReadObject<SerTestNS::Foo>();
+  ASSERT_TRUE(obj);
+  EXPECT_EQ(obj->m_value, 42U);
+}
+
+TEST(CArchive, readObjectInPreMRPT055FormatWithBadPaddingThrows)
+{
+  std::vector<uint8_t> v;
+  v.push_back(3);
+  v.insert(v.end(), {0x00, 0x01, 0x00});  // non-zero padding: not a valid header
+  v.insert(v.end(), {'F', 'o', 'o'});
+
+  auto a = archiveFrom(v);
+  EXPECT_ANY_THROW(a.ReadObject());
+}
+
+TEST(CArchive, variantRoundTrip)
+{
+  SerTestNS::registerTestClasses();
+
+  using variant_t = std::variant<std::monostate, SerTestNS::Foo::Ptr>;
+
+  {
+    std::vector<uint8_t> v;
+    auto a = archiveFrom(v);
+
+    auto foo = SerTestNS::Foo::Create();
+    foo->m_value = 11;
+    const variant_t in = foo;
+    a.WriteVariant(in);
+
+    const auto out = a.ReadVariant<std::monostate, SerTestNS::Foo::Ptr>();
+    ASSERT_TRUE(std::holds_alternative<SerTestNS::Foo::Ptr>(out));
+    EXPECT_EQ(std::get<SerTestNS::Foo::Ptr>(out)->m_value, 11U);
+  }
+  {
+    // A variant holding no value serializes as the "std::monostate" class:
+    std::vector<uint8_t> v;
+    auto a = archiveFrom(v);
+
+    const variant_t in;
+    a.WriteVariant(in);
+
+    const auto out = a.ReadVariant<std::monostate, SerTestNS::Foo::Ptr>();
+    EXPECT_TRUE(std::holds_alternative<std::monostate>(out));
+  }
+}
+
+TEST(CArchive, variantOfUnregisteredClassThrows)
+{
+  std::vector<uint8_t> v;
+  appendNewFormatHeader(v, "SerTestNS::NotRegistered");
+  v.push_back(0);  // version
+
+  auto a = archiveFrom(v);
+  EXPECT_ANY_THROW((a.ReadVariant<std::monostate, SerTestNS::Foo::Ptr>()));
+}
+
+TEST(CArchive, objectToAndFromOctetVector)
+{
+  SerTestNS::registerTestClasses();
+
+  SerTestNS::Foo src;
+  src.m_value = 55;
+
+  std::vector<uint8_t> data;
+  mrpt::serialization::ObjectToOctetVector(&src, data);
+  EXPECT_FALSE(data.empty());
+
+  CSerializable::Ptr obj;
+  mrpt::serialization::OctetVectorToObject(data, obj);
+  ASSERT_TRUE(obj);
+  EXPECT_EQ(std::dynamic_pointer_cast<SerTestNS::Foo>(obj)->m_value, 55U);
+}
+
+TEST(CArchive, octetVectorToObjectWithEmptyInput)
+{
+  CSerializable::Ptr obj = SerTestNS::Foo::Create();
+  mrpt::serialization::OctetVectorToObject({}, obj);
+  EXPECT_FALSE(obj);
+}
+
+TEST(CArchive, readOnlyVectorArchiveRejectsWrites)
+{
+  const std::vector<uint8_t> v = {1, 2, 3};
+  auto a = archiveFrom(v);
+
+  uint8_t b = 0;
+  EXPECT_ANY_THROW(a.WriteBuffer(&b, 1));
+
+  // ...but reading works, until it runs out of data:
+  EXPECT_EQ(a.ReadBuffer(&b, 1), 1U);
+  EXPECT_EQ(b, 1);
+  uint8_t big[4] = {};
+  EXPECT_ANY_THROW(a.ReadBuffer(big, 4));
+}
+
+TEST(CArchive, vectorArchiveReadPastEndThrows)
+{
+  std::vector<uint8_t> v;
+  auto a = archiveFrom(v);
+
+  a << static_cast<uint8_t>(1);
+
+  uint8_t b = 0;
+  EXPECT_EQ(a.ReadBuffer(&b, 1), 1U);
+  EXPECT_ANY_THROW(a.ReadBuffer(&b, 1));
+}
+
+TEST(CArchive, stdIOStreamRoundTrip)
+{
+  SerTestNS::registerTestClasses();
+
+  std::stringstream ss;
+  auto a = mrpt::serialization::archiveFrom<std::iostream>(ss);
+
+  SerTestNS::Foo src;
+  src.m_value = 123;
+  a << src;
+
+  auto obj = a.ReadObject<SerTestNS::Foo>();
+  ASSERT_TRUE(obj);
+  EXPECT_EQ(obj->m_value, 123U);
+}
+
+TEST(CArchive, stdIStreamIsReadOnly)
+{
+  std::istringstream in("abcd");
+  auto a = mrpt::serialization::archiveFrom<std::istream>(in);
+
+  uint8_t b = 0;
+  EXPECT_EQ(a.ReadBuffer(&b, 1), 1U);
+  EXPECT_EQ(b, 'a');
+  EXPECT_ANY_THROW(a.WriteBuffer(&b, 1));
+
+  // Reading beyond the end reports zero bytes read, i.e. an EOF:
+  uint8_t big[8] = {};
+  EXPECT_ANY_THROW(a.ReadBuffer(big, 8));
+}
+
+TEST(CArchive, stdOStreamIsWriteOnly)
+{
+  std::ostringstream out;
+  auto a = mrpt::serialization::archiveFrom<std::ostream>(out);
+
+  const uint8_t b = 'z';
+  EXPECT_NO_THROW(a.WriteBuffer(&b, 1));
+  EXPECT_EQ(out.str(), "z");
+
+  uint8_t r = 0;
+  EXPECT_ANY_THROW(a.ReadBuffer(&r, 1));
+}
+
+TEST(CArchive, archivePtrAndUniquePtrFrom)
+{
+  std::stringstream ss;
+  {
+    auto a = mrpt::serialization::archivePtrFrom<std::iostream>(ss);
+    ASSERT_TRUE(a);
+    (*a) << static_cast<uint32_t>(5);
+  }
+  {
+    auto a = mrpt::serialization::archiveUniquePtrFrom<std::iostream>(ss);
+    ASSERT_TRUE(a);
+    EXPECT_EQ(a->ReadAs<uint32_t>(), 5U);
+  }
+}
+
+TEST(CArchive, defaultArchiveDescription)
+{
+  std::vector<uint8_t> v;
+  auto a = archiveFrom(v);
+  EXPECT_EQ(a.getArchiveDescription(), "generic CArchive");
+}
+
+TEST(CArchive, enumRoundTrip)
+{
+  std::vector<uint8_t> v;
+  auto a = archiveFrom(v);
+
+  a << SerTestNS::TestEnum::Second;
+
+  auto out = SerTestNS::TestEnum::First;
+  a >> out;
+  EXPECT_EQ(out, SerTestNS::TestEnum::Second);
+}
+
+TEST(CArchive, sharedPtrToNonSerializableRoundTrip)
+{
+  {
+    std::vector<uint8_t> v;
+    auto a = archiveFrom(v);
+
+    const auto in = std::make_shared<double>(2.5);
+    a << in;
+
+    std::shared_ptr<double> out;
+    a >> out;
+    ASSERT_TRUE(out);
+    EXPECT_EQ(*out, 2.5);
+  }
+  {
+    // A null pointer round-trips as such:
+    std::vector<uint8_t> v;
+    auto a = archiveFrom(v);
+
+    const std::shared_ptr<double> in;
+    a << in;
+
+    auto out = std::make_shared<double>(1.0);
+    a >> out;
+    EXPECT_FALSE(out);
+  }
+  {
+    // ...and a type mismatch is caught:
+    std::vector<uint8_t> v;
+    auto a = archiveFrom(v);
+
+    a << std::make_shared<double>(2.5);
+
+    std::shared_ptr<float> out;
+    EXPECT_ANY_THROW(a >> out);
+  }
+}

--- a/modules/mrpt_serialization/tests/CMessage_unittest.cpp
+++ b/modules/mrpt_serialization/tests/CMessage_unittest.cpp
@@ -1,0 +1,200 @@
+/*                    _
+                     | |    Mobile Robot Programming Toolkit (MRPT)
+ _ __ ___  _ __ _ __ | |_
+| '_ ` _ \| '__| '_ \| __|          https://www.mrpt.org/
+| | | | | | |  | |_) | |_
+|_| |_| |_|_|  | .__/ \__|     https://github.com/MRPT/mrpt/
+               | |
+               |_|
+
+ Copyright (c) 2005-2026, Individual contributors, see AUTHORS file
+ See: https://www.mrpt.org/Authors - All rights reserved.
+ SPDX-License-Identifier: BSD-3-Clause
+*/
+
+#include <gtest/gtest.h>
+#include <mrpt/serialization/CArchive.h>
+#include <mrpt/serialization/CMessage.h>
+#include <mrpt/serialization/archiveFrom_std_vector.h>
+
+#include <cstdint>
+#include <string>
+#include <vector>
+
+#include "serialization_test_types.h"
+
+using mrpt::serialization::archiveFrom;
+using mrpt::serialization::CMessage;
+
+namespace
+{
+/** Round-trips a message through the binary framing of sendMessage(). */
+void checkFrameRoundTrip(uint32_t type, const std::vector<uint8_t>& content)
+{
+  CMessage out;
+  out.type = type;
+  out.content = content;
+
+  std::vector<uint8_t> v;
+  auto a = archiveFrom(v);
+  a.sendMessage(out);
+
+  CMessage in;
+  ASSERT_TRUE(a.receiveMessage(in));
+  EXPECT_EQ(in.type, type);
+  EXPECT_EQ(in.content, content);
+}
+}  // namespace
+
+TEST(CMessage, tinyFrameRoundTrip) { checkFrameRoundTrip(7, {1, 2, 3, 4, 5}); }
+
+TEST(CMessage, emptyFrameRoundTrip) { checkFrameRoundTrip(0, {}); }
+
+TEST(CMessage, largestTinyFrameRoundTrip)
+{
+  // 255 bytes is the largest payload the 1-byte-length ("tiny") format holds:
+  checkFrameRoundTrip(3, std::vector<uint8_t>(255, 0xAB));
+}
+
+TEST(CMessage, largeFrameRoundTrip)
+{
+  // 256 bytes and above switch to the 2-byte-length frame format:
+  checkFrameRoundTrip(4, std::vector<uint8_t>(256, 0xCD));
+
+  std::vector<uint8_t> big(5000);
+  for (size_t i = 0; i < big.size(); i++)
+  {
+    big[i] = static_cast<uint8_t>(i & 0xff);
+  }
+  checkFrameRoundTrip(9, big);
+}
+
+TEST(CMessage, receiveMessageFromEmptyStreamFails)
+{
+  std::vector<uint8_t> v;
+  auto a = archiveFrom(v);
+
+  CMessage msg;
+  EXPECT_FALSE(a.receiveMessage(msg));
+}
+
+TEST(CMessage, receiveMessageRejectsBadStartFlag)
+{
+  // Three consecutive bytes that are neither 0x69 nor 0x79 exhaust the
+  // re-synchronization attempts:
+  std::vector<uint8_t> v = {0x00, 0x01, 0x02, 0x03};
+  auto a = archiveFrom(v);
+
+  CMessage msg;
+  EXPECT_FALSE(a.receiveMessage(msg));
+}
+
+TEST(CMessage, receiveMessageRejectsBadEndFlag)
+{
+  std::vector<uint8_t> v;
+  {
+    CMessage out;
+    out.type = 1;
+    out.content = {1, 2, 3};
+    auto a = archiveFrom(v);
+    a.sendMessage(out);
+  }
+  ASSERT_FALSE(v.empty());
+  v.back() = 0x00;  // corrupt the end flag
+
+  auto a = archiveFrom(v);
+  CMessage msg;
+  EXPECT_FALSE(a.receiveMessage(msg));
+}
+
+TEST(CMessage, receiveMessageOnTruncatedFrameFails)
+{
+  std::vector<uint8_t> v;
+  {
+    CMessage out;
+    out.type = 1;
+    out.content = std::vector<uint8_t>(300, 0x11);
+    auto a = archiveFrom(v);
+    a.sendMessage(out);
+  }
+  v.resize(v.size() / 2);
+
+  auto a = archiveFrom(v);
+  CMessage msg;
+  EXPECT_FALSE(a.receiveMessage(msg));
+}
+
+TEST(CMessage, contentAsString)
+{
+  CMessage msg;
+  msg.setContentFromString("hello world");
+  EXPECT_EQ(msg.content.size(), 11U);
+
+  std::string s;
+  msg.getContentAsString(s);
+  EXPECT_EQ(s, "hello world");
+}
+
+TEST(CMessage, emptyContentAsString)
+{
+  CMessage msg;
+  msg.setContentFromString("");
+  EXPECT_TRUE(msg.content.empty());
+
+  std::string s = "junk";
+  msg.getContentAsString(s);
+  EXPECT_TRUE(s.empty());
+}
+
+TEST(CMessage, serializeObjectIntoNewObject)
+{
+  SerTestNS::registerTestClasses();
+
+  SerTestNS::Foo src;
+  src.m_value = 4242;
+
+  CMessage msg;
+  msg.type = 1;
+  msg.serializeObject(&src);
+  EXPECT_FALSE(msg.content.empty());
+
+  mrpt::serialization::CSerializable::Ptr obj;
+  msg.deserializeIntoNewObject(obj);
+  ASSERT_TRUE(obj);
+  EXPECT_EQ(std::dynamic_pointer_cast<SerTestNS::Foo>(obj)->m_value, 4242U);
+}
+
+TEST(CMessage, deserializeIntoNewObjectWithEmptyContent)
+{
+  CMessage msg;
+  auto obj = mrpt::serialization::CSerializable::Ptr(SerTestNS::Foo::Create());
+  msg.deserializeIntoNewObject(obj);
+  EXPECT_FALSE(obj);
+}
+
+TEST(CMessage, serializeObjectIntoExistingObject)
+{
+  SerTestNS::registerTestClasses();
+
+  SerTestNS::Foo src;
+  src.m_value = 17;
+
+  CMessage msg;
+  msg.serializeObject(&src);
+
+  SerTestNS::Foo dst;
+  msg.deserializeIntoExistingObject(&dst);
+  EXPECT_EQ(dst.m_value, 17U);
+}
+
+TEST(CMessage, deserializeIntoExistingObjectOfWrongClassThrows)
+{
+  SerTestNS::registerTestClasses();
+
+  SerTestNS::Foo src;
+  CMessage msg;
+  msg.serializeObject(&src);
+
+  SerTestNS::Bar dst;
+  EXPECT_ANY_THROW(msg.deserializeIntoExistingObject(&dst));
+}

--- a/modules/mrpt_serialization/tests/CMessage_unittest.cpp
+++ b/modules/mrpt_serialization/tests/CMessage_unittest.cpp
@@ -69,6 +69,24 @@ TEST(CMessage, largeFrameRoundTrip)
   checkFrameRoundTrip(9, big);
 }
 
+TEST(CMessage, largestRepresentableFrameRoundTrip)
+{
+  // 65535 bytes is the largest payload the 16-bit length field can describe:
+  checkFrameRoundTrip(1, std::vector<uint8_t>(0xffff, 0xEF));
+}
+
+TEST(CMessage, oversizedPayloadIsRejected)
+{
+  CMessage msg;
+  msg.type = 1;
+  msg.content.assign(0x10000, 0x01);  // one byte too long
+
+  std::vector<uint8_t> v;
+  auto a = archiveFrom(v);
+  EXPECT_ANY_THROW(a.sendMessage(msg));
+  EXPECT_TRUE(v.empty());
+}
+
 TEST(CMessage, receiveMessageFromEmptyStreamFails)
 {
   std::vector<uint8_t> v;

--- a/modules/mrpt_serialization/tests/CSchemeArchive_unittest.cpp
+++ b/modules/mrpt_serialization/tests/CSchemeArchive_unittest.cpp
@@ -1,0 +1,135 @@
+/*                    _
+                     | |    Mobile Robot Programming Toolkit (MRPT)
+ _ __ ___  _ __ _ __ | |_
+| '_ ` _ \| '__| '_ \| __|          https://www.mrpt.org/
+| | | | | | |  | |_) | |_
+|_| |_| |_|_|  | .__/ \__|     https://github.com/MRPT/mrpt/
+               | |
+               |_|
+
+ Copyright (c) 2005-2026, Individual contributors, see AUTHORS file
+ See: https://www.mrpt.org/Authors - All rights reserved.
+ SPDX-License-Identifier: BSD-3-Clause
+*/
+
+#include <gtest/gtest.h>
+#include <mrpt/serialization/CSchemeArchive.h>
+#include <mrpt/serialization/config.h>
+
+#include <sstream>
+#include <string>
+
+#include "serialization_test_types.h"
+
+#if MRPT_HAS_JSONCPP
+
+TEST(CSchemeArchive, scalarAssignmentAndConversion)
+{
+  auto arch = mrpt::serialization::archiveJSON();
+
+  arch["i32"] = static_cast<int32_t>(-5);
+  arch["u32"] = static_cast<uint32_t>(5);
+  arch["i64"] = static_cast<int64_t>(-6000000000LL);
+  arch["u64"] = static_cast<uint64_t>(6000000000ULL);
+  arch["f"] = 1.5f;
+  arch["d"] = 2.5;
+  arch["s"] = std::string("text");
+  arch["b"] = true;
+
+  EXPECT_EQ(static_cast<int32_t>(arch["i32"]), -5);
+  EXPECT_EQ(static_cast<uint32_t>(arch["u32"]), 5U);
+  EXPECT_EQ(static_cast<int64_t>(arch["i64"]), -6000000000LL);
+  EXPECT_EQ(static_cast<uint64_t>(arch["u64"]), 6000000000ULL);
+  EXPECT_EQ(static_cast<float>(arch["f"]), 1.5f);
+  EXPECT_EQ(static_cast<double>(arch["d"]), 2.5);
+  EXPECT_EQ(static_cast<std::string>(arch["s"]), "text");
+  EXPECT_TRUE(static_cast<bool>(arch["b"]));
+}
+
+TEST(CSchemeArchive, listAccessor)
+{
+  auto arch = mrpt::serialization::archiveJSON();
+
+  arch["list"][static_cast<size_t>(0)] = static_cast<int32_t>(10);
+  arch["list"][static_cast<size_t>(1)] = static_cast<int32_t>(20);
+
+  EXPECT_EQ(static_cast<int32_t>(arch["list"][static_cast<size_t>(0)]), 10);
+  EXPECT_EQ(static_cast<int32_t>(arch["list"][static_cast<size_t>(1)]), 20);
+}
+
+TEST(CSchemeArchive, objectRoundTrip)
+{
+  SerTestNS::registerTestClasses();
+
+  SerTestNS::WithSchema src;
+  src.m_int = 33;
+  src.m_str = "hello";
+
+  auto arch = mrpt::serialization::archiveJSON();
+  arch = src;
+
+  SerTestNS::WithSchema dst;
+  arch.readTo(dst);
+
+  EXPECT_EQ(dst.m_int, 33);
+  EXPECT_EQ(dst.m_str, "hello");
+}
+
+TEST(CSchemeArchive, streamRoundTrip)
+{
+  SerTestNS::registerTestClasses();
+
+  SerTestNS::WithSchema src;
+  src.m_int = -7;
+  src.m_str = "streamed";
+
+  std::stringstream ss;
+  {
+    auto arch = mrpt::serialization::archiveJSON();
+    arch = src;
+    ss << arch;
+  }
+  EXPECT_FALSE(ss.str().empty());
+
+  SerTestNS::WithSchema dst;
+  {
+    auto arch = mrpt::serialization::archiveJSON();
+    ss >> arch;
+    arch.readTo(dst);
+  }
+  EXPECT_EQ(dst.m_int, -7);
+  EXPECT_EQ(dst.m_str, "streamed");
+}
+
+TEST(CSchemeArchive, readingIntoAnotherClassThrows)
+{
+  SerTestNS::registerTestClasses();
+
+  SerTestNS::WithSchema src;
+  auto arch = mrpt::serialization::archiveJSON();
+  arch = src;
+
+  // The "datatype" field pins the class the document was written from:
+  SerTestNS::Foo dst;
+  EXPECT_ANY_THROW(arch.readTo(dst));
+}
+
+#endif  // MRPT_HAS_JSONCPP
+
+TEST(CSchemeArchive, classesWithoutSchemaSupportThrow)
+{
+  SerTestNS::registerTestClasses();
+
+  // The default implementations in CSerializable reject schema-based archives:
+  SerTestNS::Foo obj;
+  auto& asSerializable = static_cast<mrpt::serialization::CSerializable&>(obj);
+
+#if MRPT_HAS_JSONCPP
+  auto arch = mrpt::serialization::archiveJSON();
+  EXPECT_ANY_THROW(arch = asSerializable);
+  EXPECT_ANY_THROW(arch.readTo(asSerializable));
+#else
+  (void)asSerializable;
+  EXPECT_ANY_THROW(mrpt::serialization::archiveJSON());
+#endif
+}

--- a/modules/mrpt_serialization/tests/serialization_test_types.cpp
+++ b/modules/mrpt_serialization/tests/serialization_test_types.cpp
@@ -1,0 +1,75 @@
+/*                    _
+                     | |    Mobile Robot Programming Toolkit (MRPT)
+ _ __ ___  _ __ _ __ | |_
+| '_ ` _ \| '__| '_ \| __|          https://www.mrpt.org/
+| | | | | | |  | |_) | |_
+|_| |_| |_|_|  | .__/ \__|     https://github.com/MRPT/mrpt/
+               | |
+               |_|
+
+ Copyright (c) 2005-2026, Individual contributors, see AUTHORS file
+ See: https://www.mrpt.org/Authors - All rights reserved.
+ SPDX-License-Identifier: BSD-3-Clause
+*/
+
+#include "serialization_test_types.h"
+
+#include <mrpt/serialization/CArchive.h>
+#include <mrpt/serialization/CSchemeArchiveBase.h>
+
+using namespace mrpt::serialization;
+
+IMPLEMENTS_SERIALIZABLE(Foo, CSerializable, SerTestNS)
+IMPLEMENTS_SERIALIZABLE(Bar, CSerializable, SerTestNS)
+IMPLEMENTS_SERIALIZABLE(WithSchema, CSerializable, SerTestNS)
+
+uint8_t SerTestNS::Foo::serializeGetVersion() const { return 0; }
+void SerTestNS::Foo::serializeTo(CArchive& out) const { out << m_value; }
+void SerTestNS::Foo::serializeFrom(CArchive& in, uint8_t version)
+{
+  ASSERT_EQUAL_(version, 0U);
+  in >> m_value;
+}
+
+uint8_t SerTestNS::Bar::serializeGetVersion() const { return 0; }
+void SerTestNS::Bar::serializeTo(CArchive& out) const { out << m_value; }
+void SerTestNS::Bar::serializeFrom(CArchive& in, uint8_t version)
+{
+  ASSERT_EQUAL_(version, 0U);
+  in >> m_value;
+}
+
+uint8_t SerTestNS::WithSchema::serializeGetVersion() const { return 1; }
+void SerTestNS::WithSchema::serializeTo(CArchive& out) const { out << m_int << m_str; }
+void SerTestNS::WithSchema::serializeFrom(CArchive& in, uint8_t version)
+{
+  ASSERT_EQUAL_(version, 1U);
+  in >> m_int >> m_str;
+}
+
+void SerTestNS::WithSchema::serializeTo(CSchemeArchiveBase& out) const
+{
+  SCHEMA_SERIALIZE_DATATYPE_VERSION(1);
+  out["int"] = m_int;
+  out["str"] = m_str;
+}
+void SerTestNS::WithSchema::serializeFrom(CSchemeArchiveBase& in)
+{
+  int version = 0;
+  SCHEMA_DESERIALIZE_DATATYPE_VERSION();
+  ASSERT_EQUAL_(version, 1);
+  m_int = static_cast<int32_t>(in["int"]);
+  m_str = static_cast<std::string>(in["str"]);
+}
+
+void SerTestNS::registerTestClasses()
+{
+  static const bool done = []()
+  {
+    mrpt::rtti::registerClass(CLASS_ID_NAMESPACE(Foo, SerTestNS));
+    mrpt::rtti::registerClass(CLASS_ID_NAMESPACE(Bar, SerTestNS));
+    mrpt::rtti::registerClass(CLASS_ID_NAMESPACE(WithSchema, SerTestNS));
+    return true;
+  }();
+  (void)done;
+}

--- a/modules/mrpt_serialization/tests/serialization_test_types.h
+++ b/modules/mrpt_serialization/tests/serialization_test_types.h
@@ -1,0 +1,69 @@
+/*                    _
+                     | |    Mobile Robot Programming Toolkit (MRPT)
+ _ __ ___  _ __ _ __ | |_
+| '_ ` _ \| '__| '_ \| __|          https://www.mrpt.org/
+| | | | | | |  | |_) | |_
+|_| |_| |_|_|  | .__/ \__|     https://github.com/MRPT/mrpt/
+               | |
+               |_|
+
+ Copyright (c) 2005-2026, Individual contributors, see AUTHORS file
+ See: https://www.mrpt.org/Authors - All rights reserved.
+ SPDX-License-Identifier: BSD-3-Clause
+*/
+#pragma once
+
+#include <mrpt/serialization/CSerializable.h>
+#include <mrpt/typemeta/TEnumType.h>
+
+#include <cstdint>
+
+/** Minimal serializable classes shared by this module's unit tests. */
+namespace SerTestNS
+{
+/** Note the short class name: stripped of its namespace it is exactly 3 chars,
+ * which keeps the hand-crafted pre-MRPT-0.5.5 stream headers in the tests
+ * readable. */
+class Foo : public mrpt::serialization::CSerializable
+{
+ public:
+  uint32_t m_value{0};
+
+  DEFINE_SERIALIZABLE(Foo, SerTestNS)
+};
+
+/** A second class, to check that class identities are enforced on reading. */
+class Bar : public mrpt::serialization::CSerializable
+{
+ public:
+  double m_value{0};
+
+  DEFINE_SERIALIZABLE(Bar, SerTestNS)
+};
+
+/** A class that does support schema-based (JSON,...) serialization. */
+class WithSchema : public mrpt::serialization::CSerializable
+{
+ public:
+  int32_t m_int{0};
+  std::string m_str;
+
+  DEFINE_SERIALIZABLE(WithSchema, SerTestNS)
+  DEFINE_SCHEMA_SERIALIZABLE()
+};
+
+enum class TestEnum : uint8_t
+{
+  First = 0,
+  Second
+};
+
+/** Registers the classes above exactly once, whatever test runs first. */
+void registerTestClasses();
+
+}  // namespace SerTestNS
+
+MRPT_ENUM_TYPE_BEGIN(SerTestNS::TestEnum)
+MRPT_FILL_ENUM_MEMBER(SerTestNS::TestEnum, First);
+MRPT_FILL_ENUM_MEMBER(SerTestNS::TestEnum, Second);
+MRPT_ENUM_TYPE_END()

--- a/modules/mrpt_serialization/tests/stl_serialization_unittest.cpp
+++ b/modules/mrpt_serialization/tests/stl_serialization_unittest.cpp
@@ -1,0 +1,340 @@
+/*                    _
+                     | |    Mobile Robot Programming Toolkit (MRPT)
+ _ __ ___  _ __ _ __ | |_
+| '_ ` _ \| '__| '_ \| __|          https://www.mrpt.org/
+| | | | | | |  | |_) | |_
+|_| |_| |_|_|  | .__/ \__|     https://github.com/MRPT/mrpt/
+               | |
+               |_|
+
+ Copyright (c) 2005-2026, Individual contributors, see AUTHORS file
+ See: https://www.mrpt.org/Authors - All rights reserved.
+ SPDX-License-Identifier: BSD-3-Clause
+*/
+
+#include <gtest/gtest.h>
+#include <mrpt/serialization/archiveFrom_std_vector.h>
+#include <mrpt/serialization/optional_serialization.h>
+#include <mrpt/serialization/stl_serialization.h>
+
+#include <array>
+#include <cstdint>
+#include <deque>
+#include <list>
+#include <map>
+#include <optional>
+#include <set>
+#include <string>
+#include <utility>
+#include <vector>
+
+using mrpt::serialization::archiveFrom;
+
+TEST(stl_serialization, dequeRoundTrip)
+{
+  std::vector<uint8_t> v;
+  auto a = archiveFrom(v);
+
+  const std::deque<int32_t> in = {1, -2, 3};
+  a << in;
+
+  std::deque<int32_t> out = {99};
+  a >> out;
+  EXPECT_EQ(out, in);
+}
+
+TEST(stl_serialization, listRoundTrip)
+{
+  std::vector<uint8_t> v;
+  auto a = archiveFrom(v);
+
+  const std::list<double> in = {1.5, -2.5};
+  const std::list<double> empty;
+  a << in << empty;
+
+  std::list<double> out;
+  std::list<double> outEmpty = {1.0};
+  a >> out >> outEmpty;
+  EXPECT_EQ(out, in);
+  EXPECT_TRUE(outEmpty.empty());
+}
+
+TEST(stl_serialization, setRoundTrip)
+{
+  std::vector<uint8_t> v;
+  auto a = archiveFrom(v);
+
+  const std::set<int32_t> in = {3, 1, 2};
+  a << in;
+
+  std::set<int32_t> out = {99};
+  a >> out;
+  EXPECT_EQ(out, in);
+}
+
+TEST(stl_serialization, multisetRoundTrip)
+{
+  std::vector<uint8_t> v;
+  auto a = archiveFrom(v);
+
+  const std::multiset<int32_t> in = {1, 1, 2};
+  a << in;
+
+  std::multiset<int32_t> out;
+  a >> out;
+  EXPECT_EQ(out, in);
+}
+
+TEST(stl_serialization, mapRoundTrip)
+{
+  std::vector<uint8_t> v;
+  auto a = archiveFrom(v);
+
+  const std::map<int32_t, double> in = {
+      {1,  1.5},
+      {2, -2.5}
+  };
+  a << in;
+
+  std::map<int32_t, double> out = {
+      {99, 0.0}
+  };
+  a >> out;
+  EXPECT_EQ(out, in);
+}
+
+TEST(stl_serialization, multimapRoundTrip)
+{
+  std::vector<uint8_t> v;
+  auto a = archiveFrom(v);
+
+  const std::multimap<int32_t, double> in = {
+      {1,  1.5},
+      {1,  2.5},
+      {2, -2.5}
+  };
+  a << in;
+
+  std::multimap<int32_t, double> out;
+  a >> out;
+  EXPECT_EQ(out, in);
+}
+
+TEST(stl_serialization, arrayRoundTrip)
+{
+  std::vector<uint8_t> v;
+  auto a = archiveFrom(v);
+
+  const std::array<double, 3> in = {1.0, 2.0, 3.0};
+  a << in;
+
+  std::array<double, 3> out = {};
+  a >> out;
+  EXPECT_EQ(out, in);
+}
+
+TEST(stl_serialization, pairRoundTrip)
+{
+  std::vector<uint8_t> v;
+  auto a = archiveFrom(v);
+
+  const std::pair<int32_t, std::string> in{7, "seven"};
+  a << in;
+
+  std::pair<int32_t, std::string> out;
+  a >> out;
+  EXPECT_EQ(out, in);
+}
+
+TEST(stl_serialization, optionalRoundTrip)
+{
+  std::vector<uint8_t> v;
+  auto a = archiveFrom(v);
+
+  const std::optional<double> withValue = 3.5;
+  const std::optional<double> without;
+  a << withValue << without;
+
+  std::optional<double> out1;
+  std::optional<double> out2 = 1.0;
+  a >> out1 >> out2;
+
+  ASSERT_TRUE(out1.has_value());
+  EXPECT_EQ(*out1, 3.5);
+  EXPECT_FALSE(out2.has_value());
+}
+
+TEST(stl_serialization, sequenceContainerWrongPreambleThrows)
+{
+  std::vector<uint8_t> v;
+  auto a = archiveFrom(v);
+
+  const std::list<double> in = {1.0};
+  a << in;
+
+  // Same element type, different container: the preamble no longer matches.
+  std::deque<double> out;
+  EXPECT_ANY_THROW(a >> out);
+}
+
+TEST(stl_serialization, sequenceContainerWrongElementTypeThrows)
+{
+  std::vector<uint8_t> v;
+  auto a = archiveFrom(v);
+
+  const std::deque<double> in = {1.0};
+  a << in;
+
+  std::deque<int32_t> out;
+  EXPECT_ANY_THROW(a >> out);
+}
+
+TEST(stl_serialization, simpleAssocContainerWrongPreambleThrows)
+{
+  std::vector<uint8_t> v;
+  auto a = archiveFrom(v);
+
+  const std::multiset<int32_t> in = {1};
+  a << in;
+
+  std::set<int32_t> out;
+  EXPECT_ANY_THROW(a >> out);
+}
+
+TEST(stl_serialization, simpleAssocContainerWrongKeyTypeThrows)
+{
+  std::vector<uint8_t> v;
+  auto a = archiveFrom(v);
+
+  const std::set<int32_t> in = {1};
+  a << in;
+
+  std::set<double> out;
+  EXPECT_ANY_THROW(a >> out);
+}
+
+TEST(stl_serialization, mapWrongPreambleThrows)
+{
+  std::vector<uint8_t> v;
+  auto a = archiveFrom(v);
+
+  const std::multimap<int32_t, double> in = {
+      {1, 1.0}
+  };
+  a << in;
+
+  std::map<int32_t, double> out;
+  EXPECT_ANY_THROW(a >> out);
+}
+
+TEST(stl_serialization, mapWrongKeyTypeThrows)
+{
+  std::vector<uint8_t> v;
+  auto a = archiveFrom(v);
+
+  const std::map<int32_t, double> in = {
+      {1, 1.0}
+  };
+  a << in;
+
+  std::map<int64_t, double> out;
+  EXPECT_ANY_THROW(a >> out);
+}
+
+TEST(stl_serialization, mapWrongValueTypeThrows)
+{
+  std::vector<uint8_t> v;
+  auto a = archiveFrom(v);
+
+  const std::map<int32_t, double> in = {
+      {1, 1.0}
+  };
+  a << in;
+
+  std::map<int32_t, float> out;
+  EXPECT_ANY_THROW(a >> out);
+}
+
+TEST(stl_serialization, arrayWrongLengthThrows)
+{
+  std::vector<uint8_t> v;
+  auto a = archiveFrom(v);
+
+  const std::array<double, 3> in = {1.0, 2.0, 3.0};
+  a << in;
+
+  std::array<double, 2> out = {};
+  EXPECT_ANY_THROW(a >> out);
+}
+
+TEST(stl_serialization, arrayWrongElementTypeThrows)
+{
+  std::vector<uint8_t> v;
+  auto a = archiveFrom(v);
+
+  const std::array<double, 2> in = {1.0, 2.0};
+  a << in;
+
+  std::array<float, 2> out = {};
+  EXPECT_ANY_THROW(a >> out);
+}
+
+TEST(stl_serialization, pairWrongPreambleThrows)
+{
+  std::vector<uint8_t> v;
+  auto a = archiveFrom(v);
+
+  const std::set<int32_t> in = {1};
+  a << in;
+
+  std::pair<int32_t, int32_t> out;
+  EXPECT_ANY_THROW(a >> out);
+}
+
+TEST(stl_serialization, pairWrongFirstTypeThrows)
+{
+  std::vector<uint8_t> v;
+  auto a = archiveFrom(v);
+
+  const std::pair<int32_t, double> in{1, 2.0};
+  a << in;
+
+  std::pair<int64_t, double> out;
+  EXPECT_ANY_THROW(a >> out);
+}
+
+TEST(stl_serialization, pairWrongSecondTypeThrows)
+{
+  std::vector<uint8_t> v;
+  auto a = archiveFrom(v);
+
+  const std::pair<int32_t, double> in{1, 2.0};
+  a << in;
+
+  std::pair<int32_t, float> out;
+  EXPECT_ANY_THROW(a >> out);
+}
+
+TEST(stl_serialization, optionalWrongPreambleThrows)
+{
+  std::vector<uint8_t> v;
+  auto a = archiveFrom(v);
+
+  const std::set<int32_t> in = {1};
+  a << in;
+
+  std::optional<int32_t> out;
+  EXPECT_ANY_THROW(a >> out);
+}
+
+TEST(stl_serialization, optionalWrongValueTypeThrows)
+{
+  std::vector<uint8_t> v;
+  auto a = archiveFrom(v);
+
+  const std::optional<double> in = 1.0;
+  a << in;
+
+  std::optional<float> out;
+  EXPECT_ANY_THROW(a >> out);
+}


### PR DESCRIPTION
## What

`mrpt_serialization` had **no unit tests of its own at all** — its `CMakeLists.txt` said so explicitly ("unit tests for this module are in other modules downstream"). Everything was only exercised indirectly, via `mrpt_io`/`mrpt_poses`. It now has its own suite, which needs nothing beyond `std::stringstream` / `std::vector<uint8_t>` archives.

New test files:

| file | covers |
|---|---|
| `mrpt_serialization/tests/CArchive_unittest.cpp` | POD/string/vector/object round-trips, the pre-MRPT-0.5.5 stream format, `std::variant`, `ObjectToOctetVector`, the std-stream archive wrappers, and the corrupted-header / unregistered-class / truncated-stream / EOF failure paths |
| `mrpt_serialization/tests/CMessage_unittest.cpp` | both frame formats (tiny and 2-byte-length), empty payloads, and the framing error paths |
| `mrpt_serialization/tests/stl_serialization_unittest.cpp` | `deque`/`list`/`set`/`multiset`/`map`/`multimap`/`array`/`pair`/`optional`, including every preamble and element-type mismatch throw |
| `mrpt_serialization/tests/CSchemeArchive_unittest.cpp` | the JSON scheme archive, and the default "class does not support schema based serialization" throws |
| `mrpt_rtti/tests/rtti_registry_unittest.cpp` | the class registry (custom names, namespace-less lookup, children enumeration, duplicate registration), `derivedFrom()` by name, cloning of a non-copy-constructible class, `CListOfClasses` string round-trip |

## Bugs found and fixed

1. **`sendMessage()` byte order** — it wrote the payload length **low byte first**, while both `receiveMessage()` and the frame format documented in `CArchive.h` (`<HIBYTE(LENGTH)> <LOBYTE(LENGTH)>`) expect the high byte first. No message of 256 bytes or more could ever be received back. Fixed in `sendMessage()`, the odd one out.

2. **`receiveMessage()` rejected empty messages** — it computed how many bytes were still missing and then always read them; for a frame with an empty payload that count is zero, and a zero-length read was taken for an end-of-stream condition. The completeness check now happens before the read.

3. **`std::variant` holding no value could not be deserialized** — `operator<<(const std::monostate&)` writes no version byte, but `internal_ReadObjectHeader()` only skipped that byte for `"nullptr"`, so it ran off the end of the stream.

4. **Swapped format arguments** in `internal_ReadObjectHeader()`'s error message (archive description and class name the wrong way round).

Bugs 1, 3 and 4 are also present in the 2.x branch.

## Coverage

Module-scoped `gcovr` runs, before → after:

* `mrpt_serialization`: **72.2% → 96.4%** lines, 62.8% → 81.0% branches
* `mrpt_rtti`: 71.6% (2026-07-03 baseline) / 83.0% (measured today) → **85.8%** lines

## Note for the maintainer, not changed here

`mrpt_rtti`'s remaining uncovered lines are almost entirely the **deferred class-registration queue**: `pending_class_registers()`, `pending_class_registers_count()`, `queue_register_functions_t` (in the private `src/internal_class_registry.h`) and the drain loop inside `registerAllPendingClasses()`. Nothing anywhere in the repo ever pushes to that queue — it is a leftover of MRPT 1.x's `CLASS_INIT` mechanism, so `registerAllPendingClasses()` always takes its early return. Removing it would take `mrpt_rtti` to ~94% lines, but `registerAllPendingClasses()` is declared in the public `CObject.h`, so that call is yours.

## Testing

Full `colcon build` + `colcon test` over all 35 packages: green. `scripts/clang_format_codebase.sh --check`: clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed serialization of empty messages and large message frames.
  * Corrected message byte ordering for reliable transmission.
  * Improved handling of truncated, corrupted, and legacy archive data.
  * Fixed serialization compatibility for `std::monostate` values.
  * Improved error reporting for invalid object and archive data.

* **Tests**
  * Expanded coverage for RTTI, binary and JSON serialization, STL containers, message transport, object conversion, and archive error handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->