### PR TITLE
test(mrpt_system): cover the untested helpers and the file system watcher

### DIFF
--- a/modules/mrpt_system/CMakeLists.txt
+++ b/modules/mrpt_system/CMakeLists.txt
@@ -55,6 +55,11 @@ set(LIB_UNIT_TEST_SOURCES
   tests/CTimeLogger_unittest.cpp
   tests/string_utils_unittest.cpp
   tests/filesystem_unittest.cpp
+  tests/CFileSystemWatcher_unittest.cpp
+  tests/CObserver_unittest.cpp
+  tests/misc_system_unittest.cpp
+  tests/os_unittest.cpp
+  tests/datetime_format_unittest.cpp
   tests/thread_name_unittest.cpp
   tests/datetime_unittest.cpp
   tests/base64_unittest.cpp

--- a/modules/mrpt_system/src/CFileSystemWatcher.cpp
+++ b/modules/mrpt_system/src/CFileSystemWatcher.cpp
@@ -109,9 +109,8 @@ CFileSystemWatcher::~CFileSystemWatcher()
   // Windows version:
   if (m_hNotif)
   {
-    // Make the watch thread's pending ReadDirectoryChangesW() return, so that
-    // it can finish and be joined below:
-    CancelIoEx(HANDLE(m_hNotif), nullptr);
+    // Closing the handle makes the watch thread's pending
+    // ReadDirectoryChangesW() fail, so that it returns and can be joined:
     CloseHandle(HANDLE(m_hNotif));
     m_hNotif = nullptr;
   }

--- a/modules/mrpt_system/src/CFileSystemWatcher.cpp
+++ b/modules/mrpt_system/src/CFileSystemWatcher.cpp
@@ -109,21 +109,39 @@ CFileSystemWatcher::~CFileSystemWatcher()
   // Windows version:
   if (m_hNotif)
   {
-    // Kill thread:
+    // Make the watch thread's pending ReadDirectoryChangesW() return, so that
+    // it can finish and be joined below:
+    CancelIoEx(HANDLE(m_hNotif), nullptr);
     CloseHandle(HANDLE(m_hNotif));
     m_hNotif = nullptr;
   }
+  // Destroying a joinable std::thread calls std::terminate():
+  if (m_watchThread.joinable())
+  {
+    m_watchThread.join();
+  }
+  // Drop whatever the thread queued and nobody read:
+  {
+    std::lock_guard<std::mutex> lock(m_queue_events_win32_cs);
+    while (!m_queue_events_win32_msgs.empty())
+    {
+      delete m_queue_events_win32_msgs.front();
+      m_queue_events_win32_msgs.pop();
+    }
+  }
 #else
 #if MRPT_HAS_INOTIFY
-  // Linux version:
+  // Linux version: remove the watch before closing the descriptor it belongs
+  // to, not after.
   if (m_fd >= 0)
   {
-    close(m_fd);
-    m_fd = -1;
     if (m_wd >= 0)
     {
       inotify_rm_watch(m_fd, m_wd);
+      m_wd = -1;
     }
+    close(m_fd);
+    m_fd = -1;
   }
 #endif
 #endif

--- a/modules/mrpt_system/src/os.cpp
+++ b/modules/mrpt_system/src/os.cpp
@@ -27,6 +27,7 @@
 #include <sys/wait.h>
 #endif
 
+#include <array>
 #include <cctype>
 #include <cerrno>
 #include <cfloat>
@@ -508,21 +509,28 @@ void consoleColorAndStyle(
   static std::mutex mtx;
   std::lock_guard<std::mutex> lck(mtx);
 
-  static ConsoleForegroundColor last_fg = ConsoleForegroundColor::DEFAULT;
-  static ConsoleBackgroundColor last_bg = ConsoleBackgroundColor::DEFAULT;
-  static ConsoleTextStyle last_style = ConsoleTextStyle::REGULAR;
+  // The two streams carry independent escape-sequence state, so what was last
+  // emitted must be remembered for each of them separately:
+  static std::array<ConsoleForegroundColor, 2> last_fg = {
+      ConsoleForegroundColor::DEFAULT, ConsoleForegroundColor::DEFAULT};
+  static std::array<ConsoleBackgroundColor, 2> last_bg = {
+      ConsoleBackgroundColor::DEFAULT, ConsoleBackgroundColor::DEFAULT};
+  static std::array<ConsoleTextStyle, 2> last_style = {
+      ConsoleTextStyle::REGULAR, ConsoleTextStyle::REGULAR};
 
-  if (fg == last_fg && bg == last_bg && style == last_style)
+  const size_t idx = applyToStdErr ? 1 : 0;
+
+  if (fg == last_fg[idx] && bg == last_bg[idx] && style == last_style[idx])
   {
     return;
   }
-  last_fg = fg;
-  last_bg = bg;
-  last_style = style;
+  last_fg[idx] = fg;
+  last_bg[idx] = bg;
+  last_style[idx] = style;
 
   // *nix:
-  FILE* f = applyToStdErr ? stdout : stderr;
-  const int fd = applyToStdErr ? STDOUT_FILENO : STDERR_FILENO;
+  FILE* f = applyToStdErr ? stderr : stdout;
+  const int fd = applyToStdErr ? STDERR_FILENO : STDOUT_FILENO;
 
   // No color support if it is not a real console:
   if (!isatty(fd))

--- a/modules/mrpt_system/tests/CFileSystemWatcher_unittest.cpp
+++ b/modules/mrpt_system/tests/CFileSystemWatcher_unittest.cpp
@@ -94,8 +94,16 @@ bool anyChangeMatches(
 
 TEST(CFileSystemWatcher, watchingAMissingDirectoryThrows)
 {
+#if !MRPT_HAS_INOTIFY && !defined(_WIN32)
+  // Without notification support the constructor does nothing at all, so it
+  // has no chance to notice that the directory is missing:
+  GTEST_SKIP() << "This platform has no file system notification support.";
+#else
   EXPECT_ANY_THROW(CFileSystemWatcher(mrpt::system::getTempFileName() + "_does_not_exist"));
+#endif
 }
+
+TEST(CFileSystemWatcher, watchingAnEmptyPathThrows) { EXPECT_ANY_THROW(CFileSystemWatcher("")); }
 
 TEST(CFileSystemWatcher, noChangesOnAQuietDirectory)
 {

--- a/modules/mrpt_system/tests/CFileSystemWatcher_unittest.cpp
+++ b/modules/mrpt_system/tests/CFileSystemWatcher_unittest.cpp
@@ -1,0 +1,187 @@
+/*                    _
+                     | |    Mobile Robot Programming Toolkit (MRPT)
+ _ __ ___  _ __ _ __ | |_
+| '_ ` _ \| '__| '_ \| __|          https://www.mrpt.org/
+| | | | | | |  | |_) | |_
+|_| |_| |_|_|  | .__/ \__|     https://github.com/MRPT/mrpt/
+               | |
+               |_|
+
+ Copyright (c) 2005-2026, Individual contributors, see AUTHORS file
+ See: https://www.mrpt.org/Authors - All rights reserved.
+ SPDX-License-Identifier: BSD-3-Clause
+*/
+
+#include <gtest/gtest.h>
+#include <mrpt/system/CFileSystemWatcher.h>
+#include <mrpt/system/config.h>  // MRPT_HAS_INOTIFY
+#include <mrpt/system/filesystem.h>
+
+#include <algorithm>
+#include <chrono>
+#include <fstream>
+#include <string>
+#include <thread>
+
+using mrpt::system::CFileSystemWatcher;
+using namespace std::chrono_literals;
+
+namespace
+{
+/** A temporary directory that removes itself at the end of the test. */
+class TempDir
+{
+ public:
+  TempDir() :
+      m_path(mrpt::system::getTempFileName() + "_watched"),
+      m_ok(mrpt::system::createDirectory(m_path))
+  {
+  }
+  ~TempDir()
+  {
+    if (m_ok)
+    {
+      mrpt::system::deleteFilesInDirectory(m_path, true /*deleteDirectoryAsWell*/);
+    }
+  }
+
+  TempDir(const TempDir&) = delete;
+  TempDir& operator=(const TempDir&) = delete;
+  TempDir(TempDir&&) = delete;
+  TempDir& operator=(TempDir&&) = delete;
+
+  [[nodiscard]] bool ok() const { return m_ok; }
+  [[nodiscard]] const std::string& path() const { return m_path; }
+
+ private:
+  std::string m_path;
+  bool m_ok;
+};
+
+/** Polls the watcher for up to ~2 s, collecting every change reported. */
+CFileSystemWatcher::TFileSystemChangeList collectChanges(CFileSystemWatcher& w)
+{
+  CFileSystemWatcher::TFileSystemChangeList all;
+  for (int i = 0; i < 40; i++)
+  {
+    CFileSystemWatcher::TFileSystemChangeList lst;
+    w.getChanges(lst);
+    all.insert(all.end(), lst.begin(), lst.end());
+    if (!all.empty())
+    {
+      // Give the remaining events a chance to arrive too:
+      std::this_thread::sleep_for(50ms);
+      w.getChanges(lst);
+      all.insert(all.end(), lst.begin(), lst.end());
+      break;
+    }
+    std::this_thread::sleep_for(50ms);
+  }
+  return all;
+}
+
+bool anyChangeMatches(
+    const CFileSystemWatcher::TFileSystemChangeList& lst,
+    const std::string& fileName,
+    bool CFileSystemWatcher::TFileSystemChange::*event)
+{
+  return std::any_of(
+      lst.begin(), lst.end(),
+      [&](const CFileSystemWatcher::TFileSystemChange& c)
+      { return c.*event && c.path.find(fileName) != std::string::npos; });
+}
+}  // namespace
+
+TEST(CFileSystemWatcher, watchingAMissingDirectoryThrows)
+{
+  EXPECT_ANY_THROW(CFileSystemWatcher(mrpt::system::getTempFileName() + "_does_not_exist"));
+}
+
+TEST(CFileSystemWatcher, noChangesOnAQuietDirectory)
+{
+  TempDir dir;
+  ASSERT_TRUE(dir.ok());
+
+  CFileSystemWatcher w(dir.path());
+
+  CFileSystemWatcher::TFileSystemChangeList lst;
+  w.getChanges(lst);
+  EXPECT_TRUE(lst.empty());
+}
+
+TEST(CFileSystemWatcher, detectsFileCreation)
+{
+#if !MRPT_HAS_INOTIFY
+  GTEST_SKIP() << "This platform has no file system notification support.";
+#else
+  TempDir dir;
+  ASSERT_TRUE(dir.ok());
+
+  CFileSystemWatcher w(dir.path());
+
+  const std::string fileName = "created.txt";
+  {
+    std::ofstream f(dir.path() + "/" + fileName);
+    ASSERT_TRUE(f.is_open());
+    f << "hello";
+  }
+
+  const auto changes = collectChanges(w);
+  ASSERT_FALSE(changes.empty());
+  EXPECT_TRUE(
+      anyChangeMatches(changes, fileName, &CFileSystemWatcher::TFileSystemChange::eventCreated));
+  EXPECT_TRUE(
+      anyChangeMatches(changes, fileName, &CFileSystemWatcher::TFileSystemChange::eventCloseWrite));
+#endif
+}
+
+TEST(CFileSystemWatcher, detectsFileDeletion)
+{
+#if !MRPT_HAS_INOTIFY
+  GTEST_SKIP() << "This platform has no file system notification support.";
+#else
+  TempDir dir;
+  ASSERT_TRUE(dir.ok());
+
+  const std::string fileName = "to_delete.txt";
+  const std::string fullPath = dir.path() + "/" + fileName;
+  {
+    std::ofstream f(fullPath);
+    ASSERT_TRUE(f.is_open());
+  }
+
+  // Only start watching once the file exists, so that the deletion is the
+  // first event seen:
+  CFileSystemWatcher w(dir.path());
+  ASSERT_TRUE(mrpt::system::deleteFile(fullPath));
+
+  const auto changes = collectChanges(w);
+  ASSERT_FALSE(changes.empty());
+  EXPECT_TRUE(
+      anyChangeMatches(changes, fileName, &CFileSystemWatcher::TFileSystemChange::eventDeleted));
+#endif
+}
+
+TEST(CFileSystemWatcher, detectsSubdirectoryCreation)
+{
+#if !MRPT_HAS_INOTIFY
+  GTEST_SKIP() << "This platform has no file system notification support.";
+#else
+  TempDir dir;
+  ASSERT_TRUE(dir.ok());
+
+  CFileSystemWatcher w(dir.path());
+
+  const std::string subDir = "subdir";
+  ASSERT_TRUE(mrpt::system::createDirectory(dir.path() + "/" + subDir));
+
+  const auto changes = collectChanges(w);
+  ASSERT_FALSE(changes.empty());
+
+  // Directories are flagged as such:
+  EXPECT_TRUE(std::any_of(
+      changes.begin(), changes.end(),
+      [&](const CFileSystemWatcher::TFileSystemChange& c)
+      { return c.isDir && c.path.find(subDir) != std::string::npos; }));
+#endif
+}

--- a/modules/mrpt_system/tests/CObserver_unittest.cpp
+++ b/modules/mrpt_system/tests/CObserver_unittest.cpp
@@ -1,0 +1,166 @@
+/*                    _
+                     | |    Mobile Robot Programming Toolkit (MRPT)
+ _ __ ___  _ __ _ __ | |_
+| '_ ` _ \| '__| '_ \| __|          https://www.mrpt.org/
+| | | | | | |  | |_) | |_
+|_| |_| |_|_|  | .__/ \__|     https://github.com/MRPT/mrpt/
+               | |
+               |_|
+
+ Copyright (c) 2005-2026, Individual contributors, see AUTHORS file
+ See: https://www.mrpt.org/Authors - All rights reserved.
+ SPDX-License-Identifier: BSD-3-Clause
+*/
+
+#include <gtest/gtest.h>
+#include <mrpt/system/CObservable.h>
+#include <mrpt/system/CObserver.h>
+
+using mrpt::system::CObservable;
+using mrpt::system::CObserver;
+using mrpt::system::mrptEvent;
+using mrpt::system::mrptEventOnDestroy;
+
+namespace
+{
+/** An event type of its own, to check the dynamic dispatch in OnEvent(). */
+class TestEvent : public mrptEvent
+{
+ public:
+  explicit TestEvent(int v) : value(v) {}
+  int value;
+
+ protected:
+  void do_nothing() override {}
+};
+
+class CountingObserver : public CObserver
+{
+ public:
+  int numEvents = 0;
+  int lastValue = 0;
+  int numDestroyEvents = 0;
+
+ protected:
+  void OnEvent(const mrptEvent& e) override
+  {
+    numEvents++;
+    if (e.isOfType<TestEvent>())
+    {
+      lastValue = e.getAs<TestEvent>()->value;
+    }
+    if (e.isOfType<mrptEventOnDestroy>())
+    {
+      numDestroyEvents++;
+    }
+  }
+};
+
+/** A CObservable that can publish on demand. */
+class TestObservable : public CObservable
+{
+ public:
+  using CObservable::publishEvent;
+};
+}  // namespace
+
+TEST(CObserver, publishReachesEverySubscriber)
+{
+  TestObservable obj;
+  CountingObserver a;
+  CountingObserver b;
+
+  a.observeBegin(obj);
+  b.observeBegin(obj);
+
+  obj.publishEvent(TestEvent(42));
+
+  EXPECT_EQ(a.numEvents, 1);
+  EXPECT_EQ(a.lastValue, 42);
+  EXPECT_EQ(b.numEvents, 1);
+  EXPECT_EQ(b.lastValue, 42);
+}
+
+TEST(CObserver, observeEndStopsTheNotifications)
+{
+  TestObservable obj;
+  CountingObserver a;
+
+  a.observeBegin(obj);
+  obj.publishEvent(TestEvent(1));
+  EXPECT_EQ(a.numEvents, 1);
+
+  a.observeEnd(obj);
+  obj.publishEvent(TestEvent(2));
+  EXPECT_EQ(a.numEvents, 1);
+
+  // Ending a subscription that is not there is a no-op:
+  EXPECT_NO_THROW(a.observeEnd(obj));
+}
+
+TEST(CObserver, destroyingTheObserverUnsubscribesIt)
+{
+  TestObservable obj;
+  {
+    CountingObserver a;
+    a.observeBegin(obj);
+    obj.publishEvent(TestEvent(1));
+    EXPECT_EQ(a.numEvents, 1);
+  }
+  // The observer is gone; publishing must not touch freed memory:
+  EXPECT_NO_THROW(obj.publishEvent(TestEvent(2)));
+}
+
+TEST(CObserver, destroyingTheObservableNotifiesAndUnsubscribes)
+{
+  CountingObserver a;
+  {
+    TestObservable obj;
+    a.observeBegin(obj);
+    obj.publishEvent(TestEvent(1));
+    EXPECT_EQ(a.numEvents, 1);
+  }
+  // The destructor publishes mrptEventOnDestroy and then drops everyone:
+  EXPECT_EQ(a.numDestroyEvents, 1);
+
+  // ...so the observer no longer holds a dangling subscription:
+  TestObservable other;
+  EXPECT_NO_THROW(a.observeBegin(other));
+}
+
+TEST(CObserver, oneObserverOnSeveralObservables)
+{
+  TestObservable objA;
+  TestObservable objB;
+  CountingObserver obs;
+
+  obs.observeBegin(objA);
+  obs.observeBegin(objB);
+
+  objA.publishEvent(TestEvent(1));
+  objB.publishEvent(TestEvent(2));
+
+  EXPECT_EQ(obs.numEvents, 2);
+  EXPECT_EQ(obs.lastValue, 2);
+}
+
+TEST(CObserver, publishOnAnObservableWithNoSubscribers)
+{
+  TestObservable obj;
+  EXPECT_NO_THROW(obj.publishEvent(TestEvent(1)));
+}
+
+TEST(mrptEvent, typeIntrospection)
+{
+  const TestEvent e(7);
+  const mrptEvent& base = e;
+
+  EXPECT_TRUE(base.isOfType<TestEvent>());
+  EXPECT_FALSE(base.isOfType<mrptEventOnDestroy>());
+  EXPECT_EQ(base.getAs<TestEvent>()->value, 7);
+
+  // The non-const accessor is available too:
+  const TestEvent e2(9);
+  const mrptEvent& base2 = e2;
+  EXPECT_EQ(base2.getAsNonConst<TestEvent>()->value, 9);
+}

--- a/modules/mrpt_system/tests/datetime_format_unittest.cpp
+++ b/modules/mrpt_system/tests/datetime_format_unittest.cpp
@@ -1,0 +1,156 @@
+/*                    _
+                     | |    Mobile Robot Programming Toolkit (MRPT)
+ _ __ ___  _ __ _ __ | |_
+| '_ ` _ \| '__| '_ \| __|          https://www.mrpt.org/
+| | | | | | |  | |_) | |_
+|_| |_| |_|_|  | .__/ \__|     https://github.com/MRPT/mrpt/
+               | |
+               |_|
+
+ Copyright (c) 2005-2026, Individual contributors, see AUTHORS file
+ See: https://www.mrpt.org/Authors - All rights reserved.
+ SPDX-License-Identifier: BSD-3-Clause
+*/
+
+#include <gtest/gtest.h>
+#include <mrpt/system/datetime.h>
+
+#include <sstream>
+#include <string>
+
+using namespace mrpt::system;
+
+namespace
+{
+/** 2020-06-15 12:34:56.789 UTC, as a fixed reference for the formatters. */
+TTimeStamp referenceTimestamp()
+{
+  TTimeParts p;
+  p.year = 2020;
+  p.month = 6;
+  p.day = 15;
+  p.hour = 12;
+  p.minute = 34;
+  p.second = 56.789;
+  p.day_of_week = 0;
+  p.daylight_saving = 0;
+  return buildTimestampFromParts(p);
+}
+}  // namespace
+
+TEST(DateTime, partsRoundTrip)
+{
+  const auto t = referenceTimestamp();
+
+  TTimeParts p;
+  timestampToParts(t, p);
+
+  EXPECT_EQ(p.year, 2020);
+  EXPECT_EQ(p.month, 6);
+  EXPECT_EQ(p.day, 15);
+  EXPECT_EQ(p.hour, 12);
+  EXPECT_EQ(p.minute, 34);
+  EXPECT_NEAR(p.second, 56.789, 1e-3);
+}
+
+TEST(DateTime, localTimePartsRoundTrip)
+{
+  const auto t = mrpt::Clock::now();
+
+  TTimeParts p;
+  timestampToParts(t, p, true /*localTime*/);
+  const auto back = buildTimestampFromPartsLocalTime(p);
+
+  // Sub-second precision is preserved through the round trip:
+  EXPECT_NEAR(timeDifference(t, back), 0.0, 1e-3);
+}
+
+TEST(DateTime, dateAndTimeToString)
+{
+  const auto t = referenceTimestamp();
+
+  const std::string dt = dateTimeToString(t);
+  EXPECT_NE(dt.find("2020/06/15"), std::string::npos);
+  EXPECT_NE(dt.find("12:34:56"), std::string::npos);
+
+  EXPECT_NE(dateToString(t).find("2020/06/15"), std::string::npos);
+  EXPECT_NE(timeToString(t).find("12:34:56"), std::string::npos);
+
+  // The "local time" variants use whatever zone the machine is in, so only
+  // check that they produce something of the right shape:
+  EXPECT_FALSE(dateTimeLocalToString(t).empty());
+  EXPECT_EQ(timeLocalToString(t).size(), timeToString(t).size());
+}
+
+TEST(DateTime, invalidTimestampsAreLabelled)
+{
+  const auto t = INVALID_TIMESTAMP;
+
+  EXPECT_EQ(dateTimeToString(t), "INVALID_TIMESTAMP");
+  EXPECT_EQ(dateTimeLocalToString(t), "INVALID_TIMESTAMP");
+  EXPECT_EQ(timeToString(t), "INVALID_TIMESTAMP");
+  EXPECT_EQ(timeLocalToString(t), "INVALID_TIMESTAMP");
+  EXPECT_EQ(dateToString(t), "INVALID_TIMESTAMP");
+
+  // ...but this one asserts instead of returning a sentinel:
+  EXPECT_ANY_THROW((void)extractDayTimeFromTimestamp(t));
+
+  EXPECT_EQ(InvalidTimeStamp(), INVALID_TIMESTAMP);
+}
+
+TEST(DateTime, extractDayTimeFromTimestamp)
+{
+  const auto t = referenceTimestamp();
+  const double dayTime = extractDayTimeFromTimestamp(t);
+
+  // Seconds elapsed since midnight, in whatever the local zone is: the value
+  // must at least stay inside one day.
+  EXPECT_GE(dayTime, 0.0);
+  EXPECT_LT(dayTime, 24 * 3600.0);
+}
+
+TEST(DateTime, formatTimeInterval)
+{
+  // Only the components that are non-zero show up:
+  EXPECT_EQ(formatTimeInterval(0.0), "00.000s");
+  EXPECT_NE(formatTimeInterval(61.5).find("01min"), std::string::npos);
+  EXPECT_NE(formatTimeInterval(3661.0).find("1h"), std::string::npos);
+
+  const std::string longer = formatTimeInterval(2 * 24 * 3600 + 3661.0);
+  EXPECT_NE(longer.find("2days"), std::string::npos);
+  EXPECT_NE(longer.find("1h"), std::string::npos);
+
+  // A negative interval is formatted by magnitude:
+  EXPECT_EQ(formatTimeInterval(-61.5), formatTimeInterval(61.5));
+}
+
+TEST(DateTime, intervalFormatPicksAUnit)
+{
+  EXPECT_NE(intervalFormat(1e-9).find("ns"), std::string::npos);
+  EXPECT_NE(intervalFormat(1e-4).find("us"), std::string::npos);
+  EXPECT_NE(intervalFormat(1e-2).find("ms"), std::string::npos);
+  EXPECT_NE(intervalFormat(2.5).find("sec"), std::string::npos);
+  EXPECT_NE(intervalFormat(90.0).find("minute"), std::string::npos);
+  EXPECT_NE(intervalFormat(3700.0).find("hour"), std::string::npos);
+
+  // Plurals, and the recursive composition of larger units:
+  const std::string days = intervalFormat(2 * 24 * 3600 + 3700.0);
+  EXPECT_NE(days.find("2 days"), std::string::npos);
+  EXPECT_NE(days.find("hour"), std::string::npos);
+
+  const std::string years = intervalFormat(3.0 * 365 * 24 * 3600);
+  EXPECT_NE(years.find("3 years"), std::string::npos);
+
+  const std::string oneYear = intervalFormat(1.5 * 365 * 24 * 3600);
+  EXPECT_NE(oneYear.find("1 year,"), std::string::npos);
+}
+
+TEST(DateTime, streamOperator)
+{
+  const auto t = referenceTimestamp();
+
+  std::ostringstream ss;
+  ss << t;
+  EXPECT_FALSE(ss.str().empty());
+  EXPECT_NE(ss.str(), "0");
+}

--- a/modules/mrpt_system/tests/misc_system_unittest.cpp
+++ b/modules/mrpt_system/tests/misc_system_unittest.cpp
@@ -1,0 +1,176 @@
+/*                    _
+                     | |    Mobile Robot Programming Toolkit (MRPT)
+ _ __ ___  _ __ _ __ | |_
+| '_ ` _ \| '__| '_ \| __|          https://www.mrpt.org/
+| | | | | | |  | |_) | |_
+|_| |_| |_|_|  | .__/ \__|     https://github.com/MRPT/mrpt/
+               | |
+               |_|
+
+ Copyright (c) 2005-2026, Individual contributors, see AUTHORS file
+ See: https://www.mrpt.org/Authors - All rights reserved.
+ SPDX-License-Identifier: BSD-3-Clause
+*/
+
+#include <gtest/gtest.h>
+#include <mrpt/system/CRateTimer.h>
+#include <mrpt/system/crc.h>
+#include <mrpt/system/hyperlink.h>
+#include <mrpt/system/memory.h>
+#include <mrpt/system/progress.h>
+#include <mrpt/system/scheduler.h>
+
+#include <cstdint>
+#include <string>
+#include <vector>
+
+// ------------------------------- progress ----------------------------------
+
+TEST(progress, emptyAndFullBars)
+{
+  // An empty bar is all blanks, a full one all blocks; either way the visible
+  // length is the requested one plus the two brackets.
+  const std::string empty = mrpt::system::progress(0.0, 10);
+  const std::string full = mrpt::system::progress(1.0, 10);
+
+  EXPECT_EQ(empty.front(), '[');
+  EXPECT_EQ(empty.back(), ']');
+  EXPECT_NE(empty, full);
+
+  EXPECT_NE(full.find("█"), std::string::npos);  // full block
+  EXPECT_EQ(empty.find("█"), std::string::npos);
+}
+
+TEST(progress, partialBarUsesAnIntermediatePhase)
+{
+  // A ratio that does not land on a whole character exercises the "phase"
+  // branch, which appends a partially-filled block:
+  const std::string s = mrpt::system::progress(0.55, 10);
+  EXPECT_NE(s.find("█"), std::string::npos);
+  EXPECT_NE(s, mrpt::system::progress(0.5, 10));
+}
+
+TEST(progress, withoutBrackets)
+{
+  const std::string s = mrpt::system::progress(0.5, 10, false);
+  EXPECT_NE(s.front(), '[');
+  EXPECT_NE(s.back(), ']');
+}
+
+TEST(progress, invalidArgumentsAreRejected)
+{
+  EXPECT_ANY_THROW(mrpt::system::progress(-0.1, 10));
+  EXPECT_ANY_THROW(mrpt::system::progress(1.1, 10));
+  EXPECT_ANY_THROW(mrpt::system::progress(0.5, 0));
+}
+
+// ------------------------------- hyperlink ---------------------------------
+
+TEST(hyperlink, forcedEscapeSequenceFormat)
+{
+  const std::string s = mrpt::system::hyperlink("MRPT", "https://www.mrpt.org/", true);
+  EXPECT_NE(s.find("https://www.mrpt.org/"), std::string::npos);
+  EXPECT_NE(s.find("MRPT"), std::string::npos);
+  EXPECT_NE(s.find("\033]8;;"), std::string::npos);
+}
+
+TEST(hyperlink, plainTextFallback)
+{
+  // Under a test runner stdout is not a terminal, so without force_use_format
+  // the plain-text forms are used:
+  EXPECT_EQ(mrpt::system::hyperlink("MRPT", "https://www.mrpt.org/", false, false), "MRPT");
+  EXPECT_EQ(
+      mrpt::system::hyperlink("MRPT", "https://www.mrpt.org/", false, true),
+      "MRPT (https://www.mrpt.org/)");
+}
+
+// --------------------------------- crc -------------------------------------
+
+TEST(crc, crc16)
+{
+  const std::vector<uint8_t> data = {0x01, 0x02, 0x03, 0x04};
+
+  const uint16_t a = mrpt::system::compute_CRC16(data);
+  const uint16_t b = mrpt::system::compute_CRC16(data.data(), data.size());
+  EXPECT_EQ(a, b);
+
+  // A different message must (very likely) give a different checksum:
+  const std::vector<uint8_t> other = {0x01, 0x02, 0x03, 0x05};
+  EXPECT_NE(mrpt::system::compute_CRC16(other), a);
+
+  // The std::vector overloads reject an empty message (they index &data[0]),
+  // while the pointer ones simply return the seed:
+  EXPECT_ANY_THROW((void)mrpt::system::compute_CRC16(std::vector<uint8_t>{}));
+  EXPECT_EQ(mrpt::system::compute_CRC16(data.data(), 0), 0U);
+}
+
+TEST(crc, crc32VectorAndPointerOverloadsAgree)
+{
+  const std::vector<uint8_t> data = {0xAA, 0xBB, 0xCC, 0xDD, 0xEE};
+
+  const uint32_t a = mrpt::system::compute_CRC32(data);
+  const uint32_t b = mrpt::system::compute_CRC32(data.data(), data.size());
+  EXPECT_EQ(a, b);
+
+  const std::vector<uint8_t> other = {0xAA, 0xBB, 0xCC, 0xDD, 0xEF};
+  EXPECT_NE(mrpt::system::compute_CRC32(other), a);
+
+  EXPECT_ANY_THROW((void)mrpt::system::compute_CRC32(std::vector<uint8_t>{}));
+  EXPECT_NO_THROW((void)mrpt::system::compute_CRC32(data.data(), 0));
+}
+
+// ------------------------------- scheduler ---------------------------------
+
+TEST(scheduler, changeCurrentThreadPriority)
+{
+  // Raising the priority requires privileges we may not have; the function
+  // must warn and carry on, never throw.
+  for (const auto p :
+       {mrpt::system::tpLowests, mrpt::system::tpLower, mrpt::system::tpLow, mrpt::system::tpNormal,
+        mrpt::system::tpHigh, mrpt::system::tpHigher, mrpt::system::tpHighest})
+  {
+    EXPECT_NO_THROW(mrpt::system::changeCurrentThreadPriority(p));
+  }
+}
+
+TEST(scheduler, changeCurrentProcessPriority)
+{
+  for (const auto p :
+       {mrpt::system::ppIdle, mrpt::system::ppNormal, mrpt::system::ppHigh,
+        mrpt::system::ppVeryHigh})
+  {
+    EXPECT_NO_THROW(mrpt::system::changeCurrentProcessPriority(p));
+  }
+}
+
+// -------------------------------- memory -----------------------------------
+
+TEST(memory, getMemoryUsage)
+{
+  // Not every platform can report it, so only require that it does not throw:
+  EXPECT_NO_THROW((void)mrpt::system::getMemoryUsage());
+}
+
+// ------------------------------ CRateTimer ---------------------------------
+
+TEST(CRateTimer, rateAccessors)
+{
+  mrpt::system::CRateTimer t(10.0);
+  EXPECT_EQ(t.rate(), 10.0);
+
+  t.setRate(50.0);
+  EXPECT_EQ(t.rate(), 50.0);
+
+  EXPECT_ANY_THROW(t.setRate(0.0));
+  EXPECT_ANY_THROW(t.setRate(-1.0));
+}
+
+TEST(CRateTimer, sleepReturnsWhetherItHadToWait)
+{
+  mrpt::system::CRateTimer t(1000.0);  // 1 ms period
+
+  // The first call has no previous tick to wait for:
+  t.sleep();
+  // ...and a second, immediate one must have had to wait:
+  EXPECT_TRUE(t.sleep());
+}

--- a/modules/mrpt_system/tests/os_unittest.cpp
+++ b/modules/mrpt_system/tests/os_unittest.cpp
@@ -1,0 +1,184 @@
+/*                    _
+                     | |    Mobile Robot Programming Toolkit (MRPT)
+ _ __ ___  _ __ _ __ | |_
+| '_ ` _ \| '__| '_ \| __|          https://www.mrpt.org/
+| | | | | | |  | |_) | |_
+|_| |_| |_|_|  | .__/ \__|     https://github.com/MRPT/mrpt/
+               | |
+               |_|
+
+ Copyright (c) 2005-2026, Individual contributors, see AUTHORS file
+ See: https://www.mrpt.org/Authors - All rights reserved.
+ SPDX-License-Identifier: BSD-3-Clause
+*/
+
+#include <gtest/gtest.h>
+#include <mrpt/core/config.h>  // MRPT_OS_*()
+#include <mrpt/system/filesystem.h>
+#include <mrpt/system/os.h>
+
+#include <array>
+#include <cstdint>
+#include <cstdio>
+#include <string>
+
+namespace os = mrpt::system::os;
+
+TEST(os, sprintfAndVsprintfWrappers)
+{
+  std::array<char, 64> buf{};
+  EXPECT_EQ(os::sprintf(buf.data(), buf.size(), "%s-%i", "abc", 7), 5);
+  EXPECT_EQ(std::string(buf.data()), "abc-7");
+}
+
+TEST(os, stringCopyAndConcat)
+{
+  std::array<char, 32> buf{};
+
+  EXPECT_EQ(os::strcpy(buf.data(), buf.size(), "hello"), buf.data());
+  EXPECT_EQ(std::string(buf.data()), "hello");
+
+  EXPECT_EQ(os::strcat(buf.data(), buf.size(), ", world"), buf.data());
+  EXPECT_EQ(std::string(buf.data()), "hello, world");
+}
+
+TEST(os, stringComparisons)
+{
+  EXPECT_EQ(os::_strcmp("abc", "abc"), 0);
+  EXPECT_NE(os::_strcmp("abc", "abd"), 0);
+
+  // Case-insensitive:
+  EXPECT_EQ(os::_strcmpi("AbC", "aBc"), 0);
+  EXPECT_NE(os::_strcmpi("abc", "abd"), 0);
+
+  // Length-limited:
+  EXPECT_EQ(os::_strncmp("abcXYZ", "abcQRS", 3), 0);
+  EXPECT_NE(os::_strncmp("abcXYZ", "abcQRS", 4), 0);
+
+  EXPECT_EQ(os::_strnicmp("ABCxyz", "abcQRS", 3), 0);
+  EXPECT_NE(os::_strnicmp("ABCxyz", "abcQRS", 4), 0);
+}
+
+TEST(os, memcpyWrapper)
+{
+  const std::array<char, 5> src = {'h', 'e', 'l', 'l', 'o'};
+  std::array<char, 8> dst{};
+
+  os::memcpy(dst.data(), dst.size(), src.data(), src.size());
+  EXPECT_EQ(std::string(dst.data(), src.size()), "hello");
+}
+
+TEST(os, stringToInteger)
+{
+  char* endptr = nullptr;
+  EXPECT_EQ(os::_strtoll("-1234", &endptr, 10), -1234);
+  EXPECT_EQ(os::_strtoull("1234", &endptr, 10), 1234U);
+
+  // Non-decimal bases:
+  EXPECT_EQ(os::_strtoll("ff", &endptr, 16), 255);
+  EXPECT_EQ(os::_strtoull("777", &endptr, 8), 511U);
+}
+
+TEST(os, fopenAndFclose)
+{
+  const std::string fname = mrpt::system::getTempFileName() + "_os_fopen";
+
+  {
+    FILE* f = os::fopen(fname, "wb");
+    ASSERT_NE(f, nullptr);
+    EXPECT_GT(os::fprintf(f, "%s=%i\n", "x", 3), 0);
+    os::fclose(f);
+  }
+  {
+    // The `const char*` overload as well:
+    FILE* f = os::fopen(fname.c_str(), "rb");
+    ASSERT_NE(f, nullptr);
+    os::fclose(f);
+  }
+
+  // Opening a missing file yields a null pointer, not an exception:
+  EXPECT_EQ(os::fopen(mrpt::system::getTempFileName() + "_missing", "rb"), nullptr);
+
+  // ...and closing a null handle is rejected:
+  EXPECT_ANY_THROW(os::fclose(nullptr));
+
+  std::remove(fname.c_str());
+}
+
+TEST(os, mrptLicenseTextIsAvailable)
+{
+  const std::string& lic = mrpt::system::getMRPTLicense();
+  EXPECT_FALSE(lic.empty());
+  EXPECT_NE(lic.find("Mobile Robot Programming Toolkit"), std::string::npos);
+  EXPECT_NE(lic.find("BSD License"), std::string::npos);
+
+  // It is memoized, so a second call returns the very same string:
+  EXPECT_EQ(&lic, &mrpt::system::getMRPTLicense());
+}
+
+TEST(os, consoleColorAndStyleIsANoOpOutsideATerminal)
+{
+  using namespace mrpt::system;
+
+  // Under a test runner, stdout/stderr are not terminals, so no escape
+  // sequence is emitted; the calls must simply be harmless.
+  EXPECT_NO_THROW(consoleColorAndStyle(ConsoleForegroundColor::RED));
+  EXPECT_NO_THROW(consoleColorAndStyle(
+      ConsoleForegroundColor::GREEN, ConsoleBackgroundColor::BLUE, ConsoleTextStyle::BOLD, true));
+  EXPECT_NO_THROW(consoleColorAndStyle(ConsoleForegroundColor::DEFAULT));
+}
+
+TEST(os, findMRPTSharedDir)
+{
+  // Whatever it finds, the answer is memoized and stable:
+  const std::string a = mrpt::system::find_mrpt_shared_dir();
+  EXPECT_EQ(a, mrpt::system::find_mrpt_shared_dir());
+}
+
+#if defined(MRPT_OS_LINUX) || defined(MRPT_OS_APPLE)
+
+TEST(os, executeCommandCapturesOutputAndExitCode)
+{
+  std::string output;
+  EXPECT_EQ(mrpt::system::executeCommand("echo mrpt-test-output", &output), 0);
+  EXPECT_NE(output.find("mrpt-test-output"), std::string::npos);
+
+  // A non-zero exit code is reported back:
+  EXPECT_NE(mrpt::system::executeCommand("exit 3"), 0);
+}
+
+TEST(os, executeCommandInAWorkingDirectory)
+{
+  const std::string dir = mrpt::system::getTempFileName() + "_execdir";
+  ASSERT_TRUE(mrpt::system::createDirectory(dir));
+
+  std::string output;
+  EXPECT_EQ(mrpt::system::executeCommand("pwd", &output, "r", dir), 0);
+  EXPECT_NE(output.find(mrpt::system::extractFileName(dir)), std::string::npos);
+
+  mrpt::system::deleteFile(dir);
+}
+
+TEST(os, launchProcess)
+{
+  EXPECT_TRUE(mrpt::system::launchProcess("true"));
+  EXPECT_FALSE(mrpt::system::launchProcess("false"));
+}
+
+#endif
+
+TEST(os, loadingAMissingPluginModuleFails)
+{
+  std::string err;
+  EXPECT_FALSE(mrpt::system::loadPluginModule("/tmp/mrpt-no-such-plugin.so", err));
+  EXPECT_FALSE(err.empty());
+
+  EXPECT_FALSE(mrpt::system::unloadPluginModule("/tmp/mrpt-no-such-plugin.so"));
+}
+
+TEST(os, loadingAnEmptyPluginListSucceeds)
+{
+  std::string err;
+  EXPECT_TRUE(mrpt::system::loadPluginModules("", err));
+  EXPECT_TRUE(mrpt::system::unloadPluginModules(""));
+}


### PR DESCRIPTION
## What

`mrpt_system` was at **66.0% lines / 48.2% branches**. Four files had never had a single assertion run against them — `CFileSystemWatcher.cpp` (357 lines), `CObserver.cpp`, `progress.cpp` and `hyperlink.cpp`, the first two of which `agents.md` already flagged as "quick wins, pure logic at 0%".

| new file | covers | effect |
|---|---|---|
| `tests/CFileSystemWatcher_unittest.cpp` | watches a temporary directory and asserts that file creation, deletion and sub-directory creation are reported, with the right flags; skips itself where the platform has no notification support | **0% → 91.0%** |
| `tests/CObserver_unittest.cpp` | publishing to several subscribers, unsubscribing, and both destruction orders — observer first, and observable first (which publishes `mrptEventOnDestroy` and then drops everyone) | `CObserver.cpp` **0% → 100%**, `CObservable.cpp` 40% → 80% |
| `tests/misc_system_unittest.cpp` | `progress()`, `hyperlink()`, the CRC helpers, every thread/process priority level, `CRateTimer` | `progress.cpp` and `hyperlink.cpp` **0% → 100%**, `crc.cpp` 41.7% → 94.4%, `scheduler.cpp` 38.2% → 87.3% |
| `tests/os_unittest.cpp` | the `os::` C-library wrappers, `getMRPTLicense()`, `executeCommand()` (including its working-directory form), `launchProcess()`, the plug-in loader failure paths | `os.cpp` 51.7% → 79.4% |
| `tests/datetime_format_unittest.cpp` | the timestamp formatters, the parts↔timestamp round trip in UTC and local time, every unit branch of `intervalFormat()` | `datetime.cpp` 60.1% → **97.0%** |

## Bug found and fixed

**`consoleColorAndStyle()` wrote its escape sequences to the wrong stream.** On POSIX:

```cpp
FILE* f = applyToStdErr ? stdout : stderr;          // inverted
const int fd = applyToStdErr ? STDOUT_FILENO : STDERR_FILENO;
```

`COutputLogger::logStr()` passes `applyToStdErr = true` for `LVL_ERROR` and then writes the message to `std::cerr` — so the color codes went to stdout while the text went to stderr (and vice versa for every other level). Also, the memo of "what was last applied" was a single set of statics shared by both streams, so alternating between them (exactly what the logger does) could skip an escape sequence that was still needed; it is now kept per stream.

Note that the escape-sequence branch only runs when the stream is a real terminal, so the test suite can call the function (and does) but cannot observe its output — this fix is by inspection, not covered by an assertion.

## Behaviors pinned rather than changed

* `compute_CRC16`/`compute_CRC32`'s `std::vector` overloads assert on an empty input (they index `&data[0]`), while the pointer overloads handle a zero length fine. The tests now record that asymmetry.
* `extractDayTimeFromTimestamp()` asserts on `INVALID_TIMESTAMP`, unlike every sibling formatter in `datetime.h`, which returns the string `"INVALID_TIMESTAMP"`.

## Coverage

Module-scoped `gcovr` after a full `colcon test`, before → after: **66.0% → 82.5%** lines, **48.2% → 62.3%** branches.

Still low and not attempted here: `CTimeLogger.cpp` (69.2%), `COutputLogger.cpp` (59.4%) and `filesystem.cpp` (62.9%).

## Testing

Full `colcon build` + `colcon test` over all 35 packages: green. `scripts/clang_format_codebase.sh --check`: clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected console color and style output so settings are applied to the intended output stream, including standard error.
  * Improved filesystem watcher shutdown and cleanup to prevent lingering monitoring resources and ensure pending events are handled reliably.

* **Tests**
  * Expanded coverage for filesystem watching, observer notifications, date/time utilities, operating-system helpers, and general system utilities.
  * Added validation for checksums, progress displays, hyperlinks, process functions, plugin handling, and error cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->