### PR TITLE
test(slam): raise mrpt_slam coverage to 90% and fix the bugs it uncovered

### DIFF
--- a/agents.md
+++ b/agents.md
@@ -201,10 +201,10 @@ files needed changes.
 A full rebuild of all 33 `modules/*` packages was done with coverage
 instrumentation, followed by a full `colcon test` run (all tests passed) and a
 `gcovr` line/branch report. **Goal: 90% line coverage per module.** Current
-overall (2026-08-29, deduplicated the same way as
-`scripts/coverage_module_report.py`): **72.5% lines / 53.2% branches**
+overall (2026-08-31, deduplicated the same way as
+`scripts/coverage_module_report.py`): **73.6% lines / 54.4% branches**
 - still short of goal, dominated by the hardware/GUI modules below.
-The whole table below was re-measured on 2026-08-29; the date tags on some
+The whole table below was re-measured on 2026-08-31; the date tags on some
 rows mark when that module last had a dedicated unit-test pass, and point at
 the footnote describing it.
 
@@ -303,33 +303,33 @@ and accurate path — pick two.
 | mrpt_opengl | 2041/4234 | 48.2% | 30.3% |
 | mrpt_libapps_cli | 1129/1910 | 59.1% | 38.0% |
 | mrpt_libapps_gui | 803/1288 | 62.3% | 45.8% |
-| mrpt_slam (2026-08-28)¤ | 2919/4299 | 67.9% | 45.4% |
-| mrpt_viz (2026-08-02) | 6502/9440 | 68.9% | 50.5% |
+| mrpt_viz (2026-08-02) | 6511/9440 | 69.0% | 50.5% |
 | mrpt_common | 5/7 | 71.4% | 0.0% |
 | mrpt_graphslam (2026-08-28)¤ | 453/618 | 73.3% | 60.5% |
 | mrpt_comms (2026-08-29)» | 687/906 | 75.8% | 54.4% |
 | mrpt_examples_cpp | 99/128 | 77.3% | 46.3% |
 | mrpt_system (2026-08-29)» | 1622/1963 | 82.6% | 58.5% |
-| mrpt_rtti (2026-08-29)» | 151/176 | 85.8% | 75.1% |
-| mrpt_maps (2026-08-03)§ | 10108/11698 | 86.4% | 62.6% |
+| mrpt_rtti (2026-08-29)» | 151/176 | 85.8% | 77.4% |
+| mrpt_maps (2026-08-03)§ | 10118/11698 | 86.5% | 62.8% |
 | mrpt_io (2026-08-29)» | 1133/1310 | 86.5% | 69.7% |
-| mrpt_containers (2026-07-11) | 1632/1848 | 88.3% | 53.7%‡ |
-| mrpt_obs (2026-07-10) | 6054/6848 | 88.4% | 60.4% |
-| mrpt_math (2026-07-05) | 6808/7674 | 88.7% | 59.9% |
-| mrpt_core | 571/636 | 89.8% | 68.6% |
+| mrpt_containers (2026-07-11) | 1633/1848 | 88.4% | 54.4%‡ |
+| mrpt_obs (2026-07-10) | 6066/6856 | 88.5% | 61.0% |
+| mrpt_math (2026-07-05) | 6816/7674 | 88.8% | 60.3% |
+| mrpt_core | 571/636 | 89.8% | 69.9% |
+| mrpt_slam (2026-08-31)× | 3921/4346 | 90.2% | 62.3% |
 | mrpt_nav (2026-08-28)¶ | 5683/6287 | 90.4% | 68.9% |
 | mrpt_graphs (2026-07-06) | 1023/1112 | 92.0% | 76.5% |
-| mrpt_poses | 6272/6787 | 92.4% | 60.2% |
-| mrpt_img (2026-07-10)† | 2838/3061 | 92.7% | 70.9% |
+| mrpt_poses | 6279/6787 | 92.5% | 60.9% |
+| mrpt_img (2026-07-10)† | 2839/3061 | 92.7% | 71.0% |
 | mrpt_expr | 93/100 | 93.0% | 60.2% |
-| mrpt_bayes (2026-07-09) | 1047/1090 | 96.1% | 78.9% |
-| mrpt_serialization (2026-08-29)» | 728/754 | 96.6% | 73.8% |
+| mrpt_bayes (2026-07-09) | 1049/1090 | 96.2% | 80.2% |
+| mrpt_serialization (2026-08-29)» | 728/754 | 96.6% | 74.7% |
 | mrpt_random | 162/167 | 97.0% | 88.4% |
 | mrpt_tfest (2026-07-07) | 635/654 | 97.1% | 73.1% |
 | mrpt_kinematics (2026-08-28)¶ | 503/518 | 97.1% | 81.2% |
-| mrpt_config (2026-07-09) | 536/548 | 97.8% | 84.1% |
+| mrpt_config (2026-07-09) | 536/548 | 97.8% | 84.6% |
 | mrpt_topography (2026-07-10) | 414/417 | 99.3% | 83.2% |
-| mrpt_typemeta | 57/57 | 100.0% | 79.2% |
+| mrpt_typemeta | 57/57 | 100.0% | 80.9% |
 
 † `mrpt_img` vendors third-party `src/stb/*.h` (stb_image/stb_image_resize2/
 stb_image_write, public-domain), which is out of scope for tests like any
@@ -760,6 +760,73 @@ Left documented rather than changed:
   it is dead code left over from MRPT 1.x's `CLASS_INIT` mechanism.
   Removing it would take the module to ~94%.
 
+× Coverage pass of 2026-08-31 on `mrpt_slam` (67.9% -> 90.2%), the last
+pure-logic module still far from the goal. New tests avoid dataset files by
+simulating everything: `mrpt_slam/tests/slam_synthetic_room.h` builds a closed
+10x10 m gridmap and simulates 2D scans and odometry actions from it (shared by
+the ICP-builder, RBPF and MCL tests), while the EKF-SLAM tests drive
+`CLandmarksMap::simulateRangeBearingReadings()` over a handful of landmarks.
+Files that had never had a single assertion run against them:
+`src/slam/CLandmarksMap.cpp` (0%) and `src/slam/observations_overlap.cpp` (0%).
+
+Real bugs found and fixed: (1) `observationsOverlap()`'s `CSensoryFrame`
+overload declared its relative-pose argument `[[maybe_unused]]` and never
+forwarded it, so `CIncrementalMapPartitioner`'s `smOBSERVATION_OVERLAP`
+similarity compared every keyframe pair as if co-located; (2)
+`CIncrementalMapPartitioner::addMapFrame()` passed the *same* relative pose to
+both directions of its symmetrized similarity, but the callback always expects
+"kf2 with respect to kf1", so the swapped evaluation needs the inverse -- this
+moves one keyframe between partitions in the malaga dataset test, whose
+expected output was updated; (3) `removeSetOfNodes(..., changeCoordsRef=true)`
+composed `+p` instead of `-p`, doubling the first node's coordinates instead of
+moving it to the origin as documented (it now reuses
+`changeCoordinatesOriginPoseIndex(0)`); (4) two `TOptions` entries were loaded
+with a *quoted* first argument to `MRPT_LOAD_HERE_CONFIG_VAR`, which
+stringifies it again, so `minDistForCorrespondence`/`minMahaDistForCorrespondence`
+could never be read from a config file; (5) `mrpt::maps::CLandmarksMap` is
+`IMPLEMENTS_SERIALIZABLE` but was never registered in
+`registerAllClasses_mrpt_slam()`, so it could not be deserialized;
+(6) `TSetOfMetricMapInitializers::saveToConfigFile()` (in `mrpt_obs`) wrote a
+format `loadFromConfigFile()` cannot read -- no `<class>_count` keys and
+section names without the map index or the `_creationOpts` suffix -- so the
+round trip always yielded zero maps; (7) `CMultiMetricMapPDF::getLastPose()`
+never set its `is_valid_pose` output on the success path, unlike the two
+sibling implementations; (8) `CMetricMapBuilderICP::saveCurrentEstimationToImage()`
+dereferenced the gridmap pointer right after null-checking it, segfaulting when
+the multi-metric map has no gridmap; (9) the range-only (beacon) branch of
+`CMultiMetricMapPDF::prediction_and_update_pfOptimalProposal()` only ever set
+`firstEstimateRobotHeading` in the no-odometry path and in the unreachable SOG
+sub-method, so with odometry present it always hit the assert guarding it --
+RO-SLAM with the exact optimal proposal could not run at all. It also printed
+the drawn position to `std::cout` on every particle; that is now a debug-level
+log message.
+
+Both `CRangeBearingKFSLAM::TOptions::dumpToTextStream()` and its 2D
+counterpart silently omitted every noise parameter they load
+(`std_sensor_*`, `stds_Q_no_odo`, `std_odo_z_additional`, ...); they now print
+them.
+
+Worth knowing for future tests here:
+
+* `CMetricMapBuilderRBPF::TConstructionOptions::loadFromConfigFile()` reads
+  `insertionAngDistance_deg`, but `CMetricMapBuilderICP::TConfigParams` reads
+  `insertionAngDistance` (already in degrees). The KF-SLAM classes'
+  `loadOptions()` always read from the section named `RangeBearingKFSLAM`,
+  whatever the file is called.
+* `CRangeBearingKFSLAM2D` asserts `pitch == 0` on every observation, so a
+  simulated `CObservationBearingRange` for it must use a zero pitch *noise*,
+  not just coplanar landmarks.
+* `CMonteCarloLocalization2D`/`3D` do not implement `pfOptimalProposal` (only
+  the standard and the two auxiliary variants); `CParticleFilter` throws for
+  it. An adaptive (KLD) sample size additionally requires
+  `resamplingMethod = prMultinomial`.
+* With known landmark IDs, the EKF-SLAM filters skip data association
+  altogether: `getLastDataAssociation().predictions_IDs` stays empty and only
+  `results.associations` is filled from the IDs.
+* The beacon branch of the RBPF optimal proposal only handles `pdfGauss`/
+  `pdfSOG` beacons, so a `CBeaconMap` feeding it needs
+  `insertionOpts.insertAsMonteCarlo = false`.
+
 ### Weak areas, grouped by root cause
 
 1. **Hardware drivers - `mrpt_hwdrivers` (13.9%)**: inherently hard to
@@ -786,6 +853,8 @@ Left documented rather than changed:
 4. **Quick wins — pure-logic files at 0% with no hardware/GUI dependency**
    (highest-value gaps, ordinary unit tests would work immediately):
    `mrpt_graphslam/src/CWindowObserver.cpp`.
+   (`mrpt_slam/src/slam/{CLandmarksMap,observations_overlap}.cpp` cleared this
+   bucket as of 2026-08-31 — see × above.)
    (`mrpt_system/src/CFileSystemWatcher.cpp`, `mrpt_system/src/{progress,
    hyperlink,CObserver}.cpp`, `mrpt_io/src/{detect_compression,
    lazy_load_path}.cpp` and `mrpt_comms/src/{net_utils,CSerialPort}.cpp` all
@@ -820,6 +889,10 @@ Left documented rather than changed:
    registration queue noted in » above), `mrpt_io` (86.5%; `CPipe.cpp` needs
    child processes), `mrpt_comms` (75.8%; the rest is `CInterfaceFTDI`, which
    needs a real FTDI device).
+   (`mrpt_slam` cleared this bucket as of 2026-08-31, now at 90.2%; what is
+   left there is `PF_implementations.h` (60.6%, mostly the auxiliary-PF
+   sub-variants and the KLD adaptive-sampling paths), `CICP.cpp` (87.9%) and
+   `data_association.cpp` (84.5%).)
    (`mrpt_serialization` cleared this bucket as of 2026-08-29, now at 96.6%;
    `mrpt_graphs` and `mrpt_random` cleared it as of 2026-07-06;
    `mrpt_bayes` and `mrpt_config` cleared it as of 2026-07-09, both now >96%;

--- a/agents.md
+++ b/agents.md
@@ -826,6 +826,17 @@ Worth knowing for future tests here:
 * The beacon branch of the RBPF optimal proposal only handles `pdfGauss`/
   `pdfSOG` beacons, so a `CBeaconMap` feeding it needs
   `insertionOpts.insertAsMonteCarlo = false`.
+* Do **not** timestamp simulated observations/actions with one
+  `mrpt::Clock::now()` call per step: on Windows its resolution (~15 ms) is
+  coarse enough that consecutive calls return the *same* value, and
+  `CRobot2DPoseEstimator::processUpdateNewOdometry()` then drops every update
+  ("Diff. in timestamps between odometry should be >0"), so the ICP builder's
+  pose never advances. `slam_synthetic_room.h::nextTimestamp()` hands out
+  timestamps 100 ms apart instead; give the action and the observation of the
+  same step the *same* one, or the pose gets extrapolated twice.
+* `RecursiveSpectralPartition()` returns a stable set of clusters, but their
+  order depends on the sign of the eigenvector and differs between platforms:
+  sort them before comparing.
 
 ### Weak areas, grouped by root cause
 

--- a/modules/mrpt_maps/CMakeLists.txt
+++ b/modules/mrpt_maps/CMakeLists.txt
@@ -65,6 +65,7 @@ set(LIB_UNIT_TEST_SOURCES
   tests/CHeightGridMap2Ds_unittest.cpp
   tests/CLogOddsGridMapLUT_unittest.cpp
   tests/CMultiMetricMap_unittest.cpp
+  tests/TSetOfMetricMapInitializers_unittest.cpp
   tests/CObservation3DRangeScan_unittest.cpp
   tests/CObservationPointCloud_unittest.cpp
   tests/CObservationRotatingScan_unittest.cpp

--- a/modules/mrpt_maps/tests/TSetOfMetricMapInitializers_unittest.cpp
+++ b/modules/mrpt_maps/tests/TSetOfMetricMapInitializers_unittest.cpp
@@ -67,6 +67,9 @@ TEST(TSetOfMetricMapInitializers, saveLoadRoundTrip)
       std::string(got[2]->getMetricMapClassType()->className), "mrpt::maps::CSimplePointsMap");
 
   EXPECT_FALSE(got[0]->genericMapParams.enableSaveAs3DObject);
+  // Only the generic params round trip: there is no saving counterpart to
+  // loadFromConfigFile_map_specific(), so map-specific options stay at their
+  // defaults.
   EXPECT_FALSE(got[1]->genericMapParams.enableObservationLikelihood);
   EXPECT_TRUE(got[2]->genericMapParams.enableObservationLikelihood);
 }

--- a/modules/mrpt_maps/tests/TSetOfMetricMapInitializers_unittest.cpp
+++ b/modules/mrpt_maps/tests/TSetOfMetricMapInitializers_unittest.cpp
@@ -1,0 +1,104 @@
+/*                    _
+                     | |    Mobile Robot Programming Toolkit (MRPT)
+ _ __ ___  _ __ _ __ | |_
+| '_ ` _ \| '__| '_ \| __|          https://www.mrpt.org/
+| | | | | | |  | |_) | |_
+|_| |_| |_|_|  | .__/ \__|     https://github.com/MRPT/mrpt/
+               | |
+               |_|
+
+ Copyright (c) 2005-2026, Individual contributors, see AUTHORS file
+ See: https://www.mrpt.org/Authors - All rights reserved.
+ SPDX-License-Identifier: BSD-3-Clause
+*/
+
+/** Unit tests for mrpt::maps::TSetOfMetricMapInitializers config-file I/O:
+ *  what saveToConfigFile() writes must be readable back by
+ *  loadFromConfigFile().
+ */
+
+#include <gtest/gtest.h>
+#include <mrpt/config/CConfigFileMemory.h>
+#include <mrpt/maps/COccupancyGridMap2D.h>
+#include <mrpt/maps/CSimplePointsMap.h>
+#include <mrpt/maps/TMetricMapInitializer.h>
+
+#include <sstream>
+#include <vector>
+
+using mrpt::maps::TSetOfMetricMapInitializers;
+
+TEST(TSetOfMetricMapInitializers, saveLoadRoundTrip)
+{
+  TSetOfMetricMapInitializers mapsIni;
+  {
+    mrpt::maps::CSimplePointsMap::TMapDefinition def;
+    def.genericMapParams.enableObservationLikelihood = false;
+    mapsIni.push_back(def);
+  }
+  {
+    mrpt::maps::COccupancyGridMap2D::TMapDefinition def;
+    def.genericMapParams.enableSaveAs3DObject = false;
+    mapsIni.push_back(def);
+  }
+  {
+    mrpt::maps::CSimplePointsMap::TMapDefinition def;
+    mapsIni.push_back(def);
+  }
+  ASSERT_EQ(mapsIni.size(), 3U);
+
+  mrpt::config::CConfigFileMemory cfg;
+  mapsIni.saveToConfigFile(cfg, "MAPS");
+
+  TSetOfMetricMapInitializers restored;
+  restored.loadFromConfigFile(cfg, "MAPS");
+
+  ASSERT_EQ(restored.size(), 3U);
+
+  std::vector<mrpt::maps::TMetricMapInitializer::Ptr> got;
+  for (const auto& mi : restored) got.push_back(mi);
+
+  // Maps are grouped per class by the loader, hence the ordering below:
+  EXPECT_EQ(
+      std::string(got[0]->getMetricMapClassType()->className), "mrpt::maps::COccupancyGridMap2D");
+  EXPECT_EQ(
+      std::string(got[1]->getMetricMapClassType()->className), "mrpt::maps::CSimplePointsMap");
+  EXPECT_EQ(
+      std::string(got[2]->getMetricMapClassType()->className), "mrpt::maps::CSimplePointsMap");
+
+  EXPECT_FALSE(got[0]->genericMapParams.enableSaveAs3DObject);
+  EXPECT_FALSE(got[1]->genericMapParams.enableObservationLikelihood);
+  EXPECT_TRUE(got[2]->genericMapParams.enableObservationLikelihood);
+}
+
+TEST(TSetOfMetricMapInitializers, emptySetSavesNothing)
+{
+  TSetOfMetricMapInitializers mapsIni;
+
+  mrpt::config::CConfigFileMemory cfg;
+  mapsIni.saveToConfigFile(cfg, "MAPS");
+
+  TSetOfMetricMapInitializers restored;
+  restored.loadFromConfigFile(cfg, "MAPS");
+  EXPECT_EQ(restored.size(), 0U);
+}
+
+TEST(TSetOfMetricMapInitializers, unknownMapClassThrows)
+{
+  mrpt::config::CConfigFileMemory cfg;
+  cfg.write("MAPS", "thisIsNotAMapClass_count", 1);
+
+  TSetOfMetricMapInitializers mapsIni;
+  EXPECT_THROW(mapsIni.loadFromConfigFile(cfg, "MAPS"), std::exception);
+}
+
+TEST(TSetOfMetricMapInitializers, dumpToTextStream)
+{
+  TSetOfMetricMapInitializers mapsIni;
+  mrpt::maps::CSimplePointsMap::TMapDefinition def;
+  mapsIni.push_back(def);
+
+  std::stringstream ss;
+  mapsIni.dumpToTextStream(ss);
+  EXPECT_NE(ss.str().find("CSimplePointsMap"), std::string::npos);
+}

--- a/modules/mrpt_obs/include/mrpt/maps/TMetricMapInitializer.h
+++ b/modules/mrpt_obs/include/mrpt/maps/TMetricMapInitializer.h
@@ -56,7 +56,12 @@ struct TMetricMapInitializer : public mrpt::config::CLoadableOptions
       const mrpt::config::CConfigFileBase& source,
       const std::string& sectionNamePrefix) override;  // See base docs
   /** Saves the params to a config file, using the same section names read
-   * back by loadFromConfigFile() */
+   * back by loadFromConfigFile().
+   * \note Only the common `genericMapParams` are saved: map-specific options
+   * (`<sectionNamePrefix>_insertOpts`, `_likelihoodOpts`, ...) have no
+   * saving counterpart to `loadFromConfigFile_map_specific()`, so a
+   * save/load round trip restores the list of maps and their generic params,
+   * but leaves the map-specific ones at their defaults. */
   void saveToConfigFile(
       mrpt::config::CConfigFileBase& target, const std::string& sectionNamePrefix) const override;
   void dumpToTextStream(std::ostream& out) const override;  // See base docs

--- a/modules/mrpt_obs/include/mrpt/maps/TMetricMapInitializer.h
+++ b/modules/mrpt_obs/include/mrpt/maps/TMetricMapInitializer.h
@@ -55,8 +55,10 @@ struct TMetricMapInitializer : public mrpt::config::CLoadableOptions
   void loadFromConfigFile(
       const mrpt::config::CConfigFileBase& source,
       const std::string& sectionNamePrefix) override;  // See base docs
+  /** Saves the params to a config file, using the same section names read
+   * back by loadFromConfigFile() */
   void saveToConfigFile(
-      mrpt::config::CConfigFileBase& target, const std::string& section) const override;
+      mrpt::config::CConfigFileBase& target, const std::string& sectionNamePrefix) const override;
   void dumpToTextStream(std::ostream& out) const override;  // See base docs
 
   /** Query the map type (C++ class), as set by the factory method

--- a/modules/mrpt_obs/src/TMetricMapInitializer.cpp
+++ b/modules/mrpt_obs/src/TMetricMapInitializer.cpp
@@ -16,6 +16,8 @@
 #include <mrpt/maps/TMetricMapInitializer.h>
 #include <mrpt/serialization/CArchive.h>
 
+#include <map>
+
 using namespace std;
 using namespace mrpt;
 using namespace mrpt::maps;
@@ -48,10 +50,12 @@ void TMetricMapInitializer::loadFromConfigFile(
 }
 
 void TMetricMapInitializer::saveToConfigFile(
-    mrpt::config::CConfigFileBase& target, const std::string& section) const
+    mrpt::config::CConfigFileBase& target, const std::string& sectionNamePrefix) const
 {
-  auto s = section + std::string("_") + std::string(this->metricMapClassType->className);
-  this->genericMapParams.saveToConfigFile(target, s);
+  // Common: same section naming than loadFromConfigFile(), so the result can
+  // be read back:
+  const std::string sctCreat = sectionNamePrefix + std::string("_creationOpts");
+  this->genericMapParams.saveToConfigFile(target, sctCreat);
 }
 
 void TMetricMapInitializer::dumpToTextStream(std::ostream& out) const
@@ -126,7 +130,19 @@ void TSetOfMetricMapInitializers::loadFromConfigFile(
 void TSetOfMetricMapInitializers::saveToConfigFile(
     mrpt::config::CConfigFileBase& target, const std::string& section) const
 {
-  for (auto& mi : *this) mi->saveToConfigFile(target, section);
+  // Write one "<mapClassName>_count" entry per map type, plus the per-map
+  // sections, in the format expected by loadFromConfigFile():
+  std::map<std::string, unsigned int> mapCounts;
+  for (const auto& mi : *this)
+  {
+    const std::string sMapName = mi->metricMapClassType->className;
+    const unsigned int idx = mapCounts[sMapName]++;
+
+    mi->saveToConfigFile(
+        target, mrpt::format("%s_%s_%02u", section.c_str(), sMapName.c_str(), idx));
+  }
+  for (const auto& [sMapName, count] : mapCounts)
+    target.write(section, sMapName + std::string("_count"), static_cast<uint64_t>(count));
 }
 
 void TSetOfMetricMapInitializers::dumpToTextStream(std::ostream& out) const

--- a/modules/mrpt_slam/CMakeLists.txt
+++ b/modules/mrpt_slam/CMakeLists.txt
@@ -45,6 +45,13 @@ set(LIB_UNIT_TEST_SOURCES
   tests/path_from_rtk_gps_unittest.cpp
   tests/se3_ransac_unittest.cpp
   tests/CRejectionSamplingRangeOnlyLocalization_unittest.cpp
+  tests/observations_overlap_unittest.cpp
+  tests/CLandmarksMap_unittest.cpp
+  tests/CIncrementalMapPartitioner_api_unittest.cpp
+  tests/CMetricMapBuilderRBPF_unittest.cpp
+  tests/CMetricMapBuilderICP_unittest.cpp
+  tests/CRangeBearingKFSLAM_unittest.cpp
+  tests/CMonteCarloLocalization_unittest.cpp
 )
 
 set(LIB_PUBLIC_HEADERS

--- a/modules/mrpt_slam/src/registerAllClasses.cpp
+++ b/modules/mrpt_slam/src/registerAllClasses.cpp
@@ -13,6 +13,7 @@
 */
 
 #include <mrpt/core/initializer.h>
+#include <mrpt/maps/CLandmarksMap.h>
 #include <mrpt/maps/CMultiMetricMapPDF.h>
 #include <mrpt/slam/CIncrementalMapPartitioner.h>
 #include <mrpt/slam/registerAllClasses.h>
@@ -26,6 +27,7 @@ MRPT_INITIALIZER(registerAllClasses_mrpt_slam)
 
 #if !defined(DISABLE_MRPT_AUTO_CLASS_REGISTRATION)
   registerClass(CLASS_ID(CIncrementalMapPartitioner));
+  registerClass(CLASS_ID(CLandmarksMap));
   registerClass(CLASS_ID(CMultiMetricMapPDF));
 #endif
 }

--- a/modules/mrpt_slam/src/slam/CIncrementalMapPartitioner.cpp
+++ b/modules/mrpt_slam/src/slam/CIncrementalMapPartitioner.cpp
@@ -70,9 +70,10 @@ void CIncrementalMapPartitioner::TOptions::loadFromConfigFile(
   MRPT_LOAD_CONFIG_VAR(forceBisectionOnly, bool, source, section);
   MRPT_LOAD_CONFIG_VAR(simil_method, enum, source, section);
   MRPT_LOAD_CONFIG_VAR(minimumNumberElementsEachCluster, uint64_t, source, section);
-  MRPT_LOAD_HERE_CONFIG_VAR("minDistForCorrespondence", float, mrp.maxDistForCorr, source, section);
+  // Note: the first macro argument is stringified, so it must NOT be quoted.
+  MRPT_LOAD_HERE_CONFIG_VAR(minDistForCorrespondence, float, mrp.maxDistForCorr, source, section);
   MRPT_LOAD_HERE_CONFIG_VAR(
-      "minMahaDistForCorrespondence", float, mrp.maxMahaDistForCorr, source, section);
+      minMahaDistForCorrespondence, float, mrp.maxMahaDistForCorr, source, section);
   MRPT_LOAD_CONFIG_VAR(maxKeyFrameDistanceToEval, uint64_t, source, section);
 
   mrpt::config::CConfigFilePrefixer cfp(source, section + std::string("."), "");
@@ -195,9 +196,11 @@ uint32_t CIncrementalMapPartitioner::addMapFrame(
 
         auto relPose = pose_j - pose_i;
 
-        // Evaluate similarity metric & make it symetric:
+        // Evaluate similarity metric & make it symetric. Note that the
+        // relative pose must be inverted for the swapped evaluation, since
+        // it is always expected as "kf2 with respect to kf1":
         const auto s_ij = sim_func(map_i, map_j, relPose);
-        const auto s_ji = sim_func(map_j, map_i, relPose);
+        const auto s_ji = sim_func(map_j, map_i, -relPose);
         s_sym = 0.5 * (s_ij + s_ji);
       }
       m_A(i, j) = m_A(j, i) = s_sym;
@@ -310,14 +313,12 @@ void CIncrementalMapPartitioner::removeSetOfNodes(
   for (auto it = indexesToRemove.rbegin(); it != indexesToRemove.rend(); ++it)
     m_individualFrames.remove(*it);
 
-  // Change coordinates reference of frames:
+  // Change coordinates reference of frames, so the first one lies at the
+  // origin:
   if (changeCoordsRef)
   {
     ASSERT_(m_individualFrames.size() > 0);
-    const auto& kf = m_individualFrames.get(0);
-
-    const CPose3D p = kf.pose->getMeanVal();
-    m_individualFrames.changeCoordinatesOrigin(p);
+    changeCoordinatesOriginPoseIndex(0);
   }
 
   // All done!

--- a/modules/mrpt_slam/src/slam/CMetricMapBuilderICP.cpp
+++ b/modules/mrpt_slam/src/slam/CMetricMapBuilderICP.cpp
@@ -564,7 +564,8 @@ void CMetricMapBuilderICP::saveCurrentEstimationToImage(const std::string& file)
 
   // grid map as bitmap:
   auto pGrid = metricMap.mapByClass<COccupancyGridMap2D>();
-  if (pGrid) pGrid->getAsImage(img);
+  ASSERTMSG_(pGrid, "A gridmap is required to render the current estimation");
+  pGrid->getAsImage(img);
 
   int imgHeight = static_cast<int>(img.getHeight());
 

--- a/modules/mrpt_slam/src/slam/CMultiMetricMapPDF.cpp
+++ b/modules/mrpt_slam/src/slam/CMultiMetricMapPDF.cpp
@@ -264,6 +264,7 @@ TPose3D CMultiMetricMapPDF::getLastPose(size_t i, bool& is_valid_pose) const
   }
   else
   {
+    is_valid_pose = true;
     return *m_particles[i].d->robotPath.rbegin();
   }
 }

--- a/modules/mrpt_slam/src/slam/CMultiMetricMapPDF_RBPF.cpp
+++ b/modules/mrpt_slam/src/slam/CMultiMetricMapPDF_RBPF.cpp
@@ -394,7 +394,10 @@ void CMultiMetricMapPDF::prediction_and_update_pfOptimalProposal(
       // =================================================================
       bool methodSOGorGrid = false;  // TRUE=SOG
       CPoint3D newDrawnPosition;
-      float firstEstimateRobotHeading = std::numeric_limits<float>::max();
+      // Range-only measurements say nothing about the heading, so it is
+      // taken from the motion model (identity if there is no odometry):
+      float firstEstimateRobotHeading =
+          static_cast<float>((ith_last_pose + motionModelMeanIncr).yaw());
 
       // The parameters to discard too far gaussians:
       CPoint3D centerPositionPrior(ith_last_pose);
@@ -402,7 +405,6 @@ void CMultiMetricMapPDF::prediction_and_update_pfOptimalProposal(
 
       if (!robotActionSampler.isPrepared())
       {
-        firstEstimateRobotHeading = static_cast<float>(ith_last_pose.yaw());
         // If the map is empty: There is no solution!:
         // THROW_EXCEPTION("There is no odometry & the initial beacon
         // map is empty: RO-SLAM has no solution -> ABORTED!!!");
@@ -502,7 +504,6 @@ void CMultiMetricMapPDF::prediction_and_update_pfOptimalProposal(
           CPose3D auxPose =
               ith_last_pose +
               motionModelMeanIncr;  // CPose3D(robotMovement->poseChange->getEstimatedPose()));
-          firstEstimateRobotHeading = static_cast<float>(auxPose.yaw());
 
           newMode.val.mean = CPoint3D(auxPose);
 
@@ -768,12 +769,7 @@ void CMultiMetricMapPDF::prediction_and_update_pfOptimalProposal(
       }
       else
       {
-        std::cout << "Drawn: " << newDrawnPosition << "\n";
-        // std::cout << "Final cov was:\n" <<
-        // fusedObsModels.getEstimatedCovariance() << endl << "\n";
-
-        // Make sure it was initialized
-        ASSERT_(firstEstimateRobotHeading != std::numeric_limits<float>::max());
+        MRPT_LOG_DEBUG_STREAM("[RO-SLAM] Drawn position: " << newDrawnPosition);
 
         finalPose.setFromValues(
             newDrawnPosition.x(), newDrawnPosition.y(), newDrawnPosition.z(),

--- a/modules/mrpt_slam/src/slam/CRangeBearingKFSLAM.cpp
+++ b/modules/mrpt_slam/src/slam/CRangeBearingKFSLAM.cpp
@@ -766,6 +766,19 @@ void CRangeBearingKFSLAM::TOptions::dumpToTextStream(std::ostream& out) const
 
   out << "\n----------- [CRangeBearingKFSLAM::TOptions] ------------ \n\n";
 
+  out << mrpt::format("std_sensor_range                        = %f m\n", std_sensor_range);
+  out << mrpt::format(
+      "std_sensor_yaw                          = %f deg\n", RAD2DEG(std_sensor_yaw));
+  out << mrpt::format(
+      "std_sensor_pitch                        = %f deg\n", RAD2DEG(std_sensor_pitch));
+  out << mrpt::format("std_odo_z_additional                    = %f m\n", std_odo_z_additional);
+  out << "stds_Q_no_odo                           = " << stds_Q_no_odo.asString() << "\n";
+  out << mrpt::format(
+      "create_simplemap                        = %c\n", create_simplemap ? 'Y' : 'N');
+  out << mrpt::format(
+      "force_ignore_odometry                   = %c\n", force_ignore_odometry ? 'Y' : 'N');
+  out << mrpt::format(
+      "quantiles_3D_representation             = %f\n", quantiles_3D_representation);
   out << mrpt::format(
       "doPartitioningExperiment                = %c\n", doPartitioningExperiment ? 'Y' : 'N');
   out << mrpt::format("partitioningMethod                      = %i\n", partitioningMethod);

--- a/modules/mrpt_slam/src/slam/CRangeBearingKFSLAM2D.cpp
+++ b/modules/mrpt_slam/src/slam/CRangeBearingKFSLAM2D.cpp
@@ -753,7 +753,10 @@ void CRangeBearingKFSLAM2D::TOptions::dumpToTextStream(std::ostream& out) const
   out << mrpt::format("std_sensor_range                        = %f m\n", std_sensor_range);
   out << mrpt::format(
       "std_sensor_yaw                          = %f deg\n", RAD2DEG(std_sensor_yaw));
-  out << "stds_Q_no_odo                           = " << stds_Q_no_odo.asString() << "\n";
+  // Same units as in the config file: the third component is a heading.
+  out << mrpt::format(
+      "stds_Q_no_odo                           = [%f m, %f m, %f deg]\n", stds_Q_no_odo[0],
+      stds_Q_no_odo[1], RAD2DEG(stds_Q_no_odo[2]));
   out << mrpt::format(
       "create_simplemap                        = %c\n", create_simplemap ? 'Y' : 'N');
   out << mrpt::format(

--- a/modules/mrpt_slam/src/slam/CRangeBearingKFSLAM2D.cpp
+++ b/modules/mrpt_slam/src/slam/CRangeBearingKFSLAM2D.cpp
@@ -750,6 +750,14 @@ void CRangeBearingKFSLAM2D::TOptions::dumpToTextStream(std::ostream& out) const
 
   out << "\n----------- [CRangeBearingKFSLAM2D::TOptions] ------------ \n\n";
 
+  out << mrpt::format("std_sensor_range                        = %f m\n", std_sensor_range);
+  out << mrpt::format(
+      "std_sensor_yaw                          = %f deg\n", RAD2DEG(std_sensor_yaw));
+  out << "stds_Q_no_odo                           = " << stds_Q_no_odo.asString() << "\n";
+  out << mrpt::format(
+      "create_simplemap                        = %c\n", create_simplemap ? 'Y' : 'N');
+  out << mrpt::format(
+      "quantiles_3D_representation             = %f\n", quantiles_3D_representation);
   out << mrpt::format(
       "data_assoc_method                       = %s\n",
       TEnumType<TDataAssociationMethod>::value2name(data_assoc_method).c_str());

--- a/modules/mrpt_slam/src/slam/observations_overlap.cpp
+++ b/modules/mrpt_slam/src/slam/observations_overlap.cpp
@@ -72,7 +72,7 @@ double mrpt::slam::observationsOverlap(
 double mrpt::slam::observationsOverlap(
     const mrpt::obs::CSensoryFrame& sf1,
     const mrpt::obs::CSensoryFrame& sf2,
-    [[maybe_unused]] const mrpt::poses::CPose3D* pose_sf2_wrt_sf1)
+    const mrpt::poses::CPose3D* pose_sf2_wrt_sf1)
 {
   // Return the average value:
   size_t N = 0;
@@ -81,7 +81,7 @@ double mrpt::slam::observationsOverlap(
   {
     for (const auto& i2 : sf2)
     {
-      accum += observationsOverlap(i1, i2);
+      accum += observationsOverlap(i1, i2, pose_sf2_wrt_sf1);
       N++;
     }
   }

--- a/modules/mrpt_slam/tests/CIncrementalMapPartitioner_api_unittest.cpp
+++ b/modules/mrpt_slam/tests/CIncrementalMapPartitioner_api_unittest.cpp
@@ -1,0 +1,345 @@
+/*                    _
+                     | |    Mobile Robot Programming Toolkit (MRPT)
+ _ __ ___  _ __ _ __ | |_
+| '_ ` _ \| '__| '_ \| __|          https://www.mrpt.org/
+| | | | | | |  | |_) | |_
+|_| |_| |_|_|  | .__/ \__|     https://github.com/MRPT/mrpt/
+               | |
+               |_|
+
+ Copyright (c) 2005-2026, Individual contributors, see AUTHORS file
+ See: https://www.mrpt.org/Authors - All rights reserved.
+ SPDX-License-Identifier: BSD-3-Clause
+*/
+
+/** Unit tests for the non-dataset part of CIncrementalMapPartitioner: its
+ *  options, the three similarity methods, node removal, coordinate origin
+ *  changes, the 3D representation and serialization.
+ *  \sa CIncrementalMapPartitioner_unittest.cpp for the end-to-end test on a
+ *      real dataset.
+ */
+
+#include <gtest/gtest.h>
+#include <mrpt/config/CConfigFileMemory.h>
+#include <mrpt/obs/CObservation2DRangeScan.h>
+#include <mrpt/obs/CSensoryFrame.h>
+#include <mrpt/obs/stock_observations.h>
+#include <mrpt/poses/CPose3DPDFGaussian.h>
+#include <mrpt/serialization/CArchive.h>
+#include <mrpt/serialization/archiveFrom_std_streams.h>
+#include <mrpt/slam/CIncrementalMapPartitioner.h>
+
+#include <sstream>
+
+using mrpt::slam::CIncrementalMapPartitioner;
+
+namespace
+{
+mrpt::obs::CSensoryFrame makeFrame(int scanIndex = 0)
+{
+  auto scan = mrpt::obs::CObservation2DRangeScan::Create();
+  mrpt::obs::stock_observations::example2DRangeScan(*scan, scanIndex);
+
+  mrpt::obs::CSensoryFrame sf;
+  sf.insert(scan);
+  return sf;
+}
+
+mrpt::poses::CPose3DPDFGaussian poseAt(double x, double y = 0, double phi = 0)
+{
+  mrpt::poses::CPose3DPDFGaussian p;
+  p.mean = mrpt::poses::CPose3D(x, y, 0, phi, 0, 0);
+  return p;
+}
+
+/** Adds n keyframes at x=0,1,2,... */
+void addNodes(CIncrementalMapPartitioner& imp, size_t n)
+{
+  for (size_t i = 0; i < n; i++)
+  {
+    const auto sf = makeFrame(static_cast<int>(i % 2));
+    imp.addMapFrame(sf, poseAt(static_cast<double>(i)));
+  }
+}
+}  // namespace
+
+TEST(CIncrementalMapPartitionerAPI, optionsSaveLoadRoundTrip)
+{
+  CIncrementalMapPartitioner::TOptions o;
+  o.partitionThreshold = 0.75;
+  o.forceBisectionOnly = true;
+  o.simil_method = mrpt::slam::smOBSERVATION_OVERLAP;
+  o.minimumNumberElementsEachCluster = 4;
+  o.maxKeyFrameDistanceToEval = 20;
+  o.mrp.maxDistForCorr = 0.33f;
+  o.mrp.maxMahaDistForCorr = 7.5f;
+
+  mrpt::config::CConfigFileMemory cfg;
+  o.saveToConfigFile(cfg, "PART");
+
+  CIncrementalMapPartitioner::TOptions o2;
+  o2.loadFromConfigFile(cfg, "PART");
+
+  EXPECT_NEAR(o2.partitionThreshold, 0.75, 1e-9);
+  EXPECT_TRUE(o2.forceBisectionOnly);
+  EXPECT_EQ(o2.simil_method, mrpt::slam::smOBSERVATION_OVERLAP);
+  EXPECT_EQ(o2.minimumNumberElementsEachCluster, 4U);
+  EXPECT_EQ(o2.maxKeyFrameDistanceToEval, 20U);
+  EXPECT_NEAR(o2.mrp.maxDistForCorr, 0.33f, 1e-6);
+  EXPECT_NEAR(o2.mrp.maxMahaDistForCorr, 7.5f, 1e-6);
+
+  // The default map is one CSimplePointsMap:
+  EXPECT_EQ(o2.metricmap.size(), 1U);
+
+  std::stringstream ss;
+  o.dumpToTextStream(ss);
+  EXPECT_FALSE(ss.str().empty());
+}
+
+TEST(CIncrementalMapPartitionerAPI, addMapFrameFillsAdjacencyMatrix)
+{
+  CIncrementalMapPartitioner imp;
+  imp.options.simil_method = mrpt::slam::smMETRIC_MAP_MATCHING;
+
+  EXPECT_EQ(imp.getNodesCount(), 0U);
+
+  EXPECT_EQ(imp.addMapFrame(makeFrame(0), poseAt(0)), 0U);
+  EXPECT_EQ(imp.addMapFrame(makeFrame(0), poseAt(0)), 1U);
+
+  EXPECT_EQ(imp.getNodesCount(), 2U);
+
+  const auto& A = imp.getAdjacencyMatrix();
+  ASSERT_EQ(A.rows(), 2);
+  ASSERT_EQ(A.cols(), 2);
+  // Same scan at the same pose: maximum similarity, and self-similarity is
+  // not used (left at zero):
+  EXPECT_NEAR(A(0, 1), 1.0, 1e-6);
+  EXPECT_NEAR(A(1, 0), 1.0, 1e-6);
+  EXPECT_EQ(A(0, 0), 0.0);
+
+  mrpt::math::CMatrixDouble Acopy;
+  imp.getAdjacencyMatrix(Acopy);
+  EXPECT_EQ(Acopy.rows(), A.rows());
+
+  EXPECT_EQ(imp.getSequenceOfFrames()->size(), 2U);
+  const auto& cimp = imp;
+  EXPECT_EQ(cimp.getSequenceOfFrames()->size(), 2U);
+
+  imp.clear();
+  EXPECT_EQ(imp.getNodesCount(), 0U);
+  EXPECT_EQ(imp.getAdjacencyMatrix().rows(), 0);
+}
+
+TEST(CIncrementalMapPartitionerAPI, observationOverlapSimilarity)
+{
+  CIncrementalMapPartitioner imp;
+  imp.setSimilarityMethod(mrpt::slam::smOBSERVATION_OVERLAP);
+  EXPECT_EQ(imp.options.simil_method, mrpt::slam::smOBSERVATION_OVERLAP);
+
+  imp.addMapFrame(makeFrame(0), poseAt(0));
+  imp.addMapFrame(makeFrame(0), poseAt(0));
+  imp.addMapFrame(makeFrame(0), poseAt(100));  // way too far to overlap
+
+  const auto& A = imp.getAdjacencyMatrix();
+  EXPECT_NEAR(A(0, 1), 1.0, 1e-6);
+  EXPECT_NEAR(A(0, 2), 0.0, 1e-6);
+}
+
+TEST(CIncrementalMapPartitionerAPI, invalidSimilarityMethodThrows)
+{
+  CIncrementalMapPartitioner imp;
+  imp.addMapFrame(makeFrame(0), poseAt(0));
+
+  imp.options.simil_method = static_cast<mrpt::slam::similarity_method_t>(99);
+  EXPECT_THROW(imp.addMapFrame(makeFrame(0), poseAt(1)), std::exception);
+}
+
+// The similarity function is always called with "kf2 with respect to kf1", so
+// the symmetrized evaluation must invert the relative pose when swapping the
+// two keyframes.
+TEST(CIncrementalMapPartitionerAPI, customSimilarityGetsConsistentRelativePoses)
+{
+  struct Call
+  {
+    uint32_t id1, id2;
+    mrpt::poses::CPose3D relPose;
+  };
+  std::vector<Call> calls;
+
+  CIncrementalMapPartitioner imp;
+  imp.setSimilarityMethod(
+      [&calls](
+          const mrpt::slam::map_keyframe_t& kf1, const mrpt::slam::map_keyframe_t& kf2,
+          const mrpt::poses::CPose3D& relPose2wrt1)
+      {
+        calls.push_back({kf1.kf_id, kf2.kf_id, relPose2wrt1});
+        EXPECT_TRUE(kf1.metric_map);
+        EXPECT_TRUE(kf1.raw_observations);
+        return 0.5;
+      });
+  EXPECT_EQ(imp.options.simil_method, mrpt::slam::smCUSTOM_FUNCTION);
+
+  imp.addMapFrame(makeFrame(0), poseAt(0));
+  imp.addMapFrame(makeFrame(0), poseAt(3.0, 0, 0.0));
+
+  ASSERT_EQ(calls.size(), 2U);
+
+  // Both keyframes were compared in both directions:
+  EXPECT_EQ(calls[0].id1, 1U);
+  EXPECT_EQ(calls[0].id2, 0U);
+  EXPECT_EQ(calls[1].id1, 0U);
+  EXPECT_EQ(calls[1].id2, 1U);
+
+  // ...and the two relative poses are the inverse of each other:
+  const auto composed = calls[0].relPose + calls[1].relPose;
+  EXPECT_NEAR(composed.norm(), 0.0, 1e-9);
+  EXPECT_NEAR(std::abs(calls[0].relPose.x()), 3.0, 1e-9);
+
+  EXPECT_NEAR(imp.getAdjacencyMatrix()(0, 1), 0.5, 1e-9);
+}
+
+TEST(CIncrementalMapPartitionerAPI, maxKeyFrameDistanceToEvalSkipsFarKeyframes)
+{
+  CIncrementalMapPartitioner imp;
+  imp.options.maxKeyFrameDistanceToEval = 1;
+  imp.setSimilarityMethod([](const mrpt::slam::map_keyframe_t&, const mrpt::slam::map_keyframe_t&,
+                             const mrpt::poses::CPose3D&) { return 1.0; });
+
+  addNodes(imp, 3);
+
+  const auto& A = imp.getAdjacencyMatrix();
+  EXPECT_NEAR(A(0, 1), 1.0, 1e-9);
+  EXPECT_NEAR(A(1, 2), 1.0, 1e-9);
+  // |2-0| > 1 => not evaluated at all:
+  EXPECT_EQ(A(0, 2), 0.0);
+}
+
+TEST(CIncrementalMapPartitionerAPI, updatePartitionsSplitsTwoClusters)
+{
+  CIncrementalMapPartitioner imp;
+  imp.options.partitionThreshold = 1.0;
+  imp.setSimilarityMethod([](const mrpt::slam::map_keyframe_t& kf1,
+                             const mrpt::slam::map_keyframe_t& kf2, const mrpt::poses::CPose3D&)
+                          { return (kf1.kf_id < 3) == (kf2.kf_id < 3) ? 1.0 : 0.0; });
+
+  addNodes(imp, 6);
+
+  std::vector<std::vector<uint32_t>> parts;
+  imp.updatePartitions(parts);
+
+  ASSERT_EQ(parts.size(), 2U);
+  const std::vector<uint32_t> expected_a = {0, 1, 2}, expected_b = {3, 4, 5};
+  EXPECT_TRUE(
+      (parts[0] == expected_a && parts[1] == expected_b) ||
+      (parts[0] == expected_b && parts[1] == expected_a));
+
+  // With bisection forced, the result is the same first split:
+  imp.options.forceBisectionOnly = true;
+  std::vector<std::vector<uint32_t>> parts2;
+  imp.updatePartitions(parts2);
+  EXPECT_EQ(parts2.size(), 2U);
+}
+
+TEST(CIncrementalMapPartitionerAPI, removeSetOfNodes)
+{
+  CIncrementalMapPartitioner imp;
+  imp.setSimilarityMethod(
+      [](const mrpt::slam::map_keyframe_t& kf1, const mrpt::slam::map_keyframe_t& kf2,
+         const mrpt::poses::CPose3D&)
+      { return 1.0 / (1.0 + std::abs(static_cast<double>(kf1.kf_id) - kf2.kf_id)); });
+
+  addNodes(imp, 4);
+  const auto A_before = imp.getAdjacencyMatrix();
+
+  imp.removeSetOfNodes({1}, false /* changeCoordsRef */);
+
+  EXPECT_EQ(imp.getNodesCount(), 3U);
+  const auto& A = imp.getAdjacencyMatrix();
+  ASSERT_EQ(A.rows(), 3);
+  // Old nodes 0,2,3 became 0,1,2:
+  EXPECT_NEAR(A(0, 1), A_before(0, 2), 1e-12);
+  EXPECT_NEAR(A(1, 2), A_before(2, 3), 1e-12);
+
+  // The first surviving keyframe keeps its global pose:
+  EXPECT_NEAR(imp.getSequenceOfFrames()->get(0).pose->getMeanVal().x(), 0.0, 1e-9);
+
+  // Removing with changeCoordsRef leaves the first node at the origin:
+  imp.removeSetOfNodes({0}, true);
+  EXPECT_EQ(imp.getNodesCount(), 2U);
+  EXPECT_NEAR(imp.getSequenceOfFrames()->get(0).pose->getMeanVal().x(), 0.0, 1e-9);
+  EXPECT_NEAR(imp.getSequenceOfFrames()->get(1).pose->getMeanVal().x(), 1.0, 1e-9);
+}
+
+TEST(CIncrementalMapPartitionerAPI, removeAllNodesIsRejected)
+{
+  CIncrementalMapPartitioner imp;
+  addNodes(imp, 2);
+  EXPECT_THROW(imp.removeSetOfNodes({0, 1}), std::exception);
+}
+
+TEST(CIncrementalMapPartitionerAPI, changeCoordinatesOrigin)
+{
+  CIncrementalMapPartitioner imp;
+  addNodes(imp, 3);
+
+  imp.changeCoordinatesOrigin(mrpt::poses::CPose3D(1.0, 0, 0, 0, 0, 0));
+  EXPECT_NEAR(imp.getSequenceOfFrames()->get(0).pose->getMeanVal().x(), 1.0, 1e-9);
+
+  // Now put the origin at keyframe #2 (which is at x=1+2=3):
+  imp.changeCoordinatesOriginPoseIndex(2);
+  EXPECT_NEAR(imp.getSequenceOfFrames()->get(2).pose->getMeanVal().x(), 0.0, 1e-9);
+  EXPECT_NEAR(imp.getSequenceOfFrames()->get(0).pose->getMeanVal().x(), -2.0, 1e-9);
+}
+
+TEST(CIncrementalMapPartitionerAPI, getAs3DScene)
+{
+  CIncrementalMapPartitioner imp;
+  imp.setSimilarityMethod(
+      [](const mrpt::slam::map_keyframe_t& kf1, const mrpt::slam::map_keyframe_t& kf2,
+         const mrpt::poses::CPose3D&) {
+        return std::abs(static_cast<int>(kf1.kf_id) - static_cast<int>(kf2.kf_id)) == 1 ? 0.9 : 0.0;
+      });
+  addNodes(imp, 3);
+
+  auto objs = mrpt::viz::CSetOfObjects::Create();
+  imp.getAs3DScene(objs);
+  // 1 grid + 3 spheres + 2 links (the 0-2 pair is below the 0.01 threshold):
+  EXPECT_EQ(objs->size(), 6U);
+  EXPECT_TRUE(objs->getByName("1"));
+
+  // With renamed indices:
+  std::map<uint32_t, int64_t> renames;
+  for (uint32_t i = 0; i < 3; i++) renames[i] = 100 + i;
+  imp.getAs3DScene(objs, &renames);
+  EXPECT_EQ(objs->size(), 6U);
+  EXPECT_TRUE(objs->getByName("101"));
+
+  // A missing entry in the rename map is an error:
+  renames.erase(1);
+  EXPECT_THROW(imp.getAs3DScene(objs, &renames), std::exception);
+}
+
+TEST(CIncrementalMapPartitionerAPI, serializationRoundTrip)
+{
+  CIncrementalMapPartitioner imp;
+  addNodes(imp, 3);
+  std::vector<std::vector<uint32_t>> parts;
+  imp.updatePartitions(parts);
+
+  std::stringstream ss;
+  auto arch = mrpt::serialization::archiveFrom<std::iostream>(ss);
+  arch << imp;
+
+  CIncrementalMapPartitioner imp2;
+  arch >> imp2;
+
+  EXPECT_EQ(imp2.getNodesCount(), imp.getNodesCount());
+  EXPECT_EQ(imp2.getAdjacencyMatrix().rows(), imp.getAdjacencyMatrix().rows());
+  for (int r = 0; r < imp.getAdjacencyMatrix().rows(); r++)
+    for (int c = 0; c < imp.getAdjacencyMatrix().cols(); c++)
+      EXPECT_NEAR(imp2.getAdjacencyMatrix()(r, c), imp.getAdjacencyMatrix()(r, c), 1e-12);
+
+  std::vector<std::vector<uint32_t>> parts2;
+  imp2.updatePartitions(parts2);
+  EXPECT_EQ(parts2, parts);
+}

--- a/modules/mrpt_slam/tests/CIncrementalMapPartitioner_unittest.cpp
+++ b/modules/mrpt_slam/tests/CIncrementalMapPartitioner_unittest.cpp
@@ -45,14 +45,11 @@ TEST(CIncrementalMapPartitioner, test_dataset)
   {
     return;
   }
-  const std::vector<uint32_t> expected_p0 = {0,  1,  2,  3,  4,  5,  6,  7,  8,  9,  10, 11, 12,
-                                             13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25,
-                                             26, 27, 62, 63, 64, 65, 66, 67, 68, 69, 70, 71, 72,
-                                             73, 74, 75, 76, 77, 78, 79, 80, 81, 82, 83, 84, 85,
-                                             86, 87, 88, 89, 90, 91, 92, 93, 94, 95, 96, 97, 98},
-                              expected_p1 = {28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39,
-                                             40, 41, 42, 43, 44, 45, 46, 47, 48, 49, 50, 51,
-                                             52, 53, 54, 55, 56, 57, 58, 59, 60, 61};
+  // Partition #0: keyframes [0,26] + [62,98]; partition #1: [27,61].
+  std::vector<uint32_t> expected_p0, expected_p1;
+  for (uint32_t i = 0; i <= 26; i++) expected_p0.push_back(i);
+  for (uint32_t i = 62; i <= 98; i++) expected_p0.push_back(i);
+  for (uint32_t i = 27; i <= 61; i++) expected_p1.push_back(i);
 
   EXPECT_EQ(parts[0], expected_p0);
   EXPECT_EQ(parts[1], expected_p1);

--- a/modules/mrpt_slam/tests/CIncrementalMapPartitioner_unittest.cpp
+++ b/modules/mrpt_slam/tests/CIncrementalMapPartitioner_unittest.cpp
@@ -18,6 +18,8 @@
 #include <mrpt/system/filesystem.h>
 #include <test_mrpt_common.h>
 
+#include <algorithm>
+
 TEST(CIncrementalMapPartitioner, test_dataset)
 {
   mrpt::slam::CIncrementalMapPartitioner imp;
@@ -45,12 +47,19 @@ TEST(CIncrementalMapPartitioner, test_dataset)
   {
     return;
   }
-  // Partition #0: keyframes [0,26] + [62,98]; partition #1: [27,61].
-  std::vector<uint32_t> expected_p0, expected_p1;
-  for (uint32_t i = 0; i <= 26; i++) expected_p0.push_back(i);
-  for (uint32_t i = 62; i <= 98; i++) expected_p0.push_back(i);
-  for (uint32_t i = 27; i <= 61; i++) expected_p1.push_back(i);
+  // The two clusters are keyframes [0,26]+[62,98] and [27,61]. Which of them
+  // the spectral partitioner returns first is not stable across platforms
+  // (it depends on the sign of the eigenvector), so compare them in a
+  // canonical order:
+  std::vector<uint32_t> expected_a, expected_b;
+  for (uint32_t i = 0; i <= 26; i++) expected_a.push_back(i);
+  for (uint32_t i = 62; i <= 98; i++) expected_a.push_back(i);
+  for (uint32_t i = 27; i <= 61; i++) expected_b.push_back(i);
 
-  EXPECT_EQ(parts[0], expected_p0);
-  EXPECT_EQ(parts[1], expected_p1);
+  std::sort(
+      parts.begin(), parts.end(),
+      [](const auto& a, const auto& b) { return a.front() < b.front(); });
+
+  EXPECT_EQ(parts[0], expected_a);
+  EXPECT_EQ(parts[1], expected_b);
 }

--- a/modules/mrpt_slam/tests/CLandmarksMap_unittest.cpp
+++ b/modules/mrpt_slam/tests/CLandmarksMap_unittest.cpp
@@ -1,0 +1,333 @@
+/*                    _
+                     | |    Mobile Robot Programming Toolkit (MRPT)
+ _ __ ___  _ __ _ __ | |_
+| '_ ` _ \| '__| '_ \| __|          https://www.mrpt.org/
+| | | | | | |  | |_) | |_
+|_| |_| |_|_|  | .__/ \__|     https://github.com/MRPT/mrpt/
+               | |
+               |_|
+
+ Copyright (c) 2005-2026, Individual contributors, see AUTHORS file
+ See: https://www.mrpt.org/Authors - All rights reserved.
+ SPDX-License-Identifier: BSD-3-Clause
+*/
+
+/** Unit tests for mrpt::maps::CLandmarksMap: its container accessors, the
+ *  minimal CMetricMap interface it implements, serialization, and the
+ *  range-bearing sensor simulator.
+ */
+
+#include <gtest/gtest.h>
+#include <mrpt/maps/CLandmarksMap.h>
+#include <mrpt/obs/CObservationOdometry.h>
+#include <mrpt/random.h>
+#include <mrpt/serialization/CArchive.h>
+#include <mrpt/serialization/archiveFrom_std_streams.h>
+
+#include <cmath>
+#include <sstream>
+#include <tuple>
+
+using mrpt::maps::CLandmark;
+using mrpt::maps::CLandmarksMap;
+
+namespace
+{
+CLandmarksMap makeMap(const std::vector<mrpt::math::TPoint3D>& pts)
+{
+  CLandmarksMap m;
+  int64_t id = 100;
+  for (const auto& p : pts)
+  {
+    CLandmark lm;
+    lm.ID = id++;
+    lm.pose_mean = p;
+    lm.seenTimesCount = 3;
+    m.landmarks.push_back(lm);
+  }
+  return m;
+}
+
+/** A bearing-range observation with a wide-open sensor (everything visible). */
+mrpt::obs::CObservationBearingRange makeWideOpenObs()
+{
+  mrpt::obs::CObservationBearingRange o;
+  o.minSensorDistance = 0;
+  o.maxSensorDistance = 1e6f;
+  o.fieldOfView_yaw = 2 * M_PIf;
+  o.fieldOfView_pitch = 2 * M_PIf;
+  return o;
+}
+}  // namespace
+
+TEST(CLandmarksMap, containerAccessors)
+{
+  auto m = makeMap({
+      {1, 0, 0},
+      {0, 2, 0},
+      {0, 0, 3}
+  });
+
+  EXPECT_EQ(m.size(), 3U);
+  EXPECT_FALSE(m.isEmpty());
+  EXPECT_EQ(m.asString(), "CLandmarksMap");
+
+  EXPECT_EQ(m.landmarks.get(1)->ID, 101);
+  const auto& cm = m;
+  EXPECT_EQ(cm.landmarks.get(1)->ID, 101);
+
+  EXPECT_THROW(std::ignore = m.landmarks.get(3), std::exception);
+  EXPECT_THROW(std::ignore = cm.landmarks.get(3), std::exception);
+
+  ASSERT_TRUE(cm.landmarks.getByBeaconID(102) != nullptr);
+  EXPECT_NEAR(cm.landmarks.getByBeaconID(102)->pose_mean.z, 3.0, 1e-9);
+  EXPECT_EQ(cm.landmarks.getByBeaconID(999), nullptr);
+
+  // Range-for over both const and non-const iterators:
+  size_t n = 0;
+  for (auto& lm : m.landmarks)
+  {
+    lm.seenTimesCount++;
+    n++;
+  }
+  for (const auto& lm : cm.landmarks)
+  {
+    EXPECT_EQ(lm.seenTimesCount, 4U);
+  }
+  EXPECT_EQ(n, 3U);
+
+  m.clear();  // CMetricMap::clear() -> internal_clear()
+  EXPECT_EQ(m.size(), 0U);
+  EXPECT_TRUE(m.isEmpty());
+}
+
+TEST(CLandmarksMap, metricMapInterfaceIsInert)
+{
+  auto m = makeMap({
+      {1, 0, 0}
+  });
+  mrpt::obs::CObservationOdometry obs;
+
+  EXPECT_FALSE(m.insertObservation(obs));
+  EXPECT_FALSE(m.canComputeObservationLikelihood(obs));
+  EXPECT_EQ(m.computeObservationLikelihood(obs, mrpt::poses::CPose3D()), 0.0);
+
+  mrpt::viz::CSetOfObjects objs;
+  m.getVisualizationInto(objs);
+  EXPECT_EQ(objs.size(), 0U);
+
+  // A no-op, but it must not throw:
+  EXPECT_NO_THROW(m.saveMetricMapRepresentationToFile("unused"));
+}
+
+TEST(CLandmarksMap, serializationRoundTrip)
+{
+  auto m = makeMap({
+      { 1, 2,  3},
+      {-4, 5, -6}
+  });
+  m.landmarks.get(0)->pose_cov_11 = 0.5;
+  m.landmarks.get(0)->pose_cov_22 = 0.25;
+  m.landmarks.get(0)->pose_cov_33 = 0.125;
+  m.landmarks.get(0)->pose_cov_12 = 0.1;
+  m.landmarks.get(0)->pose_cov_13 = 0.2;
+  m.landmarks.get(0)->pose_cov_23 = 0.3;
+
+  std::stringstream ss;
+  auto arch = mrpt::serialization::archiveFrom<std::iostream>(ss);
+  arch << m;
+
+  CLandmarksMap m2;
+  // Not empty beforehand, to check that serializeFrom() clears it:
+  m2.landmarks.push_back(CLandmark());
+  arch >> m2;
+
+  ASSERT_EQ(m2.size(), m.size());
+  for (size_t i = 0; i < m.size(); i++)
+  {
+    const auto& a = *m.landmarks.get(i);
+    const auto& b = *m2.landmarks.get(i);
+    EXPECT_EQ(a.ID, b.ID);
+    EXPECT_NEAR(a.pose_mean.x, b.pose_mean.x, 1e-9);
+    EXPECT_NEAR(a.pose_mean.y, b.pose_mean.y, 1e-9);
+    EXPECT_NEAR(a.pose_mean.z, b.pose_mean.z, 1e-9);
+    EXPECT_NEAR(a.pose_cov_12, b.pose_cov_12, 1e-9);
+    EXPECT_NEAR(a.pose_cov_13, b.pose_cov_13, 1e-9);
+    EXPECT_NEAR(a.pose_cov_23, b.pose_cov_23, 1e-9);
+    EXPECT_EQ(a.seenTimesCount, b.seenTimesCount);
+  }
+}
+
+TEST(CLandmarksMap, simulateNoiselessGeometry)
+{
+  // One landmark 5 m ahead of the robot, 1 m to its left:
+  const auto m = makeMap({
+      {5.0, 1.0, 0.0}
+  });
+
+  auto obs = makeWideOpenObs();
+  std::vector<size_t> assoc;
+  m.simulateRangeBearingReadings(
+      mrpt::poses::CPose3D(0, 0, 0, 0, 0, 0), mrpt::poses::CPose3D(0, 0, 0, 0, 0, 0), obs,
+      true /*ids*/, 0, 0, 0, &assoc);
+
+  ASSERT_EQ(obs.sensedData.size(), 1U);
+  EXPECT_EQ(obs.sensedData[0].landmarkID, 100);
+  EXPECT_NEAR(obs.sensedData[0].range, std::sqrt(26.0), 1e-4);
+  EXPECT_NEAR(obs.sensedData[0].yaw, std::atan2(1.0, 5.0), 1e-5);
+  EXPECT_NEAR(obs.sensedData[0].pitch, 0.0, 1e-5);
+  EXPECT_FALSE(obs.validCovariances);
+  ASSERT_EQ(assoc.size(), 1U);
+  EXPECT_EQ(assoc[0], 0U);
+
+  // The very same landmark seen from a robot already at it: zero range.
+  m.simulateRangeBearingReadings(
+      mrpt::poses::CPose3D(5.0, 1.0, 0.0, 0, 0, 0), mrpt::poses::CPose3D(0, 0, 0, 0, 0, 0), obs);
+  ASSERT_EQ(obs.sensedData.size(), 1U);
+  EXPECT_NEAR(obs.sensedData[0].range, 0.0, 1e-5);
+}
+
+TEST(CLandmarksMap, simulateHonorsSensorPoseOnRobot)
+{
+  const auto m = makeMap({
+      {5.0, 0.0, 0.0}
+  });
+
+  auto obs = makeWideOpenObs();
+  // Sensor 1 m ahead of the robot origin => 1 m closer to the landmark:
+  m.simulateRangeBearingReadings(
+      mrpt::poses::CPose3D(0, 0, 0, 0, 0, 0), mrpt::poses::CPose3D(1.0, 0, 0, 0, 0, 0), obs);
+
+  ASSERT_EQ(obs.sensedData.size(), 1U);
+  EXPECT_NEAR(obs.sensedData[0].range, 4.0, 1e-4);
+  EXPECT_NEAR(obs.sensorLocationOnRobot.x(), 1.0, 1e-9);
+}
+
+TEST(CLandmarksMap, simulateAnonymousLandmarks)
+{
+  const auto m = makeMap({
+      {5.0, 0.0, 0.0}
+  });
+
+  auto obs = makeWideOpenObs();
+  m.simulateRangeBearingReadings(
+      mrpt::poses::CPose3D(0, 0, 0, 0, 0, 0), mrpt::poses::CPose3D(0, 0, 0, 0, 0, 0), obs,
+      false /* sensorDetectsIDs */);
+
+  ASSERT_EQ(obs.sensedData.size(), 1U);
+  EXPECT_EQ(obs.sensedData[0].landmarkID, mrpt::obs::INVALID_LANDMARK_ID);
+}
+
+TEST(CLandmarksMap, simulateFiltersOutOfRangeAndOutOfFOV)
+{
+  const auto m = makeMap({
+      {  1.0, 0.0, 0.0}, // too close
+      {  5.0, 0.0, 0.0}, // visible
+      {100.0, 0.0, 0.0}, // too far
+      { -5.0, 0.0, 0.0}, // behind the sensor: out of the yaw FOV
+      {  0.0, 0.0, 5.0}, // straight up: out of the pitch FOV
+  });
+
+  mrpt::obs::CObservationBearingRange obs;
+  obs.minSensorDistance = 2.0f;
+  obs.maxSensorDistance = 50.0f;
+  obs.fieldOfView_yaw = mrpt::DEG2RAD(90.0f);
+  obs.fieldOfView_pitch = mrpt::DEG2RAD(20.0f);
+
+  std::vector<size_t> assoc;
+  m.simulateRangeBearingReadings(
+      mrpt::poses::CPose3D(0, 0, 0, 0, 0, 0), mrpt::poses::CPose3D(0, 0, 0, 0, 0, 0), obs, true, 0,
+      0, 0, &assoc);
+
+  ASSERT_EQ(obs.sensedData.size(), 1U);
+  EXPECT_EQ(obs.sensedData[0].landmarkID, 101);
+  ASSERT_EQ(assoc.size(), 1U);
+  EXPECT_EQ(assoc[0], 1U);
+}
+
+TEST(CLandmarksMap, simulateNoiseIsAppliedAndRangeStaysNonNegative)
+{
+  mrpt::random::getRandomGenerator().randomize(1234);
+
+  const auto m = makeMap({
+      {0.001, 0.0, 0.0}
+  });
+  auto obs = makeWideOpenObs();
+
+  bool anyDifferent = false;
+  for (int i = 0; i < 50; i++)
+  {
+    m.simulateRangeBearingReadings(
+        mrpt::poses::CPose3D(0, 0, 0, 0, 0, 0), mrpt::poses::CPose3D(0, 0, 0, 0, 0, 0), obs, true,
+        1.0 /*sigmaRange*/, 0.05 /*sigmaYaw*/, 0.05 /*sigmaPitch*/);
+    if (obs.sensedData.empty()) continue;
+    EXPECT_GE(obs.sensedData[0].range, 0.0f);
+    if (std::abs(obs.sensedData[0].range - 0.001f) > 1e-4f) anyDifferent = true;
+    EXPECT_LE(std::abs(obs.sensedData[0].yaw), M_PIf);
+  }
+  EXPECT_TRUE(anyDifferent);
+
+  EXPECT_NEAR(obs.sensor_std_range, 1.0f, 1e-6);
+  EXPECT_NEAR(obs.sensor_std_yaw, 0.05f, 1e-6);
+  EXPECT_NEAR(obs.sensor_std_pitch, 0.05f, 1e-6);
+}
+
+TEST(CLandmarksMap, simulateSpuriousDetections)
+{
+  mrpt::random::getRandomGenerator().randomize(4321);
+
+  const auto m = makeMap({
+      {5.0, 0.0, 0.0}
+  });
+  auto obs = makeWideOpenObs();
+  obs.minSensorDistance = 1.0f;
+  obs.maxSensorDistance = 20.0f;
+  obs.fieldOfView_yaw = mrpt::DEG2RAD(180.0f);
+  obs.fieldOfView_pitch = mrpt::DEG2RAD(90.0f);
+
+  std::vector<size_t> assoc;
+  m.simulateRangeBearingReadings(
+      mrpt::poses::CPose3D(0, 0, 0, 0, 0, 0), mrpt::poses::CPose3D(0, 0, 0, 0, 0, 0), obs, true,
+      0.01, 0.01, 0.01, &assoc, 4.0 /*spuriousMean*/, 0.5 /*spuriousStd*/);
+
+  ASSERT_EQ(assoc.size(), obs.sensedData.size());
+  ASSERT_GT(obs.sensedData.size(), 1U);
+
+  size_t nSpurious = 0;
+  for (size_t i = 0; i < assoc.size(); i++)
+  {
+    if (assoc[i] != std::string::npos) continue;
+    nSpurious++;
+    EXPECT_EQ(obs.sensedData[i].landmarkID, mrpt::obs::INVALID_LANDMARK_ID);
+    EXPECT_GE(obs.sensedData[i].range, obs.minSensorDistance);
+    EXPECT_LE(obs.sensedData[i].range, obs.maxSensorDistance);
+    EXPECT_LE(std::abs(obs.sensedData[i].yaw), 0.5f * obs.fieldOfView_yaw);
+    EXPECT_LE(std::abs(obs.sensedData[i].pitch), 0.5f * obs.fieldOfView_pitch);
+  }
+  EXPECT_GT(nSpurious, 0U);
+}
+
+// With zero angular noise the spurious detections are placed at the sensor
+// axis (yaw=pitch=0), the convention for range-only sensors.
+TEST(CLandmarksMap, spuriousOfRangeOnlySensorsAreOnAxis)
+{
+  mrpt::random::getRandomGenerator().randomize(777);
+
+  const CLandmarksMap m;  // no real landmarks at all
+  auto obs = makeWideOpenObs();
+  obs.minSensorDistance = 1.0f;
+  obs.maxSensorDistance = 20.0f;
+
+  std::vector<size_t> assoc;
+  m.simulateRangeBearingReadings(
+      mrpt::poses::CPose3D(0, 0, 0, 0, 0, 0), mrpt::poses::CPose3D(0, 0, 0, 0, 0, 0), obs, true, 0,
+      0, 0, &assoc, 3.0, 0.0);
+
+  ASSERT_GT(obs.sensedData.size(), 0U);
+  for (size_t i = 0; i < obs.sensedData.size(); i++)
+  {
+    EXPECT_EQ(assoc[i], std::string::npos);
+    EXPECT_EQ(obs.sensedData[i].yaw, 0.0f);
+    EXPECT_EQ(obs.sensedData[i].pitch, 0.0f);
+  }
+}

--- a/modules/mrpt_slam/tests/CMetricMapBuilderICP_unittest.cpp
+++ b/modules/mrpt_slam/tests/CMetricMapBuilderICP_unittest.cpp
@@ -62,17 +62,21 @@ mrpt::poses::CPose2D runShortSession(CMetricMapBuilderICP& b, size_t nSteps = 5)
 {
   mrpt::poses::CPose2D gtPose(-2.0, 0.0, 0.0);
 
-  auto acts0 = makeOdometryAction(mrpt::poses::CPose2D(0, 0, 0));
-  auto sf0 = simulateSF(gtPose);
-  b.processActionObservation(*acts0, *sf0);
+  {
+    const auto t = mrpt::test::nextTimestamp();
+    auto acts0 = makeOdometryAction(mrpt::poses::CPose2D(0, 0, 0), t);
+    auto sf0 = simulateSF(gtPose, t);
+    b.processActionObservation(*acts0, *sf0);
+  }
 
   for (size_t i = 0; i < nSteps; i++)
   {
     const mrpt::poses::CPose2D incr(0.4, 0, 0);
     gtPose = gtPose + incr;
 
-    auto acts = makeOdometryAction(incr);
-    auto sf = simulateSF(gtPose);
+    const auto t = mrpt::test::nextTimestamp();
+    auto acts = makeOdometryAction(incr, t);
+    auto sf = simulateSF(gtPose, t);
     b.processActionObservation(*acts, *sf);
   }
   return gtPose;
@@ -147,12 +151,13 @@ TEST(CMetricMapBuilderICP, usesGridAltitudeFilter)
   EXPECT_GT(nAtAltitude, 0U);
 
   // ...while one at a different altitude cannot feed ICP:
-  auto sf = simulateSF(mrpt::poses::CPose2D(0, 0, 0));
+  const auto t = mrpt::test::nextTimestamp();
+  auto sf = simulateSF(mrpt::poses::CPose2D(0, 0, 0), t);
   auto scan =
       std::dynamic_pointer_cast<mrpt::obs::CObservation2DRangeScan>(sf->getObservationByIndex(0));
   ASSERT_TRUE(scan);
   scan->sensorPose = mrpt::poses::CPose3D(0, 0, 5.0, 0, 0, 0);
-  auto acts = makeOdometryAction(mrpt::poses::CPose2D(1.0, 0, 0));
+  auto acts = makeOdometryAction(mrpt::poses::CPose2D(1.0, 0, 0), t);
   EXPECT_NO_THROW(b.processActionObservation(*acts, *sf));
 }
 
@@ -163,7 +168,7 @@ TEST(CMetricMapBuilderICP, refusesToRunWithoutMaps)
   b.ICP_options.mapInitializers.clear();
   b.initialize();
 
-  auto sf = simulateSF(mrpt::poses::CPose2D(0, 0, 0));
+  auto sf = simulateSF(mrpt::poses::CPose2D(0, 0, 0), mrpt::test::nextTimestamp());
   EXPECT_THROW(b.processObservation(sf->getObservationByIndex(0)), std::exception);
 }
 
@@ -203,7 +208,7 @@ TEST(CMetricMapBuilderICP, observationsWithoutTimestamp)
   CMetricMapBuilderICP b;
   setDefaultMaps(b);
 
-  auto sf = simulateSF(mrpt::poses::CPose2D(0, 0, 0));
+  auto sf = simulateSF(mrpt::poses::CPose2D(0, 0, 0), mrpt::test::nextTimestamp());
   auto obs = sf->getObservationByIndex(0);
   obs->timestamp = INVALID_TIMESTAMP;
   EXPECT_NO_THROW(b.processObservation(obs));

--- a/modules/mrpt_slam/tests/CMetricMapBuilderICP_unittest.cpp
+++ b/modules/mrpt_slam/tests/CMetricMapBuilderICP_unittest.cpp
@@ -1,0 +1,351 @@
+/*                    _
+                     | |    Mobile Robot Programming Toolkit (MRPT)
+ _ __ ___  _ __ _ __ | |_
+| '_ ` _ \| '__| '_ \| __|          https://www.mrpt.org/
+| | | | | | |  | |_) | |_
+|_| |_| |_|_|  | .__/ \__|     https://github.com/MRPT/mrpt/
+               | |
+               |_|
+
+ Copyright (c) 2005-2026, Individual contributors, see AUTHORS file
+ See: https://www.mrpt.org/Authors - All rights reserved.
+ SPDX-License-Identifier: BSD-3-Clause
+*/
+
+/** Unit tests for the ICP-based map builder and the CMetricMapBuilder base
+ *  class, driven by 2D laser scans simulated from a synthetic room.
+ */
+
+#include <gtest/gtest.h>
+#include <mrpt/config/CConfigFileMemory.h>
+#include <mrpt/maps/CSimplePointsMap.h>
+#include <mrpt/obs/CObservationOdometry.h>
+#include <mrpt/random.h>
+#include <mrpt/slam/CMetricMapBuilderICP.h>
+#include <mrpt/system/filesystem.h>
+
+#include <sstream>
+
+#include "slam_synthetic_room.h"
+
+using mrpt::slam::CMetricMapBuilderICP;
+using mrpt::test::makeOdometryAction;
+using mrpt::test::simulateSF;
+
+namespace
+{
+void setDefaultMaps(CMetricMapBuilderICP& b, bool withGrid = true)
+{
+  b.setVerbosityLevel(mrpt::system::LVL_ERROR);
+  b.ICP_options.mapInitializers.clear();
+  if (withGrid)
+  {
+    mrpt::maps::COccupancyGridMap2D::TMapDefinition def;
+    def.resolution = 0.10f;
+    def.insertionOpts.maxDistanceInsertion = 15.0f;
+    b.ICP_options.mapInitializers.push_back(def);
+  }
+  {
+    mrpt::maps::CSimplePointsMap::TMapDefinition def;
+    def.insertionOpts.minDistBetweenLaserPoints = 0.05f;
+    b.ICP_options.mapInitializers.push_back(def);
+  }
+  b.ICP_options.insertionLinDistance = 0.3;
+  b.ICP_options.insertionAngDistance = mrpt::DEG2RAD(20.0);
+  b.ICP_options.localizationLinDistance = 0.1;
+  b.ICP_options.localizationAngDistance = mrpt::DEG2RAD(5.0);
+  b.initialize();
+}
+
+/** Drives the builder along a straight path, feeding odometry + scans. */
+mrpt::poses::CPose2D runShortSession(CMetricMapBuilderICP& b, size_t nSteps = 5)
+{
+  mrpt::poses::CPose2D gtPose(-2.0, 0.0, 0.0);
+
+  auto acts0 = makeOdometryAction(mrpt::poses::CPose2D(0, 0, 0));
+  auto sf0 = simulateSF(gtPose);
+  b.processActionObservation(*acts0, *sf0);
+
+  for (size_t i = 0; i < nSteps; i++)
+  {
+    const mrpt::poses::CPose2D incr(0.4, 0, 0);
+    gtPose = gtPose + incr;
+
+    auto acts = makeOdometryAction(incr);
+    auto sf = simulateSF(gtPose);
+    b.processActionObservation(*acts, *sf);
+  }
+  return gtPose;
+}
+}  // namespace
+
+TEST(CMetricMapBuilderICP, buildsAMapMatchingAgainstPoints)
+{
+  mrpt::random::getRandomGenerator().randomize(1234);
+
+  CMetricMapBuilderICP b;
+  setDefaultMaps(b);
+  b.ICP_options.matchAgainstTheGrid = false;
+
+  EXPECT_EQ(b.getCurrentlyBuiltMapSize(), 0U);
+  runShortSession(b);
+
+  EXPECT_GT(b.getCurrentlyBuiltMapSize(), 1U);
+
+  const auto pose = b.getCurrentPoseEstimation();
+  ASSERT_TRUE(pose);
+  // 2.0 m travelled from the starting point:
+  EXPECT_NEAR(pose->getMeanVal().x(), 2.0, 0.4);
+
+  mrpt::maps::CSimpleMap sm;
+  b.getCurrentlyBuiltMap(sm);
+  EXPECT_EQ(sm.size(), b.getCurrentlyBuiltMapSize());
+
+  EXPECT_FALSE(b.getCurrentlyBuiltMetricMap().isEmpty());
+
+  std::vector<float> xs, ys;
+  b.getCurrentMapPoints(xs, ys);
+  EXPECT_GT(xs.size(), 0U);
+  EXPECT_EQ(xs.size(), ys.size());
+}
+
+TEST(CMetricMapBuilderICP, buildsAMapMatchingAgainstTheGrid)
+{
+  mrpt::random::getRandomGenerator().randomize(4321);
+
+  CMetricMapBuilderICP b;
+  setDefaultMaps(b);
+  b.ICP_options.matchAgainstTheGrid = true;
+
+  runShortSession(b);
+  EXPECT_GT(b.getCurrentlyBuiltMapSize(), 1U);
+}
+
+TEST(CMetricMapBuilderICP, usesGridAltitudeFilter)
+{
+  mrpt::random::getRandomGenerator().randomize(555);
+
+  CMetricMapBuilderICP b;
+  b.setVerbosityLevel(mrpt::system::LVL_ERROR);
+  {
+    mrpt::maps::COccupancyGridMap2D::TMapDefinition def;
+    def.resolution = 0.10f;
+    def.insertionOpts.useMapAltitude = true;
+    def.insertionOpts.mapAltitude = 0;
+    b.ICP_options.mapInitializers.push_back(def);
+  }
+  {
+    mrpt::maps::CSimplePointsMap::TMapDefinition def;
+    b.ICP_options.mapInitializers.push_back(def);
+  }
+  b.ICP_options.matchAgainstTheGrid = true;
+  b.initialize();
+
+  // A scan at the grid altitude is used...
+  runShortSession(b, 2);
+  const size_t nAtAltitude = b.getCurrentlyBuiltMapSize();
+  EXPECT_GT(nAtAltitude, 0U);
+
+  // ...while one at a different altitude cannot feed ICP:
+  auto sf = simulateSF(mrpt::poses::CPose2D(0, 0, 0));
+  auto scan =
+      std::dynamic_pointer_cast<mrpt::obs::CObservation2DRangeScan>(sf->getObservationByIndex(0));
+  ASSERT_TRUE(scan);
+  scan->sensorPose = mrpt::poses::CPose3D(0, 0, 5.0, 0, 0, 0);
+  auto acts = makeOdometryAction(mrpt::poses::CPose2D(1.0, 0, 0));
+  EXPECT_NO_THROW(b.processActionObservation(*acts, *sf));
+}
+
+TEST(CMetricMapBuilderICP, refusesToRunWithoutMaps)
+{
+  CMetricMapBuilderICP b;
+  b.setVerbosityLevel(mrpt::system::LVL_ERROR);
+  b.ICP_options.mapInitializers.clear();
+  b.initialize();
+
+  auto sf = simulateSF(mrpt::poses::CPose2D(0, 0, 0));
+  EXPECT_THROW(b.processObservation(sf->getObservationByIndex(0)), std::exception);
+}
+
+TEST(CMetricMapBuilderICP, mapUpdatingCanBeDisabled)
+{
+  mrpt::random::getRandomGenerator().randomize(7);
+
+  CMetricMapBuilderICP b;
+  setDefaultMaps(b);
+  b.enableMapUpdating(false);
+
+  runShortSession(b, 3);
+  EXPECT_EQ(b.getCurrentlyBuiltMapSize(), 0U);
+  EXPECT_TRUE(b.getCurrentlyBuiltMetricMap().isEmpty());
+}
+
+TEST(CMetricMapBuilderICP, alwaysInsertByClass)
+{
+  mrpt::random::getRandomGenerator().randomize(8);
+
+  CMetricMapBuilderICP b;
+  setDefaultMaps(b);
+  // Insertion distances so large that nothing would ever be inserted...
+  b.ICP_options.insertionLinDistance = 1e6;
+  b.ICP_options.insertionAngDistance = 1e6;
+  // ...unless the observation class is force-inserted:
+  b.options.alwaysInsertByClass.insert(CLASS_ID(mrpt::obs::CObservation2DRangeScan));
+
+  runShortSession(b, 3);
+  EXPECT_GT(b.getCurrentlyBuiltMapSize(), 3U);
+}
+
+TEST(CMetricMapBuilderICP, observationsWithoutTimestamp)
+{
+  mrpt::random::getRandomGenerator().randomize(9);
+
+  CMetricMapBuilderICP b;
+  setDefaultMaps(b);
+
+  auto sf = simulateSF(mrpt::poses::CPose2D(0, 0, 0));
+  auto obs = sf->getObservationByIndex(0);
+  obs->timestamp = INVALID_TIMESTAMP;
+  EXPECT_NO_THROW(b.processObservation(obs));
+  EXPECT_GT(b.getCurrentlyBuiltMapSize(), 0U);
+}
+
+TEST(CMetricMapBuilderICP, initializeFromAPreviousMap)
+{
+  mrpt::random::getRandomGenerator().randomize(10);
+
+  CMetricMapBuilderICP first;
+  setDefaultMaps(first);
+  runShortSession(first, 3);
+
+  mrpt::maps::CSimpleMap prevMap;
+  first.getCurrentlyBuiltMap(prevMap);
+  ASSERT_GT(prevMap.size(), 1U);
+
+  CMetricMapBuilderICP second;
+  second.setVerbosityLevel(mrpt::system::LVL_ERROR);
+  second.ICP_options = first.ICP_options;
+
+  mrpt::poses::CPosePDFGaussian x0;
+  x0.mean = mrpt::poses::CPose2D(1.0, 0.0, 0.0);
+  second.initialize(prevMap, &x0);
+
+  EXPECT_EQ(second.getCurrentlyBuiltMapSize(), prevMap.size());
+  EXPECT_FALSE(second.getCurrentlyBuiltMetricMap().isEmpty());
+  EXPECT_NEAR(second.getCurrentPoseEstimation()->getMeanVal().x(), 1.0, 1e-6);
+
+  // clear() resets everything back to an empty map at the origin:
+  second.clear();
+  EXPECT_EQ(second.getCurrentlyBuiltMapSize(), 0U);
+  EXPECT_NEAR(second.getCurrentPoseEstimation()->getMeanVal().x(), 0.0, 1e-9);
+}
+
+TEST(CMetricMapBuilderICP, saveAndLoadCurrentMapFile)
+{
+  mrpt::random::getRandomGenerator().randomize(12);
+
+  CMetricMapBuilderICP b;
+  setDefaultMaps(b);
+  runShortSession(b, 3);
+  const size_t n = b.getCurrentlyBuiltMapSize();
+  ASSERT_GT(n, 1U);
+
+  const std::string f = mrpt::system::getTempFileName() + std::string(".simplemap.gz");
+  b.saveCurrentMapToFile(f, true /*gz*/);
+  EXPECT_TRUE(mrpt::system::fileExists(f));
+
+  CMetricMapBuilderICP b2;
+  b2.setVerbosityLevel(mrpt::system::LVL_ERROR);
+  b2.ICP_options = b.ICP_options;
+  b2.initialize();
+  b2.loadCurrentMapFromFile(f);
+  EXPECT_EQ(b2.getCurrentlyBuiltMapSize(), n);
+  mrpt::system::deleteFile(f);
+
+  // Uncompressed variant:
+  const std::string f2 = mrpt::system::getTempFileName() + std::string(".simplemap");
+  b.saveCurrentMapToFile(f2, false);
+  EXPECT_TRUE(mrpt::system::fileExists(f2));
+  mrpt::system::deleteFile(f2);
+
+  // A non-existing file leaves the builder with an empty map:
+  CMetricMapBuilderICP b3;
+  b3.setVerbosityLevel(mrpt::system::LVL_ERROR);
+  b3.ICP_options = b.ICP_options;
+  b3.initialize();
+  b3.loadCurrentMapFromFile("/tmp/this_file_does_not_exist.simplemap");
+  EXPECT_EQ(b3.getCurrentlyBuiltMapSize(), 0U);
+}
+
+TEST(CMetricMapBuilderICP, setCurrentMapFile)
+{
+  mrpt::random::getRandomGenerator().randomize(13);
+
+  const std::string f = mrpt::system::getTempFileName() + std::string(".simplemap.gz");
+
+  {
+    CMetricMapBuilderICP b;
+    setDefaultMaps(b);
+    // Starts a "new" (non-existing) map file...
+    b.setCurrentMapFile(f.c_str());
+    runShortSession(b, 3);
+    // ...which is flushed to disk when detaching from it:
+    b.setCurrentMapFile("");
+  }
+  EXPECT_TRUE(mrpt::system::fileExists(f));
+  mrpt::system::deleteFile(f);
+}
+
+TEST(CMetricMapBuilderICP, saveCurrentEstimationToImage)
+{
+  mrpt::random::getRandomGenerator().randomize(14);
+
+  CMetricMapBuilderICP b;
+  setDefaultMaps(b);
+  runShortSession(b, 3);
+
+  const std::string f = mrpt::system::getTempFileName() + std::string(".png");
+  b.saveCurrentEstimationToImage(f);
+  EXPECT_TRUE(mrpt::system::fileExists(f));
+  mrpt::system::deleteFile(f);
+
+  // Without a gridmap there is nothing to render: a clear error, not a crash.
+  CMetricMapBuilderICP bNoGrid;
+  setDefaultMaps(bNoGrid, false /*withGrid*/);
+  runShortSession(bNoGrid, 2);
+  EXPECT_THROW(bNoGrid.saveCurrentEstimationToImage(f), std::exception);
+}
+
+TEST(CMetricMapBuilderICP, configParamsLoadDumpAndAssign)
+{
+  mrpt::config::CConfigFileMemory cfg;
+  cfg.write("ICP", "matchAgainstTheGrid", true);
+  cfg.write("ICP", "insertionLinDistance", 2.5);
+  cfg.write("ICP", "insertionAngDistance", 45.0);
+  cfg.write("ICP", "localizationLinDistance", 0.75);
+  cfg.write("ICP", "localizationAngDistance", 15.0);
+  cfg.write("ICP", "minICPgoodnessToAccept", 0.55);
+  cfg.write("ICP", "verbosity_level", "LVL_ERROR");
+  cfg.write("ICP", "mrpt::maps::CSimplePointsMap_count", 1);
+
+  CMetricMapBuilderICP b;
+  b.ICP_options.loadFromConfigFile(cfg, "ICP");
+
+  EXPECT_TRUE(b.ICP_options.matchAgainstTheGrid);
+  EXPECT_NEAR(b.ICP_options.insertionLinDistance, 2.5, 1e-9);
+  EXPECT_NEAR(b.ICP_options.insertionAngDistance, mrpt::DEG2RAD(45.0), 1e-9);
+  EXPECT_NEAR(b.ICP_options.localizationLinDistance, 0.75, 1e-9);
+  EXPECT_NEAR(b.ICP_options.localizationAngDistance, mrpt::DEG2RAD(15.0), 1e-9);
+  EXPECT_NEAR(b.ICP_options.minICPgoodnessToAccept, 0.55, 1e-9);
+  EXPECT_EQ(b.ICP_options.mapInitializers.size(), 1U);
+
+  std::stringstream ss;
+  b.ICP_options.dumpToTextStream(ss);
+  EXPECT_NE(ss.str().find("insertionLinDistance"), std::string::npos);
+
+  // operator=() copies everything but the verbosity reference:
+  CMetricMapBuilderICP b2;
+  b2.ICP_options = b.ICP_options;
+  EXPECT_NEAR(b2.ICP_options.insertionLinDistance, 2.5, 1e-9);
+  EXPECT_EQ(b2.ICP_options.mapInitializers.size(), 1U);
+}

--- a/modules/mrpt_slam/tests/CMetricMapBuilderRBPF_unittest.cpp
+++ b/modules/mrpt_slam/tests/CMetricMapBuilderRBPF_unittest.cpp
@@ -1,0 +1,509 @@
+/*                    _
+                     | |    Mobile Robot Programming Toolkit (MRPT)
+ _ __ ___  _ __ _ __ | |_
+| '_ ` _ \| '__| '_ \| __|          https://www.mrpt.org/
+| | | | | | |  | |_) | |_
+|_| |_| |_|_|  | .__/ \__|     https://github.com/MRPT/mrpt/
+               | |
+               |_|
+
+ Copyright (c) 2005-2026, Individual contributors, see AUTHORS file
+ See: https://www.mrpt.org/Authors - All rights reserved.
+ SPDX-License-Identifier: BSD-3-Clause
+*/
+
+/** Unit tests for the RBPF map builder and its underlying
+ *  mrpt::maps::CMultiMetricMapPDF, driven by 2D laser scans simulated from a
+ *  synthetic room (no dataset files needed).
+ */
+
+#include <gtest/gtest.h>
+#include <mrpt/config/CConfigFileMemory.h>
+#include <mrpt/img/CImage.h>
+#include <mrpt/maps/CBeaconMap.h>
+#include <mrpt/maps/CMultiMetricMapPDF.h>
+#include <mrpt/maps/COccupancyGridMap2D.h>
+#include <mrpt/maps/CSimplePointsMap.h>
+#include <mrpt/obs/CActionCollection.h>
+#include <mrpt/obs/CActionRobotMovement2D.h>
+#include <mrpt/obs/CObservation2DRangeScan.h>
+#include <mrpt/obs/CObservationBeaconRanges.h>
+#include <mrpt/obs/CSensoryFrame.h>
+#include <mrpt/random.h>
+#include <mrpt/serialization/CArchive.h>
+#include <mrpt/serialization/archiveFrom_std_streams.h>
+#include <mrpt/slam/CMetricMapBuilderRBPF.h>
+#include <mrpt/system/filesystem.h>
+
+#include <sstream>
+
+#include "slam_synthetic_room.h"
+
+using mrpt::maps::CMultiMetricMapPDF;
+using mrpt::slam::CMetricMapBuilderRBPF;
+
+namespace
+{
+using mrpt::test::makeOdometryAction;
+using mrpt::test::simulateSF;
+
+CMetricMapBuilderRBPF::TConstructionOptions defaultRBPFOptions(
+    mrpt::bayes::CParticleFilter::TParticleFilterAlgorithm algo =
+        mrpt::bayes::CParticleFilter::pfStandardProposal)
+{
+  CMetricMapBuilderRBPF::TConstructionOptions o;
+  o.verbosity_level = mrpt::system::LVL_ERROR;
+  o.insertionLinDistance = 0.5;
+  o.insertionAngDistance = mrpt::DEG2RAD(20.0);
+  o.localizeLinDistance = 0.1;
+  o.localizeAngDistance = mrpt::DEG2RAD(5.0);
+
+  o.PF_options.PF_algorithm = algo;
+  o.PF_options.adaptiveSampleSize = false;
+  o.PF_options.sampleSize = 5;
+  o.PF_options.resamplingMethod = mrpt::bayes::CParticleFilter::prSystematic;
+
+  {
+    mrpt::maps::COccupancyGridMap2D::TMapDefinition def;
+    def.resolution = 0.10f;
+    def.insertionOpts.maxDistanceInsertion = 15.0f;
+    o.mapsInitializers.push_back(def);
+  }
+  {
+    mrpt::maps::CSimplePointsMap::TMapDefinition def;
+    o.mapsInitializers.push_back(def);
+  }
+  return o;
+}
+
+/** Drives the map builder along a straight path of `nSteps` steps of 0.4 m. */
+void runShortSession(CMetricMapBuilderRBPF& b, size_t nSteps = 5)
+{
+  mrpt::poses::CPose2D gtPose(-2.0, 0.0, 0.0);
+
+  // First observation, with no movement:
+  {
+    auto acts = makeOdometryAction(mrpt::poses::CPose2D(0, 0, 0));
+    auto sf = simulateSF(gtPose);
+    b.processActionObservation(*acts, *sf);
+  }
+
+  for (size_t i = 0; i < nSteps; i++)
+  {
+    const mrpt::poses::CPose2D incr(0.4, 0, 0);
+    gtPose = gtPose + incr;
+
+    auto acts = makeOdometryAction(incr);
+    auto sf = simulateSF(gtPose);
+    b.processActionObservation(*acts, *sf);
+  }
+}
+}  // namespace
+
+TEST(CMetricMapBuilderRBPF, buildsAMapWithStandardProposal)
+{
+  mrpt::random::getRandomGenerator().randomize(1234);
+
+  CMetricMapBuilderRBPF builder(defaultRBPFOptions());
+  EXPECT_EQ(builder.getCurrentlyBuiltMapSize(), 0U);
+
+  runShortSession(builder);
+
+  EXPECT_GT(builder.getCurrentlyBuiltMapSize(), 1U);
+
+  // The gridmap of the most likely particle must contain the room walls:
+  const auto& mmap = builder.getCurrentlyBuiltMetricMap();
+  auto grid = mmap.mapByClass<mrpt::maps::COccupancyGridMap2D>();
+  ASSERT_TRUE(grid);
+  EXPECT_FALSE(grid->isEmpty());
+
+  mrpt::maps::CSimpleMap sm;
+  builder.getCurrentlyBuiltMap(sm);
+  EXPECT_EQ(sm.size(), builder.getCurrentlyBuiltMapSize());
+
+  // The estimated displacement must be close to the true 2.0 m travelled:
+  const auto poseEst = builder.getCurrentPoseEstimation();
+  ASSERT_TRUE(poseEst);
+  EXPECT_NEAR(poseEst->getMeanVal().x(), 2.0, 0.5);
+
+  std::deque<mrpt::math::TPose3D> path;
+  builder.getCurrentMostLikelyPath(path);
+  EXPECT_GT(path.size(), 1U);
+
+  EXPECT_GT(builder.mapPDF.getNumberOfObservationsInSimplemap(), 0U);
+}
+
+TEST(CMetricMapBuilderRBPF, alternativePFAlgorithms)
+{
+  for (const auto algo :
+       {mrpt::bayes::CParticleFilter::pfAuxiliaryPFStandard,
+        mrpt::bayes::CParticleFilter::pfOptimalProposal,
+        mrpt::bayes::CParticleFilter::pfAuxiliaryPFOptimal})
+  {
+    mrpt::random::getRandomGenerator().randomize(1000 + static_cast<int>(algo));
+
+    auto opts = defaultRBPFOptions(algo);
+    // Use the gridmap-based approximation to the optimal proposal:
+    opts.predictionOptions.pfOptimalProposal_mapSelection = 0;
+
+    CMetricMapBuilderRBPF builder(opts);
+    runShortSession(builder, 3);
+
+    EXPECT_GT(builder.getCurrentlyBuiltMapSize(), 1U) << "PF algorithm #" << static_cast<int>(algo);
+  }
+}
+
+TEST(CMetricMapBuilderRBPF, optimalProposalWithPointsMap)
+{
+  mrpt::random::getRandomGenerator().randomize(99);
+
+  auto opts = defaultRBPFOptions(mrpt::bayes::CParticleFilter::pfOptimalProposal);
+  opts.predictionOptions.pfOptimalProposal_mapSelection = 3;  // points map
+
+  CMetricMapBuilderRBPF builder(opts);
+  runShortSession(builder, 3);
+
+  EXPECT_GT(builder.getCurrentlyBuiltMapSize(), 1U);
+}
+
+TEST(CMetricMapBuilderRBPF, adaptiveSampleSize)
+{
+  mrpt::random::getRandomGenerator().randomize(77);
+
+  auto opts = defaultRBPFOptions();
+  opts.PF_options.adaptiveSampleSize = true;
+  // A dynamic number of particles requires multinomial resampling:
+  opts.PF_options.resamplingMethod = mrpt::bayes::CParticleFilter::prMultinomial;
+  opts.predictionOptions.KLD_params.KLD_minSampleSize = 3;
+  opts.predictionOptions.KLD_params.KLD_maxSampleSize = 20;
+
+  CMetricMapBuilderRBPF builder(opts);
+  runShortSession(builder, 3);
+
+  EXPECT_GE(builder.mapPDF.particlesCount(), 3U);
+}
+
+TEST(CMetricMapBuilderRBPF, constructionOptionsLoadFromConfigFile)
+{
+  mrpt::config::CConfigFileMemory cfg;
+  // PF options (several of them have no default and must be present):
+  cfg.write("RBPF", "adaptiveSampleSize", false);
+  cfg.write("RBPF", "BETA", 0.5);
+  cfg.write("RBPF", "sampleSize", 7);
+  cfg.write("RBPF", "PF_algorithm", "pfStandardProposal");
+  cfg.write("RBPF", "resamplingMethod", "prSystematic");
+  // ...and this class' own options:
+  cfg.write("RBPF", "insertionLinDistance", 1.25);
+  cfg.write("RBPF", "insertionAngDistance_deg", 22.0);
+  cfg.write("RBPF", "localizeLinDistance", 0.55);
+  cfg.write("RBPF", "localizeAngDistance_deg", 11.0);
+  cfg.write("RBPF", "verbosity_level", "LVL_ERROR");
+  cfg.write("RBPF", "mrpt::maps::CSimplePointsMap_count", 1);
+  cfg.write("RBPF", "pfOptimalProposal_mapSelection", 0);
+
+  CMetricMapBuilderRBPF::TConstructionOptions o2;
+  o2.loadFromConfigFile(cfg, "RBPF");
+
+  EXPECT_EQ(o2.PF_options.sampleSize, 7U);
+  EXPECT_NEAR(o2.insertionLinDistance, 1.25, 1e-9);
+  EXPECT_NEAR(o2.insertionAngDistance, mrpt::DEG2RAD(22.0), 1e-9);
+  EXPECT_NEAR(o2.localizeLinDistance, 0.55, 1e-9);
+  EXPECT_NEAR(o2.localizeAngDistance, mrpt::DEG2RAD(11.0), 1e-9);
+  EXPECT_EQ(o2.verbosity_level, mrpt::system::LVL_ERROR);
+  EXPECT_EQ(o2.mapsInitializers.size(), 1U);
+
+  // A missing mandatory entry is an error:
+  mrpt::config::CConfigFileMemory empty;
+  CMetricMapBuilderRBPF::TConstructionOptions o3;
+  EXPECT_THROW(o3.loadFromConfigFile(empty, "RBPF"), std::exception);
+
+  std::stringstream ss;
+  defaultRBPFOptions().dumpToTextStream(ss);
+  EXPECT_FALSE(ss.str().empty());
+}
+
+TEST(CMetricMapBuilderRBPF, copyAssignmentAndDefaultCtor)
+{
+  mrpt::random::getRandomGenerator().randomize(5);
+
+  CMetricMapBuilderRBPF src(defaultRBPFOptions());
+  runShortSession(src, 2);
+
+  CMetricMapBuilderRBPF dst;  // "empty" constructor
+  dst = src;
+  EXPECT_EQ(dst.getCurrentlyBuiltMapSize(), src.getCurrentlyBuiltMapSize());
+
+  // Self-assignment must be a no-op:
+  CMetricMapBuilderRBPF* pSrc = &src;
+  src = *pSrc;
+  EXPECT_EQ(dst.getCurrentlyBuiltMapSize(), src.getCurrentlyBuiltMapSize());
+}
+
+TEST(CMetricMapBuilderRBPF, initializeFromPreviousMap)
+{
+  mrpt::random::getRandomGenerator().randomize(11);
+
+  CMetricMapBuilderRBPF first(defaultRBPFOptions());
+  runShortSession(first, 3);
+
+  mrpt::maps::CSimpleMap prevMap;
+  first.getCurrentlyBuiltMap(prevMap);
+  ASSERT_GT(prevMap.size(), 1U);
+
+  CMetricMapBuilderRBPF second(defaultRBPFOptions());
+  second.initialize(prevMap);
+  EXPECT_EQ(second.getCurrentlyBuiltMapSize(), prevMap.size());
+
+  // Each particle path holds one node per previous keyframe:
+  std::deque<mrpt::math::TPose3D> path;
+  second.mapPDF.getPath(0, path);
+  EXPECT_EQ(path.size(), prevMap.size());
+
+  // Also with an explicit initial pose:
+  mrpt::poses::CPosePDFGaussian x0;
+  x0.mean = mrpt::poses::CPose2D(1.0, 2.0, 0.0);
+  CMetricMapBuilderRBPF third(defaultRBPFOptions());
+  third.initialize(mrpt::maps::CSimpleMap(), &x0);
+  bool valid = false;
+  const auto p0 = third.mapPDF.getLastPose(0, valid);
+  EXPECT_TRUE(valid);
+  EXPECT_NEAR(p0.x, 1.0, 1e-9);
+  EXPECT_NEAR(p0.y, 2.0, 1e-9);
+}
+
+TEST(CMetricMapBuilderRBPF, debugOutputs)
+{
+  mrpt::random::getRandomGenerator().randomize(21);
+
+  CMetricMapBuilderRBPF builder(defaultRBPFOptions());
+  runShortSession(builder, 2);
+
+  const std::string pathFile = mrpt::system::getTempFileName();
+  builder.saveCurrentPathEstimationToTextFile(pathFile);
+  EXPECT_TRUE(mrpt::system::fileExists(pathFile));
+  EXPECT_GT(mrpt::system::getFileSize(pathFile), 0U);
+  mrpt::system::deleteFile(pathFile);
+
+  const std::string imgFile = mrpt::system::getTempFileName() + std::string(".png");
+  builder.saveCurrentEstimationToImage(imgFile);
+  EXPECT_TRUE(mrpt::system::fileExists(imgFile));
+  mrpt::system::deleteFile(imgFile);
+
+  mrpt::img::CImage img(200, 200);
+  EXPECT_NO_THROW(builder.drawCurrentEstimationToImage(&img));
+
+  EXPECT_TRUE(std::isfinite(builder.getCurrentJointEntropy()));
+}
+
+TEST(CMultiMetricMapPDF, clearVariants)
+{
+  auto opts = defaultRBPFOptions();
+  CMultiMetricMapPDF pdf(opts.PF_options, opts.mapsInitializers, opts.predictionOptions);
+
+  ASSERT_EQ(pdf.particlesCount(), 5U);
+
+  pdf.clear(mrpt::poses::CPose2D(1.0, 2.0, 0.5));
+  bool valid = false;
+  auto p = pdf.getLastPose(0, valid);
+  EXPECT_TRUE(valid);
+  EXPECT_NEAR(p.x, 1.0, 1e-9);
+  EXPECT_NEAR(p.yaw, 0.5, 1e-9);
+
+  pdf.clear(mrpt::poses::CPose3D(3.0, 0, 0, 0, 0, 0));
+  p = pdf.getLastPose(0, valid);
+  EXPECT_NEAR(p.x, 3.0, 1e-9);
+  EXPECT_EQ(pdf.getNumberOfObservationsInSimplemap(), 0U);
+
+  // clear() with an empty previous map falls back to the pose-only version:
+  pdf.clear(mrpt::maps::CSimpleMap(), mrpt::poses::CPose3D(4.0, 0, 0, 0, 0, 0));
+  p = pdf.getLastPose(0, valid);
+  EXPECT_NEAR(p.x, 4.0, 1e-9);
+
+  EXPECT_THROW(std::ignore = pdf.getLastPose(99, valid), std::exception);
+  std::deque<mrpt::math::TPose3D> path;
+  EXPECT_THROW(pdf.getPath(99, path), std::exception);
+}
+
+TEST(CMultiMetricMapPDF, pathsEntropyAndAveragedMap)
+{
+  mrpt::random::getRandomGenerator().randomize(31);
+
+  CMetricMapBuilderRBPF builder(defaultRBPFOptions());
+  runShortSession(builder, 3);
+
+  auto& pdf = builder.mapPDF;
+
+  EXPECT_GT(pdf.getCurrentEntropyOfPaths(), -1e10);
+
+  // The averaged map is cached until the next insertion:
+  const auto* avg1 = pdf.getAveragedMetricMapEstimation();
+  ASSERT_TRUE(avg1);
+  const auto* avg2 = pdf.getAveragedMetricMapEstimation();
+  EXPECT_EQ(avg1, avg2);
+  EXPECT_TRUE(avg1->mapByClass<mrpt::maps::COccupancyGridMap2D>());
+
+  const auto* best = pdf.getCurrentMostLikelyMetricMap();
+  ASSERT_TRUE(best);
+  EXPECT_TRUE(best->mapByClass<mrpt::maps::COccupancyGridMap2D>());
+
+  // Updating the SF poses from the current paths must not change their count:
+  const size_t n = pdf.getNumberOfObservationsInSimplemap();
+  pdf.updateSensoryFrameSequence();
+  EXPECT_EQ(pdf.getNumberOfObservationsInSimplemap(), n);
+
+  mrpt::poses::CPose3DPDFParticles est;
+  pdf.getEstimatedPosePDFAtTime(0, est);
+  EXPECT_EQ(est.size(), pdf.particlesCount());
+}
+
+TEST(CMultiMetricMapPDF, serializationRoundTrip)
+{
+  mrpt::random::getRandomGenerator().randomize(41);
+
+  CMetricMapBuilderRBPF builder(defaultRBPFOptions());
+  runShortSession(builder, 2);
+
+  std::stringstream ss;
+  auto arch = mrpt::serialization::archiveFrom<std::iostream>(ss);
+  arch << builder.mapPDF;
+
+  CMultiMetricMapPDF pdf2;
+  arch >> pdf2;
+
+  ASSERT_EQ(pdf2.particlesCount(), builder.mapPDF.particlesCount());
+  EXPECT_EQ(
+      pdf2.getNumberOfObservationsInSimplemap(),
+      builder.mapPDF.getNumberOfObservationsInSimplemap());
+
+  std::deque<mrpt::math::TPose3D> p1, p2;
+  builder.mapPDF.getPath(0, p1);
+  pdf2.getPath(0, p2);
+  ASSERT_EQ(p1.size(), p2.size());
+  for (size_t i = 0; i < p1.size(); i++) EXPECT_NEAR(p1[i].x, p2[i].x, 1e-9);
+}
+
+TEST(CMultiMetricMapPDF, predictionParamsSaveLoad)
+{
+  mrpt::config::CConfigFileMemory cfg;
+  cfg.write("PDF", "pfOptimalProposal_mapSelection", 3);
+  cfg.write("PDF", "ICPGlobalAlign_MinQuality", 0.5);
+  cfg.write("PDF", "KLD_minSampleSize", 30);
+
+  CMultiMetricMapPDF::TPredictionParams p;
+  p.loadFromConfigFile(cfg, "PDF");
+
+  EXPECT_EQ(p.pfOptimalProposal_mapSelection, 3);
+  EXPECT_NEAR(p.ICPGlobalAlign_MinQuality, 0.5f, 1e-6);
+  EXPECT_EQ(p.KLD_params.KLD_minSampleSize, 30U);
+
+  std::stringstream ss;
+  p.dumpToTextStream(ss);
+  EXPECT_NE(ss.str().find("pfOptimalProposal_mapSelection"), std::string::npos);
+}
+
+namespace
+{
+/** Three beacons around the robot path, for the range-only SLAM tests. */
+const std::vector<mrpt::math::TPoint3D>& beaconPositions()
+{
+  static const std::vector<mrpt::math::TPoint3D> pts = {
+      { 0.0,  3.0, 0.0},
+      { 4.0, -2.0, 0.0},
+      {-3.0, -2.0, 0.0}
+  };
+  return pts;
+}
+
+mrpt::obs::CSensoryFrame::Ptr simulateBeaconRanges(const mrpt::poses::CPose2D& robotPose)
+{
+  auto obs = mrpt::obs::CObservationBeaconRanges::Create();
+  obs->timestamp = mrpt::Clock::now();
+  obs->stdError = 0.05f;
+
+  int64_t id = 0;
+  for (const auto& p : beaconPositions())
+  {
+    mrpt::obs::CObservationBeaconRanges::TMeasurement m;
+    m.beaconID = id++;
+    m.sensorLocationOnRobot = mrpt::poses::CPoint3D(0, 0, 0);
+    m.sensedDistance = static_cast<float>(mrpt::poses::CPoint3D(p).distanceTo(
+        mrpt::poses::CPoint3D(robotPose.x(), robotPose.y(), 0)));
+    obs->sensedData.push_back(m);
+  }
+
+  auto sf = mrpt::obs::CSensoryFrame::Create();
+  sf->insert(obs);
+  return sf;
+}
+
+CMetricMapBuilderRBPF::TConstructionOptions rangeOnlySLAMOptions(
+    mrpt::bayes::CParticleFilter::TParticleFilterAlgorithm algo)
+{
+  CMetricMapBuilderRBPF::TConstructionOptions o;
+  o.verbosity_level = mrpt::system::LVL_ERROR;
+  o.insertionLinDistance = 0;  // insert every step
+  o.insertionAngDistance = 0;
+  o.localizeLinDistance = 0;
+  o.localizeAngDistance = 0;
+
+  o.PF_options.PF_algorithm = algo;
+  o.PF_options.adaptiveSampleSize = false;
+  o.PF_options.sampleSize = 5;
+  o.PF_options.resamplingMethod = mrpt::bayes::CParticleFilter::prSystematic;
+
+  mrpt::maps::CBeaconMap::TMapDefinition def;
+  // The optimal-proposal path only handles Gaussian/SOG beacon PDFs:
+  def.insertionOpts.insertAsMonteCarlo = false;
+  o.mapsInitializers.push_back(def);
+
+  o.predictionOptions.pfOptimalProposal_mapSelection = 2;  // beacon map
+  return o;
+}
+
+/** Drives a range-only SLAM session along a short straight path. */
+void runRangeOnlySession(CMetricMapBuilderRBPF& b, size_t nSteps = 4)
+{
+  mrpt::poses::CPose2D gtPose(0, 0, 0);
+  {
+    auto acts = makeOdometryAction(mrpt::poses::CPose2D(0, 0, 0));
+    auto sf = simulateBeaconRanges(gtPose);
+    b.processActionObservation(*acts, *sf);
+  }
+  for (size_t i = 0; i < nSteps; i++)
+  {
+    const mrpt::poses::CPose2D incr(0.3, 0, 0);
+    gtPose = gtPose + incr;
+    auto acts = makeOdometryAction(incr);
+    auto sf = simulateBeaconRanges(gtPose);
+    b.processActionObservation(*acts, *sf);
+  }
+}
+}  // namespace
+
+TEST(CMetricMapBuilderRBPF, rangeOnlySLAMWithOptimalProposal)
+{
+  mrpt::random::getRandomGenerator().randomize(2026);
+
+  CMetricMapBuilderRBPF builder(
+      rangeOnlySLAMOptions(mrpt::bayes::CParticleFilter::pfOptimalProposal));
+  runRangeOnlySession(builder);
+
+  const auto& mmap = builder.getCurrentlyBuiltMetricMap();
+  auto beacons = mmap.mapByClass<mrpt::maps::CBeaconMap>();
+  ASSERT_TRUE(beacons);
+  EXPECT_EQ(beacons->size(), beaconPositions().size());
+  EXPECT_GT(builder.getCurrentlyBuiltMapSize(), 1U);
+}
+
+TEST(CMetricMapBuilderRBPF, rangeOnlySLAMWithAuxiliaryOptimal)
+{
+  mrpt::random::getRandomGenerator().randomize(2027);
+
+  CMetricMapBuilderRBPF builder(
+      rangeOnlySLAMOptions(mrpt::bayes::CParticleFilter::pfAuxiliaryPFOptimal));
+  runRangeOnlySession(builder, 3);
+
+  auto beacons = builder.getCurrentlyBuiltMetricMap().mapByClass<mrpt::maps::CBeaconMap>();
+  ASSERT_TRUE(beacons);
+  EXPECT_EQ(beacons->size(), beaconPositions().size());
+}

--- a/modules/mrpt_slam/tests/CMetricMapBuilderRBPF_unittest.cpp
+++ b/modules/mrpt_slam/tests/CMetricMapBuilderRBPF_unittest.cpp
@@ -83,8 +83,9 @@ void runShortSession(CMetricMapBuilderRBPF& b, size_t nSteps = 5)
 
   // First observation, with no movement:
   {
-    auto acts = makeOdometryAction(mrpt::poses::CPose2D(0, 0, 0));
-    auto sf = simulateSF(gtPose);
+    const auto t = mrpt::test::nextTimestamp();
+    auto acts = makeOdometryAction(mrpt::poses::CPose2D(0, 0, 0), t);
+    auto sf = simulateSF(gtPose, t);
     b.processActionObservation(*acts, *sf);
   }
 
@@ -93,8 +94,9 @@ void runShortSession(CMetricMapBuilderRBPF& b, size_t nSteps = 5)
     const mrpt::poses::CPose2D incr(0.4, 0, 0);
     gtPose = gtPose + incr;
 
-    auto acts = makeOdometryAction(incr);
-    auto sf = simulateSF(gtPose);
+    const auto t = mrpt::test::nextTimestamp();
+    auto acts = makeOdometryAction(incr, t);
+    auto sf = simulateSF(gtPose, t);
     b.processActionObservation(*acts, *sf);
   }
 }
@@ -414,10 +416,11 @@ const std::vector<mrpt::math::TPoint3D>& beaconPositions()
   return pts;
 }
 
-mrpt::obs::CSensoryFrame::Ptr simulateBeaconRanges(const mrpt::poses::CPose2D& robotPose)
+mrpt::obs::CSensoryFrame::Ptr simulateBeaconRanges(
+    const mrpt::poses::CPose2D& robotPose, const mrpt::system::TTimeStamp t)
 {
   auto obs = mrpt::obs::CObservationBeaconRanges::Create();
-  obs->timestamp = mrpt::Clock::now();
+  obs->timestamp = t;
   obs->stdError = 0.05f;
 
   int64_t id = 0;
@@ -465,16 +468,18 @@ void runRangeOnlySession(CMetricMapBuilderRBPF& b, size_t nSteps = 4)
 {
   mrpt::poses::CPose2D gtPose(0, 0, 0);
   {
-    auto acts = makeOdometryAction(mrpt::poses::CPose2D(0, 0, 0));
-    auto sf = simulateBeaconRanges(gtPose);
+    const auto t = mrpt::test::nextTimestamp();
+    auto acts = makeOdometryAction(mrpt::poses::CPose2D(0, 0, 0), t);
+    auto sf = simulateBeaconRanges(gtPose, t);
     b.processActionObservation(*acts, *sf);
   }
   for (size_t i = 0; i < nSteps; i++)
   {
     const mrpt::poses::CPose2D incr(0.3, 0, 0);
     gtPose = gtPose + incr;
-    auto acts = makeOdometryAction(incr);
-    auto sf = simulateBeaconRanges(gtPose);
+    const auto t = mrpt::test::nextTimestamp();
+    auto acts = makeOdometryAction(incr, t);
+    auto sf = simulateBeaconRanges(gtPose, t);
     b.processActionObservation(*acts, *sf);
   }
 }

--- a/modules/mrpt_slam/tests/CMonteCarloLocalization_unittest.cpp
+++ b/modules/mrpt_slam/tests/CMonteCarloLocalization_unittest.cpp
@@ -1,0 +1,226 @@
+/*                    _
+                     | |    Mobile Robot Programming Toolkit (MRPT)
+ _ __ ___  _ __ _ __ | |_
+| '_ ` _ \| '__| '_ \| __|          https://www.mrpt.org/
+| | | | | | |  | |_) | |_
+|_| |_| |_|_|  | .__/ \__|     https://github.com/MRPT/mrpt/
+               | |
+               |_|
+
+ Copyright (c) 2005-2026, Individual contributors, see AUTHORS file
+ See: https://www.mrpt.org/Authors - All rights reserved.
+ SPDX-License-Identifier: BSD-3-Clause
+*/
+
+/** Unit tests for the Monte Carlo localization PDFs (SE(2) and SE(3)) over a
+ *  synthetic room, exercising the four particle filter algorithms without
+ *  needing any dataset file.
+ *  \sa CMonteCarloLocalization2D_unittest.cpp for the dataset-based test.
+ */
+
+#include <gtest/gtest.h>
+#include <mrpt/bayes/CParticleFilter.h>
+#include <mrpt/maps/COccupancyGridMap2D.h>
+#include <mrpt/random.h>
+#include <mrpt/slam/CMonteCarloLocalization2D.h>
+#include <mrpt/slam/CMonteCarloLocalization3D.h>
+
+#include "slam_synthetic_room.h"
+
+using mrpt::slam::CMonteCarloLocalization2D;
+using mrpt::slam::CMonteCarloLocalization3D;
+using mrpt::test::makeOdometryAction;
+using mrpt::test::simulateSF;
+
+namespace
+{
+mrpt::maps::COccupancyGridMap2D::Ptr referenceMap()
+{
+  auto m = mrpt::maps::COccupancyGridMap2D::Create();
+  *m = mrpt::test::groundTruthRoom();
+  return m;
+}
+
+mrpt::bayes::CParticleFilter::TParticleFilterOptions pfOptions(
+    mrpt::bayes::CParticleFilter::TParticleFilterAlgorithm algo, bool adaptive = false)
+{
+  mrpt::bayes::CParticleFilter::TParticleFilterOptions o;
+  o.PF_algorithm = algo;
+  o.adaptiveSampleSize = adaptive;
+  o.sampleSize = 50;
+  o.resamplingMethod = adaptive ? mrpt::bayes::CParticleFilter::prMultinomial
+                                : mrpt::bayes::CParticleFilter::prSystematic;
+  o.BETA = 0.5;
+  return o;
+}
+
+/** Runs a short localization session from a known starting area, returning the
+ *  final mean estimate. */
+template <class PDF>
+mrpt::poses::CPose3D runLocalization(
+    PDF& pdf, const mrpt::bayes::CParticleFilter::TParticleFilterOptions& opts, size_t nSteps = 4)
+{
+  mrpt::bayes::CParticleFilter pf;
+  pf.m_options = opts;
+
+  mrpt::poses::CPose2D gtPose(-2.0, 0.0, 0.0);
+  {
+    auto acts = makeOdometryAction(mrpt::poses::CPose2D(0, 0, 0));
+    auto sf = simulateSF(gtPose);
+    pf.executeOn(pdf, acts.get(), sf.get());
+  }
+  for (size_t i = 0; i < nSteps; i++)
+  {
+    const mrpt::poses::CPose2D incr(0.3, 0, 0);
+    gtPose = gtPose + incr;
+    auto acts = makeOdometryAction(incr);
+    auto sf = simulateSF(gtPose);
+    pf.executeOn(pdf, acts.get(), sf.get());
+  }
+  return mrpt::poses::CPose3D(gtPose);
+}
+}  // namespace
+
+TEST(CMonteCarloLocalization2DSynthetic, resetUniformFreeSpace)
+{
+  mrpt::random::getRandomGenerator().randomize(1);
+
+  auto map = referenceMap();
+
+  CMonteCarloLocalization2D pdf(1);
+  pdf.resetUniformFreeSpace(map.get(), 0.7, 40, -1.0, 1.0, -1.0, 1.0, -M_PI, M_PI);
+
+  EXPECT_EQ(pdf.particlesCount(), 40U);
+  for (size_t i = 0; i < pdf.particlesCount(); i++)
+  {
+    const auto p = pdf.getParticlePose(i);
+    EXPECT_LT(std::abs(p.x), 1.5);
+    EXPECT_LT(std::abs(p.y), 1.5);
+  }
+
+  // Without area limits, the whole free space of the map is used:
+  pdf.resetUniformFreeSpace(map.get(), 0.7, 20);
+  EXPECT_EQ(pdf.particlesCount(), 20U);
+
+  // A fully occupied map has no free cell to place particles at:
+  auto occupied = mrpt::maps::COccupancyGridMap2D::Create();
+  *occupied = mrpt::test::groundTruthRoom();
+  occupied->fill(0.0f);
+  EXPECT_THROW(pdf.resetUniformFreeSpace(occupied.get()), std::exception);
+}
+
+TEST(CMonteCarloLocalization2DSynthetic, convergesWithAllPFAlgorithms)
+{
+  const std::vector<mrpt::bayes::CParticleFilter::TParticleFilterAlgorithm> algos = {
+      mrpt::bayes::CParticleFilter::pfStandardProposal,
+      mrpt::bayes::CParticleFilter::pfAuxiliaryPFStandard,
+      mrpt::bayes::CParticleFilter::pfAuxiliaryPFOptimal};
+
+  auto map = referenceMap();
+
+  for (const auto algo : algos)
+  {
+    mrpt::random::getRandomGenerator().randomize(100 + static_cast<int>(algo));
+
+    CMonteCarloLocalization2D pdf(50);
+    pdf.options.metricMap = map;
+    pdf.resetUniform(-2.5, -1.5, -0.5, 0.5, -mrpt::DEG2RAD(20.0), mrpt::DEG2RAD(20.0));
+
+    const auto gt = runLocalization(pdf, pfOptions(algo));
+
+    const auto est = pdf.getMeanVal();
+    EXPECT_NEAR(est.x(), gt.x(), 0.6) << "PF algorithm #" << static_cast<int>(algo);
+    EXPECT_NEAR(est.y(), gt.y(), 0.6) << "PF algorithm #" << static_cast<int>(algo);
+  }
+}
+
+// The exact optimal proposal is not implemented for plain localization:
+TEST(CMonteCarloLocalization2DSynthetic, optimalProposalIsNotImplemented)
+{
+  mrpt::random::getRandomGenerator().randomize(2);
+
+  auto map = referenceMap();
+
+  CMonteCarloLocalization2D pdf(10);
+  pdf.options.metricMap = map;
+  pdf.resetUniform(-2.5, -1.5, -0.5, 0.5, -mrpt::DEG2RAD(20.0), mrpt::DEG2RAD(20.0));
+
+  EXPECT_THROW(
+      runLocalization(pdf, pfOptions(mrpt::bayes::CParticleFilter::pfOptimalProposal), 1),
+      std::exception);
+}
+
+TEST(CMonteCarloLocalization2DSynthetic, adaptiveSampleSizeKLD)
+{
+  mrpt::random::getRandomGenerator().randomize(3);
+
+  auto map = referenceMap();
+
+  CMonteCarloLocalization2D pdf(50);
+  pdf.options.metricMap = map;
+  pdf.options.KLD_params.KLD_minSampleSize = 20;
+  pdf.options.KLD_params.KLD_maxSampleSize = 200;
+  pdf.resetUniform(-2.5, -1.5, -0.5, 0.5, -mrpt::DEG2RAD(20.0), mrpt::DEG2RAD(20.0));
+
+  runLocalization(pdf, pfOptions(mrpt::bayes::CParticleFilter::pfStandardProposal, true), 3);
+
+  EXPECT_GE(pdf.particlesCount(), 20U);
+  EXPECT_LE(pdf.particlesCount(), 200U);
+}
+
+TEST(CMonteCarloLocalization2DSynthetic, oneMapPerParticle)
+{
+  mrpt::random::getRandomGenerator().randomize(4);
+
+  auto map = referenceMap();
+
+  CMonteCarloLocalization2D pdf(10);
+  pdf.options.metricMaps.assign(10, map);
+  pdf.resetUniform(-2.5, -1.5, -0.5, 0.5, -mrpt::DEG2RAD(20.0), mrpt::DEG2RAD(20.0));
+
+  const auto gt =
+      runLocalization(pdf, pfOptions(mrpt::bayes::CParticleFilter::pfStandardProposal), 2);
+  EXPECT_NEAR(pdf.getMeanVal().x(), gt.x(), 1.0);
+}
+
+TEST(CMonteCarloLocalization3DSynthetic, convergesWithStandardProposal)
+{
+  mrpt::random::getRandomGenerator().randomize(5);
+
+  auto map = referenceMap();
+
+  CMonteCarloLocalization3D pdf(50);
+  pdf.options.metricMap = map;
+  pdf.resetUniform(
+      mrpt::math::TPose3D(-2.5, -0.5, 0, -mrpt::DEG2RAD(20.0), 0, 0),
+      mrpt::math::TPose3D(-1.5, 0.5, 0, mrpt::DEG2RAD(20.0), 0, 0));
+
+  const auto gt = runLocalization(pdf, pfOptions(mrpt::bayes::CParticleFilter::pfStandardProposal));
+
+  const auto est = pdf.getMeanVal();
+  EXPECT_NEAR(est.x(), gt.x(), 0.7);
+  EXPECT_NEAR(est.y(), gt.y(), 0.7);
+
+  bool valid = false;
+  const auto p0 = pdf.getLastPose(0, valid);
+  EXPECT_TRUE(valid);
+  EXPECT_TRUE(std::isfinite(p0.x));
+  EXPECT_THROW(std::ignore = pdf.getLastPose(pdf.particlesCount(), valid), std::exception);
+}
+
+TEST(CMonteCarloLocalization3DSynthetic, auxiliaryPFStandard)
+{
+  mrpt::random::getRandomGenerator().randomize(6);
+
+  auto map = referenceMap();
+
+  CMonteCarloLocalization3D pdf(40);
+  pdf.options.metricMap = map;
+  pdf.resetUniform(
+      mrpt::math::TPose3D(-2.5, -0.5, 0, -mrpt::DEG2RAD(20.0), 0, 0),
+      mrpt::math::TPose3D(-1.5, 0.5, 0, mrpt::DEG2RAD(20.0), 0, 0));
+
+  const auto gt =
+      runLocalization(pdf, pfOptions(mrpt::bayes::CParticleFilter::pfAuxiliaryPFStandard), 3);
+  EXPECT_NEAR(pdf.getMeanVal().x(), gt.x(), 1.0);
+}

--- a/modules/mrpt_slam/tests/CMonteCarloLocalization_unittest.cpp
+++ b/modules/mrpt_slam/tests/CMonteCarloLocalization_unittest.cpp
@@ -65,16 +65,18 @@ mrpt::poses::CPose3D runLocalization(
 
   mrpt::poses::CPose2D gtPose(-2.0, 0.0, 0.0);
   {
-    auto acts = makeOdometryAction(mrpt::poses::CPose2D(0, 0, 0));
-    auto sf = simulateSF(gtPose);
+    const auto t = mrpt::test::nextTimestamp();
+    auto acts = makeOdometryAction(mrpt::poses::CPose2D(0, 0, 0), t);
+    auto sf = simulateSF(gtPose, t);
     pf.executeOn(pdf, acts.get(), sf.get());
   }
   for (size_t i = 0; i < nSteps; i++)
   {
     const mrpt::poses::CPose2D incr(0.3, 0, 0);
     gtPose = gtPose + incr;
-    auto acts = makeOdometryAction(incr);
-    auto sf = simulateSF(gtPose);
+    const auto t = mrpt::test::nextTimestamp();
+    auto acts = makeOdometryAction(incr, t);
+    auto sf = simulateSF(gtPose, t);
     pf.executeOn(pdf, acts.get(), sf.get());
   }
   return mrpt::poses::CPose3D(gtPose);

--- a/modules/mrpt_slam/tests/CRangeBearingKFSLAM_unittest.cpp
+++ b/modules/mrpt_slam/tests/CRangeBearingKFSLAM_unittest.cpp
@@ -258,6 +258,11 @@ TEST(CRangeBearingKFSLAM2D, optionsLoadAndDump)
   std::stringstream ss;
   f.options.dumpToTextStream(ss);
   EXPECT_NE(ss.str().find("std_sensor_range"), std::string::npos);
+  // The heading component is reported in degrees, as it is read:
+  EXPECT_NE(
+      ss.str().find("stds_Q_no_odo                           = [0.050000 m, "
+                    "0.050000 m, 0.020000 deg]"),
+      std::string::npos);
 }
 
 TEST(CRangeBearingKFSLAM2D, saveMapAsMATLABFile)

--- a/modules/mrpt_slam/tests/CRangeBearingKFSLAM_unittest.cpp
+++ b/modules/mrpt_slam/tests/CRangeBearingKFSLAM_unittest.cpp
@@ -1,0 +1,441 @@
+/*                    _
+                     | |    Mobile Robot Programming Toolkit (MRPT)
+ _ __ ___  _ __ _ __ | |_
+| '_ ` _ \| '__| '_ \| __|          https://www.mrpt.org/
+| | | | | | |  | |_) | |_
+|_| |_| |_|_|  | .__/ \__|     https://github.com/MRPT/mrpt/
+               | |
+               |_|
+
+ Copyright (c) 2005-2026, Individual contributors, see AUTHORS file
+ See: https://www.mrpt.org/Authors - All rights reserved.
+ SPDX-License-Identifier: BSD-3-Clause
+*/
+
+/** Unit tests for the EKF range-bearing SLAM filters (SE(2) and SE(3)),
+ *  driven by observations simulated from a synthetic landmark map.
+ */
+
+#include <gtest/gtest.h>
+#include <mrpt/config/CConfigFileMemory.h>
+#include <mrpt/maps/CLandmarksMap.h>
+#include <mrpt/obs/CActionCollection.h>
+#include <mrpt/obs/CActionRobotMovement2D.h>
+#include <mrpt/obs/CObservationBearingRange.h>
+#include <mrpt/obs/CSensoryFrame.h>
+#include <mrpt/random.h>
+#include <mrpt/slam/CRangeBearingKFSLAM.h>
+#include <mrpt/slam/CRangeBearingKFSLAM2D.h>
+#include <mrpt/system/filesystem.h>
+
+#include <sstream>
+
+using mrpt::slam::CRangeBearingKFSLAM;
+using mrpt::slam::CRangeBearingKFSLAM2D;
+
+namespace
+{
+/** Four landmarks around the origin, all at z=0 so both the 2D and the 6D
+ *  filters can see them. */
+mrpt::maps::CLandmarksMap makeLandmarks()
+{
+  const std::vector<mrpt::math::TPoint3D> pts = {
+      {4.0,  1.0, 0.0},
+      {5.0, -2.0, 0.0},
+      {8.0,  2.0, 0.0},
+      {9.0, -1.0, 0.0}
+  };
+
+  mrpt::maps::CLandmarksMap m;
+  int64_t id = 0;
+  for (const auto& p : pts)
+  {
+    mrpt::maps::CLandmark lm;
+    lm.ID = id++;
+    lm.pose_mean = p;
+    m.landmarks.push_back(lm);
+  }
+  return m;
+}
+
+mrpt::obs::CSensoryFrame::Ptr simulateObs(
+    const mrpt::maps::CLandmarksMap& lms,
+    const mrpt::poses::CPose3D& robotPose,
+    bool withIDs,
+    double sigmaPitch)
+{
+  auto obs = mrpt::obs::CObservationBearingRange::Create();
+  obs->minSensorDistance = 0;
+  obs->maxSensorDistance = 100.0f;
+  obs->fieldOfView_yaw = 2 * M_PIf;
+  obs->fieldOfView_pitch = M_PIf;
+  obs->sensor_std_range = 0.01f;
+  obs->sensor_std_yaw = mrpt::DEG2RAD(0.2f);
+  obs->sensor_std_pitch = static_cast<float>(sigmaPitch);
+
+  lms.simulateRangeBearingReadings(
+      robotPose, mrpt::poses::CPose3D(), *obs, withIDs, 0.01 /*sigmaRange*/,
+      mrpt::DEG2RAD(0.2) /*sigmaYaw*/, sigmaPitch);
+
+  auto sf = mrpt::obs::CSensoryFrame::Create();
+  sf->insert(obs);
+  return sf;
+}
+
+mrpt::obs::CActionCollection::Ptr makeOdometry(const mrpt::poses::CPose2D& incr)
+{
+  mrpt::obs::CActionRobotMovement2D act;
+  mrpt::obs::CActionRobotMovement2D::TMotionModelOptions o;
+  o.modelSelection = mrpt::obs::CActionRobotMovement2D::mmGaussian;
+  o.gaussianModel.minStdXY = 0.02;
+  o.gaussianModel.minStdPHI = mrpt::DEG2RAD(0.5);
+  act.computeFromOdometry(incr, o);
+  act.timestamp = mrpt::Clock::now();
+
+  auto acts = mrpt::obs::CActionCollection::Create();
+  acts->insert(act);
+  return acts;
+}
+
+/** Runs the given filter along a short straight path, returning the true
+ *  final robot pose. */
+template <class FILTER>
+mrpt::poses::CPose2D runSession(
+    FILTER& f,
+    const mrpt::maps::CLandmarksMap& lms,
+    size_t nSteps = 4,
+    bool withIDs = true,
+    bool withOdometry = true,
+    double sigmaPitch = mrpt::DEG2RAD(0.2))
+{
+  mrpt::poses::CPose2D gtPose(0, 0, 0);
+
+  {
+    auto acts = makeOdometry(mrpt::poses::CPose2D(0, 0, 0));
+    auto sf = simulateObs(lms, mrpt::poses::CPose3D(gtPose), withIDs, sigmaPitch);
+    if (!withOdometry) acts = mrpt::obs::CActionCollection::Create();
+    f.processActionObservation(acts, sf);
+  }
+
+  for (size_t i = 0; i < nSteps; i++)
+  {
+    const mrpt::poses::CPose2D incr(0.25, 0, 0);
+    gtPose = gtPose + incr;
+
+    auto acts = makeOdometry(incr);
+    if (!withOdometry) acts = mrpt::obs::CActionCollection::Create();
+    auto sf = simulateObs(lms, mrpt::poses::CPose3D(gtPose), withIDs, sigmaPitch);
+    f.processActionObservation(acts, sf);
+  }
+  return gtPose;
+}
+}  // namespace
+
+// ------------------------- SE(2) filter -------------------------
+
+TEST(CRangeBearingKFSLAM2D, mapsFourLandmarksWithKnownIDs)
+{
+  mrpt::random::getRandomGenerator().randomize(1234);
+
+  const auto lms = makeLandmarks();
+
+  CRangeBearingKFSLAM2D f;
+  f.options.create_simplemap = true;
+  const auto gtPose = runSession(f, lms, 4, true, true, 0 /*sigmaPitch*/);
+
+  mrpt::poses::CPosePDFGaussian robotPose;
+  std::vector<mrpt::math::TPoint2D> lmPos;
+  std::map<unsigned int, mrpt::maps::CLandmark::TLandmarkID> lmIDs;
+  mrpt::math::CVectorDouble fullState;
+  mrpt::math::CMatrixDouble fullCov;
+  f.getCurrentState(robotPose, lmPos, lmIDs, fullState, fullCov);
+
+  EXPECT_EQ(lmPos.size(), 4U);
+  EXPECT_EQ(lmIDs.size(), 4U);
+  EXPECT_EQ(static_cast<size_t>(fullState.size()), 3U + 2U * 4U);
+  EXPECT_EQ(fullCov.rows(), fullState.size());
+
+  EXPECT_NEAR(robotPose.mean.x(), gtPose.x(), 0.25);
+  EXPECT_NEAR(robotPose.mean.y(), gtPose.y(), 0.25);
+
+  // Each mapped landmark must be near its ground truth position:
+  for (const auto& [idxInMap, id] : lmIDs)
+  {
+    const auto* gtLm = lms.landmarks.getByBeaconID(id);
+    ASSERT_TRUE(gtLm != nullptr);
+    EXPECT_NEAR(lmPos[idxInMap].x, gtLm->pose_mean.x, 0.35);
+    EXPECT_NEAR(lmPos[idxInMap].y, gtLm->pose_mean.y, 0.35);
+  }
+
+  mrpt::poses::CPosePDFGaussian onlyPose;
+  f.getCurrentRobotPose(onlyPose);
+  EXPECT_NEAR(onlyPose.mean.x(), robotPose.mean.x(), 1e-9);
+
+  // With known landmark IDs no data association is run, but the ID-based
+  // matching is still reported back:
+  const auto& da = f.getLastDataAssociation();
+  EXPECT_TRUE(da.predictions_IDs.empty());
+  EXPECT_EQ(da.results.associations.size(), 4U);
+
+  auto obj = mrpt::viz::CSetOfObjects::Create();
+  f.getAs3DObject(obj);
+  EXPECT_GT(obj->size(), 4U);
+
+  f.reset();
+  f.getCurrentState(robotPose, lmPos, lmIDs, fullState, fullCov);
+  EXPECT_EQ(lmPos.size(), 0U);
+  EXPECT_NEAR(robotPose.mean.x(), 0.0, 1e-9);
+}
+
+TEST(CRangeBearingKFSLAM2D, unknownIDsAreDataAssociated)
+{
+  mrpt::random::getRandomGenerator().randomize(4321);
+
+  const auto lms = makeLandmarks();
+
+  CRangeBearingKFSLAM2D f;
+  f.options.data_assoc_method = mrpt::slam::assocJCBB;
+  f.options.data_assoc_metric = mrpt::slam::metricMaha;
+  f.options.data_assoc_IC_metric = mrpt::slam::metricMaha;
+
+  runSession(f, lms, 4, false /* no landmark IDs */, true, 0 /*sigmaPitch*/);
+
+  mrpt::poses::CPosePDFGaussian robotPose;
+  std::vector<mrpt::math::TPoint2D> lmPos;
+  std::map<unsigned int, mrpt::maps::CLandmark::TLandmarkID> lmIDs;
+  mrpt::math::CVectorDouble fullState;
+  mrpt::math::CMatrixDouble fullCov;
+  f.getCurrentState(robotPose, lmPos, lmIDs, fullState, fullCov);
+
+  // Data association must not duplicate the 4 real landmarks:
+  EXPECT_EQ(lmPos.size(), 4U);
+
+  const auto& daInfo = f.getLastDataAssociation();
+  EXPECT_EQ(daInfo.predictions_IDs.size(), 4U);
+  EXPECT_EQ(daInfo.results.associations.size(), 4U);
+}
+
+TEST(CRangeBearingKFSLAM2D, worksWithoutOdometry)
+{
+  mrpt::random::getRandomGenerator().randomize(99);
+
+  const auto lms = makeLandmarks();
+
+  CRangeBearingKFSLAM2D f;
+  // The 2D filter has no "force_ignore_odometry" flag: feed empty actions.
+  runSession(f, lms, 3, true /*withIDs*/, false /*withOdometry*/, 0 /*sigmaPitch*/);
+
+  mrpt::poses::CPosePDFGaussian robotPose;
+  std::vector<mrpt::math::TPoint2D> lmPos;
+  std::map<unsigned int, mrpt::maps::CLandmark::TLandmarkID> lmIDs;
+  mrpt::math::CVectorDouble fullState;
+  mrpt::math::CMatrixDouble fullCov;
+  f.getCurrentState(robotPose, lmPos, lmIDs, fullState, fullCov);
+  EXPECT_EQ(lmPos.size(), 4U);
+}
+
+TEST(CRangeBearingKFSLAM2D, optionsLoadAndDump)
+{
+  mrpt::config::CConfigFileMemory cfg;
+  cfg.write("RangeBearingKFSLAM", "stds_Q_no_odo", "[0.05 0.05 0.02]");
+  cfg.write("RangeBearingKFSLAM", "std_sensor_range", 0.05);
+  cfg.write("RangeBearingKFSLAM", "std_sensor_yaw_deg", 1.5);
+  cfg.write("RangeBearingKFSLAM", "quantiles_3D_representation", 2.0);
+  cfg.write("RangeBearingKFSLAM", "create_simplemap", true);
+  cfg.write("RangeBearingKFSLAM", "data_assoc_method", "assocJCBB");
+  cfg.write("RangeBearingKFSLAM", "data_assoc_metric", "metricMaha");
+  cfg.write("RangeBearingKFSLAM", "data_assoc_IC_metric", "metricMaha");
+
+  CRangeBearingKFSLAM2D f;
+  f.loadOptions(cfg);
+
+  EXPECT_NEAR(f.options.std_sensor_range, 0.05f, 1e-6);
+  EXPECT_NEAR(f.options.std_sensor_yaw, mrpt::DEG2RAD(1.5f), 1e-6);
+  EXPECT_NEAR(f.options.quantiles_3D_representation, 2.0f, 1e-6);
+  EXPECT_TRUE(f.options.create_simplemap);
+  EXPECT_EQ(f.options.data_assoc_method, mrpt::slam::assocJCBB);
+
+  std::stringstream ss;
+  f.options.dumpToTextStream(ss);
+  EXPECT_NE(ss.str().find("std_sensor_range"), std::string::npos);
+}
+
+TEST(CRangeBearingKFSLAM2D, saveMapAsMATLABFile)
+{
+  mrpt::random::getRandomGenerator().randomize(7);
+
+  const auto lms = makeLandmarks();
+  CRangeBearingKFSLAM2D f;
+  f.options.create_simplemap = true;
+  runSession(f, lms, 3, true, true, 0 /*sigmaPitch*/);
+
+  const std::string file = mrpt::system::getTempFileName() + std::string(".m");
+  f.saveMapAndPath2DRepresentationAsMATLABFile(file);
+  EXPECT_TRUE(mrpt::system::fileExists(file));
+  EXPECT_GT(mrpt::system::getFileSize(file), 0U);
+  mrpt::system::deleteFile(file);
+}
+
+// ------------------------- SE(3) filter -------------------------
+
+TEST(CRangeBearingKFSLAM, mapsFourLandmarksWithKnownIDs)
+{
+  mrpt::random::getRandomGenerator().randomize(1234);
+
+  const auto lms = makeLandmarks();
+
+  CRangeBearingKFSLAM f;
+  f.options.create_simplemap = true;
+  const auto gtPose = runSession(f, lms);
+
+  mrpt::poses::CPose3DQuatPDFGaussian robotPose;
+  std::vector<mrpt::math::TPoint3D> lmPos;
+  std::map<unsigned int, mrpt::maps::CLandmark::TLandmarkID> lmIDs;
+  mrpt::math::CVectorDouble fullState;
+  mrpt::math::CMatrixDouble fullCov;
+  f.getCurrentState(robotPose, lmPos, lmIDs, fullState, fullCov);
+
+  EXPECT_EQ(lmPos.size(), 4U);
+  EXPECT_EQ(static_cast<size_t>(fullState.size()), 7U + 3U * 4U);
+
+  EXPECT_NEAR(robotPose.mean.x(), gtPose.x(), 0.3);
+  EXPECT_NEAR(robotPose.mean.y(), gtPose.y(), 0.3);
+
+  for (const auto& [idxInMap, id] : lmIDs)
+  {
+    const auto* gtLm = lms.landmarks.getByBeaconID(id);
+    ASSERT_TRUE(gtLm != nullptr);
+    EXPECT_NEAR(lmPos[idxInMap].x, gtLm->pose_mean.x, 0.5);
+    EXPECT_NEAR(lmPos[idxInMap].y, gtLm->pose_mean.y, 0.5);
+  }
+
+  // The 6D-angles flavor of the same getters:
+  mrpt::poses::CPose3DPDFGaussian rpEuler;
+  f.getCurrentState(rpEuler, lmPos, lmIDs, fullState, fullCov);
+  EXPECT_NEAR(rpEuler.mean.x(), robotPose.mean.x(), 1e-9);
+  f.getCurrentRobotPose(rpEuler);
+  EXPECT_NEAR(rpEuler.mean.x(), robotPose.mean.x(), 1e-9);
+  EXPECT_NEAR(f.getCurrentRobotPoseMean().x(), robotPose.mean.x(), 1e-9);
+
+  auto obj = mrpt::viz::CSetOfObjects::Create();
+  f.getAs3DObject(obj);
+  EXPECT_GT(obj->size(), 4U);
+
+  f.reset();
+  f.getCurrentState(robotPose, lmPos, lmIDs, fullState, fullCov);
+  EXPECT_EQ(lmPos.size(), 0U);
+}
+
+TEST(CRangeBearingKFSLAM, worksWithoutOdometry)
+{
+  mrpt::random::getRandomGenerator().randomize(55);
+
+  const auto lms = makeLandmarks();
+
+  CRangeBearingKFSLAM f;
+  f.options.force_ignore_odometry = true;
+  runSession(f, lms, 3);
+
+  mrpt::poses::CPose3DQuatPDFGaussian robotPose;
+  std::vector<mrpt::math::TPoint3D> lmPos;
+  std::map<unsigned int, mrpt::maps::CLandmark::TLandmarkID> lmIDs;
+  mrpt::math::CVectorDouble fullState;
+  mrpt::math::CMatrixDouble fullCov;
+  f.getCurrentState(robotPose, lmPos, lmIDs, fullState, fullCov);
+  EXPECT_EQ(lmPos.size(), 4U);
+}
+
+TEST(CRangeBearingKFSLAM, partitioningExperimentSpectral)
+{
+  mrpt::random::getRandomGenerator().randomize(21);
+
+  const auto lms = makeLandmarks();
+
+  CRangeBearingKFSLAM f;
+  f.options.create_simplemap = true;
+  f.options.doPartitioningExperiment = true;
+  f.options.partitioningMethod = 0;  // spectral graph-cut
+  runSession(f, lms, 4);
+
+  std::vector<std::vector<uint32_t>> parts;
+  f.getLastPartition(parts);
+  EXPECT_GT(parts.size(), 0U);
+
+  std::vector<std::vector<uint32_t>> membership;
+  f.getLastPartitionLandmarks(membership);
+  EXPECT_EQ(membership.size(), 4U);
+
+  EXPECT_TRUE(std::isfinite(f.computeOffDiagonalBlocksApproximationError(membership)));
+
+  f.getLastPartitionLandmarksAsIfFixedSubmaps(2, membership);
+  EXPECT_EQ(membership.size(), 4U);
+
+  EXPECT_NO_THROW(f.reconsiderPartitionsNow());
+
+  // The 3D representation labels each landmark with its partitions:
+  auto obj = mrpt::viz::CSetOfObjects::Create();
+  f.getAs3DObject(obj);
+  EXPECT_GT(obj->size(), 4U);
+}
+
+TEST(CRangeBearingKFSLAM, partitioningExperimentFixedSize)
+{
+  mrpt::random::getRandomGenerator().randomize(22);
+
+  const auto lms = makeLandmarks();
+
+  CRangeBearingKFSLAM f;
+  f.options.create_simplemap = true;
+  f.options.doPartitioningExperiment = true;
+  f.options.partitioningMethod = 2;  // one cut every 2 observations
+  runSession(f, lms, 4);
+
+  std::vector<std::vector<uint32_t>> parts;
+  f.getLastPartition(parts);
+  EXPECT_GT(parts.size(), 0U);
+}
+
+TEST(CRangeBearingKFSLAM, optionsLoadAndDump)
+{
+  mrpt::config::CConfigFileMemory cfg;
+  cfg.write("RangeBearingKFSLAM", "stds_Q_no_odo", "[0.05 0.05 0.05 0.01 0.01 0.01 0.01]");
+  cfg.write("RangeBearingKFSLAM", "std_sensor_range", 0.07);
+  cfg.write("RangeBearingKFSLAM", "std_sensor_yaw_deg", 1.0);
+  cfg.write("RangeBearingKFSLAM", "std_sensor_pitch_deg", 1.0);
+  cfg.write("RangeBearingKFSLAM", "std_odo_z_additional", 0.02);
+  cfg.write("RangeBearingKFSLAM", "doPartitioningExperiment", true);
+  cfg.write("RangeBearingKFSLAM", "partitioningMethod", 3);
+  cfg.write("RangeBearingKFSLAM", "data_assoc_method", "assocNN");
+  cfg.write("RangeBearingKFSLAM", "data_assoc_metric", "metricML");
+  cfg.write("RangeBearingKFSLAM", "data_assoc_IC_metric", "metricML");
+
+  CRangeBearingKFSLAM f;
+  f.loadOptions(cfg);
+
+  EXPECT_NEAR(f.options.std_sensor_range, 0.07f, 1e-6);
+  EXPECT_NEAR(f.options.std_sensor_pitch, mrpt::DEG2RAD(1.0f), 1e-6);
+  EXPECT_NEAR(f.options.std_odo_z_additional, 0.02f, 1e-6);
+  EXPECT_TRUE(f.options.doPartitioningExperiment);
+  EXPECT_EQ(f.options.partitioningMethod, 3);
+  EXPECT_EQ(f.options.data_assoc_metric, mrpt::slam::metricML);
+
+  std::stringstream ss;
+  f.options.dumpToTextStream(ss);
+  EXPECT_NE(ss.str().find("std_sensor_range"), std::string::npos);
+}
+
+TEST(CRangeBearingKFSLAM, saveMapAsMATLABFile)
+{
+  mrpt::random::getRandomGenerator().randomize(23);
+
+  const auto lms = makeLandmarks();
+  CRangeBearingKFSLAM f;
+  f.options.create_simplemap = true;
+  runSession(f, lms, 3);
+
+  const std::string file = mrpt::system::getTempFileName() + std::string(".m");
+  f.saveMapAndPath2DRepresentationAsMATLABFile(file);
+  EXPECT_TRUE(mrpt::system::fileExists(file));
+  EXPECT_GT(mrpt::system::getFileSize(file), 0U);
+  mrpt::system::deleteFile(file);
+}

--- a/modules/mrpt_slam/tests/observations_overlap_unittest.cpp
+++ b/modules/mrpt_slam/tests/observations_overlap_unittest.cpp
@@ -1,0 +1,120 @@
+/*                    _
+                     | |    Mobile Robot Programming Toolkit (MRPT)
+ _ __ ___  _ __ _ __ | |_
+| '_ ` _ \| '__| '_ \| __|          https://www.mrpt.org/
+| | | | | | |  | |_) | |_
+|_| |_| |_|_|  | .__/ \__|     https://github.com/MRPT/mrpt/
+               | |
+               |_|
+
+ Copyright (c) 2005-2026, Individual contributors, see AUTHORS file
+ See: https://www.mrpt.org/Authors - All rights reserved.
+ SPDX-License-Identifier: BSD-3-Clause
+*/
+
+/** Unit tests for mrpt::slam::observationsOverlap(): the per-observation
+ *  overlap ratio, its sensory-frame average, and the effect of the optional
+ *  relative pose between both observations.
+ */
+
+#include <gtest/gtest.h>
+#include <mrpt/obs/CObservation2DRangeScan.h>
+#include <mrpt/obs/CObservationOdometry.h>
+#include <mrpt/obs/CSensoryFrame.h>
+#include <mrpt/obs/stock_observations.h>
+#include <mrpt/poses/CPose3D.h>
+#include <mrpt/slam/observations_overlap.h>
+
+using mrpt::slam::observationsOverlap;
+
+namespace
+{
+mrpt::obs::CObservation2DRangeScan::Ptr makeScan(int index)
+{
+  auto scan = mrpt::obs::CObservation2DRangeScan::Create();
+  mrpt::obs::stock_observations::example2DRangeScan(*scan, index);
+  return scan;
+}
+}  // namespace
+
+TEST(observationsOverlap, identicalScansFullOverlap)
+{
+  const auto s = makeScan(0);
+  EXPECT_NEAR(observationsOverlap(s, s), 1.0, 1e-6);
+}
+
+TEST(observationsOverlap, displacedScansDoNotOverlap)
+{
+  const auto s = makeScan(0);
+
+  // Move the second scan 10 m away: no point can be matched anymore.
+  const mrpt::poses::CPose3D farAway(10.0, 0, 0, 0, 0, 0);
+  EXPECT_NEAR(observationsOverlap(s, s, &farAway), 0.0, 1e-6);
+}
+
+TEST(observationsOverlap, differentScansPartialOverlap)
+{
+  const auto s0 = makeScan(0);
+  const auto s1 = makeScan(1);
+
+  const double ov = observationsOverlap(s0, s1);
+  EXPECT_GT(ov, 0.0);
+  EXPECT_LT(ov, 1.0);
+}
+
+TEST(observationsOverlap, nonLaserObservationsGiveZero)
+{
+  auto odo = mrpt::obs::CObservationOdometry::Create();
+  const auto s = makeScan(0);
+
+  EXPECT_EQ(observationsOverlap(odo, odo), 0.0);
+  EXPECT_EQ(observationsOverlap(odo, s), 0.0);
+  EXPECT_EQ(observationsOverlap(s, odo), 0.0);
+}
+
+TEST(observationsOverlap, sensoryFrameAveragesPairs)
+{
+  const auto s0 = makeScan(0);
+  const auto s1 = makeScan(1);
+
+  auto sf1 = mrpt::obs::CSensoryFrame::Create();
+  sf1->insert(s0);
+
+  auto sf2 = mrpt::obs::CSensoryFrame::Create();
+  sf2->insert(s0);
+  sf2->insert(s1);
+
+  // Average of the 1x2 pairs:
+  const double expected = 0.5 * (observationsOverlap(s0, s0) + observationsOverlap(s0, s1));
+  EXPECT_NEAR(observationsOverlap(sf1, sf2), expected, 1e-9);
+  EXPECT_NEAR(observationsOverlap(*sf1, *sf2), expected, 1e-9);
+}
+
+TEST(observationsOverlap, emptySensoryFramesGiveZero)
+{
+  auto empty = mrpt::obs::CSensoryFrame::Create();
+  auto sf = mrpt::obs::CSensoryFrame::Create();
+  sf->insert(makeScan(0));
+
+  EXPECT_EQ(observationsOverlap(empty, empty), 0.0);
+  EXPECT_EQ(observationsOverlap(empty, sf), 0.0);
+  EXPECT_EQ(observationsOverlap(sf, empty), 0.0);
+}
+
+// The relative pose argument must be honored by the sensory-frame overload
+// too, otherwise callers silently compare observations as if co-located.
+TEST(observationsOverlap, sensoryFrameHonorsRelativePose)
+{
+  const auto s = makeScan(0);
+
+  auto sf1 = mrpt::obs::CSensoryFrame::Create();
+  sf1->insert(s);
+  auto sf2 = mrpt::obs::CSensoryFrame::Create();
+  sf2->insert(s);
+
+  const mrpt::poses::CPose3D farAway(10.0, 0, 0, 0, 0, 0);
+
+  EXPECT_NEAR(observationsOverlap(sf1, sf2), 1.0, 1e-6);
+  EXPECT_NEAR(observationsOverlap(sf1, sf2, &farAway), 0.0, 1e-6);
+  EXPECT_NEAR(observationsOverlap(*sf1, *sf2, &farAway), 0.0, 1e-6);
+}

--- a/modules/mrpt_slam/tests/slam_synthetic_room.h
+++ b/modules/mrpt_slam/tests/slam_synthetic_room.h
@@ -1,0 +1,85 @@
+/*                    _
+                     | |    Mobile Robot Programming Toolkit (MRPT)
+ _ __ ___  _ __ _ __ | |_
+| '_ ` _ \| '__| '_ \| __|          https://www.mrpt.org/
+| | | | | | |  | |_) | |_
+|_| |_| |_|_|  | .__/ \__|     https://github.com/MRPT/mrpt/
+               | |
+               |_|
+
+ Copyright (c) 2005-2026, Individual contributors, see AUTHORS file
+ See: https://www.mrpt.org/Authors - All rights reserved.
+ SPDX-License-Identifier: BSD-3-Clause
+*/
+#pragma once
+
+/** Helpers shared by the SLAM unit tests: a synthetic closed room used as
+ *  ground truth, plus 2D laser scans and odometry actions simulated from it,
+ *  so that no dataset files are needed.
+ */
+
+#include <mrpt/maps/COccupancyGridMap2D.h>
+#include <mrpt/obs/CActionCollection.h>
+#include <mrpt/obs/CActionRobotMovement2D.h>
+#include <mrpt/obs/CObservation2DRangeScan.h>
+#include <mrpt/obs/CSensoryFrame.h>
+#include <mrpt/poses/CPose2D.h>
+
+namespace mrpt::test
+{
+/** A closed 10x10 m rectangular room, used as ground truth to simulate scans. */
+inline const mrpt::maps::COccupancyGridMap2D& groundTruthRoom()
+{
+  static mrpt::maps::COccupancyGridMap2D grid = []()
+  {
+    mrpt::maps::COccupancyGridMap2D g(-5.0f, 5.0f, -5.0f, 5.0f, 0.05f);
+    g.fill(0.9f);  // all free
+    for (unsigned int cx = 0; cx < g.getSizeX(); cx++)
+    {
+      g.setCell(cx, 0, 0.0f);
+      g.setCell(cx, g.getSizeY() - 1, 0.0f);
+    }
+    for (unsigned int cy = 0; cy < g.getSizeY(); cy++)
+    {
+      g.setCell(0, cy, 0.0f);
+      g.setCell(g.getSizeX() - 1, cy, 0.0f);
+    }
+    return g;
+  }();
+  return grid;
+}
+
+inline mrpt::obs::CObservation2DRangeScan::Ptr simulateScan(const mrpt::poses::CPose2D& robotPose)
+{
+  auto scan = mrpt::obs::CObservation2DRangeScan::Create();
+  scan->aperture = 2 * M_PIf;
+  scan->maxRange = 20.0f;
+  scan->sensorLabel = "LASER";
+  scan->timestamp = mrpt::Clock::now();
+  groundTruthRoom().laserScanSimulator(
+      *scan, robotPose, 0.5f /*threshold*/, 181 /*N*/, 0.0f /*noiseStd*/);
+  return scan;
+}
+
+inline mrpt::obs::CSensoryFrame::Ptr simulateSF(const mrpt::poses::CPose2D& robotPose)
+{
+  auto sf = mrpt::obs::CSensoryFrame::Create();
+  sf->insert(simulateScan(robotPose));
+  return sf;
+}
+
+inline mrpt::obs::CActionCollection::Ptr makeOdometryAction(const mrpt::poses::CPose2D& increment)
+{
+  mrpt::obs::CActionRobotMovement2D act;
+  mrpt::obs::CActionRobotMovement2D::TMotionModelOptions opts;
+  opts.modelSelection = mrpt::obs::CActionRobotMovement2D::mmGaussian;
+  opts.gaussianModel.minStdXY = 0.02;
+  opts.gaussianModel.minStdPHI = mrpt::DEG2RAD(0.5);
+  act.computeFromOdometry(increment, opts);
+  act.timestamp = mrpt::Clock::now();
+
+  auto acts = mrpt::obs::CActionCollection::Create();
+  acts->insert(act);
+  return acts;
+}
+}  // namespace mrpt::test

--- a/modules/mrpt_slam/tests/slam_synthetic_room.h
+++ b/modules/mrpt_slam/tests/slam_synthetic_room.h
@@ -24,6 +24,7 @@
 #include <mrpt/obs/CObservation2DRangeScan.h>
 #include <mrpt/obs/CSensoryFrame.h>
 #include <mrpt/poses/CPose2D.h>
+#include <mrpt/system/datetime.h>
 
 namespace mrpt::test
 {
@@ -49,26 +50,42 @@ inline const mrpt::maps::COccupancyGridMap2D& groundTruthRoom()
   return grid;
 }
 
-inline mrpt::obs::CObservation2DRangeScan::Ptr simulateScan(const mrpt::poses::CPose2D& robotPose)
+/** Successive calls return timestamps 100 ms apart. Do not use Clock::now()
+ *  for each simulated step: its resolution is coarse enough on some platforms
+ *  that consecutive calls return the *same* value, and consumers that need a
+ *  strictly increasing clock (e.g. CRobot2DPoseEstimator) then drop the
+ *  updates.
+ */
+inline mrpt::system::TTimeStamp nextTimestamp()
+{
+  static mrpt::system::TTimeStamp t = mrpt::Clock::now();
+  t = mrpt::system::timestampAdd(t, 0.1);
+  return t;
+}
+
+inline mrpt::obs::CObservation2DRangeScan::Ptr simulateScan(
+    const mrpt::poses::CPose2D& robotPose, const mrpt::system::TTimeStamp t)
 {
   auto scan = mrpt::obs::CObservation2DRangeScan::Create();
   scan->aperture = 2 * M_PIf;
   scan->maxRange = 20.0f;
   scan->sensorLabel = "LASER";
-  scan->timestamp = mrpt::Clock::now();
+  scan->timestamp = t;
   groundTruthRoom().laserScanSimulator(
       *scan, robotPose, 0.5f /*threshold*/, 181 /*N*/, 0.0f /*noiseStd*/);
   return scan;
 }
 
-inline mrpt::obs::CSensoryFrame::Ptr simulateSF(const mrpt::poses::CPose2D& robotPose)
+inline mrpt::obs::CSensoryFrame::Ptr simulateSF(
+    const mrpt::poses::CPose2D& robotPose, const mrpt::system::TTimeStamp t)
 {
   auto sf = mrpt::obs::CSensoryFrame::Create();
-  sf->insert(simulateScan(robotPose));
+  sf->insert(simulateScan(robotPose, t));
   return sf;
 }
 
-inline mrpt::obs::CActionCollection::Ptr makeOdometryAction(const mrpt::poses::CPose2D& increment)
+inline mrpt::obs::CActionCollection::Ptr makeOdometryAction(
+    const mrpt::poses::CPose2D& increment, const mrpt::system::TTimeStamp t)
 {
   mrpt::obs::CActionRobotMovement2D act;
   mrpt::obs::CActionRobotMovement2D::TMotionModelOptions opts;
@@ -76,7 +93,7 @@ inline mrpt::obs::CActionCollection::Ptr makeOdometryAction(const mrpt::poses::C
   opts.gaussianModel.minStdXY = 0.02;
   opts.gaussianModel.minStdPHI = mrpt::DEG2RAD(0.5);
   act.computeFromOdometry(increment, opts);
-  act.timestamp = mrpt::Clock::now();
+  act.timestamp = t;
 
   auto acts = mrpt::obs::CActionCollection::Create();
   acts->insert(act);


### PR DESCRIPTION
## Summary

Coverage pass on `mrpt_slam`, the last pure-logic module far from the 90% goal.
All new tests are driven by synthetic data — a simulated closed room for 2D
laser scans, a small landmark map for range-bearing readings — so none of them
need dataset files.

**`mrpt_slam`: 67.9% → 90.2% lines, 45.4% → 62.3% branches.**
Repo-wide: 72.5% → 73.6% lines, 53.2% → 54.4% branches.

New test files:

| File | Covers |
|---|---|
| `tests/observations_overlap_unittest.cpp` | `observations_overlap.cpp` (was 0%) |
| `tests/CLandmarksMap_unittest.cpp` | `CLandmarksMap.cpp` (was 0%) |
| `tests/CIncrementalMapPartitioner_api_unittest.cpp` | options I/O, the three similarity methods, node removal, origin changes, 3D scene, serialization |
| `tests/CMetricMapBuilderICP_unittest.cpp` | `CMetricMapBuilderICP` + the `CMetricMapBuilder` base |
| `tests/CMetricMapBuilderRBPF_unittest.cpp` | `CMetricMapBuilderRBPF`, `CMultiMetricMapPDF`, incl. range-only (beacon) SLAM |
| `tests/CRangeBearingKFSLAM_unittest.cpp` | both EKF-SLAM filters, SE(2) and SE(3) |
| `tests/CMonteCarloLocalization_unittest.cpp` | MCL 2D/3D over the PF algorithms |
| `mrpt_maps/tests/TSetOfMetricMapInitializers_unittest.cpp` | config-file round trip |

`tests/slam_synthetic_room.h` holds the shared simulated environment.

## Bugs found and fixed

1. **`observationsOverlap()`'s `CSensoryFrame` overload silently dropped the relative pose.** The argument was marked `[[maybe_unused]]` and never forwarded, so `CIncrementalMapPartitioner`'s `smOBSERVATION_OVERLAP` similarity compared every keyframe pair as if co-located.
2. **`CIncrementalMapPartitioner::addMapFrame()` used the wrong pose for half of its symmetrized similarity.** The callback always expects *"kf2 with respect to kf1"*, so the swapped evaluation needs the inverse. ⚠️ This changes the partitioning slightly: one keyframe moves between the two clusters in the malaga dataset test, whose expected output is updated in this PR.
3. **`removeSetOfNodes(..., changeCoordsRef=true)` composed `+p` instead of `-p`,** doubling the first node's coordinates instead of moving it to the origin as documented.
4. **Two options could never be loaded from a config file:** `MRPT_LOAD_HERE_CONFIG_VAR` stringifies its first argument, and it was being passed an already-quoted string, so the key looked up was `"\"minDistForCorrespondence\""`.
5. **`mrpt::maps::CLandmarksMap` was never registered for RTTI** despite being `IMPLEMENTS_SERIALIZABLE`, so it could not be deserialized.
6. **`TSetOfMetricMapInitializers::saveToConfigFile()` wrote a format `loadFromConfigFile()` cannot read** (no `<class>_count` keys, section names missing the map index and the `_creationOpts` suffix), so the round trip always yielded zero maps.
7. **`CMultiMetricMapPDF::getLastPose()` never set its `is_valid_pose` output** on the success path, unlike its two sibling implementations.
8. **`CMetricMapBuilderICP::saveCurrentEstimationToImage()` dereferenced the gridmap pointer right after null-checking it** — a segfault whenever the multi-metric map has no gridmap.
9. **Range-only SLAM with the exact optimal proposal could not run at all.** `firstEstimateRobotHeading` was only assigned in the no-odometry path and in an unreachable sub-method, so with odometry present the assert guarding it always fired. It also printed the drawn position to `std::cout` for every particle; that is now a debug log message.

Both `CRangeBearingKFSLAM::TOptions::dumpToTextStream()` and its 2D counterpart
now report the noise parameters (`std_sensor_*`, `stds_Q_no_odo`,
`std_odo_z_additional`, …) they load but were silently omitting.

`agents.md` section 10 is refreshed with the new table and a footnote for this
pass.

## Testing

Full `colcon build` + `colcon test` over `modules` and `apps` with coverage
instrumentation: **80 test binaries, 0 failures**. `clang-format` check passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MM2ZETNT1GpMdCtVhD7TmL

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected map configuration serialization and loading for multiple map types.
  * Fixed SLAM pose validity, coordinate updates, observation overlap, and heading calculations.
  * Improved configuration output to include additional sensor and motion-model settings.
  * Added automatic registration for landmark maps.

* **Tests**
  * Added extensive SLAM, localization, mapping, landmark, and configuration round-trip coverage.
  * Added synthetic test scenarios that run without external datasets.
  * Updated coverage reporting, including 90.2% coverage for `mrpt_slam`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->