### PR TITLE
yaml: add missing yaml_cref::getOrDefault()

### DIFF
--- a/modules/mrpt_containers/include/mrpt/containers/yaml.h
+++ b/modules/mrpt_containers/include/mrpt/containers/yaml.h
@@ -1232,12 +1232,17 @@ class yaml_cref
   yaml_cref operator[](const char* key) const;
   yaml_cref operator[](int index) const;
 
-  // ── scalarType, asRef ────────────────────────────────────────────────────
+  // ── scalarType, getOrDefault, asRef ──────────────────────────────────────
   [[nodiscard]] const std::type_info& scalarType() const
   {
     if (node_->isNullNode()) return typeid(void);
     return std::visit(
         [](const auto& v) -> const std::type_info& { return typeid(v); }, node_->asScalar());
+  }
+  template <typename T>
+  [[nodiscard]] T getOrDefault(const std::string& key, const T& def) const
+  {
+    return yaml(*node_).template getOrDefault<T>(key, def);
   }
   template <typename T>
   [[nodiscard]] const T& asRef() const


### PR DESCRIPTION
## Summary
- `yaml_ref` forwards `getOrDefault()` to the underlying `yaml` wrapper; `yaml_cref` - the const proxy returned by `operator[]` on a `const yaml&` - does not, even though the rest of its read API (`has()`, `operator[]`, `asMap`/`asSequence`, `scalarType`, `asRef`) mirrors `yaml_ref` symmetrically.
- Found while porting MOLA's `mola_viz` to MRPT 3.x: `const Yaml& c; auto cfg = c["params"];` deduces `cfg` as `yaml_cref`, and the standard `cfg.getOrDefault<T>(key, def)` pattern for reading an optional config key failed to compile.
- Same class of defect as the missing `yaml_ref`/`yaml_cref::asSequenceRange()` fixed in #1397 (asymmetric method coverage between the two proxy types). This fix mirrors `yaml_ref`'s existing `getOrDefault()` implementation.

## Test plan
- [x] Builds clean against the fix in an out-of-tree MOLA workspace (`mola_viz`'s `YAML_LOAD_MEMBER_OPT` macro, which calls `.getOrDefault()` on a `yaml_cref`, now compiles)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015w31kEa1kRfKA3rcqDRXyZ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `getOrDefault` support to read YAML values with a fallback when a key is unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->