### PR TITLE
Restore CPointsMapXYZIRT as a deserialization-only compat shim

### DIFF
--- a/modules/mrpt_maps/CMakeLists.txt
+++ b/modules/mrpt_maps/CMakeLists.txt
@@ -83,6 +83,7 @@ set(LIB_UNIT_TEST_SOURCES
   tests/CPointCloudFilterByDistance_unittest.cpp
   tests/CGenericPointsMap_unittest.cpp
   tests/CPointsMap_unittest.cpp
+  tests/CPointsMapXYZIRT_unittest.cpp
   tests/CRandomFieldGridMap2D_unittest.cpp
   tests/CRandomFieldGridMap3D_unittest.cpp
   tests/serializations_unittest.cpp

--- a/modules/mrpt_maps/CMakeLists.txt
+++ b/modules/mrpt_maps/CMakeLists.txt
@@ -26,6 +26,7 @@ set(LIB_SOURCES
   src/maps/CBeaconMap.cpp
   src/maps/CGasConcentrationGridMap2D.cpp
   src/maps/CGenericPointsMap.cpp
+  src/maps/CPointsMapXYZIRT.cpp
   src/maps/CColouredOctoMap.cpp
   src/maps/CHeightGridMap2D.cpp
   src/maps/CHeightGridMap2D_Base.cpp

--- a/modules/mrpt_maps/include/mrpt/maps.h
+++ b/modules/mrpt_maps/include/mrpt/maps.h
@@ -32,6 +32,7 @@ MRPT_WARNING(
 #include <mrpt/maps/COccupancyGridMap3D.h>
 #include <mrpt/maps/COctoMap.h>
 #include <mrpt/maps/CPointsMap.h>
+#include <mrpt/maps/CPointsMapXYZIRT.h>
 #include <mrpt/maps/CRandomFieldGridMap3D.h>
 #include <mrpt/maps/CReflectivityGridMap2D.h>
 #include <mrpt/maps/CSimplePointsMap.h>

--- a/modules/mrpt_maps/include/mrpt/maps/CPointsMapXYZIRT.h
+++ b/modules/mrpt_maps/include/mrpt/maps/CPointsMapXYZIRT.h
@@ -1,0 +1,48 @@
+/*                    _
+                     | |    Mobile Robot Programming Toolkit (MRPT)
+ _ __ ___  _ __ _ __ | |_
+| '_ ` _ \| '__| '_ \| __|          https://www.mrpt.org/
+| | | | | | |  | |_) | |_
+|_| |_| |_|_|  | .__/ \__|     https://github.com/MRPT/mrpt/
+               | |
+               |_|
+
+ Copyright (c) 2005-2026, Individual contributors, see AUTHORS file
+ See: https://www.mrpt.org/Authors - All rights reserved.
+ SPDX-License-Identifier: BSD-3-Clause
+*/
+#pragma once
+
+#include <mrpt/maps/CGenericPointsMap.h>
+
+namespace mrpt::maps
+{
+/** Deserialization-only compatibility stub for the old CPointsMapXYZIRT class.
+ *
+ * This class carries no functionality of its own beyond decoding the binary
+ * layout that CPointsMapXYZIRT used before it was replaced by
+ * CGenericPointsMap. Its only purpose is to keep pre-existing
+ * `.simplemap`/`.rawlog` files (or any other CSerializable-based archive)
+ * that were saved with a CPointsMapXYZIRT layer loadable: without this class
+ * being registered under its original name, CArchive::ReadObject() throws on
+ * any such file with "Stored object has class 'mrpt::maps::CPointsMapXYZIRT'
+ * which is not registered!".
+ *
+ * Once loaded, the point cloud is a regular CGenericPointsMap with fields
+ * `intensity`, `ring`, and `t` populated as applicable, so all normal
+ * CPointsMap/CGenericPointsMap APIs apply.
+ *
+ * \sa mrpt::maps::CGenericPointsMap
+ * \ingroup mrpt_maps_grp
+ */
+class [[deprecated(
+    "Use CGenericPointsMap instead. CPointsMapXYZIRT is kept only to "
+    "deserialize pre-existing files.")]] CPointsMapXYZIRT : public CGenericPointsMap
+{
+  DEFINE_SERIALIZABLE(CPointsMapXYZIRT, mrpt::maps)
+
+ public:
+  CPointsMapXYZIRT() = default;
+};
+
+}  // namespace mrpt::maps

--- a/modules/mrpt_maps/src/maps/CPointsMapXYZIRT.cpp
+++ b/modules/mrpt_maps/src/maps/CPointsMapXYZIRT.cpp
@@ -1,0 +1,108 @@
+/*                    _
+                     | |    Mobile Robot Programming Toolkit (MRPT)
+ _ __ ___  _ __ _ __ | |_
+| '_ ` _ \| '__| '_ \| __|          https://www.mrpt.org/
+| | | | | | |  | |_) | |_
+|_| |_| |_|_|  | .__/ \__|     https://github.com/MRPT/mrpt/
+               | |
+               |_|
+
+ Copyright (c) 2005-2026, Individual contributors, see AUTHORS file
+ See: https://www.mrpt.org/Authors - All rights reserved.
+ SPDX-License-Identifier: BSD-3-Clause
+*/
+
+#include <mrpt/maps/CPointsMapXYZIRT.h>
+#include <mrpt/serialization/CArchive.h>
+
+using namespace mrpt::maps;
+
+IMPLEMENTS_SERIALIZABLE(CPointsMapXYZIRT, CGenericPointsMap, mrpt::maps)
+
+uint8_t CPointsMapXYZIRT::serializeGetVersion() const { return 0; }
+
+// Binary layout kept identical to the pre-deprecation implementation, so
+// files this class writes stay loadable by itself and vice versa.
+void CPointsMapXYZIRT::serializeTo(mrpt::serialization::CArchive& out) const
+{
+  const uint32_t n = static_cast<uint32_t>(m_x.size());
+  out << n;
+  if (n > 0)
+  {
+    out.WriteBufferFixEndianness(m_x.data(), n);
+    out.WriteBufferFixEndianness(m_y.data(), n);
+    out.WriteBufferFixEndianness(m_z.data(), n);
+  }
+
+  const auto* intensity = getPointsBufferRef_float_field(POINT_FIELD_INTENSITY);
+  const uint32_t nI = intensity ? static_cast<uint32_t>(intensity->size()) : 0;
+  out << nI;
+  if (nI > 0) out.WriteBufferFixEndianness(intensity->data(), nI);
+
+  const auto* ring = getPointsBufferRef_uint16_field(POINT_FIELD_RING_ID);
+  const uint32_t nR = ring ? static_cast<uint32_t>(ring->size()) : 0;
+  out << nR;
+  if (nR > 0) out.WriteBufferFixEndianness(ring->data(), nR);
+
+  const auto* time = getPointsBufferRef_float_field(POINT_FIELD_TIMESTAMP);
+  const uint32_t nT = time ? static_cast<uint32_t>(time->size()) : 0;
+  out << nT;
+  if (nT > 0) out.WriteBufferFixEndianness(time->data(), nT);
+
+  insertionOptions.writeToStream(out);
+  likelihoodOptions.writeToStream(out);
+}
+
+void CPointsMapXYZIRT::serializeFrom(mrpt::serialization::CArchive& in, uint8_t version)
+{
+  switch (version)
+  {
+    case 0:
+    {
+      mark_as_modified();
+
+      uint32_t n;
+      in >> n;
+      resize(n);
+      if (n > 0)
+      {
+        in.ReadBufferFixEndianness(m_x.data(), n);
+        in.ReadBufferFixEndianness(m_y.data(), n);
+        in.ReadBufferFixEndianness(m_z.data(), n);
+      }
+
+      uint32_t nI;
+      in >> nI;
+      if (nI > 0)
+      {
+        ASSERT_EQUAL_(nI, n);
+        registerField_float(POINT_FIELD_INTENSITY);
+        in.ReadBufferFixEndianness(m_float_fields.at(POINT_FIELD_INTENSITY).data(), nI);
+      }
+
+      uint32_t nR;
+      in >> nR;
+      if (nR > 0)
+      {
+        ASSERT_EQUAL_(nR, n);
+        registerField_uint16(POINT_FIELD_RING_ID);
+        in.ReadBufferFixEndianness(m_uint16_fields.at(POINT_FIELD_RING_ID).data(), nR);
+      }
+
+      uint32_t nT;
+      in >> nT;
+      if (nT > 0)
+      {
+        ASSERT_EQUAL_(nT, n);
+        registerField_float(POINT_FIELD_TIMESTAMP);
+        in.ReadBufferFixEndianness(m_float_fields.at(POINT_FIELD_TIMESTAMP).data(), nT);
+      }
+
+      insertionOptions.readFromStream(in);
+      likelihoodOptions.readFromStream(in);
+    }
+    break;
+    default:
+      MRPT_THROW_UNKNOWN_SERIALIZATION_VERSION(version);
+  };
+}

--- a/modules/mrpt_maps/src/registerAllClasses.cpp
+++ b/modules/mrpt_maps/src/registerAllClasses.cpp
@@ -34,6 +34,7 @@ MRPT_INITIALIZER(registerAllClasses_mrpt_maps)
   registerClass(CLASS_ID(CPointsMap));
   registerClass(CLASS_ID(CSimplePointsMap));
   registerClass(CLASS_ID(CGenericPointsMap));
+  registerClass(CLASS_ID(CPointsMapXYZIRT));  // deserialization compat only
   registerClass(CLASS_ID(COccupancyGridMap2D));
   registerClass(CLASS_ID(COccupancyGridMap3D));
   registerClass(CLASS_ID(CGasConcentrationGridMap2D));

--- a/modules/mrpt_maps/src/registerAllClasses.cpp
+++ b/modules/mrpt_maps/src/registerAllClasses.cpp
@@ -34,7 +34,21 @@ MRPT_INITIALIZER(registerAllClasses_mrpt_maps)
   registerClass(CLASS_ID(CPointsMap));
   registerClass(CLASS_ID(CSimplePointsMap));
   registerClass(CLASS_ID(CGenericPointsMap));
+#if defined(__GNUC__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+#endif
+#if defined(_MSC_VER)
+#pragma warning(push)
+#pragma warning(disable : 4996)
+#endif
   registerClass(CLASS_ID(CPointsMapXYZIRT));  // deserialization compat only
+#if defined(_MSC_VER)
+#pragma warning(pop)
+#endif
+#if defined(__GNUC__)
+#pragma GCC diagnostic pop
+#endif
   registerClass(CLASS_ID(COccupancyGridMap2D));
   registerClass(CLASS_ID(COccupancyGridMap3D));
   registerClass(CLASS_ID(CGasConcentrationGridMap2D));

--- a/modules/mrpt_maps/tests/CPointsMapXYZIRT_unittest.cpp
+++ b/modules/mrpt_maps/tests/CPointsMapXYZIRT_unittest.cpp
@@ -1,0 +1,134 @@
+/* +------------------------------------------------------------------------+
+   |                     Mobile Robot Programming Toolkit (MRPT)            |
+   |                          https://www.mrpt.org/                         |
+   |                                                                        |
+   | Copyright (c) 2005-2026, Individual contributors, see AUTHORS file     |
+   | See: https://www.mrpt.org/Authors - All rights reserved.               |
+   | Released under BSD License. See: https://www.mrpt.org/License          |
+   +------------------------------------------------------------------------+ */
+
+// Unit tests for the deserialization-only CPointsMapXYZIRT compat stub.
+
+#include <gtest/gtest.h>
+#include <mrpt/io/CMemoryStream.h>
+#include <mrpt/maps/CPointsMapXYZIRT.h>
+#include <mrpt/rtti/CObject.h>
+#include <mrpt/serialization/CArchive.h>
+
+// The class under test is deprecated on purpose; testing it is the point.
+#if defined(__GNUC__)
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+#endif
+#if defined(_MSC_VER)
+#pragma warning(disable : 4996)
+#endif
+
+using mrpt::maps::CGenericPointsMap;
+using mrpt::maps::CPointsMap;
+using mrpt::maps::CPointsMapXYZIRT;
+
+namespace
+{
+CPointsMapXYZIRT makeTestMap()
+{
+  CPointsMapXYZIRT m;
+  m.registerField_float(CPointsMap::POINT_FIELD_INTENSITY);
+  m.registerField_uint16(CPointsMap::POINT_FIELD_RING_ID);
+  m.registerField_float(CPointsMap::POINT_FIELD_TIMESTAMP);
+
+  const size_t N = 4;
+  m.resize(N);
+  for (size_t i = 0; i < N; i++)
+  {
+    m.setPointFast(i, float(i), float(i * 10), float(i * 100));
+    m.setPointField_float(i, CPointsMap::POINT_FIELD_INTENSITY, float(i) + 0.25f);
+    m.setPointField_uint16(i, CPointsMap::POINT_FIELD_RING_ID, static_cast<uint16_t>(i + 1));
+    m.setPointField_float(i, CPointsMap::POINT_FIELD_TIMESTAMP, float(i) * 0.01f);
+  }
+  return m;
+}
+}  // namespace
+
+// Without the class staying registered under its original name, reading any
+// archive holding one of these throws "class ... is not registered".
+TEST(CPointsMapXYZIRT, RegisteredUnderLegacyClassName)
+{
+  const auto* cls = mrpt::rtti::findRegisteredClass("mrpt::maps::CPointsMapXYZIRT", false);
+  ASSERT_NE(cls, nullptr);
+
+  const auto obj = cls->createObject();
+  ASSERT_NE(obj, nullptr);
+  EXPECT_NE(std::dynamic_pointer_cast<CGenericPointsMap>(obj), nullptr);
+}
+
+TEST(CPointsMapXYZIRT, SerializationRoundTrip)
+{
+  mrpt::io::CMemoryStream buf;
+  {
+    const auto src = makeTestMap();
+    auto ar = mrpt::serialization::archiveFrom(buf);
+    ar << src;
+  }
+
+  buf.Seek(0);
+  auto ar = mrpt::serialization::archiveFrom(buf);
+  mrpt::serialization::CSerializable::Ptr obj;
+  ar >> obj;
+
+  const auto m = std::dynamic_pointer_cast<CGenericPointsMap>(obj);
+  ASSERT_NE(m, nullptr);
+  ASSERT_EQ(m->size(), 4U);
+
+  EXPECT_TRUE(m->hasPointField(CPointsMap::POINT_FIELD_INTENSITY));
+  EXPECT_TRUE(m->hasPointField(CPointsMap::POINT_FIELD_RING_ID));
+  EXPECT_TRUE(m->hasPointField(CPointsMap::POINT_FIELD_TIMESTAMP));
+
+  for (size_t i = 0; i < m->size(); i++)
+  {
+    float x = 0;
+    float y = 0;
+    float z = 0;
+    m->getPointFast(i, x, y, z);
+    EXPECT_FLOAT_EQ(x, float(i));
+    EXPECT_FLOAT_EQ(y, float(i * 10));
+    EXPECT_FLOAT_EQ(z, float(i * 100));
+
+    EXPECT_FLOAT_EQ(m->getPointField_float(i, CPointsMap::POINT_FIELD_INTENSITY), float(i) + 0.25f);
+    EXPECT_EQ(
+        m->getPointField_uint16(i, CPointsMap::POINT_FIELD_RING_ID), static_cast<uint16_t>(i + 1));
+    EXPECT_FLOAT_EQ(m->getPointField_float(i, CPointsMap::POINT_FIELD_TIMESTAMP), float(i) * 0.01f);
+  }
+}
+
+// A map with no optional fields must still round-trip (all counts zero).
+TEST(CPointsMapXYZIRT, SerializationRoundTripWithoutOptionalFields)
+{
+  mrpt::io::CMemoryStream buf;
+  {
+    CPointsMapXYZIRT src;
+    src.resize(2);
+    src.setPointFast(0, 1.0f, 2.0f, 3.0f);
+    src.setPointFast(1, 4.0f, 5.0f, 6.0f);
+
+    auto ar = mrpt::serialization::archiveFrom(buf);
+    ar << src;
+  }
+
+  buf.Seek(0);
+  auto ar = mrpt::serialization::archiveFrom(buf);
+  mrpt::serialization::CSerializable::Ptr obj;
+  ar >> obj;
+
+  const auto m = std::dynamic_pointer_cast<CGenericPointsMap>(obj);
+  ASSERT_NE(m, nullptr);
+  ASSERT_EQ(m->size(), 2U);
+  EXPECT_FALSE(m->hasPointField(CPointsMap::POINT_FIELD_INTENSITY));
+
+  float x = 0;
+  float y = 0;
+  float z = 0;
+  m->getPointFast(1, x, y, z);
+  EXPECT_FLOAT_EQ(x, 4.0f);
+  EXPECT_FLOAT_EQ(y, 5.0f);
+  EXPECT_FLOAT_EQ(z, 6.0f);
+}


### PR DESCRIPTION
## Summary
- Removing `CPointsMapXYZIRT` from the RTTI registry (during the `mrpt_maps` module port) broke loading of any pre-existing `.simplemap`/`.rawlog` file with a `CPointsMapXYZIRT` point layer: `CArchive::ReadObject()` throws `Stored object has class 'mrpt::maps::CPointsMapXYZIRT' which is not registered!`, since the class name written on disk doesn't change just because the class is deprecated.
- Restores it as a minimal, deserialization-only shim deriving from `CGenericPointsMap`: it decodes the exact pre-deprecation binary layout (X,Y,Z + optional intensity/ring/time buffers) and exposes the result through `CGenericPointsMap`'s generic field interface, so downstream code keeps working transparently.
- `serializeTo()` is kept symmetric (same legacy layout) so nothing that still explicitly targets this class for round-tripping breaks either, but no new code is expected to construct it — `CGenericPointsMap` remains the class to use going forward.
- Found while validating a downstream MRPT-3.x port: `mola_sm_loop_closure`'s test suite and `mola_lidar_odometry`'s mulran regression test both failed loading their reference `.simplemap`/`.rawlog` fixtures with this exact error.

## Test plan
- [x] `mrpt_maps` test suite passes (`test_mrpt_maps_build`, `run_test_mrpt_maps`, `python_maps`)
- [x] Loaded a real production `.simplemap` file containing a `CPointsMapXYZIRT` layer (previously failing with "not registered") — now loads correctly
- [x] `clang-format-14` clean on the new files

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015w31kEa1kRfKA3rcqDRXyZ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Restored compatibility for loading older `.simplemap`, `.rawlog`, and serialized archives containing `CPointsMapXYZIRT` point clouds.
  * Preserved intensity, ring ID, and timestamp data when deserializing these legacy point clouds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->