### PR TITLE
yaml: fix TOP comment corrupting the document on serialize+reparse

### DIFF
--- a/modules/mrpt_containers/include/mrpt/containers/yaml.h
+++ b/modules/mrpt_containers/include/mrpt/containers/yaml.h
@@ -821,8 +821,10 @@ class yaml
   };
 
   // Return: true if the last printed char is a newline char
-  static bool internalPrintNodeAsYAML(
-      const node_t& p, std::ostream& o, const InternalPrintState& ps);
+  // `ps` is taken by value (not by reference) because a pending "needs
+  // newline" flag may be consumed internally (see the TOP-comment
+  // handling) before being read again by the type dispatch below.
+  static bool internalPrintNodeAsYAML(const node_t& p, std::ostream& o, InternalPrintState ps);
 
   static void internalPrintDebugStructure(const node_t& p, std::ostream& o, unsigned int indent);
 

--- a/modules/mrpt_containers/src/yaml.cpp
+++ b/modules/mrpt_containers/src/yaml.cpp
@@ -455,7 +455,7 @@ void yaml::printDebugStructure(std::ostream& o) const
   internalPrintDebugStructure(*n, o, indent);
 }
 
-bool yaml::internalPrintNodeAsYAML(const node_t& p, std::ostream& o, const InternalPrintState& ps)
+bool yaml::internalPrintNodeAsYAML(const node_t& p, std::ostream& o, InternalPrintState ps)
 {
   // Build a comments_t view (all-empty if no meta):
   static const comments_t emptyComments{};
@@ -467,10 +467,23 @@ bool yaml::internalPrintNodeAsYAML(const node_t& p, std::ostream& o, const Inter
     const std::string sInd(ps.indent, ' ');
     const std::string& comment = tc.value();
 
+    // A pending newline (e.g. this node is the value-side of a "key:" map
+    // entry, so the stream currently ends right after the ':') must be
+    // emitted before the comment text, not appended directly onto the
+    // previous line. Otherwise the comment's '#' merges with the preceding
+    // token (e.g. "modules:# comment"), which is not a valid YAML comment
+    // marker (a '#' must be preceded by whitespace) and corrupts the whole
+    // document on re-parse.
+    const bool wasPendingNL = ps.needsNL;
+    if (wasPendingNL)
+    {
+      o << "\n";
+    }
+
     // Split line by line:
     for (size_t i = 0; i < comment.size();)
     {
-      if (i > 0)
+      if (i > 0 || wasPendingNL)
       {
         o << sInd;
       }
@@ -487,8 +500,12 @@ bool yaml::internalPrintNodeAsYAML(const node_t& p, std::ostream& o, const Inter
 
       i += lineLen + 1;
     }
-    // Indent of next line:
-    if (!comment.empty())
+    // Indent of next line - only when the comment did NOT already hand off
+    // a pending newline to the value that follows: in that case, the type
+    // dispatch below (map/sequence) will emit its own newline and indent
+    // bump for that value exactly as if there had been no comment, so
+    // printing it here too would misalign (or duplicate) the indentation.
+    if (!comment.empty() && !wasPendingNL)
     {
       o << sInd;
     }


### PR DESCRIPTION
## Summary
- `internalPrintNodeAsYAML()` prints a node's TOP comment (a comment that appeared before the node in the original document) unconditionally before dispatching to the type-specific printer. When that node is the value-side of a `key:` map entry whose value is a sequence/map (i.e. `ps.needsNL` is true - the stream currently ends right after `:` with no newline emitted yet), the comment text got appended directly onto that same line:
  ```
  modules:# =====================
  # MolaViz (optional)
  ...
  ```
  A `#` not preceded by whitespace is not a YAML comment marker, so this is invalid YAML.
- Re-parsing that invalid output doesn't just fail loudly - libfyaml's recovery silently collapses the **entire remaining document** into one giant scalar. `has()`/`asMap()` then throws `Trying to access node of type 'scalar(std::string)' as a map` on what looks like a completely unrelated node deep in application code.
- Any document with a comment block preceding a sequence's first item - a very common documentation style - loses that data (and everything after it) the moment it goes through a naive parse → `printAsYAML` → reparse round trip, something `mrpt::containers::yaml` does routinely, and which downstream config-loading pipelines (e.g. MOLA's `$include`/`${VAR}` YAML preprocessing) perform unconditionally on every file they load, whether or not that file actually uses those features.
- Found via a real ROS2 launch-test YAML file whose `modules:` key's sequence value had a comment block before its first list item; the consuming app crashed on startup with the "scalar as a map" exception above, while the *raw* file parsed fine directly - only a round trip through the emitter broke it.

## Fix
When a TOP comment is about to be printed and a newline is pending, emit that newline first (instead of relying on the comment text to be appended after existing content), while leaving the pending newline/indent-bump logic for the subsequent map/sequence printer untouched so nested content still indents correctly.

## Test plan
- [x] Minimal repro (comment before a sequence's first item, `FromText` → `printAsYAML` → `FromText`) confirmed corrupting before the fix, stable after
- [x] The real-world launch YAML now round-trips byte-for-byte stable (parse → print → reparse → print gives identical text)
- [x] `mola_yaml`'s existing test suite still passes (comment-printing for RIGHT-position comments, used elsewhere, is unaffected)
- [x] `clang-format-14` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015w31kEa1kRfKA3rcqDRXyZ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved YAML output formatting for comments attached to map values.
  - Prevented comment markers from being joined to preceding content.
  - Corrected indentation and newline handling around comments to avoid duplicated or misaligned spacing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->