### PR TITLE
yaml_ref/yaml_cref: add missing asSequenceRange()

### DIFF
--- a/modules/mrpt_containers/include/mrpt/containers/yaml.h
+++ b/modules/mrpt_containers/include/mrpt/containers/yaml.h
@@ -917,6 +917,7 @@ class yaml_ref
   // ── Container access ─────────────────────────────────────────────────────
   [[nodiscard]] sequence_t& asSequence() { return node_->asSequence(); }
   [[nodiscard]] const sequence_t& asSequence() const { return node_->asSequence(); }
+  [[nodiscard]] sequence_t asSequenceRange() const { return node_->asSequence(); }
   [[nodiscard]] map_t& asMap() { return node_->asMap(); }
   [[nodiscard]] const map_t& asMap() const { return node_->asMap(); }
   [[nodiscard]] map_t asMapRange() const { return node_->asMap(); }
@@ -1205,6 +1206,7 @@ class yaml_cref
 
   // ── Container access ─────────────────────────────────────────────────────
   [[nodiscard]] const sequence_t& asSequence() const { return node_->asSequence(); }
+  [[nodiscard]] sequence_t asSequenceRange() const { return node_->asSequence(); }
   [[nodiscard]] const map_t& asMap() const { return node_->asMap(); }
   [[nodiscard]] map_t asMapRange() const { return node_->asMap(); }
   [[nodiscard]] const scalar_t& asScalar() const { return node_->asScalar(); }


### PR DESCRIPTION
## Summary
- `node_t` already provides both `asMapRange()` and `asSequenceRange()` (safe by-value variants meant for chaining off a temporary, e.g. `node["key"].asSequenceRange()`).
- The `yaml_ref` and `yaml_cref` wrapper classes only forwarded `asMapRange()`, leaving `asSequenceRange()` missing — an API asymmetry, not an intentional omission.
- Any caller doing `someNode["key"].asSequenceRange()` (a very natural pattern mirroring the map equivalent) got a hard compile error instead of the by-value sequence copy they'd reasonably expect.

## Test plan
- [x] Found via a real caller in `mp2p_icp` (being ported to MRPT 3.x) that already assumed this method existed.
- [x] Rebuilt `mrpt_containers` and downstream `mp2p_icp_core`; all 122 of its tests pass, including ones exercising this exact call pattern (`test-mp2p_quality_voxels`, `Parameters.cpp`'s `quality_checkpoints` loading).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015w31kEa1kRfKA3rcqDRXyZ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for obtaining YAML sequences as copied ranges for iteration.
  * Available for both mutable and read-only YAML references.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->