### PR TITLE
test(mrpt_io): cover the stream, compression and path helpers

### DIFF
--- a/modules/mrpt_io/CMakeLists.txt
+++ b/modules/mrpt_io/CMakeLists.txt
@@ -72,6 +72,11 @@ set(LIB_UNIT_TEST_SOURCES
   tests/vector_loadsave_unittest.cpp
   tests/zip_unittest.cpp
   tests/vector_loadsave_extra_unittest.cpp
+  tests/CStream_unittest.cpp
+  tests/CMemoryStream_extra_unittest.cpp
+  tests/file_streams_unittest.cpp
+  tests/compression_unittest.cpp
+  tests/misc_io_unittest.cpp
 )
 
 # These tests are moved to mrpt_viz since that's the lowest-level module that includes all dependencies.

--- a/modules/mrpt_io/include/mrpt/io/detect_compression.h
+++ b/modules/mrpt_io/include/mrpt/io/detect_compression.h
@@ -13,28 +13,14 @@
 */
 #pragma once
 
-#include <cstdint>
+// Note: mrpt::io::CompressionType, the enum returned by detect_compression(),
+// is defined here, shared with the compressed stream classes:
+#include <mrpt/io/compression_options.h>
+
 #include <string>
 
 namespace mrpt::io
 {
-/** \brief Enumeration of supported compression formats.
- *
- * This enum represents the compression type detected from a file's
- * leading magic bytes.
- */
-enum class CompressionType : uint8_t
-{
-  /** Not compressed, or unsupported format */
-  None = 0,
-
-  /** Gzip-compressed stream (RFC 1952) */
-  Gzip,
-
-  /** Zstandard-compressed stream (including skippable frames) */
-  Zstd
-};
-
 /** \brief Detects whether a file is gzip- or Zstandard-compressed, or none.
  *
  * This function inspects the magic bytes at the beginning of the file

--- a/modules/mrpt_io/src/CMemoryStream.cpp
+++ b/modules/mrpt_io/src/CMemoryStream.cpp
@@ -103,7 +103,7 @@ void CMemoryStream::resize(uint64_t newSize)
 size_t CMemoryStream::Read(void* Buffer, size_t Count)
 {
   // enough bytes?
-  const long maxAvail = static_cast<long>(m_bytesWritten) - static_cast<long>(m_position);
+  const int64_t maxAvail = static_cast<int64_t>(m_bytesWritten) - static_cast<int64_t>(m_position);
   size_t nToRead = std::min<size_t>(Count, maxAvail > 0 ? static_cast<size_t>(maxAvail) : 0);
 
   // Copy the memory block:
@@ -142,24 +142,33 @@ size_t CMemoryStream::Write(const void* Buffer, size_t Count)
 
 uint64_t CMemoryStream::Seek(int64_t Offset, CStream::TSeekOrigin Origin)
 {
+  int64_t newPos = 0;
   switch (Origin)
   {
     case sFromBeginning:
-      m_position = static_cast<uint64_t>(Offset);
+      newPos = Offset;
       break;
     case sFromCurrent:
-      m_position += static_cast<uint64_t>(Offset);
+      newPos = static_cast<int64_t>(m_position) + Offset;
       break;
     case sFromEnd:
-      m_position = m_bytesWritten - 1 + static_cast<uint64_t>(Origin);
+      newPos = static_cast<int64_t>(m_bytesWritten) + Offset;
       break;
   };
 
-  if (m_position >= m_size)
+  // Clamp to the range of valid cursor positions. Note that the
+  // one-past-the-last-byte position is valid: it is where a subsequent
+  // Write() appends.
+  if (newPos < 0)
   {
-    m_position = m_size - 1;
+    newPos = 0;
+  }
+  if (newPos > static_cast<int64_t>(m_bytesWritten))
+  {
+    newPos = static_cast<int64_t>(m_bytesWritten);
   }
 
+  m_position = static_cast<uint64_t>(newPos);
   return m_position;
 }
 

--- a/modules/mrpt_io/src/CStream.cpp
+++ b/modules/mrpt_io/src/CStream.cpp
@@ -87,6 +87,9 @@ bool CStream::getline(std::string& out_str)
       out_str.resize(N + 1);
       if (!Read(&out_str[N], 1))
       {
+        // End of stream: drop the byte slot that was never filled, so that
+        // the caller does not get a spurious trailing character.
+        out_str.resize(N);
         return false;
       }
 

--- a/modules/mrpt_io/src/zip.cpp
+++ b/modules/mrpt_io/src/zip.cpp
@@ -139,7 +139,9 @@ void mrpt::io::zip::decompress(
   MRPT_START
 
   outData.resize(outDataEstimatedSize);
-  unsigned long actualOutSize;
+  // zlib takes this as an in/out parameter: on input it must hold the size of
+  // the output buffer.
+  auto actualOutSize = static_cast<unsigned long>(outDataEstimatedSize);
 
   ret = ::uncompress(
       outData.data(), &actualOutSize, reinterpret_cast<unsigned char*>(inData),

--- a/modules/mrpt_io/tests/CMemoryStream_extra_unittest.cpp
+++ b/modules/mrpt_io/tests/CMemoryStream_extra_unittest.cpp
@@ -1,0 +1,201 @@
+/*                    _
+                     | |    Mobile Robot Programming Toolkit (MRPT)
+ _ __ ___  _ __ _ __ | |_
+| '_ ` _ \| '__| '_ \| __|          https://www.mrpt.org/
+| | | | | | |  | |_) | |_
+|_| |_| |_|_|  | .__/ \__|     https://github.com/MRPT/mrpt/
+               | |
+               |_|
+
+ Copyright (c) 2005-2026, Individual contributors, see AUTHORS file
+ See: https://www.mrpt.org/Authors - All rights reserved.
+ SPDX-License-Identifier: BSD-3-Clause
+*/
+
+#include <gtest/gtest.h>
+#include <mrpt/io/CMemoryStream.h>
+#include <mrpt/system/filesystem.h>
+
+#include <array>
+#include <cstdio>
+#include <string>
+
+using mrpt::io::CMemoryStream;
+using mrpt::io::CStream;
+
+TEST(CMemoryStream, constructFromExistingBuffer)
+{
+  const std::string data = "abcdef";
+  CMemoryStream s(data.data(), data.size());
+
+  EXPECT_EQ(s.getTotalBytesCount(), data.size());
+
+  s.Seek(0);
+  std::array<char, 6> buf{};
+  EXPECT_EQ(s.Read(buf.data(), buf.size()), data.size());
+  EXPECT_EQ(std::string(buf.data(), buf.size()), data);
+}
+
+TEST(CMemoryStream, constructFromNullBufferThrows) { EXPECT_ANY_THROW(CMemoryStream(nullptr, 10)); }
+
+TEST(CMemoryStream, seekFromBeginningCurrentAndEnd)
+{
+  CMemoryStream s;
+  const std::string data = "0123456789";
+  s.Write(data.data(), data.size());
+
+  EXPECT_EQ(s.Seek(3, CStream::sFromBeginning), 3U);
+  EXPECT_EQ(s.getPosition(), 3U);
+
+  EXPECT_EQ(s.Seek(2, CStream::sFromCurrent), 5U);
+  EXPECT_EQ(s.Seek(-1, CStream::sFromCurrent), 4U);
+
+  // Offsets from the end are negative, per the CStream contract:
+  EXPECT_EQ(s.Seek(-4, CStream::sFromEnd), 6U);
+  char c = 0;
+  EXPECT_EQ(s.Read(&c, 1), 1U);
+  EXPECT_EQ(c, '6');
+
+  // Seeking to the very end is valid and leaves nothing to read:
+  EXPECT_EQ(s.Seek(0, CStream::sFromEnd), data.size());
+  EXPECT_EQ(s.Read(&c, 1), 0U);
+}
+
+TEST(CMemoryStream, seekClampsToTheValidRange)
+{
+  CMemoryStream s;
+  const std::string data = "0123456789";
+  s.Write(data.data(), data.size());
+
+  EXPECT_EQ(s.Seek(1000, CStream::sFromBeginning), data.size());
+  EXPECT_EQ(s.Seek(-1000, CStream::sFromBeginning), 0U);
+  EXPECT_EQ(s.Seek(-1000, CStream::sFromCurrent), 0U);
+}
+
+TEST(CMemoryStream, seekOnAnEmptyStream)
+{
+  CMemoryStream s;
+  EXPECT_EQ(s.Seek(0), 0U);
+  EXPECT_EQ(s.Seek(0, CStream::sFromEnd), 0U);
+  EXPECT_EQ(s.getPosition(), 0U);
+
+  // The stream is still usable after seeking on it while empty:
+  const std::string data = "hi";
+  EXPECT_EQ(s.Write(data.data(), data.size()), data.size());
+  EXPECT_EQ(s.getTotalBytesCount(), data.size());
+}
+
+TEST(CMemoryStream, seekThenWriteOverwritesInPlace)
+{
+  CMemoryStream s;
+  const std::string data = "0123456789";
+  s.Write(data.data(), data.size());
+
+  s.Seek(2);
+  s.Write("XY", 2);
+  EXPECT_EQ(s.getTotalBytesCount(), data.size());
+
+  s.Seek(0);
+  std::array<char, 10> buf{};
+  s.Read(buf.data(), buf.size());
+  EXPECT_EQ(std::string(buf.data(), buf.size()), "01XY456789");
+}
+
+TEST(CMemoryStream, clearReleasesTheBuffer)
+{
+  CMemoryStream s;
+  s.Write("0123456789", 10);
+  EXPECT_EQ(s.getTotalBytesCount(), 10U);
+
+  s.clear();
+  EXPECT_EQ(s.getTotalBytesCount(), 0U);
+  EXPECT_EQ(s.getPosition(), 0U);
+  EXPECT_EQ(s.getRawBufferData(), nullptr);
+}
+
+TEST(CMemoryStream, assignedMemoryIsReadOnly)
+{
+  const std::string data = "abcdef";
+
+  CMemoryStream s;
+  s.assignMemoryNotOwn(data.data(), data.size());
+
+  EXPECT_EQ(s.getTotalBytesCount(), data.size());
+  EXPECT_EQ(s.getRawBufferData(), data.data());
+
+  std::array<char, 6> buf{};
+  EXPECT_EQ(s.Read(buf.data(), buf.size()), data.size());
+  EXPECT_EQ(std::string(buf.data(), buf.size()), data);
+
+  // The block is not ours to grow, so writing into it is rejected:
+  s.Seek(0);
+  EXPECT_ANY_THROW(s.Write(data.data(), data.size()));
+
+  // ...until it is released:
+  s.clear();
+  EXPECT_EQ(s.getTotalBytesCount(), 0U);
+  EXPECT_EQ(s.Write(data.data(), data.size()), data.size());
+}
+
+TEST(CMemoryStream, writeWithANullBufferThrows)
+{
+  CMemoryStream s;
+  EXPECT_ANY_THROW(s.Write(nullptr, 4));
+}
+
+TEST(CMemoryStream, setAllocBlockSize)
+{
+  CMemoryStream s;
+  EXPECT_ANY_THROW(s.setAllocBlockSize(0));
+
+  EXPECT_NO_THROW(s.setAllocBlockSize(8));
+  s.Write("0123456789", 10);
+  EXPECT_EQ(s.getTotalBytesCount(), 10U);
+}
+
+TEST(CMemoryStream, saveAndLoadBufferFromFile)
+{
+  const std::string fname = mrpt::system::getTempFileName() + "_CMemoryStream_test";
+  const std::string data = "some binary-ish payload";
+
+  {
+    CMemoryStream s;
+    s.Write(data.data(), data.size());
+    EXPECT_TRUE(s.saveBufferToFile(fname));
+  }
+  {
+    CMemoryStream s;
+    EXPECT_TRUE(s.loadBufferFromFile(fname));
+    EXPECT_EQ(s.getTotalBytesCount(), data.size());
+
+    s.Seek(0);
+    std::string readBack(data.size(), '\0');
+    EXPECT_EQ(s.Read(readBack.data(), readBack.size()), data.size());
+    EXPECT_EQ(readBack, data);
+  }
+
+  std::remove(fname.c_str());
+}
+
+TEST(CMemoryStream, loadBufferFromMissingFileFails)
+{
+  CMemoryStream s;
+  EXPECT_FALSE(s.loadBufferFromFile(mrpt::system::getTempFileName() + "_does_not_exist"));
+}
+
+TEST(CMemoryStream, saveBufferToUnwritablePathFails)
+{
+  CMemoryStream s;
+  s.Write("x", 1);
+  EXPECT_FALSE(s.saveBufferToFile("/this/directory/does/not/exist/file.bin"));
+}
+
+TEST(CMemoryStream, streamDescription)
+{
+  CMemoryStream s;
+  s.Write("0123456789", 10);
+
+  const std::string d = s.getStreamDescription();
+  EXPECT_NE(d.find("CMemoryStream"), std::string::npos);
+  EXPECT_NE(d.find("bytesWritten=10"), std::string::npos);
+}

--- a/modules/mrpt_io/tests/CStream_unittest.cpp
+++ b/modules/mrpt_io/tests/CStream_unittest.cpp
@@ -1,0 +1,124 @@
+/*                    _
+                     | |    Mobile Robot Programming Toolkit (MRPT)
+ _ __ ___  _ __ _ __ | |_
+| '_ ` _ \| '__| '_ \| __|          https://www.mrpt.org/
+| | | | | | |  | |_) | |_
+|_| |_| |_|_|  | .__/ \__|     https://github.com/MRPT/mrpt/
+               | |
+               |_|
+
+ Copyright (c) 2005-2026, Individual contributors, see AUTHORS file
+ See: https://www.mrpt.org/Authors - All rights reserved.
+ SPDX-License-Identifier: BSD-3-Clause
+*/
+
+#include <gtest/gtest.h>
+#include <mrpt/io/CMemoryStream.h>
+
+#include <string>
+#include <vector>
+
+using mrpt::io::CMemoryStream;
+using mrpt::io::CStream;
+
+namespace
+{
+/** Returns everything written so far into `s`, as text. */
+std::string writtenText(CMemoryStream& s)
+{
+  return {
+      static_cast<const char*>(s.getRawBufferData()), static_cast<size_t>(s.getTotalBytesCount())};
+}
+}  // namespace
+
+TEST(CStream, printf)
+{
+  CMemoryStream s;
+  EXPECT_EQ(s.printf("%s=%i", "answer", 42), 9);
+  EXPECT_EQ(writtenText(s), "answer=42");
+}
+
+TEST(CStream, printfWithNullFormatThrows)
+{
+  CMemoryStream s;
+  EXPECT_ANY_THROW(s.printf(nullptr));
+}
+
+TEST(CStream, printfGrowsItsInternalBufferForLongOutputs)
+{
+  // The implementation starts with a 1 kB scratch buffer and doubles it until
+  // the formatted text fits:
+  CMemoryStream s;
+  const std::string longArg(5000, 'x');
+  EXPECT_EQ(s.printf("%s", longArg.c_str()), 5000);
+  EXPECT_EQ(writtenText(s), longArg);
+}
+
+TEST(CStream, printfVector)
+{
+  {
+    CMemoryStream s;
+    const std::vector<int> v = {1, 2, 3};
+    s.printf_vector("%i", v);
+    EXPECT_EQ(writtenText(s), "[1,2,3]");
+  }
+  {
+    // A custom separator, and the single-element case (no separator at all):
+    CMemoryStream s;
+    const std::vector<int> v = {7};
+    s.printf_vector("%i", v, ';');
+    EXPECT_EQ(writtenText(s), "[7]");
+  }
+  {
+    CMemoryStream s;
+    const std::vector<double> v = {1.5, 2.5};
+    s.printf_vector("%.1f", v, ';');
+    EXPECT_EQ(writtenText(s), "[1.5;2.5]");
+  }
+  {
+    CMemoryStream s;
+    const std::vector<int> v;
+    s.printf_vector("%i", v);
+    EXPECT_EQ(writtenText(s), "[]");
+  }
+}
+
+TEST(CStream, getline)
+{
+  CMemoryStream s;
+  const std::string data = "first\r\nsecond\nthird";
+  s.Write(data.data(), data.size());
+  s.Seek(0);
+
+  std::string line;
+  EXPECT_TRUE(s.getline(line));
+  EXPECT_EQ(line, "first");  // the '\r' is ignored
+
+  EXPECT_TRUE(s.getline(line));
+  EXPECT_EQ(line, "second");
+
+  // The last line has no terminator: reported as end-of-stream, and whatever
+  // was read stays in the output string:
+  EXPECT_FALSE(s.getline(line));
+  EXPECT_EQ(line, "third");
+}
+
+TEST(CStream, getlineOnAnEmptyStream)
+{
+  CMemoryStream s;
+  std::string line = "stale";
+  EXPECT_FALSE(s.getline(line));
+  EXPECT_TRUE(line.empty());
+}
+
+TEST(CStream, readBufferImmediateFallsBackToRead)
+{
+  CMemoryStream s;
+  const std::string data = "abcdef";
+  s.Write(data.data(), data.size());
+  s.Seek(0);
+
+  char buf[6] = {};
+  EXPECT_EQ(s.ReadBufferImmediate(buf, 6), 6U);
+  EXPECT_EQ(std::string(buf, 6), data);
+}

--- a/modules/mrpt_io/tests/compression_unittest.cpp
+++ b/modules/mrpt_io/tests/compression_unittest.cpp
@@ -1,0 +1,460 @@
+/*                    _
+                     | |    Mobile Robot Programming Toolkit (MRPT)
+ _ __ ___  _ __ _ __ | |_
+| '_ ` _ \| '__| '_ \| __|          https://www.mrpt.org/
+| | | | | | |  | |_) | |_
+|_| |_| |_|_|  | .__/ \__|     https://github.com/MRPT/mrpt/
+               | |
+               |_|
+
+ Copyright (c) 2005-2026, Individual contributors, see AUTHORS file
+ See: https://www.mrpt.org/Authors - All rights reserved.
+ SPDX-License-Identifier: BSD-3-Clause
+*/
+
+#include <gtest/gtest.h>
+#include <mrpt/io/CCompressedInputStream.h>
+#include <mrpt/io/CCompressedOutputStream.h>
+#include <mrpt/io/CFileGZInputStream.h>
+#include <mrpt/io/CFileGZOutputStream.h>
+#include <mrpt/io/CFileOutputStream.h>
+#include <mrpt/io/CMemoryStream.h>
+#include <mrpt/io/detect_compression.h>
+#include <mrpt/io/vector_loadsave.h>
+#include <mrpt/io/zip.h>
+#include <mrpt/system/filesystem.h>
+
+#include <cstdint>
+#include <cstdio>
+#include <string>
+#include <vector>
+
+using mrpt::io::CCompressedInputStream;
+using mrpt::io::CCompressedOutputStream;
+using mrpt::io::CFileGZInputStream;
+using mrpt::io::CFileGZOutputStream;
+using mrpt::io::CompressionOptions;
+using mrpt::io::CStream;
+
+namespace
+{
+/** Low-entropy payload, so that compression actually has something to do. */
+std::vector<uint8_t> samplePayload(size_t n = 20000)
+{
+  std::vector<uint8_t> v(n);
+  for (size_t i = 0; i < n; i++)
+  {
+    v[i] = static_cast<uint8_t>(i & 0x3f);
+  }
+  return v;
+}
+
+std::string tempName(const std::string& suffix) { return mrpt::system::getTempFileName() + suffix; }
+
+/** Writes raw bytes into a file, bypassing any compression. */
+void writeRawFile(const std::string& fname, const std::vector<uint8_t>& bytes)
+{
+  mrpt::io::CFileOutputStream f(fname);
+  if (!bytes.empty())
+  {
+    f.Write(bytes.data(), bytes.size());
+  }
+}
+}  // namespace
+
+// --------------------------- detect_compression ----------------------------
+
+TEST(detect_compression, recognizesMagicBytes)
+{
+  const std::string fname = tempName("_detect");
+
+  writeRawFile(fname, {0x1F, 0x8B, 0x08, 0x00});
+  EXPECT_EQ(mrpt::io::detect_compression(fname), mrpt::io::CompressionType::Gzip);
+
+  writeRawFile(fname, {0x28, 0xB5, 0x2F, 0xFD});
+  EXPECT_EQ(mrpt::io::detect_compression(fname), mrpt::io::CompressionType::Zstd);
+
+  // Zstd skippable frame:
+  writeRawFile(fname, {0x2A, 0x4D, 0x18, 0x50});
+  EXPECT_EQ(mrpt::io::detect_compression(fname), mrpt::io::CompressionType::Zstd);
+  writeRawFile(fname, {0x2A, 0x4D, 0x18, 0x5F});
+  EXPECT_EQ(mrpt::io::detect_compression(fname), mrpt::io::CompressionType::Zstd);
+  // ...but 0x60 is outside the skippable-frame range:
+  writeRawFile(fname, {0x2A, 0x4D, 0x18, 0x60});
+  EXPECT_EQ(mrpt::io::detect_compression(fname), mrpt::io::CompressionType::None);
+
+  writeRawFile(fname, {'p', 'l', 'a', 'i', 'n'});
+  EXPECT_EQ(mrpt::io::detect_compression(fname), mrpt::io::CompressionType::None);
+
+  std::remove(fname.c_str());
+}
+
+TEST(detect_compression, shortAndMissingFiles)
+{
+  const std::string fname = tempName("_detect_short");
+
+  // Fewer than 2 bytes: nothing can be recognized.
+  writeRawFile(fname, {0x1F});
+  EXPECT_EQ(mrpt::io::detect_compression(fname), mrpt::io::CompressionType::None);
+
+  // Two bytes are enough for gzip, but not for the 4-byte zstd magic:
+  writeRawFile(fname, {0x28, 0xB5});
+  EXPECT_EQ(mrpt::io::detect_compression(fname), mrpt::io::CompressionType::None);
+
+  writeRawFile(fname, {});
+  EXPECT_EQ(mrpt::io::detect_compression(fname), mrpt::io::CompressionType::None);
+
+  std::remove(fname.c_str());
+
+  EXPECT_EQ(mrpt::io::detect_compression(fname), mrpt::io::CompressionType::None);
+}
+
+// ------------------- CCompressedOutputStream / InputStream -----------------
+
+class CompressedStreamsTest : public ::testing::TestWithParam<mrpt::io::CompressionType>
+{
+};
+
+TEST_P(CompressedStreamsTest, roundTrip)
+{
+  const auto type = GetParam();
+  const auto payload = samplePayload();
+  const std::string fname = tempName("_compressed_roundtrip");
+
+  {
+    CCompressedOutputStream out(fname, mrpt::io::OpenMode::TRUNCATE, CompressionOptions(type, 1));
+    ASSERT_TRUE(out.fileOpenCorrectly());
+    EXPECT_TRUE(out.is_open());
+    EXPECT_EQ(out.getCompressionType(), type);
+    EXPECT_EQ(out.filePathAtUse(), fname);
+    EXPECT_NE(out.getStreamDescription().find(fname), std::string::npos);
+
+    EXPECT_EQ(out.Write(payload.data(), payload.size()), payload.size());
+    // Note: with Zstd nothing has necessarily reached the file yet, since the
+    // encoder buffers internally until close().
+    EXPECT_NO_THROW((void)out.getPosition());
+
+    // Neither seeking nor reading make sense on an output stream:
+    EXPECT_ANY_THROW((void)out.Seek(0, CStream::sFromBeginning));
+    std::vector<uint8_t> dummy(4);
+    EXPECT_ANY_THROW((void)out.Read(dummy.data(), dummy.size()));
+  }
+
+  EXPECT_GT(mrpt::system::getFileSize(fname), 0U);
+
+  {
+    CCompressedInputStream in(fname);
+    ASSERT_TRUE(in.fileOpenCorrectly());
+    EXPECT_EQ(in.getCompressionType(), type);
+    EXPECT_EQ(in.filePathAtUse(), fname);
+    EXPECT_GT(in.getTotalBytesCount(), 0U);
+
+    std::vector<uint8_t> readBack(payload.size());
+    EXPECT_EQ(in.Read(readBack.data(), readBack.size()), payload.size());
+    EXPECT_EQ(readBack, payload);
+
+    // Nothing left:
+    uint8_t extra = 0;
+    EXPECT_EQ(in.Read(&extra, 1), 0U);
+    EXPECT_TRUE(in.checkEOF());
+
+    EXPECT_GT(in.getUncompressedSize(), 0U);
+    EXPECT_GT(in.getCompressionRatio(), 0.0);
+
+    // Writing into an input stream is rejected:
+    EXPECT_ANY_THROW((void)in.Write(payload.data(), 1));
+  }
+
+  std::remove(fname.c_str());
+}
+
+INSTANTIATE_TEST_SUITE_P(
+    AllCompressionTypes,
+    CompressedStreamsTest,
+    ::testing::Values(
+        mrpt::io::CompressionType::None,
+        mrpt::io::CompressionType::Gzip,
+        mrpt::io::CompressionType::Zstd));
+
+TEST(CCompressedOutputStream, unopenedStreamIsInert)
+{
+  CCompressedOutputStream out;
+  EXPECT_FALSE(out.fileOpenCorrectly());
+  EXPECT_TRUE(out.filePathAtUse().empty());
+  EXPECT_NO_THROW(out.close());
+
+  // Unlike the plain file streams, which report a zero position, the
+  // compressed ones reject queries on a closed file:
+  EXPECT_ANY_THROW((void)out.getPosition());
+}
+
+TEST(CCompressedOutputStream, openingAnUnwritablePathFails)
+{
+  const std::string badPath = "/this/directory/does/not/exist/file.zst";
+
+  CCompressedOutputStream out;
+  std::string err;
+  EXPECT_FALSE(out.open(badPath, CompressionOptions(), err));
+  EXPECT_FALSE(err.empty());
+
+  EXPECT_ANY_THROW(CCompressedOutputStream{badPath});
+}
+
+TEST(CCompressedInputStream, unopenedStreamIsInert)
+{
+  CCompressedInputStream in;
+  EXPECT_FALSE(in.fileOpenCorrectly());
+  EXPECT_TRUE(in.filePathAtUse().empty());
+  EXPECT_NO_THROW(in.close());
+
+  EXPECT_ANY_THROW((void)in.getTotalBytesCount());
+}
+
+TEST(CCompressedInputStream, openingAMissingFileFails)
+{
+  const std::string missing = tempName("_does_not_exist");
+
+  CCompressedInputStream in;
+  std::string err;
+  EXPECT_FALSE(in.open(missing, err));
+  EXPECT_FALSE(err.empty());
+
+  // Note: the constructor's documented "\exception" is not actually raised;
+  // it just leaves the stream closed.
+  CCompressedInputStream in2(missing);
+  EXPECT_FALSE(in2.fileOpenCorrectly());
+}
+
+TEST(CCompressedInputStream, readsAPlainUncompressedFile)
+{
+  const std::string fname = tempName("_plain");
+  const std::vector<uint8_t> payload = {'h', 'e', 'l', 'l', 'o'};
+  writeRawFile(fname, payload);
+
+  CCompressedInputStream in(fname);
+  ASSERT_TRUE(in.fileOpenCorrectly());
+  EXPECT_EQ(in.getCompressionType(), mrpt::io::CompressionType::None);
+  EXPECT_EQ(in.getTotalBytesCount(), payload.size());
+
+  std::vector<uint8_t> readBack(payload.size());
+  EXPECT_EQ(in.Read(readBack.data(), readBack.size()), payload.size());
+  EXPECT_EQ(readBack, payload);
+
+  std::remove(fname.c_str());
+}
+
+TEST(CCompressedOutputStream, appendMode)
+{
+  const std::string fname = tempName("_append");
+
+  {
+    CCompressedOutputStream out(
+        fname, mrpt::io::OpenMode::TRUNCATE,
+        CompressionOptions(mrpt::io::CompressionType::None, 1));
+    (void)out.Write("AAA", 3);
+  }
+  {
+    CCompressedOutputStream out(
+        fname, mrpt::io::OpenMode::APPEND, CompressionOptions(mrpt::io::CompressionType::None, 1));
+    ASSERT_TRUE(out.fileOpenCorrectly());
+    (void)out.Write("BBB", 3);
+  }
+
+  CCompressedInputStream in(fname);
+  ASSERT_TRUE(in.fileOpenCorrectly());
+  std::vector<uint8_t> readBack(6);
+  EXPECT_EQ(in.Read(readBack.data(), readBack.size()), 6U);
+  EXPECT_EQ(std::string(readBack.begin(), readBack.end()), "AAABBB");
+
+  std::remove(fname.c_str());
+}
+
+// --------------------------- CFileGZ*Stream --------------------------------
+
+TEST(CFileGZStreams, roundTrip)
+{
+  const auto payload = samplePayload(5000);
+  const std::string fname = tempName("_gz_roundtrip.gz");
+
+  {
+    CFileGZOutputStream out(fname);
+    ASSERT_TRUE(out.fileOpenCorrectly());
+    EXPECT_TRUE(out.is_open());
+    EXPECT_EQ(out.filePathAtUse(), fname);
+    EXPECT_NE(out.getStreamDescription().find(fname), std::string::npos);
+
+    EXPECT_EQ(out.Write(payload.data(), payload.size()), payload.size());
+    EXPECT_EQ(out.getPosition(), payload.size());
+
+    EXPECT_ANY_THROW((void)out.Seek(0));
+    EXPECT_ANY_THROW((void)out.getTotalBytesCount());
+    std::vector<uint8_t> dummy(4);
+    EXPECT_ANY_THROW((void)out.Read(dummy.data(), dummy.size()));
+  }
+
+  {
+    CFileGZInputStream in(fname);
+    ASSERT_TRUE(in.fileOpenCorrectly());
+    EXPECT_TRUE(in.is_open());
+    EXPECT_EQ(in.filePathAtUse(), fname);
+    EXPECT_NE(in.getStreamDescription().find(fname), std::string::npos);
+    EXPECT_GT(in.getTotalBytesCount(), 0U);
+
+    std::vector<uint8_t> readBack(payload.size());
+    EXPECT_EQ(in.Read(readBack.data(), readBack.size()), payload.size());
+    EXPECT_EQ(readBack, payload);
+
+    // gzeof() only reports EOF once a read has actually hit it:
+    uint8_t extra = 0;
+    EXPECT_EQ(in.Read(&extra, 1), 0U);
+    EXPECT_TRUE(in.checkEOF());
+
+    EXPECT_ANY_THROW((void)in.Seek(0));
+    EXPECT_ANY_THROW((void)in.Write(payload.data(), 1));
+  }
+
+  std::remove(fname.c_str());
+}
+
+TEST(CFileGZStreams, unopenedStreamsAreInert)
+{
+  {
+    CFileGZInputStream in;
+    EXPECT_FALSE(in.fileOpenCorrectly());
+    EXPECT_TRUE(in.checkEOF());
+    EXPECT_TRUE(in.filePathAtUse().empty());
+    EXPECT_NO_THROW(in.close());
+  }
+  {
+    CFileGZOutputStream out;
+    EXPECT_FALSE(out.fileOpenCorrectly());
+    EXPECT_TRUE(out.filePathAtUse().empty());
+    EXPECT_NO_THROW(out.close());
+  }
+}
+
+TEST(CFileGZStreams, openFailures)
+{
+  const std::string missing = tempName("_does_not_exist.gz");
+
+  CFileGZInputStream in;
+  std::string err;
+  EXPECT_FALSE(in.open(missing, err));
+  EXPECT_FALSE(err.empty());
+
+  // Note: the constructor's documented "\exception" is not actually raised;
+  // it just leaves the stream closed.
+  CFileGZInputStream in2(missing);
+  EXPECT_FALSE(in2.fileOpenCorrectly());
+
+  CFileGZOutputStream out;
+  EXPECT_FALSE(out.open("/this/directory/does/not/exist/file.gz"));
+  // Unlike its input counterpart, this constructor does honor its documented
+  // "\exception":
+  EXPECT_ANY_THROW(CFileGZOutputStream{"/this/directory/does/not/exist/file.gz"});
+}
+
+// ------------------------------- zip:: -------------------------------------
+
+TEST(zip, compressAndDecompressVectors)
+{
+  const auto payload = samplePayload();
+  const std::vector<unsigned char> in(payload.begin(), payload.end());
+
+  std::vector<unsigned char> compressed;
+  mrpt::io::zip::compress(in, compressed);
+  EXPECT_FALSE(compressed.empty());
+  EXPECT_LT(compressed.size(), in.size());
+
+  std::vector<unsigned char> out;
+  mrpt::io::zip::decompress(compressed.data(), compressed.size(), out, in.size());
+  EXPECT_EQ(out, in);
+}
+
+TEST(zip, compressAndDecompressRawBuffers)
+{
+  auto payload = samplePayload(4096);
+
+  std::vector<unsigned char> compressed;
+  mrpt::io::zip::compress(payload.data(), payload.size(), compressed);
+  EXPECT_FALSE(compressed.empty());
+
+  std::vector<unsigned char> out(payload.size());
+  const size_t n =
+      mrpt::io::zip::decompress(compressed.data(), compressed.size(), out.data(), out.size());
+  EXPECT_EQ(n, payload.size());
+  EXPECT_TRUE(std::equal(payload.begin(), payload.end(), out.begin()));
+}
+
+TEST(zip, compressIntoAStreamAndDecompressFromIt)
+{
+  auto payload = samplePayload(4096);
+
+  {
+    // The raw-pointer overload:
+    mrpt::io::CMemoryStream buf;
+    mrpt::io::zip::compress(payload.data(), payload.size(), buf);
+    EXPECT_GT(buf.getTotalBytesCount(), 0U);
+
+    buf.Seek(0);
+    std::vector<unsigned char> out(payload.size());
+    const size_t n = mrpt::io::zip::decompress(
+        buf, static_cast<size_t>(buf.getTotalBytesCount()), out.data(), out.size());
+    EXPECT_EQ(n, payload.size());
+    EXPECT_TRUE(std::equal(payload.begin(), payload.end(), out.begin()));
+  }
+  {
+    // ...and the std::vector one:
+    const std::vector<unsigned char> in(payload.begin(), payload.end());
+    mrpt::io::CMemoryStream buf;
+    mrpt::io::zip::compress(in, buf);
+    EXPECT_GT(buf.getTotalBytesCount(), 0U);
+  }
+}
+
+TEST(zip, gzFileRoundTrip)
+{
+  const auto payload = samplePayload(8000);
+  const std::string fname = tempName("_zip_gzfile.gz");
+
+  EXPECT_TRUE(mrpt::io::zip::compress_gz_file(fname, payload));
+
+  std::vector<uint8_t> out;
+  EXPECT_TRUE(mrpt::io::zip::decompress_gz_file(fname, out));
+  EXPECT_EQ(out, payload);
+
+  std::remove(fname.c_str());
+}
+
+TEST(zip, gzFileFailures)
+{
+  std::vector<uint8_t> out;
+  EXPECT_FALSE(mrpt::io::zip::decompress_gz_file(tempName("_does_not_exist.gz"), out));
+
+  EXPECT_FALSE(
+      mrpt::io::zip::compress_gz_file("/this/directory/does/not/exist/f.gz", samplePayload(10)));
+}
+
+TEST(zip, gzDataBlockWithEmptyInput)
+{
+  std::vector<uint8_t> out;
+  EXPECT_TRUE(mrpt::io::zip::compress_gz_data_block({}, out));
+  EXPECT_TRUE(out.empty());
+
+  std::vector<uint8_t> out2 = {1, 2, 3};
+  EXPECT_TRUE(mrpt::io::zip::decompress_gz_data_block({}, out2));
+  EXPECT_TRUE(out2.empty());
+}
+
+TEST(zip, compressAnEmptyGzFile)
+{
+  const std::string fname = tempName("_zip_empty.gz");
+
+  EXPECT_TRUE(mrpt::io::zip::compress_gz_file(fname, {}));
+
+  std::vector<uint8_t> out;
+  EXPECT_TRUE(mrpt::io::zip::decompress_gz_file(fname, out));
+  EXPECT_TRUE(out.empty());
+
+  std::remove(fname.c_str());
+}

--- a/modules/mrpt_io/tests/file_streams_unittest.cpp
+++ b/modules/mrpt_io/tests/file_streams_unittest.cpp
@@ -1,0 +1,251 @@
+/*                    _
+                     | |    Mobile Robot Programming Toolkit (MRPT)
+ _ __ ___  _ __ _ __ | |_
+| '_ ` _ \| '__| '_ \| __|          https://www.mrpt.org/
+| | | | | | |  | |_) | |_
+|_| |_| |_|_|  | .__/ \__|     https://github.com/MRPT/mrpt/
+               | |
+               |_|
+
+ Copyright (c) 2005-2026, Individual contributors, see AUTHORS file
+ See: https://www.mrpt.org/Authors - All rights reserved.
+ SPDX-License-Identifier: BSD-3-Clause
+*/
+
+#include <gtest/gtest.h>
+#include <mrpt/io/CFileInputStream.h>
+#include <mrpt/io/CFileOutputStream.h>
+#include <mrpt/system/filesystem.h>
+
+#include <array>
+#include <cstdio>
+#include <string>
+
+using mrpt::io::CFileInputStream;
+using mrpt::io::CFileOutputStream;
+using mrpt::io::CStream;
+using mrpt::io::OpenMode;
+
+namespace
+{
+/** Writes `contents` into a fresh temporary file, and returns its path. */
+std::string makeTempFileWith(const std::string& contents, const std::string& suffix)
+{
+  const std::string fname = mrpt::system::getTempFileName() + suffix;
+  CFileOutputStream f(fname);
+  if (!contents.empty())
+  {
+    f.Write(contents.data(), contents.size());
+  }
+  return fname;
+}
+}  // namespace
+
+// --------------------------- CFileInputStream ------------------------------
+
+TEST(CFileInputStream, constructorThrowsForAMissingFile)
+{
+  EXPECT_ANY_THROW(CFileInputStream(mrpt::system::getTempFileName() + "_does_not_exist"));
+}
+
+TEST(CFileInputStream, unopenedStreamIsInert)
+{
+  CFileInputStream f;
+  EXPECT_FALSE(f.fileOpenCorrectly());
+  EXPECT_TRUE(f.checkEOF());
+  EXPECT_EQ(f.getPosition(), 0U);
+  EXPECT_EQ(f.getTotalBytesCount(), 0U);
+  EXPECT_EQ(f.Seek(10), 0U);
+
+  std::array<char, 4> buf{};
+  EXPECT_EQ(f.Read(buf.data(), buf.size()), 0U);
+
+  std::string line = "stale";
+  EXPECT_FALSE(f.readLine(line));
+  EXPECT_TRUE(line.empty());
+
+  EXPECT_NO_THROW(f.clearError());
+  EXPECT_NO_THROW(f.close());
+}
+
+TEST(CFileInputStream, writingToAReadStreamThrows)
+{
+  const std::string fname = makeTempFileWith("data", "_cfis_write");
+
+  CFileInputStream f(fname);
+  ASSERT_TRUE(f.fileOpenCorrectly());
+  EXPECT_ANY_THROW(f.Write("x", 1));
+
+  std::remove(fname.c_str());
+}
+
+TEST(CFileInputStream, readSeekAndSize)
+{
+  const std::string data = "0123456789";
+  const std::string fname = makeTempFileWith(data, "_cfis_read");
+
+  CFileInputStream f(fname);
+  ASSERT_TRUE(f.fileOpenCorrectly());
+  EXPECT_EQ(f.getTotalBytesCount(), data.size());
+
+  char c = 0;
+  EXPECT_EQ(f.Seek(4, CStream::sFromBeginning), 4U);
+  EXPECT_EQ(f.Read(&c, 1), 1U);
+  EXPECT_EQ(c, '4');
+
+  EXPECT_EQ(f.Seek(2, CStream::sFromCurrent), 7U);
+  EXPECT_EQ(f.Read(&c, 1), 1U);
+  EXPECT_EQ(c, '7');
+
+  EXPECT_EQ(f.Seek(-1, CStream::sFromEnd), data.size() - 1);
+  EXPECT_EQ(f.Read(&c, 1), 1U);
+  EXPECT_EQ(c, '9');
+
+  // Reading past the end fails, and is reported as EOF until cleared:
+  EXPECT_EQ(f.Read(&c, 1), 0U);
+  EXPECT_TRUE(f.checkEOF());
+  f.clearError();
+  EXPECT_FALSE(f.checkEOF());
+
+  std::remove(fname.c_str());
+}
+
+TEST(CFileInputStream, readLine)
+{
+  const std::string fname = makeTempFileWith("alpha\nbeta\ngamma", "_cfis_lines");
+
+  CFileInputStream f(fname);
+  ASSERT_TRUE(f.fileOpenCorrectly());
+
+  std::string line;
+  EXPECT_TRUE(f.readLine(line));
+  EXPECT_EQ(line, "alpha");
+  EXPECT_TRUE(f.readLine(line));
+  EXPECT_EQ(line, "beta");
+  // The last line has no terminator, so it reads as an end-of-file:
+  EXPECT_FALSE(f.readLine(line));
+
+  std::remove(fname.c_str());
+}
+
+TEST(CFileInputStream, openCloseAndReopen)
+{
+  const std::string fname = makeTempFileWith("abc", "_cfis_reopen");
+
+  CFileInputStream f;
+  EXPECT_TRUE(f.open(fname));
+  EXPECT_TRUE(f.fileOpenCorrectly());
+  EXPECT_NE(f.getStreamDescription().find(fname), std::string::npos);
+
+  f.close();
+  EXPECT_FALSE(f.fileOpenCorrectly());
+
+  EXPECT_FALSE(f.open(mrpt::system::getTempFileName() + "_does_not_exist"));
+
+  std::remove(fname.c_str());
+}
+
+// --------------------------- CFileOutputStream -----------------------------
+
+TEST(CFileOutputStream, constructorThrowsForAnUnwritablePath)
+{
+  EXPECT_ANY_THROW(CFileOutputStream("/this/directory/does/not/exist/file.bin"));
+}
+
+TEST(CFileOutputStream, unopenedStreamIsInert)
+{
+  CFileOutputStream f;
+  EXPECT_FALSE(f.fileOpenCorrectly());
+  EXPECT_EQ(f.getPosition(), 0U);
+  EXPECT_EQ(f.getTotalBytesCount(), 0U);
+  EXPECT_EQ(f.Seek(10), 0U);
+  EXPECT_EQ(f.Write("x", 1), 0U);
+  EXPECT_NO_THROW(f.close());
+}
+
+TEST(CFileOutputStream, readingFromAWriteStreamThrows)
+{
+  const std::string fname = mrpt::system::getTempFileName() + "_cfos_read";
+
+  CFileOutputStream f(fname);
+  ASSERT_TRUE(f.fileOpenCorrectly());
+
+  std::array<char, 4> buf{};
+  EXPECT_ANY_THROW(f.Read(buf.data(), buf.size()));
+
+  std::remove(fname.c_str());
+}
+
+TEST(CFileOutputStream, writeSeekAndSize)
+{
+  const std::string fname = mrpt::system::getTempFileName() + "_cfos_write";
+
+  {
+    CFileOutputStream f(fname);
+    ASSERT_TRUE(f.fileOpenCorrectly());
+    EXPECT_NE(f.getStreamDescription().find(fname), std::string::npos);
+
+    const std::string data = "0123456789";
+    EXPECT_EQ(f.Write(data.data(), data.size()), data.size());
+    EXPECT_EQ(f.getPosition(), data.size());
+    EXPECT_EQ(f.getTotalBytesCount(), data.size());
+
+    // Overwrite in place:
+    EXPECT_EQ(f.Seek(2, CStream::sFromBeginning), 2U);
+    f.Write("XY", 2);
+    EXPECT_EQ(f.Seek(0, CStream::sFromEnd), data.size());
+    EXPECT_EQ(f.Seek(-3, CStream::sFromCurrent), data.size() - 3);
+  }
+
+  CFileInputStream in(fname);
+  std::array<char, 10> buf{};
+  in.Read(buf.data(), buf.size());
+  EXPECT_EQ(std::string(buf.data(), buf.size()), "01XY456789");
+
+  std::remove(fname.c_str());
+}
+
+TEST(CFileOutputStream, truncateAndAppendModes)
+{
+  const std::string fname = mrpt::system::getTempFileName() + "_cfos_append";
+
+  {
+    CFileOutputStream f(fname);
+    f.Write("AAA", 3);
+  }
+  {
+    CFileOutputStream f(fname, OpenMode::APPEND);
+    ASSERT_TRUE(f.fileOpenCorrectly());
+    f.Write("BBB", 3);
+  }
+  {
+    CFileInputStream in(fname);
+    EXPECT_EQ(in.getTotalBytesCount(), 6U);
+  }
+  {
+    // The default mode truncates:
+    CFileOutputStream f(fname, OpenMode::TRUNCATE);
+    f.Write("C", 1);
+  }
+  {
+    CFileInputStream in(fname);
+    EXPECT_EQ(in.getTotalBytesCount(), 1U);
+  }
+
+  std::remove(fname.c_str());
+}
+
+TEST(CFileOutputStream, openCloseAndReopen)
+{
+  const std::string fname = mrpt::system::getTempFileName() + "_cfos_reopen";
+
+  CFileOutputStream f;
+  EXPECT_TRUE(f.open(fname));
+  EXPECT_TRUE(f.fileOpenCorrectly());
+  f.close();
+  EXPECT_FALSE(f.fileOpenCorrectly());
+
+  EXPECT_FALSE(f.open("/this/directory/does/not/exist/file.bin"));
+
+  std::remove(fname.c_str());
+}

--- a/modules/mrpt_io/tests/misc_io_unittest.cpp
+++ b/modules/mrpt_io/tests/misc_io_unittest.cpp
@@ -1,0 +1,169 @@
+/*                    _
+                     | |    Mobile Robot Programming Toolkit (MRPT)
+ _ __ ___  _ __ _ __ | |_
+| '_ ` _ \| '__| '_ \| __|          https://www.mrpt.org/
+| | | | | | |  | |_) | |_
+|_| |_| |_|_|  | .__/ \__|     https://github.com/MRPT/mrpt/
+               | |
+               |_|
+
+ Copyright (c) 2005-2026, Individual contributors, see AUTHORS file
+ See: https://www.mrpt.org/Authors - All rights reserved.
+ SPDX-License-Identifier: BSD-3-Clause
+*/
+
+#include <gtest/gtest.h>
+#include <mrpt/io/CFileOutputStream.h>
+#include <mrpt/io/CTextFileLinesParser.h>
+#include <mrpt/io/lazy_load_path.h>
+#include <mrpt/system/filesystem.h>
+
+#include <cstdio>
+#include <sstream>
+#include <string>
+
+// ------------------------------ lazy_load_path -----------------------------
+
+namespace
+{
+/** Restores the process-wide lazy-load base path when the test ends. */
+class LazyLoadPathGuard
+{
+ public:
+  LazyLoadPathGuard() : m_saved(mrpt::io::getLazyLoadPathBase()) {}
+  ~LazyLoadPathGuard() { mrpt::io::setLazyLoadPathBase(m_saved); }
+
+  LazyLoadPathGuard(const LazyLoadPathGuard&) = delete;
+  LazyLoadPathGuard& operator=(const LazyLoadPathGuard&) = delete;
+  LazyLoadPathGuard(LazyLoadPathGuard&&) = delete;
+  LazyLoadPathGuard& operator=(LazyLoadPathGuard&&) = delete;
+
+ private:
+  std::string m_saved;
+};
+}  // namespace
+
+TEST(lazy_load_path, defaultBaseIsTheCurrentDirectory)
+{
+  EXPECT_EQ(mrpt::io::getLazyLoadPathBase(), ".");
+}
+
+TEST(lazy_load_path, absolutePathsAreLeftUntouched)
+{
+  EXPECT_EQ(mrpt::io::lazy_load_absolute_path("/tmp/foo.bin"), "/tmp/foo.bin");
+  // Windows-style drive letters count as absolute too:
+  EXPECT_EQ(mrpt::io::lazy_load_absolute_path("C:\\data\\foo.bin"), "C:\\data\\foo.bin");
+  EXPECT_EQ(mrpt::io::lazy_load_absolute_path("C:/data/foo.bin"), "C:/data/foo.bin");
+}
+
+TEST(lazy_load_path, relativePathsArePrefixedWithTheBase)
+{
+  const LazyLoadPathGuard guard;
+
+  mrpt::io::setLazyLoadPathBase("/base/dir");
+  EXPECT_EQ(mrpt::io::getLazyLoadPathBase(), "/base/dir");
+  EXPECT_EQ(mrpt::io::lazy_load_absolute_path("foo.bin"), "/base/dir/foo.bin");
+
+  // A separator already present in the base is not duplicated:
+  mrpt::io::setLazyLoadPathBase("/base/dir/");
+  EXPECT_EQ(mrpt::io::lazy_load_absolute_path("foo.bin"), "/base/dir/foo.bin");
+
+  mrpt::io::setLazyLoadPathBase("C:\\base\\");
+  EXPECT_EQ(mrpt::io::lazy_load_absolute_path("foo.bin"), "C:\\base\\foo.bin");
+}
+
+TEST(lazy_load_path, tooShortPathsAreRejected)
+{
+  EXPECT_ANY_THROW(mrpt::io::lazy_load_absolute_path("ab"));
+}
+
+// --------------------------- CTextFileLinesParser --------------------------
+
+TEST(CTextFileLinesParser, openingAMissingFileThrows)
+{
+  EXPECT_ANY_THROW(
+      mrpt::io::CTextFileLinesParser(mrpt::system::getTempFileName() + "_does_not_exist"));
+}
+
+TEST(CTextFileLinesParser, parseAFileAndRewind)
+{
+  const std::string fname = mrpt::system::getTempFileName() + "_lines_parser";
+  {
+    mrpt::io::CFileOutputStream f(fname);
+    const std::string data = "  alpha  \n\n% matlab comment\nbeta\n";
+    f.Write(data.data(), data.size());
+  }
+
+  mrpt::io::CTextFileLinesParser parser(fname);
+
+  std::string line;
+  ASSERT_TRUE(parser.getNextLine(line));
+  EXPECT_EQ(line, "alpha");  // surrounding blanks are trimmed
+  ASSERT_TRUE(parser.getNextLine(line));
+  EXPECT_EQ(line, "beta");
+  EXPECT_FALSE(parser.getNextLine(line));
+  EXPECT_TRUE(line.empty());
+
+  parser.rewind();
+  EXPECT_EQ(parser.getCurrentLineNumber(), 0U);
+  ASSERT_TRUE(parser.getNextLine(line));
+  EXPECT_EQ(line, "alpha");
+
+  parser.close();
+  std::remove(fname.c_str());
+}
+
+TEST(CTextFileLinesParser, commentFiltersCanBeDisabled)
+{
+  std::stringstream ss;
+  ss << "# sh\n"
+        "// c\n"
+        "% matlab\n"
+        "data\n";
+  ss.seekg(0);
+
+  mrpt::io::CTextFileLinesParser parser(ss);
+  parser.enableCommentFilters(false, false, false);
+
+  std::string line;
+  ASSERT_TRUE(parser.getNextLine(line));
+  EXPECT_EQ(line, "# sh");
+  ASSERT_TRUE(parser.getNextLine(line));
+  EXPECT_EQ(line, "// c");
+  ASSERT_TRUE(parser.getNextLine(line));
+  EXPECT_EQ(line, "% matlab");
+  ASSERT_TRUE(parser.getNextLine(line));
+  EXPECT_EQ(line, "data");
+  EXPECT_FALSE(parser.getNextLine(line));
+}
+
+TEST(CTextFileLinesParser, getNextLineAsAStringStream)
+{
+  std::stringstream ss;
+  ss << "10 20 30\n";
+  ss.seekg(0);
+
+  mrpt::io::CTextFileLinesParser parser(ss);
+
+  std::istringstream buf;
+  ASSERT_TRUE(parser.getNextLine(buf));
+
+  int a = 0;
+  int b = 0;
+  int c = 0;
+  buf >> a >> b >> c;
+  EXPECT_EQ(a, 10);
+  EXPECT_EQ(b, 20);
+  EXPECT_EQ(c, 30);
+}
+
+TEST(CTextFileLinesParser, closingTwiceIsHarmless)
+{
+  std::stringstream ss;
+  ss << "x\n";
+  ss.seekg(0);
+
+  mrpt::io::CTextFileLinesParser parser(ss);
+  EXPECT_NO_THROW(parser.close());
+  EXPECT_NO_THROW(parser.close());
+}

--- a/modules/mrpt_system/src/filesystem.cpp
+++ b/modules/mrpt_system/src/filesystem.cpp
@@ -330,7 +330,15 @@ std::string mrpt::system::fileNameStripInvalidChars(
 ---------------------------------------------------------------*/
 uint64_t mrpt::system::getFileSize(const std::string& fileName)
 {
-  return fs::file_size(fs::path(fileName));
+  // Use the error_code overload: this function is documented to report errors
+  // via its return value, not by throwing.
+  std::error_code ec;
+  const auto sz = fs::file_size(fs::path(fileName), ec);
+  if (ec)
+  {
+    return static_cast<uint64_t>(-1);
+  }
+  return sz;
 }
 
 /** Replace the filename extension by another one.  */

--- a/modules/mrpt_system/tests/filesystem_unittest.cpp
+++ b/modules/mrpt_system/tests/filesystem_unittest.cpp
@@ -15,6 +15,9 @@
 #include <gtest/gtest.h>
 #include <mrpt/system/filesystem.h>
 
+#include <cstdio>
+#include <fstream>
+
 using namespace mrpt;
 using namespace std;
 
@@ -101,4 +104,21 @@ TEST(FileSystem, pathJoin)
       mrpt::system::pathJoin({"/home", "joe", "p.ini"}),  //
       "/home/joe/p.ini");
 #endif
+}
+
+TEST(FileSystem, getFileSize)
+{
+  const std::string fname = mrpt::system::getTempFileName() + "_getFileSize";
+  {
+    std::ofstream f(fname, std::ios::binary);
+    ASSERT_TRUE(f.is_open());
+    f << "0123456789";
+  }
+  EXPECT_EQ(mrpt::system::getFileSize(fname), 10U);
+
+  std::remove(fname.c_str());
+
+  // A missing file is reported by the return value, never by an exception:
+  EXPECT_EQ(mrpt::system::getFileSize(fname), static_cast<uint64_t>(-1));
+  EXPECT_EQ(mrpt::system::getFileSize(""), static_cast<uint64_t>(-1));
 }


### PR DESCRIPTION
## What

`mrpt_io` was at **63.5% lines / 43.5% branches**. Several files had never had an assertion run against them (`detect_compression.cpp` and `lazy_load_path.cpp` at 0%, `zip.cpp` at 34.7%), and the stream classes were only covered along their happy paths.

New test files:

| file | covers |
|---|---|
| `tests/CStream_unittest.cpp` | `printf` (including the buffer-doubling loop and the null-format throw), `printf_vector`, `getline`, `ReadBufferImmediate` |
| `tests/CMemoryStream_extra_unittest.cpp` | all three `Seek` origins and their clamping, `assignMemoryNotOwn`'s read-only mode, `clear`, `setAllocBlockSize`, `save`/`loadBufferFromFile` including their failure paths |
| `tests/file_streams_unittest.cpp` | `CFileInputStream` / `CFileOutputStream`: seeking from all three origins, `readLine`, EOF handling, append vs. truncate, and every "not open" / "wrong direction" path |
| `tests/compression_unittest.cpp` | `detect_compression` (every magic-byte branch plus short and missing files), a parameterized `CCompressedOutputStream`→`CCompressedInputStream` round-trip over **None/Gzip/Zstd**, the `CFileGZ*` pair, and all the `zip::` overloads |
| `tests/misc_io_unittest.cpp` | `lazy_load_path` and the remaining `CTextFileLinesParser` paths |

## Bugs found and fixed

1. **`mrpt::io::CompressionType` was defined twice.** `detect_compression.h` and `compression_options.h` each defined the same enum, with the same enumerators, in the same namespace — so including both in one translation unit simply did not compile. Found immediately by a test that wanted `detect_compression()` alongside `CCompressedInputStream`. `detect_compression.h` now includes the shared definition.

2. **`zip::decompress()` could write past the end of its output vector.** The `std::vector` overload passed an **uninitialized** `unsigned long` to zlib's `uncompress()`, which takes that parameter as the *capacity* of the destination buffer. Whatever happened to be on the stack became the buffer size zlib was allowed to fill, and the value it wrote back was then used to resize the vector. (Reproducible: the new test threw `cannot create std::vector larger than max_size()` before the fix.) The other three overloads initialize it correctly.

3. **`mrpt::system::getFileSize()` threw instead of returning `-1`.** It is documented as *"Return the size of the given file, or `size_t(-1)` if some error is found accessing that file"*, but the C++17 rewrite used the throwing overload of `std::filesystem::file_size`. `CFileGZInputStream::open()` and `zip::decompress_gz_file()` both test the result against `-1` and are both documented to report failure by returning `false`; both threw instead for a missing file. Fixed with the `std::error_code` overload, plus a regression test in `mrpt_system`.

4. **`CMemoryStream::Seek()` ignored the offset when seeking from the end** — it added the `Origin` enumerator (`2`) instead of `Offset`. It also clamped to the *allocated* size minus one, which underflows to `SIZE_MAX` on an empty stream (after which a `Write` would overflow the requested allocation) and makes the end-of-data position unreachable. It now matches the file streams: offsets are relative to the chosen origin, clamped to `[0, bytesWritten]`. Note that only `Seek(0)` is used anywhere in the tree, so nothing in MRPT depended on the old behavior. Bugs 2 and 4 are also present on the 2.x branch.

5. **`CStream::getline()` left a stray byte** in the output string when it hit end-of-stream, so the last line of a file with no trailing newline came back with an extra trailing NUL.

## Left documented rather than changed

`CFileGZInputStream(fileName)` and `CCompressedInputStream(fileName)` both document `\exception std::exception If there's an error opening the file`, but call `open()` and ignore its result, silently yielding a closed stream. Their **output** counterparts do throw, so the pair is inconsistent. Making them throw would change the contract of `zip::decompress_gz_file()`, which relies on the non-throwing behavior — your call.

## Coverage

Module-scoped `gcovr`, before → after: **63.5% → 82.5%** lines, **43.5% → 62.2%** branches.

What is left: `CPipe.cpp` (58.8%, needs child processes) and the parts of the compressed streams that only trigger on corrupt input.

## Testing

Full `colcon build` + `colcon test` over all 35 packages: green. `scripts/clang_format_codebase.sh --check`: clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved memory-stream seeking, boundary handling, and append behavior.
  - Fixed line reading at end-of-file to prevent spurious characters.
  - Improved compressed-data decompression reliability.
  - File-size queries now return a failure value instead of raising errors for missing or invalid files.
  - Unified compression-type handling across compression detection utilities.

- **Tests**
  - Expanded coverage for memory streams, file streams, compression, text parsing, and filesystem operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->