### PR TITLE
img: fix CImage grayscale deserialization for legacy depth=0

### DIFF
--- a/modules/mrpt_img/src/CImage.cpp
+++ b/modules/mrpt_img/src/CImage.cpp
@@ -626,7 +626,10 @@ void CImage::serializeFrom(mrpt::serialization::CArchive& in, uint8_t version)
           {
             int32_t tempdepth = 0;
             in >> tempdepth;
-            depth = static_cast<PixelDepth>(tempdepth);
+            // 0 is not a valid PixelDepth (D8U=1, D16U=2): files written by
+            // pre-release MRPT 3.x snapshots serialized this field 0-based,
+            // so a literal 0 here means "D8U", not "zero bytes per pixel".
+            depth = tempdepth == 0 ? PixelDepth::D8U : static_cast<PixelDepth>(tempdepth);
           }
 
           resize(static_cast<uint32_t>(width), static_cast<uint32_t>(height), CH_GRAY, depth);

--- a/modules/mrpt_img/tests/CImage_unittest.cpp
+++ b/modules/mrpt_img/tests/CImage_unittest.cpp
@@ -1398,3 +1398,49 @@ TEST(CImage, ScaleHalfWithOddSizeTruncates)
   EXPECT_EQ(out.getWidth(), 2);
   EXPECT_EQ(out.getHeight(), 2);
 }
+
+TEST(CImage, DeserializeLegacyGrayscaleWithZeroPixelDepth)
+{
+  using namespace mrpt::img;
+
+  // Pre-release MRPT 3.x snapshots wrote the grayscale pixel-depth field of
+  // the v9 format 0-based, so such streams carry a literal 0 where D8U (=1)
+  // is meant. Build one by hand and check it still deserializes.
+  const int32_t width = 4;
+  const int32_t height = 3;
+  const int32_t imageSize = width * height;
+
+  mrpt::io::CMemoryStream buf;
+  auto arch = mrpt::serialization::archiveFrom(buf);
+
+  // Object header: class name (length OR'ed with 0x80), then version.
+  const std::string className = "CImage";
+  arch << static_cast<int8_t>(className.size() | 0x80);
+  arch.WriteBuffer(className.data(), className.size());
+  arch << static_cast<uint8_t>(9);
+
+  arch << false;                    // imgIsExternalStorage
+  arch << static_cast<uint8_t>(0);  // hasColor: grayscale
+  arch << width << height << static_cast<int32_t>(0) /* origin */ << imageSize;
+  arch << static_cast<int32_t>(0);  // pixel depth, 0-based
+  arch << false;                    // imageIsZIP
+
+  std::vector<uint8_t> pixels(static_cast<size_t>(imageSize));
+  for (size_t i = 0; i < pixels.size(); i++)
+  {
+    pixels[i] = static_cast<uint8_t>(i * 7);
+  }
+  arch.WriteBuffer(pixels.data(), pixels.size());
+
+  arch << static_cast<uint8_t>(0x88);  // end flag
+
+  buf.Seek(0);
+  CImage img;
+  arch >> img;
+
+  EXPECT_EQ(img.getWidth(), static_cast<size_t>(width));
+  EXPECT_EQ(img.getHeight(), static_cast<size_t>(height));
+  EXPECT_EQ(img.getPixelDepth(), PixelDepth::D8U);
+  EXPECT_EQ(img.at<uint8_t>(1, 0), pixels[1]);
+  EXPECT_EQ(img.at<uint8_t>(3, 2), pixels[11]);
+}


### PR DESCRIPTION
## Summary
- `CImage::serializeFrom()` (grayscale branch, version >= 9) reads a `PixelDepth` value from the stream and passes it straight to `resize()`, which computes the buffer size as `width*height*channels*depth` (see `image_buffer_size_bytes()`). `PixelDepth`'s valid enumerators are 1-based (`D8U=1`, `D16U=2`), so a stored value of `0` silently produces a **zero-byte buffer**, and the immediately following `ASSERT_EQUAL_` against the declared `imageSize` throws.
- Real-world rawlogs written by pre-release MRPT 3.x snapshots (before `PixelDepth` was finalized to be 1-based) serialize this field 0-based, so a `0` in the stream means "D8U", not "zero bytes per pixel". This PR treats a stream value of `0` as `D8U` instead of an invalid enum value.
- Found via MOLA's `test-relocalization-se2-kitti` test, which failed to load a real KITTI-derived rawlog under MRPT 3.x (loaded 1 of 12 entries, then threw) while the identical file loads all 12 entries correctly under MRPT 2.15.

## Test plan
- [x] After the fix, the KITTI test rawlog loads all 12 entries and produces output that matches MRPT 2.15 exactly (same log-likelihoods, same best pose)
- [x] `clang-format-14` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015w31kEa1kRfKA3rcqDRXyZ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved compatibility when opening legacy grayscale image files created by early MRPT 3.x snapshots.
  - Correctly interprets stored 8-bit pixel-depth information, preventing invalid grayscale image decoding.
  - Ensures affected images retain their expected dimensions and pixel values when loaded.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->