### PR TITLE
yaml: keep an unquoted leading-zero digit run as a string

### DIFF
--- a/modules/mrpt_containers/src/yaml.cpp
+++ b/modules/mrpt_containers/src/yaml.cpp
@@ -909,38 +909,43 @@ yaml::scalar_t textToScalar(const std::string& s)
     return yaml::scalar_t(false);
   }
 
+  // A leading-zero digit string (e.g. "00", "007") is ambiguous (would imply
+  // octal in YAML 1.1; YAML 1.2 forbids leading zeros in ints) and, in
+  // practice, is almost always a zero-padded identifier (a sequence number,
+  // a zip code, ...) that the user wants preserved verbatim, not a number.
+  // Guard both the int AND the float branches below with it: a plain digit
+  // run stays a string. A genuine float like "0.5" or "0e3" is unaffected
+  // (it fails the "all digits" check, since it contains '.'/'e').
+  const bool hasHexPrefix =
+      (s.size() > 2 && s[0] == '0' && (s[1] == 'x' || s[1] == 'X')) ||
+      (s.size() > 3 && (s[0] == '+' || s[0] == '-') && s[1] == '0' && (s[2] == 'x' || s[2] == 'X'));
+  const std::size_t signLen = (!s.empty() && (s[0] == '+' || s[0] == '-')) ? 1u : 0u;
+  const bool leadingZeroDigitRun = !hasHexPrefix && s.size() > signLen + 1 && s[signLen] == '0' &&
+                                   s.find_first_not_of("0123456789", signLen) == std::string::npos;
+
   // tag:yaml.org,2002:int — try signed first, then unsigned for large values
-  // Reject leading zeros (would imply octal in YAML 1.1; YAML 1.2 forbids them)
-  if (!s.empty() &&
+  if (!leadingZeroDigitRun && !s.empty() &&
       ((std::isdigit(static_cast<unsigned char>(s[0])) != 0) || s[0] == '-' || s[0] == '+'))
   {
-    const bool hasHexPrefix = (s.size() > 2 && s[0] == '0' && (s[1] == 'x' || s[1] == 'X')) ||
-                              (s.size() > 3 && (s[0] == '+' || s[0] == '-') && s[1] == '0' &&
-                               (s[2] == 'x' || s[2] == 'X'));
-    const std::size_t signLen = (s[0] == '+' || s[0] == '-') ? 1u : 0u;
-    const bool leadingZeroOctal = !hasHexPrefix && s.size() > signLen + 1 && s[signLen] == '0';
-    if (!leadingZeroOctal)
+    char* end = nullptr;
+    errno = 0;
+    const long long iv = std::strtoll(s.c_str(), &end, 0);
+    if (end != nullptr && end != s.c_str() && *end == '\0' && errno != ERANGE)
     {
-      char* end = nullptr;
-      errno = 0;
-      const long long iv = std::strtoll(s.c_str(), &end, 0);
-      if (end != nullptr && end != s.c_str() && *end == '\0' && errno != ERANGE)
-      {
-        return yaml::scalar_t(static_cast<int64_t>(iv));
-      }
+      return yaml::scalar_t(static_cast<int64_t>(iv));
+    }
 
-      // Large positive — try unsigned
-      errno = 0;
-      const unsigned long long uv = std::strtoull(s.c_str(), &end, 0);
-      if (end != nullptr && end != s.c_str() && *end == '\0' && errno != ERANGE)
-      {
-        return yaml::scalar_t(static_cast<uint64_t>(uv));
-      }
+    // Large positive — try unsigned
+    errno = 0;
+    const unsigned long long uv = std::strtoull(s.c_str(), &end, 0);
+    if (end != nullptr && end != s.c_str() && *end == '\0' && errno != ERANGE)
+    {
+      return yaml::scalar_t(static_cast<uint64_t>(uv));
     }
   }
 
   // tag:yaml.org,2002:float
-  if (!s.empty())
+  if (!leadingZeroDigitRun && !s.empty())
   {
     char* end = nullptr;
     errno = 0;

--- a/modules/mrpt_containers/tests/yaml_unittest.cpp
+++ b/modules/mrpt_containers/tests/yaml_unittest.cpp
@@ -1512,4 +1512,35 @@ MRPT_TEST(yaml, nullScalarTypeName)
 }
 MRPT_TEST_END()
 
+MRPT_TEST(yaml, leadingZeroDigitStringStaysString)
+{
+  using mrpt::containers::yaml;
+
+  // A plain digit run with a leading zero (e.g. a zero-padded sequence
+  // number) must round-trip as the exact same string: an unquoted "00" is
+  // ambiguous as a YAML int (leading zeros are octal in 1.1, forbidden in
+  // 1.2), so it is kept as a string rather than silently collapsing to the
+  // integer 0 (and, formatted back, to "0" -- the padding lost for good).
+  EXPECT_EQ(yaml::FromText("v: 00\n")["v"].as<std::string>(), "00");
+  EXPECT_EQ(yaml::FromText("v: 007\n")["v"].as<std::string>(), "007");
+  EXPECT_EQ(yaml::FromText("v: 0\n")["v"].as<std::string>(), "0");
+
+  // Still convertible to a number on request, from the string form:
+  EXPECT_EQ(yaml::FromText("v: 007\n")["v"].as<int>(), 7);
+
+  // A genuine float starting with '0' is unaffected (it is not a plain
+  // digit run: it contains '.' or an exponent):
+  EXPECT_DOUBLE_EQ(yaml::FromText("v: 0.5\n")["v"].as<double>(), 0.5);
+  EXPECT_EQ(yaml::FromText("v: 0.5\n")["v"].as<std::string>(), "0.5");
+  EXPECT_DOUBLE_EQ(yaml::FromText("v: 0e3\n")["v"].as<double>(), 0.0);
+
+  // A normal (non-leading-zero) integer is unaffected:
+  EXPECT_EQ(yaml::FromText("v: 42\n")["v"].as<std::string>(), "42");
+  EXPECT_EQ(yaml::FromText("v: -42\n")["v"].as<std::string>(), "-42");
+
+  // Hex literals are unaffected (not a plain digit run):
+  EXPECT_EQ(yaml::FromText("v: 0x1A\n")["v"].as<int>(), 26);
+}
+MRPT_TEST_END()
+
 #endif  // MRPT_HAS_FYAML


### PR DESCRIPTION
## Summary
- `textToScalar()`'s existing leading-zero guard (added to keep e.g. `00`/`007` out of the int branch, since a leading zero is ambiguous under YAML — octal in 1.1, forbidden in 1.2 core ints) was never extended to the float branch right below it.
- `"00"` fell through to `strtod("00", ...) == 0.0`, so it silently resolved as a `double`. `as<std::string>()` on it then goes through the double's `%.17g` print path and returns `"0"`, not `"00"` — real, silent data loss for any zero-padded identifier (a sequence number, a zip code, …), not just a formatting nuance.
- Fix: compute the leading-zero-digit-run check once and guard both the int and the float branches with it. A genuine float that happens to start with `0` (`0.5`, `0e3`) is unaffected, since it isn't a plain digit run (it contains `.` or an exponent).

Found via a MOLA config: `sequence: ${KITTI_SEQ}` with `KITTI_SEQ=00`, after env-var substitution and yaml reparsing, silently became sequence `"0"` and pointed at the wrong dataset directory. MRPT 2.15.20 does not have this bug — `as<std::string>()` there correctly returns `"00"`.

## Test plan
- [x] Added `yaml.leadingZeroDigitStringStaysString` to `yaml_unittest.cpp`, covering `"00"`, `"007"`, `"0"`, still-convertible-to-int, unaffected floats (`0.5`, `0e3`), unaffected normal ints (`42`, `-42`), and unaffected hex (`0x1A`).
- [x] Full `mrpt_containers` test suite passes (100/100).
- [x] clang-format-14 clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * YAML values containing leading zeros, such as `00` and `007`, are now preserved as strings instead of being interpreted as integers.
  * Genuine decimal and scientific-notation values, regular integers, and hexadecimal literals continue to be parsed correctly.

* **Tests**
  * Added coverage for leading-zero strings and related numeric formats.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->