### PR TITLE
Fix yaml double round-trip precision: %.16g -> %.17g

### DIFF
--- a/modules/mrpt_containers/include/mrpt/containers/yaml.h
+++ b/modules/mrpt_containers/include/mrpt/containers/yaml.h
@@ -1597,8 +1597,10 @@ inline std::string scalarToString(const mrpt::containers::yaml::scalar_t& s)
           return std::to_string(val);
         else if constexpr (std::is_same_v<V, double>)
         {
+          // 17 significant digits are required to round-trip any IEEE-754
+          // double exactly; 16 is not always enough.
           std::stringstream ss;
-          ss << mrpt::format("%.16g", val);
+          ss << mrpt::format("%.17g", val);
           return ss.str();
         }
         else if constexpr (std::is_same_v<V, std::string>)

--- a/modules/mrpt_containers/src/yaml.cpp
+++ b/modules/mrpt_containers/src/yaml.cpp
@@ -849,7 +849,9 @@ bool yaml::internalPrintAsYAML(
         }
         else if constexpr (std::is_same_v<V, double>)
         {
-          const std::string s = mrpt::format("%.16g", val);
+          // 17 significant digits are required to round-trip any IEEE-754
+          // double exactly; 16 is not always enough.
+          const std::string s = mrpt::format("%.17g", val);
           o << s;
           if (s.find('.') == std::string::npos && s.find('e') == std::string::npos &&
               s.find('E') == std::string::npos && s.find('n') == std::string::npos &&


### PR DESCRIPTION
## Summary
- `mrpt::containers::yaml`'s scalar-to-string conversion for `double` (both the `.as<std::string>()` getter in `yaml.h` and the stream emitter in `yaml.cpp`) used `%.16g`, which is not always enough to round-trip a 64-bit IEEE-754 double exactly — 17 significant digits are the standard guarantee, 16 is not.
- A numeric-looking YAML scalar with enough fractional digits (e.g. a sub-millisecond UNIX-epoch timestamp used as a map key) silently loses its last digit on parse-back.
- Found while porting a MOLA package to MRPT 3.x: a unit test round-tripping `LocalVelocityBuffer` timestamps through YAML passed against MRPT 2.15 and failed against unpatched MRPT 3.x for exactly this reason.

## Test plan
- [x] Reproduced with a minimal probe: serializing `1755345252.1234567` as a yaml map key and reading it back via `.as<std::string>()` returned `1755345252.123457` before the fix, and the exact original string after.
- [x] Rebuilt `mrpt_containers` and downstream `mola_imu_preintegration`; its previously-failing `test-velocity-buffer` (`unit_test_yaml_epoch_precision`) now passes, 16/16 tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015w31kEa1kRfKA3rcqDRXyZ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved YAML serialization of floating-point values to preserve exact IEEE-754 double-precision round-tripping.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->