### PR TITLE
Coverage pass on mrpt_graphslam and mrpt_gui (headless GUI tests under Xvfb)

### DIFF
--- a/.github/workflows/build-linux.yml
+++ b/.github/workflows/build-linux.yml
@@ -60,6 +60,10 @@ jobs:
                            libcli11-dev \
                            libzstd-dev
 
+          # Virtual X display + Mesa software GL, so that the mrpt_gui window
+          # tests can run headlessly (they self-skip without a display):
+          sudo apt install -y xvfb libgl1-mesa-dri
+
           # Added: python3-pip and colcon installation via pip
           sudo apt install -y pybind11-dev python3-dev python3-pip
           pip3 install --break-system-packages colcon-common-extensions colcon-lcov-result numpy
@@ -76,9 +80,12 @@ jobs:
 
       - name: Colcon Test
         run: |
-          colcon test \
-            --event-handlers console_direct+ \
-            --return-code-on-test-failure
+          # `xvfb-run` provides the virtual display the mrpt_gui tests need;
+          # every other test is unaffected by it.
+          xvfb-run -a --server-args="-screen 0 1280x1024x24" \
+            colcon test \
+              --event-handlers console_direct+ \
+              --return-code-on-test-failure
 
       - name: Generate Coverage Report
         if: matrix.coverage == 'ON'

--- a/.github/workflows/build-linux.yml
+++ b/.github/workflows/build-linux.yml
@@ -3,6 +3,11 @@ name: CI Linux
 
 on: [push, pull_request]
 
+# Nothing here writes to the repository: checkout only reads, and Codecov
+# uploads with its own token.
+permissions:
+  contents: read
+
 jobs:
   build:
     name: ${{ matrix.name }} ${{ matrix.build_type }}

--- a/agents.md
+++ b/agents.md
@@ -201,12 +201,17 @@ files needed changes.
 A full rebuild of all 33 `modules/*` packages was done with coverage
 instrumentation, followed by a full `colcon test` run (all tests passed) and a
 `gcovr` line/branch report. **Goal: 90% line coverage per module.** Current
-overall (2026-08-31, deduplicated the same way as
-`scripts/coverage_module_report.py`): **73.6% lines / 54.4% branches**
-- still short of goal, dominated by the hardware/GUI modules below.
-The whole table below was re-measured on 2026-08-31; the date tags on some
+overall (2026-09-06, deduplicated the same way as
+`scripts/coverage_module_report.py`): **76.4% lines**
+- still short of goal, dominated by the hardware modules below.
+The whole table below was re-measured on 2026-09-06; the date tags on some
 rows mark when that module last had a dedicated unit-test pass, and point at
 the footnote describing it.
+
+**The GUI tests need a display**: run `colcon test` under
+`xvfb-run -a --server-args="-screen 0 1280x1024x24"` (as CI does), or the
+`mrpt_gui` window tests `GTEST_SKIP()` and that module reads ~1% instead of
+~40%. `MRPT_SKIP_GUI_TESTS=1` forces the skip.
 
 Gotcha (2026-07-06): the system `gcov` alias (`/etc/alternatives/gcov`) may
 point to an unrelated binary (observed pointing to `/usr/bin/gc`), causing
@@ -298,17 +303,17 @@ and accurate path — pick two.
 | Module | Covered/Total lines | Line % | Branch % |
 |---|---|---|---|
 | mrpt_imgui | 0/53 | 0.0% | 0.0% |
-| mrpt_gui | 22/4621 | 0.5% | 0.2% |
 | mrpt_hwdrivers | 913/6592 | 13.9% | 9.7% |
-| mrpt_opengl | 2041/4234 | 48.2% | 30.3% |
+| mrpt_gui (2026-09-06)@ | 1888/4655 | 40.6% | 30.4% |
+| mrpt_opengl | 2323/4234 | 54.9% | 35.7% |
 | mrpt_libapps_cli | 1129/1910 | 59.1% | 38.0% |
 | mrpt_libapps_gui | 803/1288 | 62.3% | 45.8% |
-| mrpt_viz (2026-08-02) | 6511/9440 | 69.0% | 50.5% |
+| mrpt_viz (2026-08-02) | 6600/9440 | 69.9% | 51.4% |
 | mrpt_common | 5/7 | 71.4% | 0.0% |
-| mrpt_graphslam (2026-08-28)¤ | 453/618 | 73.3% | 60.5% |
+| mrpt_graphslam (2026-09-06)@ | 814/997 | 81.6% | 64.4% |
 | mrpt_comms (2026-08-29)» | 687/906 | 75.8% | 54.4% |
 | mrpt_examples_cpp | 99/128 | 77.3% | 46.3% |
-| mrpt_system (2026-08-29)» | 1622/1963 | 82.6% | 58.5% |
+| mrpt_system (2026-08-29)» | 1625/1963 | 82.8% | 58.5% |
 | mrpt_rtti (2026-08-29)» | 151/176 | 85.8% | 77.4% |
 | mrpt_maps (2026-08-03)§ | 10118/11698 | 86.5% | 62.8% |
 | mrpt_io (2026-08-29)» | 1133/1310 | 86.5% | 69.7% |
@@ -838,6 +843,98 @@ Worth knowing for future tests here:
   order depends on the sign of the eigenvector and differs between platforms:
   sort them before comparing.
 
+@ Coverage pass of 2026-09-06 on `mrpt_graphslam` (73.3% -> 81.6%) and
+`mrpt_gui` (0.5% -> 40.6%), the last two modules with whole files that had
+never had a single assertion run against them.
+
+`mrpt_gui` had **no `tests/` directory at all**. It now has one, and the
+window classes are tested headlessly: `xvfb-run` supplies a virtual X display
+and Mesa's software rasterizer, which is enough to open and drive
+`CDisplayWindow`, `CDisplayWindow3D` and `CDisplayWindowPlots`. That single
+change carried `mathplot.cpp` 0% -> 33%, `WxSubsystem.cpp` 4.7% -> 67%,
+`CDisplayWindow3D.cpp` 0% -> 74%, `CDisplayWindow.cpp` 0% -> 71% and
+`CDisplayWindowPlots.cpp` 0% -> 65%. `.github/workflows/build-linux.yml`
+installs `xvfb`/`libgl1-mesa-dri` and wraps `colcon test` in `xvfb-run`;
+`modules/mrpt_gui/package.xml` gained a matching `<test_depend>xvfb</test_depend>`
+(note that `test_depend` alone changes nothing - only rosdep reads it, and the
+ROS buildfarm skips this repo's tests entirely, see section 9 - so the CI
+wrapper is what actually makes them run).
+
+Worth knowing before adding more GUI tests:
+
+* Do **not** pixel-compare window screenshots. On a virtual display there is
+  no compositor, the window is never mapped, and reading its pixels back
+  yields a uniformly black image even though rendering did happen (the FPS
+  counter advances normally). Assert that a frame was grabbed and that it has
+  a plausible size instead. Reference-image comparisons belong in
+  `mrpt_opengl`'s offscreen EGL/FBO tests, which need no display at all.
+* The grabbed frame is the *client* area, which under a real window manager
+  is smaller than the requested outer size (title bar), while under Xvfb it
+  matches exactly - so exact dimensions cannot be asserted either.
+* `tests/gui_test_common.h` provides `SKIP_IF_NO_GUI()`; every window test
+  must use it so the suite still passes with no display, and
+  `MRPT_SKIP_GUI_TESTS=1` forces that path.
+* `mrpt/gui/WxUtils.h` pulls in wxWidgets headers, but the library links
+  wxWidgets *privately*, so the test target needs an explicit
+  `target_link_libraries(test_mrpt_gui PRIVATE imp_wxwidgets)`.
+* `CImage::at<T>()` is a raw `reinterpret_cast`: `at<mrpt::img::TColor>()` on
+  a 3-channel image reads/writes 4 bytes over a 3-byte pixel and corrupts the
+  heap on the last pixel. Use `at<uint8_t>(x, y, channel)`.
+
+Real bugs found and fixed: (1) `mrpt::system::CTicTac` declared its timestamp
+storage `alignas(16)` for no reason (it is only ever reinterpreted as
+`struct timespec`/`LARGE_INTEGER`, both 8-byte aligned). That alignment
+propagated through `CTimeLogger` up to
+`mrpt::graphslam::CRegistrationDeciderOrOptimizer`, which is used as a
+*virtual base*; GCC then compiled its member functions assuming `this` is
+16-byte aligned and emitted `movdqa`, while the virtual-base subobject inside
+a derived class sits at an offset that is only 8-byte aligned - so simply
+constructing a `CFixedIntervalsNRD` **segfaulted in any optimized build**,
+i.e. the whole `graphslam-engine` app was broken in Release. Same failure mode
+as the one already documented in `mrpt::math::CMatrixFixed`; a `static_assert`
+now pins the alignment. (2)
+`CNodeRegistrationDecider::registerNewNodeAtEnd()` seeded the *root* node with
+`getCurrentRobotPosEstimation()` instead of the origin, so the motion
+accumulated before the first registration was applied twice: node 1 ended up
+at 2x the travelled distance and the whole graph was offset. (3) The three
+decider `TParams` structs (`CFixedIntervalsNRD`,
+`CIncrementalNodeRegistrationDecider`, `CICPCriteriaNRD`) left
+`registration_max_distance`/`registration_max_angle` **uninitialized**, so a
+decider used without `loadParams()` compared against garbage thresholds; the
+documented defaults were dead code living only in `loadFromConfigFile()`.
+(4) `CIncrementalNodeRegistrationDecider` did not compile at all if
+instantiated: `getDescriptiveReport()` used an undefined `report_sep` and
+`checkRegistrationCondition()` used an unqualified `INVALID_NODEID`; its 3D
+registration check also printed `p1` twice via a leftover `std::cout` (now a
+debug log). (5) `TUncertaintyPath::hasLowerUncertaintyThan()` was likewise
+uninstantiable - it is `const` but called the non-`const` `getDeterminant()`;
+the determinant cache is now `mutable` and the getter `const`.
+(6) `CGlCanvasBase::setMousePos()`/`setMouseClicked()`/`updateLastPos()` and
+`CGlCanvasBaseHeadless::renderError()` were declared in the public header but
+never defined after the 3.x camera refactor - a link error for any caller, and
+`CGlCanvasBaseHeadless` was unusable (its key function was missing). The two
+click setters were dead (superseded by `COrbitCameraController`) and are gone;
+`updateLastPos()` is restored and is now actually called from
+`CWxGLCanvasBase`'s mouse handlers, which never recorded the pointer position,
+so `CDisplayWindow3D::getLastMousePosition()` - and hence
+`getLastMousePositionRay()` and all 3D picking - always returned pixel (0,0).
+(7) `wxImage2MRPTImage()` passed `swapRedBlue = true`, a leftover from MRPT
+2.x when `CImage` stored BGR; in 3.x both `CImage` and `wxImage` are RGB, so
+every wxImage -> CImage conversion came back with red and blue swapped. The
+matching dead `"BGR"` branch in `MRPTImage2wxImage()` was removed.
+(8) `CWindowObserver::OnEvent()` compared the key modifiers against the magic
+number `8192` with `==`, so Ctrl+C was missed whenever any other modifier
+(e.g. Shift) was also held; it now masks against `mrpt::gui::MRPTKMOD_CONTROL`.
+(9) `CNodeRegistrationDecider_impl.h` had `using namespace std;` at **global**
+scope in a public header, leaking into every translation unit that included
+any NRD; the definitions are now wrapped in their own namespace.
+
+`mrpt_graphslam`'s remaining gap is `CEdgeCounter`'s visualization half and
+`CWindowManager.h`, both of which need a live `CDisplayWindow3D` handed in
+from outside the module. `mrpt_gui`'s is `CDisplayWindowGUI.cpp` (nanogui /
+GLFW), `CQtGlCanvasBase.cpp` (Qt), `CAboutBox*`/`error_box.cpp` (modal dialogs
+that would block a test run) and the rest of `mathplot.cpp`.
+
 ### Weak areas, grouped by root cause
 
 1. **Hardware drivers - `mrpt_hwdrivers` (13.9%)**: inherently hard to
@@ -849,12 +946,13 @@ Worth knowing for future tests here:
    2026-08-29 (see » above): everything but `CInterfaceFTDI` turned out to be
    testable over loopback sockets and a pseudo-terminal.
 
-2. **GUI/rendering — `mrpt_gui` (0.5%), `mrpt_imgui` (0%), and GUI-only files
-   inside `mrpt_viz`/`mrpt_opengl`**: `mathplot.cpp`, `CDisplayWindow*.cpp`,
-   `WxUtils.cpp`, `CWxGLCanvasBase.cpp`, `CQtGlCanvasBase.cpp`,
-   `CImGuiSceneView.cpp` need a live display/OpenGL context and are 0%.
-   Realistic path to improvement is extracting non-UI logic into testable
-   helpers, or headless/offscreen-context tests, not brute-force unit tests.
+2. **GUI/rendering — `mrpt_imgui` (0%) and the GUI-only files still left in
+   `mrpt_gui` (40.6%)**: `CDisplayWindowGUI.cpp` (nanogui/GLFW),
+   `CQtGlCanvasBase.cpp` (Qt), `CImGuiSceneView.cpp`, the modal dialogs in
+   `CAboutBox*`/`error_box.cpp`, and the rest of `mathplot.cpp`. The
+   `CDisplayWindow*`/`WxUtils`/`CWxGLCanvasBase`/`mathplot` bulk cleared this
+   bucket on 2026-09-06 by running the tests under `xvfb-run` — see @ above;
+   the same technique should work for the nanogui/Qt canvases.
 
 3. **CLI apps — `mrpt_libapps_cli` (59.2% as of 2026-07-06, was 9.1%)**: some
    `rawlog-edit_*.cpp` paths remain untested. These are better suited to
@@ -862,8 +960,10 @@ Worth knowing for future tests here:
    sample rawlogs, diff the output) than pure unit tests.
 
 4. **Quick wins — pure-logic files at 0% with no hardware/GUI dependency**
-   (highest-value gaps, ordinary unit tests would work immediately):
-   `mrpt_graphslam/src/CWindowObserver.cpp`.
+   (highest-value gaps, ordinary unit tests would work immediately): none
+   left as of 2026-09-06.
+   (`mrpt_graphslam/src/CWindowObserver.cpp` and `mrpt_gui/src/CGlCanvasBase.cpp`
+   cleared this bucket as of 2026-09-06 — see @ above.)
    (`mrpt_slam/src/slam/{CLandmarksMap,observations_overlap}.cpp` cleared this
    bucket as of 2026-08-31 — see × above.)
    (`mrpt_system/src/CFileSystemWatcher.cpp`, `mrpt_system/src/{progress,

--- a/agents.md
+++ b/agents.md
@@ -873,7 +873,9 @@ Worth knowing before adding more GUI tests:
   matches exactly - so exact dimensions cannot be asserted either.
 * `tests/gui_test_common.h` provides `SKIP_IF_NO_GUI()`; every window test
   must use it so the suite still passes with no display, and
-  `MRPT_SKIP_GUI_TESTS=1` forces that path.
+  `MRPT_SKIP_GUI_TESTS=1` forces that path. Note the macOS and Windows CI
+  jobs build with `-DDISABLE_WXWIDGETS=ON`, so the window tests skip there
+  too - only the Linux jobs actually exercise them.
 * `mrpt/gui/WxUtils.h` pulls in wxWidgets headers, but the library links
   wxWidgets *privately*, so the test target needs an explicit
   `target_link_libraries(test_mrpt_gui PRIVATE imp_wxwidgets)`.

--- a/modules/mrpt_graphslam/CMakeLists.txt
+++ b/modules/mrpt_graphslam/CMakeLists.txt
@@ -17,6 +17,10 @@ set(LIB_UNIT_TEST_SOURCES
   tests/graph_slam_levmarq_unittest.cpp
   tests/TSlidingWindow_unittest.cpp
   tests/CEdgeCounter_unittest.cpp
+  tests/CWindowObserver_unittest.cpp
+  tests/TUncertaintyPath_unittest.cpp
+  tests/CFixedIntervalsNRD_unittest.cpp
+  tests/CIncrementalNodeRegistrationDecider_unittest.cpp
 )
 
 set(LIB_PUBLIC_HEADERS

--- a/modules/mrpt_graphslam/include/mrpt/graphslam/NRD/CFixedIntervalsNRD.h
+++ b/modules/mrpt_graphslam/include/mrpt/graphslam/NRD/CFixedIntervalsNRD.h
@@ -16,6 +16,7 @@
 
 #include <mrpt/config/CConfigFileBase.h>
 #include <mrpt/config/CLoadableOptions.h>
+#include <mrpt/core/bits_math.h>
 #include <mrpt/graphslam/interfaces/CNodeRegistrationDecider.h>
 #include <mrpt/obs/CActionCollection.h>
 #include <mrpt/obs/CObservationOdometry.h>
@@ -127,8 +128,8 @@ class CFixedIntervalsNRD :
     std::string getAsString() const;
 
     // max values for new node registration
-    double registration_max_distance;
-    double registration_max_angle;
+    double registration_max_distance = 0.5;               // meters
+    double registration_max_angle = mrpt::DEG2RAD(60.0);  // radians
   };
 
   TParams params;
@@ -160,7 +161,7 @@ class CFixedIntervalsNRD :
   /**\brief Keep track of whether we are reading from an observation-only
    * rawlog file or from an action-observation rawlog
    */
-  bool m_observation_only_rawlog;
+  bool m_observation_only_rawlog = false;
 };
 }  // namespace mrpt::graphslam::deciders
 #include "CFixedIntervalsNRD_impl.h"

--- a/modules/mrpt_graphslam/include/mrpt/graphslam/NRD/CICPCriteriaNRD.h
+++ b/modules/mrpt_graphslam/include/mrpt/graphslam/NRD/CICPCriteriaNRD.h
@@ -16,6 +16,7 @@
 
 #include <mrpt/config/CConfigFileBase.h>
 #include <mrpt/config/CLoadableOptions.h>
+#include <mrpt/core/bits_math.h>
 #include <mrpt/graphslam/interfaces/CNodeRegistrationDecider.h>
 #include <mrpt/graphslam/misc/CRangeScanOps.h>
 #include <mrpt/graphslam/misc/TSlidingWindow.h>
@@ -156,9 +157,9 @@ class CICPCriteriaNRD :
         const mrpt::config::CConfigFileBase& source, const std::string& section) override;
     void dumpToTextStream(std::ostream& out) const override;
     /** Maximum distance for new node registration */
-    double registration_max_distance;
+    double registration_max_distance = 0.5;  // meters
     /** Maximum angle difference for new node registration */
-    double registration_max_angle;
+    double registration_max_angle = mrpt::DEG2RAD(10.0);  // radians
   };
 
   TParams params;

--- a/modules/mrpt_graphslam/include/mrpt/graphslam/interfaces/CIncrementalNodeRegistrationDecider.h
+++ b/modules/mrpt_graphslam/include/mrpt/graphslam/interfaces/CIncrementalNodeRegistrationDecider.h
@@ -16,6 +16,7 @@
 
 #include <mrpt/config/CConfigFileBase.h>
 #include <mrpt/config/CLoadableOptions.h>
+#include <mrpt/core/bits_math.h>
 #include <mrpt/graphslam/interfaces/CNodeRegistrationDecider.h>
 #include <mrpt/poses/CPose2D.h>
 #include <mrpt/poses/CPose3D.h>
@@ -41,7 +42,7 @@ namespace mrpt::graphslam::deciders
  *
  * - \b registration_max_angle
  *  + \a Section       : NodeRegistrationDeciderParameters
- *  + \a Default value : 10 // degrees
+ *  + \a Default value : 15 // degrees
  *  + \a Required      : FALSE
  *
  * \ingroup mrpt_graphslam_grp
@@ -99,8 +100,8 @@ class CIncrementalNodeRegistrationDecider :
     std::string getAsString() const;
 
     // max values for new node registration
-    double registration_max_distance;
-    double registration_max_angle;
+    double registration_max_distance = 0.5;               // meters
+    double registration_max_angle = mrpt::DEG2RAD(15.0);  // radians
   };
 
   TParams params;

--- a/modules/mrpt_graphslam/include/mrpt/graphslam/interfaces/CIncrementalNodeRegistrationDecider_impl.h
+++ b/modules/mrpt_graphslam/include/mrpt/graphslam/interfaces/CIncrementalNodeRegistrationDecider_impl.h
@@ -23,7 +23,7 @@ bool CIncrementalNodeRegistrationDecider<GRAPH_T>::checkRegistrationCondition()
 
   // check that a node has already been registered - if not, default to
   // (0,0,0)
-  pose_t last_pose_inserted = this->m_prev_registered_nodeID != INVALID_NODEID
+  pose_t last_pose_inserted = this->m_prev_registered_nodeID != mrpt::graphs::INVALID_NODEID
                                   ? this->m_graph->nodes.at(this->m_prev_registered_nodeID)
                                   : pose_t();
 
@@ -62,8 +62,8 @@ bool CIncrementalNodeRegistrationDecider<GRAPH_T>::checkRegistrationConditionPos
 {
   using namespace mrpt::math;
 
-  std::cout << "In checkRegistrationConditionPose:\np1: " << p1.asString()
-            << "\np2: " << p1.asString() << "\n";
+  MRPT_LOG_DEBUG_STREAM(
+      "In checkRegistrationConditionPose:\np1: " << p1.asString() << "\np2: " << p2.asString());
 
   bool res = false;
   if ((p1.distanceTo(p2) > params.registration_max_distance) ||
@@ -103,7 +103,9 @@ void CIncrementalNodeRegistrationDecider<GRAPH_T>::getDescriptiveReport(
     std::string* report_str) const
 {
   MRPT_START
-  using namespace std;
+  const static std::string report_sep(2, '\n');
+
+  parent_t::getDescriptiveReport(report_str);
 
   *report_str += params.getAsString();
   *report_str += report_sep;

--- a/modules/mrpt_graphslam/include/mrpt/graphslam/interfaces/CNodeRegistrationDecider_impl.h
+++ b/modules/mrpt_graphslam/include/mrpt/graphslam/interfaces/CNodeRegistrationDecider_impl.h
@@ -13,14 +13,13 @@
 */
 #pragma once
 
-using namespace mrpt::graphslam::deciders;
-using namespace std;
-
 #include <sstream>
 
 // Implementation of classes defined in the CNodeRegistrationDecider class
 // template.
 //
+namespace mrpt::graphslam::deciders
+{
 template <class GRAPH_T>
 CNodeRegistrationDecider<GRAPH_T>::CNodeRegistrationDecider() :
     m_prev_registered_nodeID(mrpt::graphs::INVALID_NODEID)
@@ -35,7 +34,7 @@ void CNodeRegistrationDecider<GRAPH_T>::getDescriptiveReport(std::string* report
 {
   MRPT_START
 
-  stringstream ss("");
+  std::stringstream ss("");
   parent_t::getDescriptiveReport(report_str);
 
   ss << "Node Registration Decider Strategy [NRD]: "
@@ -64,7 +63,10 @@ bool CNodeRegistrationDecider<GRAPH_T>::registerNewNodeAtEnd(
   if (this->m_prev_registered_nodeID == mrpt::graphs::INVALID_NODEID)
   {  // root
     MRPT_LOG_WARN("Registering root node...");
-    global_pose_t tmp_pose = this->getCurrentRobotPosEstimation();
+    // The root node is the origin of the graph coordinate frame: the motion
+    // accumulated so far belongs to the edge towards the first node, so
+    // seeding the root with it would apply that increment twice.
+    global_pose_t tmp_pose;
     this->addNodeAnnotsToPose(&tmp_pose);
 
 // make sure that this pair hasn't been registered yet.
@@ -158,3 +160,4 @@ typename GRAPH_T::global_pose_t CNodeRegistrationDecider<GRAPH_T>::getCurrentRob
   pose_out += m_since_prev_node_PDF.getMeanVal();
   return pose_out;
 }
+}  // namespace mrpt::graphslam::deciders

--- a/modules/mrpt_graphslam/include/mrpt/graphslam/misc/TUncertaintyPath.h
+++ b/modules/mrpt_graphslam/include/mrpt/graphslam/misc/TUncertaintyPath.h
@@ -68,7 +68,7 @@ struct TUncertaintyPath : public mrpt::config::CLoadableOptions
   const mrpt::graphs::TNodeID& getSource() const;
   /**\brief Return the Destination node of this path */
   const mrpt::graphs::TNodeID& getDestination() const;
-  double getDeterminant();
+  double getDeterminant() const;
   /**\brief Test if the current path has a lower uncertainty than the other
    * path.
    *
@@ -101,10 +101,12 @@ struct TUncertaintyPath : public mrpt::config::CLoadableOptions
   constraint_t curr_pose_pdf;
 
   /**Determine whether the determinant of the Path is up-to-date and
-   * can be directly fetched or has to be computed again */
+   * can be directly fetched or has to be computed again.
+   * Mutable so that the cache can be filled in from const methods such as
+   * hasLowerUncertaintyThan(). */
   /**\{*/
-  bool determinant_is_updated;
-  double determinant_cached;
+  mutable bool determinant_is_updated;
+  mutable double determinant_cached;
   /**\}*/
 };
 }  // namespace mrpt::graphslam

--- a/modules/mrpt_graphslam/include/mrpt/graphslam/misc/TUncertaintyPath_impl.h
+++ b/modules/mrpt_graphslam/include/mrpt/graphslam/misc/TUncertaintyPath_impl.h
@@ -222,7 +222,7 @@ const mrpt::graphs::TNodeID& TUncertaintyPath<GRAPH_T>::getDestination() const
 }
 
 template <class GRAPH_T>
-double TUncertaintyPath<GRAPH_T>::getDeterminant()
+double TUncertaintyPath<GRAPH_T>::getDeterminant() const
 {
   using namespace mrpt;
   using namespace mrpt::math;

--- a/modules/mrpt_graphslam/src/CWindowObserver.cpp
+++ b/modules/mrpt_graphslam/src/CWindowObserver.cpp
@@ -88,8 +88,8 @@ void CWindowObserver::OnEvent(const mrpt::system::mrptEvent& e)
         break;
       case 'c':
       case 'C':
-        // case 3: // <C-c>
-        if (ev.key_modifiers == 8192)
+        // Accept any modifier combination including Control, e.g. Ctrl+Shift+C:
+        if ((ev.key_modifiers & mrpt::gui::MRPTKMOD_CONTROL) != 0)
         {
           std::cout << "Pressed C-c inside CDisplayWindow3D"
                     << "\n";

--- a/modules/mrpt_graphslam/tests/CEdgeCounter_unittest.cpp
+++ b/modules/mrpt_graphslam/tests/CEdgeCounter_unittest.cpp
@@ -48,6 +48,17 @@ TEST(CEdgeCounter, registering_and_counting_edge_types)
   EXPECT_ANY_THROW(c.getNumForEdgeType("nope"));
 }
 
+TEST(CEdgeCounter, querying_an_unknown_type_through_the_output_parameter_throws)
+{
+  CEdgeCounter c;
+  c.addEdgeType("odometry");
+
+  int n = -1;
+  EXPECT_NO_THROW(c.getNumForEdgeType("odometry", &n));
+  EXPECT_EQ(n, 0);
+  EXPECT_ANY_THROW(c.getNumForEdgeType("nope", &n));
+}
+
 TEST(CEdgeCounter, adding_edges_of_a_known_type)
 {
   CEdgeCounter c;

--- a/modules/mrpt_graphslam/tests/CFixedIntervalsNRD_unittest.cpp
+++ b/modules/mrpt_graphslam/tests/CFixedIntervalsNRD_unittest.cpp
@@ -1,0 +1,251 @@
+/*                    _
+                     | |    Mobile Robot Programming Toolkit (MRPT)
+ _ __ ___  _ __ _ __ | |_
+| '_ ` _ \| '__| '_ \| __|          https://www.mrpt.org/
+| | | | | | |  | |_) | |_
+|_| |_| |_|_|  | .__/ \__|     https://github.com/MRPT/mrpt/
+               | |
+               |_|
+
+ Copyright (c) 2005-2026, Individual contributors, see AUTHORS file
+ See: https://www.mrpt.org/Authors - All rights reserved.
+ SPDX-License-Identifier: BSD-3-Clause
+*/
+
+/** Unit tests for the odometry-only node registration decider
+ *  CFixedIntervalsNRD, together with the CNodeRegistrationDecider /
+ *  CRegistrationDeciderOrOptimizer interfaces it builds upon. Both supported
+ *  rawlog formats (observation-only and action-observation) are simulated
+ *  in-memory, so no dataset file nor GUI is involved.
+ */
+
+#include <gtest/gtest.h>
+#include <mrpt/config/CConfigFileMemory.h>
+#include <mrpt/graphs/CNetworkOfPoses.h>
+#include <mrpt/graphslam/NRD/CFixedIntervalsNRD.h>
+#include <mrpt/obs/CActionRobotMovement2D.h>
+#include <mrpt/obs/CObservationComment.h>
+#include <mrpt/obs/CObservationOdometry.h>
+
+#include <sstream>
+#include <string>
+
+using graph_t = mrpt::graphs::CNetworkOfPoses2DInf;
+using decider_t = mrpt::graphslam::deciders::CFixedIntervalsNRD<graph_t>;
+
+namespace
+{
+/** Exposes the protected registration-condition helpers */
+class TestNRD : public decider_t
+{
+ public:
+  using decider_t::checkRegistrationCondition;
+};
+
+mrpt::obs::CObservation::Ptr makeOdometryObs(double x, double y, double phi)
+{
+  auto o = mrpt::obs::CObservationOdometry::Create();
+  o->odometry = mrpt::poses::CPose2D(x, y, phi);
+  o->timestamp = mrpt::Clock::now();
+  return o;
+}
+
+mrpt::obs::CActionCollection::Ptr makeOdometryAction(const mrpt::poses::CPose2D& increment)
+{
+  mrpt::obs::CActionRobotMovement2D act;
+  mrpt::obs::CActionRobotMovement2D::TMotionModelOptions opts;
+  opts.modelSelection = mrpt::obs::CActionRobotMovement2D::mmGaussian;
+  opts.gaussianModel.minStdXY = 0.02;
+  opts.gaussianModel.minStdPHI = mrpt::DEG2RAD(0.5);
+  act.computeFromOdometry(increment, opts);
+
+  auto acts = mrpt::obs::CActionCollection::Create();
+  acts->insert(act);
+  return acts;
+}
+}  // namespace
+
+TEST(CFixedIntervalsNRD, params_default_to_the_documented_values)
+{
+  // The defaults must hold on a freshly constructed decider, i.e. without
+  // any call to loadParams():
+  const decider_t d;
+  EXPECT_DOUBLE_EQ(d.params.registration_max_distance, 0.5);
+  EXPECT_DOUBLE_EQ(d.params.registration_max_angle, mrpt::DEG2RAD(60.0));
+}
+
+TEST(CFixedIntervalsNRD, params_load_from_config_and_convert_the_angle_to_radians)
+{
+  mrpt::config::CConfigFileMemory cfg;
+  cfg.write("NodeRegistrationDeciderParameters", "registration_max_distance", 1.25);
+  cfg.write("NodeRegistrationDeciderParameters", "registration_max_angle", 30.0);
+
+  decider_t d;
+  d.params.loadFromConfigFile(cfg, "NodeRegistrationDeciderParameters");
+
+  EXPECT_DOUBLE_EQ(d.params.registration_max_distance, 1.25);
+  EXPECT_DOUBLE_EQ(d.params.registration_max_angle, mrpt::DEG2RAD(30.0));
+
+  // The textual representation must report both, the angle back in degrees:
+  const std::string s = d.params.getAsString();
+  EXPECT_NE(s.find("Max distance for registration = 1.25 m"), std::string::npos) << s;
+  EXPECT_NE(s.find("Max angle for registration    = 30.00 deg"), std::string::npos) << s;
+
+  std::stringstream ss;
+  d.params.dumpToTextStream(ss);
+  EXPECT_EQ(ss.str(), s);
+}
+
+TEST(CFixedIntervalsNRD, registration_condition_2D)
+{
+  TestNRD d;
+  d.params.registration_max_distance = 0.5;
+  d.params.registration_max_angle = mrpt::DEG2RAD(60.0);
+
+  const mrpt::poses::CPose2D origin(0, 0, 0);
+
+  EXPECT_FALSE(d.checkRegistrationCondition(origin, mrpt::poses::CPose2D(0.4, 0, 0)));
+  EXPECT_TRUE(d.checkRegistrationCondition(origin, mrpt::poses::CPose2D(0.6, 0, 0)));
+
+  // Angle alone is enough, and it must be compared through wrapToPi():
+  EXPECT_FALSE(
+      d.checkRegistrationCondition(origin, mrpt::poses::CPose2D(0, 0, mrpt::DEG2RAD(50.0))));
+  EXPECT_TRUE(
+      d.checkRegistrationCondition(origin, mrpt::poses::CPose2D(0, 0, mrpt::DEG2RAD(70.0))));
+  // +190 deg wraps to -170 deg, i.e. still beyond the 60 deg threshold:
+  EXPECT_TRUE(
+      d.checkRegistrationCondition(origin, mrpt::poses::CPose2D(0, 0, mrpt::DEG2RAD(190.0))));
+  // ...while +350 deg wraps to -10 deg, which is below it:
+  EXPECT_FALSE(
+      d.checkRegistrationCondition(origin, mrpt::poses::CPose2D(0, 0, mrpt::DEG2RAD(350.0))));
+}
+
+TEST(CFixedIntervalsNRD, registration_condition_3D)
+{
+  TestNRD d;
+  d.params.registration_max_distance = 0.5;
+  d.params.registration_max_angle = mrpt::DEG2RAD(60.0);
+
+  const mrpt::poses::CPose3D origin;
+
+  EXPECT_FALSE(d.checkRegistrationCondition(origin, mrpt::poses::CPose3D(0.4, 0, 0, 0, 0, 0)));
+  EXPECT_TRUE(d.checkRegistrationCondition(origin, mrpt::poses::CPose3D(0, 0, 0.6, 0, 0, 0)));
+
+  // Each of yaw/pitch/roll on its own must trigger it:
+  const double a = mrpt::DEG2RAD(70.0);
+  EXPECT_TRUE(d.checkRegistrationCondition(origin, mrpt::poses::CPose3D(0, 0, 0, a, 0, 0)));
+  EXPECT_TRUE(d.checkRegistrationCondition(origin, mrpt::poses::CPose3D(0, 0, 0, 0, a, 0)));
+  EXPECT_TRUE(d.checkRegistrationCondition(origin, mrpt::poses::CPose3D(0, 0, 0, 0, 0, a)));
+  EXPECT_FALSE(d.checkRegistrationCondition(
+      origin, mrpt::poses::CPose3D(0, 0, 0, mrpt::DEG2RAD(10.0), 0, 0)));
+}
+
+TEST(CFixedIntervalsNRD, observation_only_format_registers_nodes_by_odometry)
+{
+  graph_t graph;
+  decider_t d;
+  d.setMinLoggingLevel(mrpt::system::LVL_ERROR);
+  d.setGraphPtr(&graph);
+  d.params.registration_max_distance = 1.0;
+  d.params.registration_max_angle = mrpt::DEG2RAD(60.0);
+
+  // Below the threshold: nothing is registered yet.
+  EXPECT_FALSE(d.updateState(nullptr, nullptr, makeOdometryObs(0.5, 0, 0)));
+  EXPECT_EQ(graph.nodeCount(), 0U);
+
+  // Beyond it: both the root node and the new one appear.
+  EXPECT_TRUE(d.updateState(nullptr, nullptr, makeOdometryObs(1.5, 0, 0)));
+  EXPECT_EQ(graph.nodeCount(), 2U);
+  EXPECT_EQ(graph.edgeCount(), 1U);
+  // The root node is the origin of the graph frame:
+  EXPECT_NEAR(graph.nodes.at(0).x(), 0.0, 1e-6);
+  EXPECT_NEAR(graph.nodes.at(1).x(), 1.5, 1e-6);
+
+  // The next node is measured from the last registered one, so another
+  // 0.5 m is again not enough:
+  EXPECT_FALSE(d.updateState(nullptr, nullptr, makeOdometryObs(2.0, 0, 0)));
+  EXPECT_EQ(graph.nodeCount(), 2U);
+
+  EXPECT_TRUE(d.updateState(nullptr, nullptr, makeOdometryObs(3.0, 0, 0)));
+  EXPECT_EQ(graph.nodeCount(), 3U);
+  EXPECT_EQ(graph.edgeCount(), 2U);
+
+  EXPECT_NEAR(graph.nodes.at(2).x(), 3.0, 1e-6);
+}
+
+TEST(CFixedIntervalsNRD, observation_only_format_ignores_other_observation_types)
+{
+  graph_t graph;
+  decider_t d;
+  d.setMinLoggingLevel(mrpt::system::LVL_ERROR);
+  d.setGraphPtr(&graph);
+
+  auto obs = mrpt::obs::CObservationOdometry::Create();
+  obs->odometry = mrpt::poses::CPose2D(10, 10, 0);
+  obs->timestamp = mrpt::Clock::now();
+
+  // A non-odometry observation must leave the estimate untouched:
+  auto other = mrpt::obs::CObservationComment::Create();
+  other->timestamp = mrpt::Clock::now();
+  EXPECT_FALSE(d.updateState(nullptr, nullptr, other));
+  EXPECT_EQ(graph.nodeCount(), 0U);
+}
+
+TEST(CFixedIntervalsNRD, action_observation_format_accumulates_increments)
+{
+  graph_t graph;
+  decider_t d;
+  d.setMinLoggingLevel(mrpt::system::LVL_ERROR);
+  d.setGraphPtr(&graph);
+  d.params.registration_max_distance = 1.0;
+  d.params.registration_max_angle = mrpt::DEG2RAD(60.0);
+
+  auto sf = mrpt::obs::CSensoryFrame::Create();
+
+  // Two 0.6 m increments: the first is below the threshold, the second one
+  // accumulates past it.
+  EXPECT_FALSE(d.updateState(makeOdometryAction(mrpt::poses::CPose2D(0.6, 0, 0)), sf, nullptr));
+  EXPECT_EQ(graph.nodeCount(), 0U);
+
+  EXPECT_TRUE(d.updateState(makeOdometryAction(mrpt::poses::CPose2D(0.6, 0, 0)), sf, nullptr));
+  EXPECT_EQ(graph.nodeCount(), 2U);
+  EXPECT_NEAR(graph.nodes.at(0).x(), 0.0, 1e-6);
+  EXPECT_NEAR(graph.nodes.at(1).x(), 1.2, 1e-6);
+
+  // After a registration the accumulated PDF is reset:
+  EXPECT_FALSE(d.updateState(makeOdometryAction(mrpt::poses::CPose2D(0.3, 0, 0)), sf, nullptr));
+  EXPECT_EQ(graph.nodeCount(), 2U);
+}
+
+TEST(CFixedIntervalsNRD, action_without_a_movement_estimation_is_a_no_op)
+{
+  graph_t graph;
+  decider_t d;
+  d.setMinLoggingLevel(mrpt::system::LVL_ERROR);
+  d.setGraphPtr(&graph);
+
+  auto empty_action = mrpt::obs::CActionCollection::Create();
+  EXPECT_FALSE(d.updateState(empty_action, mrpt::obs::CSensoryFrame::Create(), nullptr));
+  EXPECT_EQ(graph.nodeCount(), 0U);
+}
+
+TEST(CFixedIntervalsNRD, descriptive_report_mentions_the_strategy_and_the_params)
+{
+  decider_t d;
+  d.setMinLoggingLevel(mrpt::system::LVL_ERROR);
+
+  std::string report = "stale contents";
+  d.getDescriptiveReport(&report);
+
+  EXPECT_NE(report.find("Fixed Odometry-based Intervals"), std::string::npos);
+  EXPECT_NE(report.find("Node Registration Decider Strategy"), std::string::npos);
+  EXPECT_NE(report.find("Max distance for registration"), std::string::npos);
+  EXPECT_EQ(report.find("stale contents"), std::string::npos);
+}
+
+TEST(CFixedIntervalsNRD, class_name_and_multi_robot_flag)
+{
+  decider_t d;
+  EXPECT_EQ(d.getClassName(), "CFixedIntervalsNRD");
+  EXPECT_FALSE(d.isMultiRobotSlamClass());
+}

--- a/modules/mrpt_graphslam/tests/CIncrementalNodeRegistrationDecider_unittest.cpp
+++ b/modules/mrpt_graphslam/tests/CIncrementalNodeRegistrationDecider_unittest.cpp
@@ -1,0 +1,132 @@
+/*                    _
+                     | |    Mobile Robot Programming Toolkit (MRPT)
+ _ __ ___  _ __ _ __ | |_
+| '_ ` _ \| '__| '_ \| __|          https://www.mrpt.org/
+| | | | | | |  | |_) | |_
+|_| |_| |_|_|  | .__/ \__|     https://github.com/MRPT/mrpt/
+               | |
+               |_|
+
+ Copyright (c) 2005-2026, Individual contributors, see AUTHORS file
+ See: https://www.mrpt.org/Authors - All rights reserved.
+ SPDX-License-Identifier: BSD-3-Clause
+*/
+
+/** Unit tests for the CIncrementalNodeRegistrationDecider interface. The class
+ *  has no concrete implementation in the library, so a minimal one is defined
+ *  here; instantiating it is also what keeps the template compiling.
+ */
+
+#include <gtest/gtest.h>
+#include <mrpt/config/CConfigFileMemory.h>
+#include <mrpt/graphs/CNetworkOfPoses.h>
+#include <mrpt/graphslam/interfaces/CIncrementalNodeRegistrationDecider.h>
+
+#include <sstream>
+#include <string>
+
+using graph_t = mrpt::graphs::CNetworkOfPoses2DInf;
+
+namespace
+{
+/** Minimal concrete decider: each updateState() call adds a fixed increment to
+ *  the pose accumulated since the last registered node.
+ */
+class StepNRD : public mrpt::graphslam::deciders::CIncrementalNodeRegistrationDecider<graph_t>
+{
+ public:
+  using base_t = mrpt::graphslam::deciders::CIncrementalNodeRegistrationDecider<graph_t>;
+  using base_t::params;
+
+  explicit StepNRD(const mrpt::poses::CPose2D& step) : m_step(step)
+  {
+    this->initializeLoggers("StepNRD");
+    this->setMinLoggingLevel(mrpt::system::LVL_ERROR);
+  }
+
+  bool updateState(
+      [[maybe_unused]] mrpt::obs::CActionCollection::Ptr action,
+      [[maybe_unused]] mrpt::obs::CSensoryFrame::Ptr observations,
+      [[maybe_unused]] mrpt::obs::CObservation::Ptr observation) override
+  {
+    this->m_since_prev_node_PDF.mean = this->m_since_prev_node_PDF.mean + m_step;
+    return this->checkRegistrationCondition();
+  }
+
+ private:
+  mrpt::poses::CPose2D m_step;
+};
+}  // namespace
+
+TEST(CIncrementalNodeRegistrationDecider, params_default_to_the_documented_values)
+{
+  const StepNRD d(mrpt::poses::CPose2D(0, 0, 0));
+  EXPECT_DOUBLE_EQ(d.params.registration_max_distance, 0.5);
+  EXPECT_DOUBLE_EQ(d.params.registration_max_angle, mrpt::DEG2RAD(15.0));
+}
+
+TEST(CIncrementalNodeRegistrationDecider, params_load_from_config_file)
+{
+  mrpt::config::CConfigFileMemory cfg;
+  cfg.write("NodeRegistrationDeciderParameters", "registration_max_distance", 2.0);
+  cfg.write("NodeRegistrationDeciderParameters", "registration_max_angle", 45.0);
+
+  StepNRD d(mrpt::poses::CPose2D(0, 0, 0));
+  d.params.loadFromConfigFile(cfg, "NodeRegistrationDeciderParameters");
+
+  EXPECT_DOUBLE_EQ(d.params.registration_max_distance, 2.0);
+  EXPECT_DOUBLE_EQ(d.params.registration_max_angle, mrpt::DEG2RAD(45.0));
+
+  std::stringstream ss;
+  d.params.dumpToTextStream(ss);
+  EXPECT_EQ(ss.str(), d.params.getAsString());
+  EXPECT_FALSE(ss.str().empty());
+}
+
+TEST(CIncrementalNodeRegistrationDecider, registers_a_node_once_the_threshold_is_crossed)
+{
+  graph_t graph;
+  StepNRD d(mrpt::poses::CPose2D(0.4, 0, 0));
+  d.setGraphPtr(&graph);
+  d.params.registration_max_distance = 1.0;
+  d.params.registration_max_angle = mrpt::DEG2RAD(60.0);
+
+  EXPECT_FALSE(d.updateState(nullptr, nullptr, nullptr));  // 0.4 m
+  EXPECT_FALSE(d.updateState(nullptr, nullptr, nullptr));  // 0.8 m
+  EXPECT_EQ(graph.nodeCount(), 0U);
+
+  EXPECT_TRUE(d.updateState(nullptr, nullptr, nullptr));  // 1.2 m
+  EXPECT_EQ(graph.nodeCount(), 2U);
+  EXPECT_EQ(graph.edgeCount(), 1U);
+  EXPECT_NEAR(graph.nodes.at(0).x(), 0.0, 1e-6);
+  EXPECT_NEAR(graph.nodes.at(1).x(), 1.2, 1e-6);
+}
+
+TEST(CIncrementalNodeRegistrationDecider, registration_condition_on_2D_and_3D_poses)
+{
+  StepNRD d(mrpt::poses::CPose2D(0, 0, 0));
+  d.params.registration_max_distance = 0.5;
+  d.params.registration_max_angle = mrpt::DEG2RAD(20.0);
+
+  const mrpt::poses::CPose2D o2;
+  EXPECT_FALSE(d.checkRegistrationConditionPose(o2, mrpt::poses::CPose2D(0.4, 0, 0)));
+  EXPECT_TRUE(d.checkRegistrationConditionPose(o2, mrpt::poses::CPose2D(0.6, 0, 0)));
+  EXPECT_TRUE(
+      d.checkRegistrationConditionPose(o2, mrpt::poses::CPose2D(0, 0, mrpt::DEG2RAD(30.0))));
+
+  const mrpt::poses::CPose3D o3;
+  EXPECT_FALSE(d.checkRegistrationConditionPose(o3, mrpt::poses::CPose3D(0.4, 0, 0, 0, 0, 0)));
+  EXPECT_TRUE(d.checkRegistrationConditionPose(o3, mrpt::poses::CPose3D(0, 0, 0.6, 0, 0, 0)));
+  EXPECT_TRUE(d.checkRegistrationConditionPose(
+      o3, mrpt::poses::CPose3D(0, 0, 0, 0, mrpt::DEG2RAD(30.0), 0)));
+}
+
+TEST(CIncrementalNodeRegistrationDecider, descriptive_report_includes_the_params)
+{
+  StepNRD d(mrpt::poses::CPose2D(0, 0, 0));
+
+  std::string report;
+  d.getDescriptiveReport(&report);
+  EXPECT_NE(report.find("Node Registration Decider Strategy"), std::string::npos) << report;
+  EXPECT_NE(report.find("Max distance for registration"), std::string::npos) << report;
+}

--- a/modules/mrpt_graphslam/tests/CWindowObserver_unittest.cpp
+++ b/modules/mrpt_graphslam/tests/CWindowObserver_unittest.cpp
@@ -1,0 +1,197 @@
+/*                    _
+                     | |    Mobile Robot Programming Toolkit (MRPT)
+ _ __ ___  _ __ _ __ | |_
+| '_ ` _ \| '__| '_ \| __|          https://www.mrpt.org/
+| | | | | | |  | |_) | |_
+|_| |_| |_|_|  | .__/ \__|     https://github.com/MRPT/mrpt/
+               | |
+               |_|
+
+ Copyright (c) 2005-2026, Individual contributors, see AUTHORS file
+ See: https://www.mrpt.org/Authors - All rights reserved.
+ SPDX-License-Identifier: BSD-3-Clause
+*/
+
+/** Unit tests for CWindowObserver. No GUI is needed: the window events are
+ *  plain value types, so a minimal CObservable stand-in can publish them
+ *  directly to the observer.
+ */
+
+#include <gtest/gtest.h>
+#include <mrpt/graphslam/misc/CWindowObserver.h>
+#include <mrpt/gui/CBaseGUIWindow.h>
+
+#include <map>
+#include <string>
+
+using mrpt::graphslam::CWindowObserver;
+
+namespace
+{
+/** Minimal event source: exposes publishEvent() so tests can inject any
+ *  mrptEvent without creating a real window.
+ */
+class EventSource : public mrpt::system::CObservable
+{
+ public:
+  void emit(const mrpt::system::mrptEvent& e) { this->publishEvent(e); }
+};
+
+/** Convenience: subscribe, publish one event, and return the resulting flags */
+std::map<std::string, bool> emitAndRead(CWindowObserver& obs, const mrpt::system::mrptEvent& e)
+{
+  EventSource src;
+  obs.observeBegin(src);
+  src.emit(e);
+  obs.observeEnd(src);
+
+  std::map<std::string, bool> flags;
+  obs.returnEventsStruct(&flags);
+  return flags;
+}
+}  // namespace
+
+TEST(CWindowObserver, default_keystrokes_are_registered_and_unpressed)
+{
+  CWindowObserver obs;
+
+  std::map<std::string, bool> flags;
+  obs.returnEventsStruct(&flags);
+
+  EXPECT_EQ(flags.size(), 4U);
+  for (const auto& [key, pressed] : flags)
+  {
+    EXPECT_FALSE(pressed) << "key: " << key;
+  }
+  EXPECT_EQ(flags.count("h"), 1U);
+  EXPECT_EQ(flags.count("Alt+Enter"), 1U);
+  EXPECT_EQ(flags.count("Ctrl+c"), 1U);
+  EXPECT_EQ(flags.count("mouse_clicked"), 1U);
+}
+
+TEST(CWindowObserver, registerKeystroke_adds_a_new_flag)
+{
+  CWindowObserver obs;
+  obs.registerKeystroke("s", "Save the current graph");
+
+  std::map<std::string, bool> flags;
+  obs.returnEventsStruct(&flags);
+
+  ASSERT_EQ(flags.count("s"), 1U);
+  EXPECT_FALSE(flags.at("s"));
+  EXPECT_EQ(flags.size(), 5U);
+}
+
+TEST(CWindowObserver, char_event_lower_and_upper_case_h)
+{
+  for (const int code : {'h', 'H'})
+  {
+    CWindowObserver obs;
+    const mrpt::gui::mrptEventWindowChar ev(nullptr, code, mrpt::gui::MRPTKMOD_NONE);
+    const auto flags = emitAndRead(obs, ev);
+    EXPECT_TRUE(flags.at("h")) << "char code: " << code;
+    EXPECT_FALSE(flags.at("Ctrl+c"));
+  }
+}
+
+TEST(CWindowObserver, char_event_ctrl_c_needs_the_control_modifier)
+{
+  // Plain 'c' must not raise the Ctrl+c flag:
+  {
+    CWindowObserver obs;
+    const mrpt::gui::mrptEventWindowChar ev(nullptr, 'c', mrpt::gui::MRPTKMOD_NONE);
+    const auto flags = emitAndRead(obs, ev);
+    EXPECT_FALSE(flags.at("Ctrl+c"));
+    // ...and it must not fall through to the "any other key" branch either:
+    EXPECT_EQ(flags.count("c"), 0U);
+  }
+  // With the control modifier it must, alone or combined with others:
+  const mrpt::gui::mrptKeyModifier mods[] = {
+      mrpt::gui::MRPTKMOD_CONTROL, static_cast<mrpt::gui::mrptKeyModifier>(
+                                       mrpt::gui::MRPTKMOD_CONTROL | mrpt::gui::MRPTKMOD_SHIFT)};
+  for (const int code : {'c', 'C'})
+  {
+    for (const auto mod : mods)
+    {
+      CWindowObserver obs;
+      const mrpt::gui::mrptEventWindowChar ev(nullptr, code, mod);
+      const auto flags = emitAndRead(obs, ev);
+      EXPECT_TRUE(flags.at("Ctrl+c")) << "char code: " << code << " modifiers: " << mod;
+    }
+  }
+}
+
+TEST(CWindowObserver, char_event_other_keys_are_stored_in_lower_case)
+{
+  CWindowObserver obs;
+  const mrpt::gui::mrptEventWindowChar ev(nullptr, 'S', mrpt::gui::MRPTKMOD_NONE);
+  const auto flags = emitAndRead(obs, ev);
+
+  ASSERT_EQ(flags.count("s"), 1U);
+  EXPECT_TRUE(flags.at("s"));
+  EXPECT_EQ(flags.count("S"), 0U);
+}
+
+TEST(CWindowObserver, mouse_down_event_raises_the_mouse_clicked_flag)
+{
+  CWindowObserver obs;
+  const mrpt::gui::mrptEventMouseDown ev(nullptr, mrpt::img::TPixelCoord(10, 20), true, false);
+  const auto flags = emitAndRead(obs, ev);
+  EXPECT_TRUE(flags.at("mouse_clicked"));
+}
+
+TEST(CWindowObserver, events_without_an_associated_flag_change_nothing)
+{
+  CWindowObserver obs;
+  EventSource src;
+  obs.observeBegin(src);
+
+  src.emit(mrpt::gui::mrptEventWindowResize(nullptr, 640, 480));
+  src.emit(mrpt::gui::mrptEventWindowClosed(nullptr, true));
+  src.emit(mrpt::gui::mrptEventMouseMove(nullptr, mrpt::img::TPixelCoord(1, 2), false, false));
+
+  std::map<std::string, bool> flags;
+  obs.returnEventsStruct(&flags);
+  for (const auto& [key, pressed] : flags)
+  {
+    EXPECT_FALSE(pressed) << "key: " << key;
+  }
+
+  obs.observeEnd(src);
+}
+
+TEST(CWindowObserver, returnEventsStruct_resets_flags_unless_asked_not_to)
+{
+  CWindowObserver obs;
+  EventSource src;
+  obs.observeBegin(src);
+  src.emit(mrpt::gui::mrptEventWindowChar(nullptr, 'h', mrpt::gui::MRPTKMOD_NONE));
+
+  std::map<std::string, bool> flags;
+
+  // Peek without resetting: the flag stays raised for the next query.
+  obs.returnEventsStruct(&flags, false /*reset_keypresses*/);
+  EXPECT_TRUE(flags.at("h"));
+
+  obs.returnEventsStruct(&flags);
+  EXPECT_TRUE(flags.at("h"));
+
+  // Now it has been consumed:
+  obs.returnEventsStruct(&flags);
+  EXPECT_FALSE(flags.at("h"));
+
+  obs.observeEnd(src);
+}
+
+TEST(CWindowObserver, observer_survives_the_destruction_of_the_observed_object)
+{
+  CWindowObserver obs;
+  {
+    EventSource src;
+    obs.observeBegin(src);
+    src.emit(mrpt::gui::mrptEventWindowChar(nullptr, 'h', mrpt::gui::MRPTKMOD_NONE));
+  }
+  std::map<std::string, bool> flags;
+  obs.returnEventsStruct(&flags);
+  EXPECT_TRUE(flags.at("h"));
+}

--- a/modules/mrpt_graphslam/tests/TUncertaintyPath_unittest.cpp
+++ b/modules/mrpt_graphslam/tests/TUncertaintyPath_unittest.cpp
@@ -1,0 +1,193 @@
+/*                    _
+                     | |    Mobile Robot Programming Toolkit (MRPT)
+ _ __ ___  _ __ _ __ | |_
+| '_ ` _ \| '__| '_ \| __|          https://www.mrpt.org/
+| | | | | | |  | |_) | |_
+|_| |_| |_|_|  | .__/ \__|     https://github.com/MRPT/mrpt/
+               | |
+               |_|
+
+ Copyright (c) 2005-2026, Individual contributors, see AUTHORS file
+ See: https://www.mrpt.org/Authors - All rights reserved.
+ SPDX-License-Identifier: BSD-3-Clause
+*/
+
+/** Unit tests for TUncertaintyPath, the node+constraint chain used by
+ *  CLoopCloserERD to compare candidate loop closures by their uncertainty.
+ */
+
+#include <gtest/gtest.h>
+#include <mrpt/graphs/CNetworkOfPoses.h>
+#include <mrpt/graphslam/misc/TUncertaintyPath.h>
+
+#include <sstream>
+#include <string>
+
+using mrpt::graphs::TNodeID;
+using path_t = mrpt::graphslam::TUncertaintyPath<mrpt::graphs::CNetworkOfPoses2DInf>;
+using constraint_t = path_t::constraint_t;
+
+namespace
+{
+/** A relative pose with the given (isotropic) information matrix */
+constraint_t makeEdge(double x, double y, double phi, double information)
+{
+  constraint_t c;
+  c.mean = mrpt::poses::CPose2D(x, y, phi);
+  c.cov_inv = mrpt::math::CMatrixDouble33::Identity() * information;
+  return c;
+}
+}  // namespace
+
+TEST(TUncertaintyPath, default_constructed_is_empty)
+{
+  const path_t p;
+  EXPECT_TRUE(p.isEmpty());
+  EXPECT_TRUE(p.nodes_traversed.empty());
+  EXPECT_EQ(p.curr_pose_pdf.mean, mrpt::poses::CPose2D(0, 0, 0));
+  // clear() seeds a very high information (i.e. a very certain origin):
+  EXPECT_DOUBLE_EQ(p.curr_pose_pdf.cov_inv(0, 0), 10000.0);
+  EXPECT_DOUBLE_EQ(p.curr_pose_pdf.cov_inv(0, 1), 0.0);
+}
+
+TEST(TUncertaintyPath, single_node_constructor)
+{
+  const path_t p(TNodeID(7));
+  EXPECT_FALSE(p.isEmpty());
+  ASSERT_EQ(p.nodes_traversed.size(), 1U);
+  EXPECT_EQ(p.getSource(), TNodeID(7));
+  EXPECT_EQ(p.getDestination(), TNodeID(7));
+}
+
+TEST(TUncertaintyPath, two_node_constructor_applies_the_edge)
+{
+  const auto edge = makeEdge(1.0, 2.0, 0.0, 5.0);
+  const path_t p(TNodeID(3), TNodeID(4), edge);
+
+  ASSERT_EQ(p.nodes_traversed.size(), 2U);
+  EXPECT_EQ(p.getSource(), TNodeID(3));
+  EXPECT_EQ(p.getDestination(), TNodeID(4));
+  EXPECT_NEAR(p.curr_pose_pdf.mean.x(), 1.0, 1e-9);
+  EXPECT_NEAR(p.curr_pose_pdf.mean.y(), 2.0, 1e-9);
+}
+
+TEST(TUncertaintyPath, addToPath_chains_relative_poses)
+{
+  path_t p(TNodeID(0));
+  p.addToPath(TNodeID(1), makeEdge(1.0, 0.0, 0.0, 100.0));
+  p.addToPath(TNodeID(2), makeEdge(1.0, 0.0, 0.0, 100.0));
+
+  ASSERT_EQ(p.nodes_traversed.size(), 3U);
+  EXPECT_EQ(p.getDestination(), TNodeID(2));
+  EXPECT_NEAR(p.curr_pose_pdf.mean.x(), 2.0, 1e-9);
+  EXPECT_NEAR(p.curr_pose_pdf.mean.y(), 0.0, 1e-9);
+}
+
+TEST(TUncertaintyPath, concatenating_two_paths)
+{
+  path_t a(TNodeID(0));
+  a.addToPath(TNodeID(1), makeEdge(1.0, 0.0, 0.0, 100.0));
+
+  path_t b(TNodeID(1));
+  b.addToPath(TNodeID(2), makeEdge(0.0, 1.0, 0.0, 100.0));
+
+  a += b;
+
+  ASSERT_EQ(a.nodes_traversed.size(), 3U);
+  EXPECT_EQ(a.getSource(), TNodeID(0));
+  EXPECT_EQ(a.getDestination(), TNodeID(2));
+  // The shared node must not be duplicated:
+  EXPECT_EQ(a.nodes_traversed[1], TNodeID(1));
+}
+
+TEST(TUncertaintyPath, equality_compares_nodes_and_pdf)
+{
+  path_t a(TNodeID(0));
+  a.addToPath(TNodeID(1), makeEdge(1.0, 0.0, 0.0, 100.0));
+
+  path_t b(TNodeID(0));
+  b.addToPath(TNodeID(1), makeEdge(1.0, 0.0, 0.0, 100.0));
+  EXPECT_TRUE(a == b);
+  EXPECT_FALSE(a != b);
+
+  // Same nodes, different constraint:
+  path_t c(TNodeID(0));
+  c.addToPath(TNodeID(1), makeEdge(2.0, 0.0, 0.0, 100.0));
+  EXPECT_TRUE(a != c);
+
+  // Same constraint, different nodes:
+  path_t d(TNodeID(0));
+  d.addToPath(TNodeID(9), makeEdge(1.0, 0.0, 0.0, 100.0));
+  EXPECT_TRUE(a != d);
+}
+
+TEST(TUncertaintyPath, assertIsBetweenNodeIDs_accepts_the_actual_ends)
+{
+  path_t p(TNodeID(4));
+  p.addToPath(TNodeID(5), makeEdge(1.0, 0.0, 0.0, 100.0));
+  EXPECT_NO_THROW(p.assertIsBetweenNodeIDs(TNodeID(4), TNodeID(5)));
+}
+
+TEST(TUncertaintyPath, getDeterminant_is_cached_and_invalidated_by_addToPath)
+{
+  path_t p(TNodeID(0));
+  const double d0 = p.getDeterminant();
+  EXPECT_TRUE(p.determinant_is_updated);
+  // A second query must return the cached value untouched:
+  EXPECT_DOUBLE_EQ(p.getDeterminant(), d0);
+
+  p.addToPath(TNodeID(1), makeEdge(1.0, 0.0, 0.0, 10.0));
+  EXPECT_FALSE(p.determinant_is_updated);
+  const double d1 = p.getDeterminant();
+  EXPECT_TRUE(p.determinant_is_updated);
+  // Adding an edge can only lose information:
+  EXPECT_LT(d1, d0);
+}
+
+TEST(TUncertaintyPath, hasLowerUncertaintyThan_in_information_form)
+{
+  // In information form the *larger* determinant is the more certain one.
+  path_t certain(TNodeID(0));
+  certain.addToPath(TNodeID(1), makeEdge(1.0, 0.0, 0.0, 1000.0));
+
+  path_t uncertain(TNodeID(0));
+  uncertain.addToPath(TNodeID(1), makeEdge(1.0, 0.0, 0.0, 1.0));
+
+  ASSERT_TRUE(certain.curr_pose_pdf.isInfType());
+  EXPECT_GT(certain.getDeterminant(), uncertain.getDeterminant());
+  EXPECT_TRUE(certain.hasLowerUncertaintyThan(uncertain));
+  EXPECT_FALSE(uncertain.hasLowerUncertaintyThan(certain));
+}
+
+TEST(TUncertaintyPath, string_representation_lists_the_traversed_nodes)
+{
+  path_t p(TNodeID(11));
+  p.addToPath(TNodeID(12), makeEdge(1.0, 0.0, 0.0, 100.0));
+
+  const std::string s = p.getAsString();
+  EXPECT_NE(s.find("Path properties"), std::string::npos);
+  EXPECT_NE(s.find("11"), std::string::npos);
+  EXPECT_NE(s.find("12"), std::string::npos);
+  EXPECT_NE(s.find("Determinant"), std::string::npos);
+
+  std::stringstream ss;
+  p.dumpToTextStream(ss);
+  EXPECT_NE(ss.str().find("Path properties"), std::string::npos);
+
+  // operator<< uses the same representation:
+  std::stringstream ss2;
+  ss2 << p;
+  EXPECT_NE(ss2.str().find("Path properties"), std::string::npos);
+}
+
+TEST(TUncertaintyPath, clear_restores_the_default_state)
+{
+  path_t p(TNodeID(0));
+  p.addToPath(TNodeID(1), makeEdge(1.0, 2.0, 0.5, 3.0));
+  ASSERT_FALSE(p.isEmpty());
+
+  p.clear();
+  EXPECT_TRUE(p.isEmpty());
+  EXPECT_TRUE(p.nodes_traversed.empty());
+  EXPECT_FALSE(p.determinant_is_updated);
+}

--- a/modules/mrpt_gui/CMakeLists.txt
+++ b/modules/mrpt_gui/CMakeLists.txt
@@ -76,9 +76,19 @@ if (CMAKE_MRPT_HAS_NANOGUI)
 	set(EXTRA_CONFIG_CMDS "find_dependency(mrpt_nanogui QUIET)")
 endif()
 
+# Unit tests. The window-based ones self-skip if there is no window server
+# available (see tests/gui_test_common.h); CI runs them under `xvfb-run`.
+set(LIB_UNIT_TEST_SOURCES
+  tests/CGlCanvasBase_unittest.cpp
+  tests/CDisplayWindow_unittest.cpp
+  tests/CDisplayWindow3D_unittest.cpp
+  tests/WxUtils_unittest.cpp
+)
+
 mrpt_add_library(
   TARGET ${PROJECT_NAME}
   SOURCES ${LIB_SOURCES} ${LIB_PUBLIC_HEADERS}
+  UNIT_TEST_SOURCES ${LIB_UNIT_TEST_SOURCES}
   PUBLIC_LINK_LIBRARIES
     mrpt::mrpt_opengl
     ${nanogui_dep}
@@ -87,6 +97,13 @@ mrpt_add_library(
     mrpt_opengl
     Eigen3 # Needed by nanogui public headers
 )
+
+# The WxUtils tests include <mrpt/gui/WxUtils.h>, which pulls in wxWidgets
+# headers; the library links wxWidgets privately, so the test target needs
+# those flags explicitly:
+if(TARGET test_${PROJECT_NAME} AND TARGET imp_wxwidgets)
+  target_link_libraries(test_${PROJECT_NAME} PRIVATE imp_wxwidgets)
+endif()
 
 # Install 3rdparty mathplot header so downstream apps can use it as
 # <mrpt/3rdparty/mathplot/mathplot.h>

--- a/modules/mrpt_gui/include/mrpt/gui/CGlCanvasBase.h
+++ b/modules/mrpt_gui/include/mrpt/gui/CGlCanvasBase.h
@@ -40,16 +40,8 @@ class CGlCanvasBase
   CGlCanvasBase(CGlCanvasBase&&) noexcept = default;
   CGlCanvasBase& operator=(CGlCanvasBase&&) noexcept = default;
 
-  /** Saves the click position of the mouse
-   * See also setMouseClicked(bool) */
-  void setMousePos(int x, int y);
-
-  /** Sets the property mouseClicked
-   * By default, this property is false.
-   * See also setMousePos(int, int) */
-  void setMouseClicked(bool is);
-
-  /** Sets the last mouse position */
+  /** Records the latest known pointer position, in widget-local pixels.
+   *  \sa getLastMousePosition() */
   void updateLastPos(int x, int y);
 
   /** Calls the glViewport function*/
@@ -71,6 +63,8 @@ class CGlCanvasBase
    */
   [[nodiscard]] bool getUseCameraFromScene() const;
 
+  /** Latest pointer position seen by the canvas, in widget-local pixels.
+   *  \sa updateLastPos() */
   void getLastMousePosition(int& x, int& y) const
   {
     x = m_mouseLastX;
@@ -107,16 +101,15 @@ class CGlCanvasBase
   std::unique_ptr<mrpt::opengl::CompiledScene> m_compiledScene;
   std::weak_ptr<mrpt::viz::Scene> m_lastCompiledScenePtr;
   int m_mouseLastX = 0, m_mouseLastY = 0;
-  int m_mouseClickX = 0, m_mouseClickY = 0;
-  bool mouseClicked = false;
 
   mrpt::viz::COrbitCameraController m_cameraCtrl;
 
 };  // end of class
 
-/** A headless dummy implementation of CGlCanvasBase: can be used to keep track
- * of user UI mouse events and update the camera parameters, with actual
- * rendering being delegated to someone else. \ingroup mrpt_gui_grp
+/** A headless dummy implementation of CGlCanvasBase: holds the scene and the
+ * camera controller (see orbitCameraController(), which is where UI mouse
+ * events are fed into), with actual rendering delegated to someone else.
+ * \ingroup mrpt_gui_grp
  */
 class CGlCanvasBaseHeadless : public CGlCanvasBase
 {

--- a/modules/mrpt_gui/package.xml
+++ b/modules/mrpt_gui/package.xml
@@ -30,6 +30,11 @@
   <build_depend>pybind11-dev</build_depend>
   <build_depend>python3-dev</build_depend>
 
+  <!-- Virtual X display for the headless window unit tests; they self-skip
+       if no display is reachable, so this is only needed to actually run
+       them (e.g. `xvfb-run -a colcon test`). -->
+  <test_depend>xvfb</test_depend>
+
   <export>
     <build_type>cmake</build_type>
   </export>

--- a/modules/mrpt_gui/src/CGlCanvasBase.cpp
+++ b/modules/mrpt_gui/src/CGlCanvasBase.cpp
@@ -58,6 +58,17 @@ void CGlCanvasBase::resizeViewport(int w, int h)  // NOLINT
 #endif
 }
 
+void CGlCanvasBase::updateLastPos(int x, int y)
+{
+  m_mouseLastX = x;
+  m_mouseLastY = y;
+}
+
+void CGlCanvasBaseHeadless::renderError(const std::string& err_msg)
+{
+  std::cerr << "[CGlCanvasBaseHeadless::renderError] Error: " << err_msg << "\n";
+}
+
 void CGlCanvasBase::setUseCameraFromScene(bool is) { useCameraFromScene = is; }
 bool CGlCanvasBase::getUseCameraFromScene() const { return useCameraFromScene; }
 

--- a/modules/mrpt_gui/src/CWxGLCanvasBase.cpp
+++ b/modules/mrpt_gui/src/CWxGLCanvasBase.cpp
@@ -137,16 +137,22 @@ uint8_t wxButtonUp(const wxMouseEvent& e)
 
 void CWxGLCanvasBase::OnMouseDown(wxMouseEvent& event)
 {
+  updateLastPos(event.GetX(), event.GetY());
   orbitCameraController().onMouseButton(event.GetX(), event.GetY(), wxButtonDown(event), true);
 }
 
 void CWxGLCanvasBase::OnMouseUp(wxMouseEvent& event)
 {
+  updateLastPos(event.GetX(), event.GetY());
   orbitCameraController().onMouseButton(event.GetX(), event.GetY(), wxButtonUp(event), false);
 }
 
 void CWxGLCanvasBase::OnMouseMove(wxMouseEvent& event)
 {
+  // Track the pointer even while no button is held: this is what
+  // CDisplayWindow3D::getLastMousePosition() (and hence 3D picking) reads.
+  updateLastPos(event.GetX(), event.GetY());
+
   uint8_t buttons = 0;
   if (event.LeftIsDown())
   {

--- a/modules/mrpt_gui/src/WxUtils.cpp
+++ b/modules/mrpt_gui/src/WxUtils.cpp
@@ -26,8 +26,7 @@ using namespace std;
 
 wxImage* mrpt::gui::MRPTImage2wxImage(const mrpt::img::CImage& img)
 {
-  using namespace std::string_literals;
-
+  // Both CImage and wxImage store 8-bit RGB, in that channel order:
   mrpt::img::CImage new_image(img, mrpt::img::SHALLOW_COPY);
 
   // If the image is GRAYSCALE, we need to convert it into RGB, so do it
@@ -35,13 +34,6 @@ wxImage* mrpt::gui::MRPTImage2wxImage(const mrpt::img::CImage& img)
   if (!new_image.isColor())
   {
     new_image = new_image.colorImage();
-  }
-
-  if (new_image.getChannelsOrder() == "BGR"s)
-  {
-    auto im = new_image.makeDeepCopy();
-    im.swapRB();
-    new_image = im;
   }
 
   const int row_in_bytes =
@@ -89,7 +81,8 @@ mrpt::img::CImage* mrpt::gui::wxImage2MRPTImage(const wxImage& img)
   const auto lx = img.GetWidth();
   const auto ly = img.GetHeight();
 
-  newImg->loadFromMemoryBuffer(lx, ly, mrpt::img::CH_RGB, img.GetData(), true /* swap RB */);
+  // wxImage holds RGB, and so does CImage: no channel swap.
+  newImg->loadFromMemoryBuffer(lx, ly, mrpt::img::CH_RGB, img.GetData(), false /* swap RB */);
 
   return newImg;
 }

--- a/modules/mrpt_gui/tests/CDisplayWindow3D_unittest.cpp
+++ b/modules/mrpt_gui/tests/CDisplayWindow3D_unittest.cpp
@@ -1,0 +1,254 @@
+/*                    _
+                     | |    Mobile Robot Programming Toolkit (MRPT)
+ _ __ ___  _ __ _ __ | |_
+| '_ ` _ \| '__| '_ \| __|          https://www.mrpt.org/
+| | | | | | |  | |_) | |_
+|_| |_| |_|_|  | .__/ \__|     https://github.com/MRPT/mrpt/
+               | |
+               |_|
+
+ Copyright (c) 2005-2026, Individual contributors, see AUTHORS file
+ See: https://www.mrpt.org/Authors - All rights reserved.
+ SPDX-License-Identifier: BSD-3-Clause
+*/
+
+/** Unit tests for the 3D scene window. They need a window server and a GL
+ *  implementation; CI provides a virtual display (`xvfb-run`) plus Mesa's
+ *  software rasterizer, and the tests self-skip when neither is available.
+ *
+ *  Rendered frames are only checked for plausibility (a frame was grabbed,
+ *  with the right size), never against reference pixels: on a virtual display
+ *  with no compositor the window is never mapped, so reading its pixels back
+ *  yields a uniformly black image even though rendering did happen. Pixel
+ *  comparisons against reference images belong in the offscreen (EGL/FBO)
+ *  tests of mrpt_opengl instead.
+ */
+
+#include <gtest/gtest.h>
+#include <mrpt/gui/CDisplayWindow3D.h>
+#include <mrpt/img/CImage.h>
+#include <mrpt/system/filesystem.h>
+#include <mrpt/viz/CBox.h>
+#include <mrpt/viz/CGridPlaneXY.h>
+#include <mrpt/viz/CSphere.h>
+#include <mrpt/viz/Scene.h>
+#include <mrpt/viz/stock_objects.h>
+
+#include <thread>
+
+#include "gui_test_common.h"
+
+namespace
+{
+constexpr unsigned int WIN_W = 320;
+constexpr unsigned int WIN_H = 240;
+
+/** Fills the window's scene with a few objects and forces a redraw. */
+void populateAndRender(mrpt::gui::CDisplayWindow3D& win)
+{
+  {
+    mrpt::viz::Scene::Ptr& scene = win.get3DSceneAndLock();
+    scene->insert(mrpt::viz::CGridPlaneXY::Create(-5, 5, -5, 5, 0, 1));
+    scene->insert(mrpt::viz::stock_objects::CornerXYZ());
+    auto box = mrpt::viz::CBox::Create();
+    box->setBoxCorners({-1, -1, 0}, {1, 1, 2});
+    scene->insert(box);
+    win.unlockAccess3DScene();
+  }
+  win.repaint();
+  std::this_thread::sleep_for(std::chrono::milliseconds(300));
+}
+
+}  // namespace
+
+TEST(CDisplayWindow3D, create_and_populate_a_scene)
+{
+  SKIP_IF_NO_GUI();
+
+  mrpt::gui::CDisplayWindow3D win("unit test 3D", WIN_W, WIN_H);
+  ASSERT_TRUE(win.isOpen());
+
+  populateAndRender(win);
+
+  {
+    mrpt::viz::Scene::Ptr& scene = win.get3DSceneAndLock();
+    EXPECT_EQ(scene->getViewport()->size(), 3U);
+    win.unlockAccess3DScene();
+  }
+  EXPECT_NE(win.getDefaultViewport(), nullptr);
+  EXPECT_TRUE(win.isOpen());
+}
+
+TEST(CDisplayWindow3D, scene_locker_helper)
+{
+  SKIP_IF_NO_GUI();
+
+  mrpt::gui::CDisplayWindow3D win("unit test locker", WIN_W, WIN_H);
+  {
+    mrpt::viz::Scene::Ptr scene;
+    mrpt::gui::CDisplayWindow3DLocker lck(win, scene);
+    ASSERT_NE(scene, nullptr);
+    scene->insert(mrpt::viz::CSphere::Create(1.0f));
+  }
+  {
+    // The overload that only locks:
+    mrpt::gui::CDisplayWindow3DLocker lck(win);
+  }
+  win.repaint();
+  std::this_thread::sleep_for(std::chrono::milliseconds(200));
+  EXPECT_TRUE(win.isOpen());
+}
+
+TEST(CDisplayWindow3D, camera_parameters_round_trip)
+{
+  SKIP_IF_NO_GUI();
+
+  mrpt::gui::CDisplayWindow3D win("unit test camera", WIN_W, WIN_H);
+
+  win.setCameraAzimuthDeg(35.0f);
+  win.setCameraElevationDeg(20.0f);
+  win.setCameraZoom(7.5f);
+  win.setCameraPointingToPoint(1.0f, 2.0f, 3.0f);
+  win.setProjectiveModel(true);
+  win.setFOV(50.0f);
+  win.setMinRange(0.05f);
+  win.setMaxRange(500.0f);
+
+  EXPECT_FLOAT_EQ(win.getCameraAzimuthDeg(), 35.0f);
+  EXPECT_FLOAT_EQ(win.getCameraElevationDeg(), 20.0f);
+  EXPECT_FLOAT_EQ(win.getCameraZoom(), 7.5f);
+  EXPECT_TRUE(win.isCameraProjective());
+  EXPECT_FLOAT_EQ(win.getFOV(), 50.0f);
+
+  float x = 0, y = 0, z = 0;
+  win.getCameraPointingToPoint(x, y, z);
+  EXPECT_FLOAT_EQ(x, 1.0f);
+  EXPECT_FLOAT_EQ(y, 2.0f);
+  EXPECT_FLOAT_EQ(z, 3.0f);
+
+  win.setProjectiveModel(false);
+  EXPECT_FALSE(win.isCameraProjective());
+
+  win.useCameraFromScene(true);
+  win.useCameraFromScene(false);
+}
+
+TEST(CDisplayWindow3D, text_messages)
+{
+  SKIP_IF_NO_GUI();
+
+  mrpt::gui::CDisplayWindow3D win("unit test text", WIN_W, WIN_H);
+
+  win.addTextMessage(0.01, 0.01, "hello", 0 /*unique_index*/);
+  EXPECT_TRUE(win.updateTextMessage(0, "hello again"));
+  EXPECT_FALSE(win.updateTextMessage(99, "no such index"));
+
+  win.repaint();
+  std::this_thread::sleep_for(std::chrono::milliseconds(200));
+
+  win.clearTextMessages();
+  EXPECT_TRUE(win.isOpen());
+}
+
+TEST(CDisplayWindow3D, capture_the_rendered_frame)
+{
+  SKIP_IF_NO_GUI();
+
+  mrpt::gui::CDisplayWindow3D win("unit test capture", WIN_W, WIN_H);
+  populateAndRender(win);
+
+  EXPECT_FALSE(win.isCapturingImgs());
+  win.captureImagesStart();
+  EXPECT_TRUE(win.isCapturingImgs());
+
+  // Render a few frames so that at least one gets grabbed:
+  mrpt::img::CImage frame;
+  bool got = false;
+  for (int i = 0; i < 20 && !got; i++)
+  {
+    win.repaint();
+    std::this_thread::sleep_for(std::chrono::milliseconds(100));
+    got = win.getLastWindowImage(frame);
+  }
+
+  win.captureImagesStop();
+  EXPECT_FALSE(win.isCapturingImgs());
+
+  if (!got)
+  {
+    GTEST_SKIP() << "No GL frame could be grabbed (no usable GL "
+                    "implementation in this environment).";
+  }
+
+  // Only the client area is grabbed, which under a window manager is smaller
+  // than the requested outer size, so exact dimensions cannot be asserted:
+  EXPECT_GT(frame.getWidth(), 0U);
+  EXPECT_GT(frame.getHeight(), 0U);
+  EXPECT_LE(frame.getWidth(), WIN_W);
+  EXPECT_LE(frame.getHeight(), WIN_H);
+  EXPECT_TRUE(frame.isColor());
+
+  EXPECT_GT(win.getRenderingFPS(), 0.0);
+}
+
+TEST(CDisplayWindow3D, grab_frames_to_disk)
+{
+  SKIP_IF_NO_GUI();
+
+  mrpt::gui::CDisplayWindow3D win("unit test grab", WIN_W, WIN_H);
+  populateAndRender(win);
+
+  const std::string prefix = mrpt::system::getTempFileName();  // unique, in the system temp dir
+  win.grabImagesStart(prefix);
+  for (int i = 0; i < 5; i++)
+  {
+    win.repaint();
+    std::this_thread::sleep_for(std::chrono::milliseconds(100));
+  }
+  win.grabImagesStop();
+
+  // Whether any file was actually written depends on the GL implementation,
+  // so only the name generation is asserted here:
+  const std::string next = win.grabImageGetNextFile();
+  EXPECT_TRUE(next.empty() || next.find(prefix) != std::string::npos);
+}
+
+TEST(CDisplayWindow3D, image_view_mode)
+{
+  SKIP_IF_NO_GUI();
+
+  mrpt::gui::CDisplayWindow3D win("unit test image view", WIN_W, WIN_H);
+
+  mrpt::img::CImage img(WIN_W, WIN_H, mrpt::img::CH_RGB);
+  img.filledRectangle(
+      mrpt::img::TPixelCoord(0, 0),
+      mrpt::img::TPixelCoord(static_cast<int>(WIN_W) - 1, static_cast<int>(WIN_H) - 1),
+      mrpt::img::TColor(200, 30, 30));
+
+  win.setImageView(img);
+  std::this_thread::sleep_for(std::chrono::milliseconds(200));
+
+  // ...and the move overload:
+  mrpt::img::CImage img2 = img.makeDeepCopy();
+  win.setImageView(std::move(img2));
+  std::this_thread::sleep_for(std::chrono::milliseconds(200));
+
+  EXPECT_TRUE(win.isOpen());
+}
+
+TEST(CDisplayWindow3D, window_geometry_and_title)
+{
+  SKIP_IF_NO_GUI();
+
+  auto win = mrpt::gui::CDisplayWindow3D::Create("unit test 3D geometry", WIN_W, WIN_H);
+  win->setWindowTitle("renamed 3D");
+  win->resize(400, 300);
+  win->setPos(30, 40);
+  win->setCursorCross(true);
+  win->setCursorCross(false);
+  std::this_thread::sleep_for(std::chrono::milliseconds(200));
+
+  EXPECT_NO_THROW((void)win->getLastMousePosition());
+  EXPECT_NO_THROW((void)win->getLastMousePositionRay());
+  EXPECT_TRUE(win->isOpen());
+}

--- a/modules/mrpt_gui/tests/CDisplayWindow_unittest.cpp
+++ b/modules/mrpt_gui/tests/CDisplayWindow_unittest.cpp
@@ -1,0 +1,161 @@
+/*                    _
+                     | |    Mobile Robot Programming Toolkit (MRPT)
+ _ __ ___  _ __ _ __ | |_
+| '_ ` _ \| '__| '_ \| __|          https://www.mrpt.org/
+| | | | | | |  | |_) | |_
+|_| |_| |_|_|  | .__/ \__|     https://github.com/MRPT/mrpt/
+               | |
+               |_|
+
+ Copyright (c) 2005-2026, Individual contributors, see AUTHORS file
+ See: https://www.mrpt.org/Authors - All rights reserved.
+ SPDX-License-Identifier: BSD-3-Clause
+*/
+
+/** Unit tests for the 2D image window and the plots window. They need a window
+ *  server; CI provides a virtual one (`xvfb-run`), and the tests self-skip
+ *  when there is none.
+ */
+
+#include <gtest/gtest.h>
+#include <mrpt/gui/CDisplayWindow.h>
+#include <mrpt/gui/CDisplayWindowPlots.h>
+#include <mrpt/img/CImage.h>
+#include <mrpt/math/CMatrixDynamic.h>
+#include <mrpt/math/CMatrixFixed.h>
+
+#include <thread>
+#include <vector>
+
+#include "gui_test_common.h"
+
+namespace
+{
+mrpt::img::CImage makeTestImage(unsigned w, unsigned h)
+{
+  mrpt::img::CImage img(w, h, mrpt::img::CH_RGB);
+  img.filledRectangle(
+      mrpt::img::TPixelCoord(0, 0),
+      mrpt::img::TPixelCoord(static_cast<int>(w) - 1, static_cast<int>(h) - 1),
+      mrpt::img::TColor(20, 120, 200));
+  return img;
+}
+
+/** Give the GUI thread a chance to process the queued requests. */
+void pumpGui() { std::this_thread::sleep_for(std::chrono::milliseconds(150)); }
+}  // namespace
+
+TEST(CDisplayWindow, create_show_image_and_close)
+{
+  SKIP_IF_NO_GUI();
+
+  mrpt::gui::CDisplayWindow win("unit test 2D", 320, 240);
+  EXPECT_TRUE(win.isOpen());
+
+  win.showImage(makeTestImage(320, 240));
+  pumpGui();
+  EXPECT_TRUE(win.isOpen());
+}
+
+TEST(CDisplayWindow, window_geometry_and_title)
+{
+  SKIP_IF_NO_GUI();
+
+  auto win = mrpt::gui::CDisplayWindow::Create("unit test resize", 200, 150);
+  ASSERT_TRUE(win->isOpen());
+
+  win->setWindowTitle("renamed");
+  win->resize(320, 240);
+  win->setPos(50, 60);
+  win->setCursorCross(true);
+  win->setCursorCross(false);
+  win->enableCursorCoordinatesVisualization(false);
+  pumpGui();
+
+  EXPECT_TRUE(win->isOpen());
+}
+
+TEST(CDisplayWindow, plot_helpers)
+{
+  SKIP_IF_NO_GUI();
+
+  mrpt::gui::CDisplayWindow win("unit test plot", 320, 240);
+
+  mrpt::math::CVectorFloat x(5), y(5);
+  for (int i = 0; i < 5; i++)
+  {
+    x[i] = static_cast<float>(i);
+    y[i] = static_cast<float>(i * i);
+  }
+  win.plot(x, y);
+  pumpGui();
+  win.plot(y);
+  pumpGui();
+
+  EXPECT_TRUE(win.isOpen());
+}
+
+TEST(CDisplayWindow, key_state_starts_clear)
+{
+  SKIP_IF_NO_GUI();
+
+  mrpt::gui::CDisplayWindow win("unit test keys", 160, 120);
+  EXPECT_FALSE(win.keyHit());
+  EXPECT_EQ(win.getPushedKey(), 0);
+
+  win.clearKeyHitFlag();
+  EXPECT_FALSE(win.keyHit());
+
+  // No mouse has entered the window yet, but the query must not throw:
+  EXPECT_NO_THROW((void)win.getLastMousePosition());
+}
+
+TEST(CDisplayWindowPlots, plot_curves_and_shapes)
+{
+  SKIP_IF_NO_GUI();
+
+  mrpt::gui::CDisplayWindowPlots win("unit test plots", 320, 240);
+  ASSERT_TRUE(win.isOpen());
+
+  std::vector<double> x{0.0, 1.0, 2.0, 3.0};
+  std::vector<double> y{0.0, 1.0, 4.0, 9.0};
+
+  win.plot(x, y, "b-", "parabola");
+  win.hold_on();
+  win.plot(x, x, "r.", "identity");
+  win.hold_off();
+  win.axis(-1, 4, -1, 10);
+  win.axis_equal(true);
+  win.axis_fit();
+  win.enableMousePanZoom(true);
+  win.setWindowTitle("plots renamed");
+  win.resize(400, 300);
+  pumpGui();
+
+  EXPECT_TRUE(win.isOpen());
+
+  win.clf();
+  pumpGui();
+  EXPECT_TRUE(win.isOpen());
+}
+
+TEST(CDisplayWindowPlots, plot_an_ellipse_and_an_image)
+{
+  SKIP_IF_NO_GUI();
+
+  mrpt::gui::CDisplayWindowPlots win("unit test plots 2", 320, 240);
+
+  mrpt::math::CMatrixFixed<double, 2, 2> cov;
+  cov.setIdentity();
+  win.plotEllipse(1.0, 2.0, cov, 2.0f, "b-", "ellipse");
+
+  mrpt::math::CMatrixDynamic<double> covDyn(2, 2);
+  covDyn.setIdentity();
+  win.plotEllipse(0.0, 0.0, covDyn, 1.0f, "r-", "ellipseDyn", true /*showName*/);
+
+  win.image(makeTestImage(64, 48), 0.0f, 0.0f, 1.0f, 1.0f, "img");
+  win.axis_fit();
+  pumpGui();
+
+  EXPECT_TRUE(win.isOpen());
+}

--- a/modules/mrpt_gui/tests/CGlCanvasBase_unittest.cpp
+++ b/modules/mrpt_gui/tests/CGlCanvasBase_unittest.cpp
@@ -1,0 +1,132 @@
+/*                    _
+                     | |    Mobile Robot Programming Toolkit (MRPT)
+ _ __ ___  _ __ _ __ | |_
+| '_ ` _ \| '__| '_ \| __|          https://www.mrpt.org/
+| | | | | | |  | |_) | |_
+|_| |_| |_|_|  | .__/ \__|     https://github.com/MRPT/mrpt/
+               | |
+               |_|
+
+ Copyright (c) 2005-2026, Individual contributors, see AUTHORS file
+ See: https://www.mrpt.org/Authors - All rights reserved.
+ SPDX-License-Identifier: BSD-3-Clause
+*/
+
+/** Unit tests for CGlCanvasBase through its headless implementation: the
+ *  mouse/camera bookkeeping needs neither a window server nor a GL context.
+ */
+
+#include <gtest/gtest.h>
+#include <mrpt/gui/CGlCanvasBase.h>
+#include <mrpt/viz/CBox.h>
+#include <mrpt/viz/Scene.h>
+
+using mrpt::gui::CGlCanvasBaseHeadless;
+
+TEST(CGlCanvasBase, default_state)
+{
+  CGlCanvasBaseHeadless c;
+
+  EXPECT_FALSE(c.getUseCameraFromScene());
+  EXPECT_NE(c.getOpenGLSceneRef(), nullptr);
+  // No scene has been compiled yet:
+  EXPECT_EQ(c.getShaderManager(), nullptr);
+
+  int x = -1, y = -1;
+  c.getLastMousePosition(x, y);
+  EXPECT_EQ(x, 0);
+  EXPECT_EQ(y, 0);
+}
+
+TEST(CGlCanvasBase, last_mouse_position_is_tracked)
+{
+  CGlCanvasBaseHeadless c;
+
+  c.updateLastPos(31, 47);
+  int x = 0, y = 0;
+  c.getLastMousePosition(x, y);
+  EXPECT_EQ(x, 31);
+  EXPECT_EQ(y, 47);
+
+  c.updateLastPos(0, 0);
+  c.getLastMousePosition(x, y);
+  EXPECT_EQ(x, 0);
+  EXPECT_EQ(y, 0);
+}
+
+TEST(CGlCanvasBase, use_camera_from_scene_flag)
+{
+  CGlCanvasBaseHeadless c;
+  c.setUseCameraFromScene(true);
+  EXPECT_TRUE(c.getUseCameraFromScene());
+  c.setUseCameraFromScene(false);
+  EXPECT_FALSE(c.getUseCameraFromScene());
+}
+
+TEST(CGlCanvasBase, scene_reference_can_be_replaced)
+{
+  CGlCanvasBaseHeadless c;
+  const auto original = c.getOpenGLSceneRef();
+  ASSERT_NE(original, nullptr);
+
+  auto scene = mrpt::viz::Scene::Create();
+  scene->insert(mrpt::viz::CBox::Create());
+  c.setOpenGLSceneRef(scene);
+
+  EXPECT_EQ(c.getOpenGLSceneRef(), scene);
+  EXPECT_NE(c.getOpenGLSceneRef(), original);
+}
+
+TEST(CGlCanvasBase, mouse_events_are_forwarded_to_the_camera_controller)
+{
+  CGlCanvasBaseHeadless c;
+  auto& ctrl = c.orbitCameraController();
+  ctrl.setAzimuthDegrees(0.0f);
+  ctrl.setElevationDegrees(0.0f);
+
+  using MB = mrpt::viz::COrbitCameraController::MouseButtons;
+  using KM = mrpt::viz::COrbitCameraController::KeyModifiers;
+
+  // Dragging with the left button must orbit the camera:
+  ctrl.onMouseButton(100, 100, MB::ButtonLeft, true /*down*/);
+  ctrl.onMouseMove(140, 120, MB::ButtonLeft, KM::ModNone);
+  ctrl.onMouseButton(140, 120, MB::ButtonLeft, false /*down*/);
+
+  EXPECT_NE(ctrl.getAzimuthDegrees(), 0.0f);
+
+  // ...and the wheel must change the zoom distance:
+  const float z0 = ctrl.getZoomDistance();
+  ctrl.onScroll(+1.0f, KM::ModNone);
+  EXPECT_LT(ctrl.getZoomDistance(), z0);
+  ctrl.onScroll(-1.0f, KM::ModNone);
+  EXPECT_GT(ctrl.getZoomDistance(), 0.0f);
+}
+
+TEST(CGlCanvasBase, orbit_camera_controller_is_exposed_and_mutable)
+{
+  CGlCanvasBaseHeadless c;
+
+  auto& ctrl = c.orbitCameraController();
+  ctrl.setAzimuthDegrees(45.0f);
+  ctrl.setElevationDegrees(30.0f);
+  ctrl.setZoomDistance(12.5f);
+  ctrl.setCameraPointing(1.0f, 2.0f, 3.0f);
+
+  const auto& constCtrl = static_cast<const CGlCanvasBaseHeadless&>(c).orbitCameraController();
+  EXPECT_FLOAT_EQ(constCtrl.getAzimuthDegrees(), 45.0f);
+  EXPECT_FLOAT_EQ(constCtrl.getElevationDegrees(), 30.0f);
+  EXPECT_FLOAT_EQ(constCtrl.getZoomDistance(), 12.5f);
+  EXPECT_FLOAT_EQ(constCtrl.getCameraPointingX(), 1.0f);
+  EXPECT_FLOAT_EQ(constCtrl.getCameraPointingY(), 2.0f);
+  EXPECT_FLOAT_EQ(constCtrl.getCameraPointingZ(), 3.0f);
+}
+
+TEST(CGlCanvasBase, resizeViewport_is_a_no_op_without_a_size)
+{
+  CGlCanvasBaseHeadless c;
+  // -1 means "unknown size" and must return before touching the GL context,
+  // which does not exist here:
+  EXPECT_NO_THROW(c.resizeViewport(-1, -1));
+  EXPECT_NO_THROW(c.resizeViewport(640, -1));
+  EXPECT_NO_THROW(c.resizeViewport(-1, 480));
+}

--- a/modules/mrpt_gui/tests/WxUtils_unittest.cpp
+++ b/modules/mrpt_gui/tests/WxUtils_unittest.cpp
@@ -1,0 +1,157 @@
+/*                    _
+                     | |    Mobile Robot Programming Toolkit (MRPT)
+ _ __ ___  _ __ _ __ | |_
+| '_ ` _ \| '__| '_ \| __|          https://www.mrpt.org/
+| | | | | | |  | |_) | |_
+|_| |_| |_|_|  | .__/ \__|     https://github.com/MRPT/mrpt/
+               | |
+               |_|
+
+ Copyright (c) 2005-2026, Individual contributors, see AUTHORS file
+ See: https://www.mrpt.org/Authors - All rights reserved.
+ SPDX-License-Identifier: BSD-3-Clause
+*/
+
+/** Unit tests for the CImage <-> wxImage conversion helpers. wxWidgets needs
+ *  its image handlers (and hence the app) initialized, so these run under the
+ *  same display gate as the window tests.
+ */
+
+#include <gtest/gtest.h>
+#include <mrpt/gui/config.h>
+
+#include "gui_test_common.h"
+
+#if MRPT_HAS_WXWIDGETS
+
+#include <mrpt/gui/CDisplayWindow.h>
+#include <mrpt/gui/WxUtils.h>
+#include <mrpt/img/CImage.h>
+
+#include <memory>
+
+namespace
+{
+/** A gradient image, so that a conversion that dropped or swapped channels
+ *  cannot go unnoticed. Pixels are written channel by channel: `at<TColor>()`
+ *  would reinterpret 4 bytes over a 3-byte RGB pixel. */
+mrpt::img::CImage makeGradient(unsigned w, unsigned h)
+{
+  mrpt::img::CImage img(w, h, mrpt::img::CH_RGB);
+  for (int y = 0; y < static_cast<int>(h); y++)
+  {
+    for (int x = 0; x < static_cast<int>(w); x++)
+    {
+      img.at<uint8_t>(x, y, 0) = static_cast<uint8_t>(x * 4);
+      img.at<uint8_t>(x, y, 1) = static_cast<uint8_t>(y * 4);
+      img.at<uint8_t>(x, y, 2) = 128;
+    }
+  }
+  return img;
+}
+
+/** wxWidgets must be up and running before any wxImage is created; opening a
+ *  window is the supported way to start MRPT's wx subsystem. */
+struct WxFixture
+{
+  std::unique_ptr<mrpt::gui::CDisplayWindow> win;
+  WxFixture() { win = std::make_unique<mrpt::gui::CDisplayWindow>("wx init", 64, 64); }
+};
+}  // namespace
+
+TEST(WxUtils, mrpt_image_to_wx_image_and_back)
+{
+  SKIP_IF_NO_GUI();
+  WxFixture fx;
+
+  const unsigned W = 32, H = 16;
+  const auto src = makeGradient(W, H);
+
+  std::unique_ptr<wxImage> wxImg(mrpt::gui::MRPTImage2wxImage(src));
+  ASSERT_NE(wxImg, nullptr);
+  ASSERT_TRUE(wxImg->IsOk());
+  EXPECT_EQ(static_cast<unsigned>(wxImg->GetWidth()), W);
+  EXPECT_EQ(static_cast<unsigned>(wxImg->GetHeight()), H);
+
+  const auto back = mrpt::gui::wxImage2MRPTImagePtr(*wxImg);
+  ASSERT_NE(back, nullptr);
+  EXPECT_EQ(back->getWidth(), W);
+  EXPECT_EQ(back->getHeight(), H);
+
+  // The round trip must preserve every pixel, in the same channel order:
+  for (int y = 0; y < static_cast<int>(H); y++)
+  {
+    for (int x = 0; x < static_cast<int>(W); x++)
+    {
+      for (int8_t ch = 0; ch < 3; ch++)
+      {
+        ASSERT_EQ(src.at<uint8_t>(x, y, ch), back->at<uint8_t>(x, y, ch))
+            << "at (" << x << "," << y << ") channel " << static_cast<int>(ch);
+      }
+    }
+  }
+}
+
+TEST(WxUtils, raw_pointer_conversion_overload)
+{
+  SKIP_IF_NO_GUI();
+  WxFixture fx;
+
+  const auto src = makeGradient(8, 8);
+  std::unique_ptr<wxImage> wxImg(mrpt::gui::MRPTImage2wxImage(src));
+  ASSERT_NE(wxImg, nullptr);
+
+  std::unique_ptr<mrpt::img::CImage> back(mrpt::gui::wxImage2MRPTImage(*wxImg));
+  ASSERT_NE(back, nullptr);
+  EXPECT_EQ(back->getWidth(), 8U);
+  EXPECT_EQ(back->getHeight(), 8U);
+}
+
+TEST(WxUtils, mrpt_image_to_wx_bitmap)
+{
+  SKIP_IF_NO_GUI();
+  WxFixture fx;
+
+  const auto src = makeGradient(20, 10);
+  std::unique_ptr<wxBitmap> bmp(mrpt::gui::MRPTImage2wxBitmap(src));
+  ASSERT_NE(bmp, nullptr);
+  EXPECT_TRUE(bmp->IsOk());
+  EXPECT_EQ(bmp->GetWidth(), 20);
+  EXPECT_EQ(bmp->GetHeight(), 10);
+}
+
+TEST(WxUtils, grayscale_images_are_expanded_to_rgb)
+{
+  SKIP_IF_NO_GUI();
+  WxFixture fx;
+
+  mrpt::img::CImage gray(12, 6, mrpt::img::CH_GRAY);
+  for (int y = 0; y < 6; y++)
+  {
+    for (int x = 0; x < 12; x++)
+    {
+      gray.at<uint8_t>(x, y) = static_cast<uint8_t>(x * 20);
+    }
+  }
+
+  std::unique_ptr<wxImage> wxImg(mrpt::gui::MRPTImage2wxImage(gray));
+  ASSERT_NE(wxImg, nullptr);
+  ASSERT_TRUE(wxImg->IsOk());
+
+  const auto back = mrpt::gui::wxImage2MRPTImagePtr(*wxImg);
+  ASSERT_NE(back, nullptr);
+  ASSERT_TRUE(back->isColor());
+  for (int y = 0; y < 6; y++)
+  {
+    for (int x = 0; x < 12; x++)
+    {
+      const auto v = gray.at<uint8_t>(x, y);
+      for (int8_t ch = 0; ch < 3; ch++)
+      {
+        ASSERT_EQ(back->at<uint8_t>(x, y, ch), v) << "at (" << x << "," << y << ")";
+      }
+    }
+  }
+}
+
+#endif  // MRPT_HAS_WXWIDGETS

--- a/modules/mrpt_gui/tests/gui_test_common.h
+++ b/modules/mrpt_gui/tests/gui_test_common.h
@@ -20,44 +20,51 @@
 
 namespace mrpt::test
 {
-/** True if a window can actually be created in this environment.
+/** Empty if a window can actually be created in this environment; otherwise a
+ * human-readable reason why not.
  *
  * On X11 systems a display is required; CI runs these tests under a virtual
  * one (`xvfb-run`), and they self-skip when none is available. Windows and
- * macOS always have a window server.
+ * macOS always have a window server, but MRPT there may have been built with
+ * `-DDISABLE_WXWIDGETS=ON`, in which case there is no window class to test.
  */
-[[nodiscard]] inline bool guiIsAvailable()
+[[nodiscard]] inline const char* guiUnavailableReason()
 {
   // Escape hatch for environments where creating windows is undesirable
   // (remote sessions, sandboxes, ...):
   if (const char* off = ::getenv("MRPT_SKIP_GUI_TESTS"); off != nullptr && off[0] == '1')
   {
-    return false;
+    return "MRPT_SKIP_GUI_TESTS=1 is set.";
   }
 
 #if !MRPT_HAS_WXWIDGETS
-  return false;
+  return "MRPT was built without wxWidgets (-DDISABLE_WXWIDGETS=ON).";
 #elif defined(_WIN32) || defined(__APPLE__)
-  return true;
+  return "";
 #else
-  const char* d = ::getenv("DISPLAY");
-  if (d != nullptr && d[0] != '\0')
+  if (const char* d = ::getenv("DISPLAY"); d != nullptr && d[0] != '\0')
   {
-    return true;
+    return "";
   }
-  const char* w = ::getenv("WAYLAND_DISPLAY");
-  return w != nullptr && w[0] != '\0';
+  if (const char* w = ::getenv("WAYLAND_DISPLAY"); w != nullptr && w[0] != '\0')
+  {
+    return "";
+  }
+  return "No window server available (set DISPLAY, or run the tests under "
+         "`xvfb-run -a`).";
 #endif
 }
+
+/** True if a window can actually be created in this environment. */
+[[nodiscard]] inline bool guiIsAvailable() { return guiUnavailableReason()[0] == '\0'; }
 }  // namespace mrpt::test
 
-/** Skips the current test if no window server is reachable. */
-#define SKIP_IF_NO_GUI()                                                     \
-  do                                                                         \
-  {                                                                          \
-    if (!mrpt::test::guiIsAvailable())                                       \
-    {                                                                        \
-      GTEST_SKIP() << "No window server available (set DISPLAY, or run the " \
-                      "tests under `xvfb-run -a`).";                         \
-    }                                                                        \
+/** Skips the current test if no window can be created, saying why. */
+#define SKIP_IF_NO_GUI()                                                      \
+  do                                                                          \
+  {                                                                           \
+    if (const char* why = mrpt::test::guiUnavailableReason(); why[0] != '\0') \
+    {                                                                         \
+      GTEST_SKIP() << why;                                                    \
+    }                                                                         \
   } while (0)

--- a/modules/mrpt_gui/tests/gui_test_common.h
+++ b/modules/mrpt_gui/tests/gui_test_common.h
@@ -27,6 +27,13 @@ namespace mrpt::test
  * one (`xvfb-run`), and they self-skip when none is available. Windows and
  * macOS always have a window server, but MRPT there may have been built with
  * `-DDISABLE_WXWIDGETS=ON`, in which case there is no window class to test.
+ *
+ * \note This only checks that a display is *configured*, not that it is
+ * reachable: a stale `DISPLAY` (e.g. a declined X11 forwarding) makes each
+ * window test wait out `CBaseGUIWindow`'s creation timeout and then fail,
+ * which is the intended signal for a broken environment. Set
+ * `MRPT_SKIP_GUI_TESTS=1` to skip them instead, or
+ * `MRPT_WXSUBSYS_TIMEOUT_MS` to shorten the wait.
  */
 [[nodiscard]] inline const char* guiUnavailableReason()
 {

--- a/modules/mrpt_gui/tests/gui_test_common.h
+++ b/modules/mrpt_gui/tests/gui_test_common.h
@@ -1,0 +1,63 @@
+/*                    _
+                     | |    Mobile Robot Programming Toolkit (MRPT)
+ _ __ ___  _ __ _ __ | |_
+| '_ ` _ \| '__| '_ \| __|          https://www.mrpt.org/
+| | | | | | |  | |_) | |_
+|_| |_| |_|_|  | .__/ \__|     https://github.com/MRPT/mrpt/
+               | |
+               |_|
+
+ Copyright (c) 2005-2026, Individual contributors, see AUTHORS file
+ See: https://www.mrpt.org/Authors - All rights reserved.
+ SPDX-License-Identifier: BSD-3-Clause
+*/
+
+#pragma once
+
+#include <mrpt/gui/config.h>
+
+#include <cstdlib>
+
+namespace mrpt::test
+{
+/** True if a window can actually be created in this environment.
+ *
+ * On X11 systems a display is required; CI runs these tests under a virtual
+ * one (`xvfb-run`), and they self-skip when none is available. Windows and
+ * macOS always have a window server.
+ */
+[[nodiscard]] inline bool guiIsAvailable()
+{
+  // Escape hatch for environments where creating windows is undesirable
+  // (remote sessions, sandboxes, ...):
+  if (const char* off = ::getenv("MRPT_SKIP_GUI_TESTS"); off != nullptr && off[0] == '1')
+  {
+    return false;
+  }
+
+#if !MRPT_HAS_WXWIDGETS
+  return false;
+#elif defined(_WIN32) || defined(__APPLE__)
+  return true;
+#else
+  const char* d = ::getenv("DISPLAY");
+  if (d != nullptr && d[0] != '\0')
+  {
+    return true;
+  }
+  const char* w = ::getenv("WAYLAND_DISPLAY");
+  return w != nullptr && w[0] != '\0';
+#endif
+}
+}  // namespace mrpt::test
+
+/** Skips the current test if no window server is reachable. */
+#define SKIP_IF_NO_GUI()                                                     \
+  do                                                                         \
+  {                                                                          \
+    if (!mrpt::test::guiIsAvailable())                                       \
+    {                                                                        \
+      GTEST_SKIP() << "No window server available (set DISPLAY, or run the " \
+                      "tests under `xvfb-run -a`).";                         \
+    }                                                                        \
+  } while (0)

--- a/modules/mrpt_system/include/mrpt/system/CTicTac.h
+++ b/modules/mrpt_system/include/mrpt/system/CTicTac.h
@@ -13,6 +13,8 @@
 */
 #pragma once
 
+#include <cstdint>
+
 namespace mrpt::system
 {
 /** A high-performance stopwatch, with typical resolution of nanoseconds.
@@ -36,21 +38,25 @@ class CTicTac
 
  private:
   /** Opaque storage, reinterpreted as `struct timespec` (POSIX) or
-   * `LARGE_INTEGER` (Windows); both only need the natural alignment of the
-   * underlying integer type.
+   * `LARGE_INTEGER` (Windows). `uint64_t` is used rather than
+   * `unsigned long` so that the 8-byte alignment both of those require holds
+   * on every platform: `unsigned long` is only 4 bytes (and 4-byte aligned)
+   * on MSVC, while `LARGE_INTEGER` contains a `LONGLONG`.
+   * `CTicTac.cpp` asserts size and alignment for the actual platform type.
    *
-   * Deliberately *not* over-aligned: CTicTac is embedded in CTimeLogger,
-   * which in turn is a member of classes used as virtual bases (e.g.
-   * mrpt::graphslam::CRegistrationDeciderOrOptimizer). GCC then compiles
-   * member functions of such a class assuming `this` has the over-aligned
-   * alignment, while the virtual-base subobject inside a derived class is
-   * only placed at its natural alignment, so the resulting aligned SIMD
-   * accesses crash. See the equivalent note in mrpt::math::CMatrixFixed. */
-  unsigned long largeInts[4]{0, 0};
+   * Deliberately *not* over-aligned beyond that: CTicTac is embedded in
+   * CTimeLogger, which in turn is a member of classes used as virtual bases
+   * (e.g. mrpt::graphslam::CRegistrationDeciderOrOptimizer). GCC then
+   * compiles member functions of such a class assuming `this` has the
+   * over-aligned alignment, while the virtual-base subobject inside a derived
+   * class is only placed at its natural alignment, so the resulting aligned
+   * SIMD accesses crash. See the equivalent note in
+   * mrpt::math::CMatrixFixed. */
+  std::uint64_t largeInts[4]{};
 };  // End of class def.
 
 static_assert(
-    alignof(CTicTac) <= alignof(unsigned long),
+    alignof(CTicTac) <= alignof(std::uint64_t),
     "CTicTac must not be over-aligned: it is embedded in classes used as "
     "virtual bases, where GCC then emits aligned SIMD accesses on "
     "subobjects that are only naturally aligned.");

--- a/modules/mrpt_system/include/mrpt/system/CTicTac.h
+++ b/modules/mrpt_system/include/mrpt/system/CTicTac.h
@@ -35,7 +35,24 @@ class CTicTac
   [[nodiscard]] double Tac() const noexcept;
 
  private:
-  alignas(16) unsigned long largeInts[4]{0, 0};
+  /** Opaque storage, reinterpreted as `struct timespec` (POSIX) or
+   * `LARGE_INTEGER` (Windows); both only need the natural alignment of the
+   * underlying integer type.
+   *
+   * Deliberately *not* over-aligned: CTicTac is embedded in CTimeLogger,
+   * which in turn is a member of classes used as virtual bases (e.g.
+   * mrpt::graphslam::CRegistrationDeciderOrOptimizer). GCC then compiles
+   * member functions of such a class assuming `this` has the over-aligned
+   * alignment, while the virtual-base subobject inside a derived class is
+   * only placed at its natural alignment, so the resulting aligned SIMD
+   * accesses crash. See the equivalent note in mrpt::math::CMatrixFixed. */
+  unsigned long largeInts[4]{0, 0};
 };  // End of class def.
+
+static_assert(
+    alignof(CTicTac) <= alignof(unsigned long),
+    "CTicTac must not be over-aligned: it is embedded in classes used as "
+    "virtual bases, where GCC then emits aligned SIMD accesses on "
+    "subobjects that are only naturally aligned.");
 
 }  // namespace mrpt::system

--- a/modules/mrpt_system/src/CTicTac.cpp
+++ b/modules/mrpt_system/src/CTicTac.cpp
@@ -67,11 +67,19 @@ CTicTac::CTicTac() noexcept
 {
   ::memset(largeInts, 0, sizeof(largeInts));
 
+  // The storage is reinterpreted as the platform's time type, so it must be
+  // both large enough and aligned at least as strictly as that type:
 #ifdef _WIN32
   static_assert(sizeof(largeInts) >= 1 * sizeof(LARGE_INTEGER), "sizeof(LARGE_INTEGER) failed!");
+  static_assert(
+      alignof(decltype(largeInts)) >= alignof(LARGE_INTEGER),
+      "largeInts is under-aligned for LARGE_INTEGER");
 #else
   static_assert(
       sizeof(largeInts) >= 1 * sizeof(struct timespec), "sizeof(struct timespec) failed!");
+  static_assert(
+      alignof(decltype(largeInts)) >= alignof(struct timespec),
+      "largeInts is under-aligned for struct timespec");
 #endif
   Tic();
 }


### PR DESCRIPTION
Raises `mrpt_graphslam` 73.3% → 81.6% and `mrpt_gui` **0.5% → 40.6%** lines (whole repo: 73.8% → 76.4%), and fixes the bugs the new tests uncovered.

## Headless GUI tests

`mrpt_gui` had no `tests/` directory at all. It has one now: `xvfb-run` plus Mesa's software rasterizer is enough to open and drive `CDisplayWindow`, `CDisplayWindow3D` and `CDisplayWindowPlots` with no real display, which carried `mathplot.cpp` 0%→33%, `WxSubsystem.cpp` 4.7%→67%, `CDisplayWindow3D.cpp` 0%→74%, `CDisplayWindow.cpp` 0%→71%, `CDisplayWindowPlots.cpp` 0%→65%.

* `.github/workflows/build-linux.yml` installs `xvfb`/`libgl1-mesa-dri` and wraps `colcon test` in `xvfb-run`.
* `modules/mrpt_gui/package.xml` gains `<test_depend>xvfb</test_depend>` (documentation/rosdep only — the CI wrapper is what actually makes the tests run).
* Every window test goes through `SKIP_IF_NO_GUI()`, so the suite still passes with no display; `MRPT_SKIP_GUI_TESTS=1` forces that path.

Deliberately **not** doing pixel comparisons of window screenshots: on a virtual display there is no compositor, the window is never mapped, and reading its pixels back gives a uniformly black image even though rendering happened. The tests assert that a frame was grabbed with a plausible size; reference-image comparisons stay in `mrpt_opengl`'s offscreen EGL/FBO tests, which need no display.

Validated locally both under `xvfb-run` (with `DISPLAY` unset) and on a real X session; full `colcon test` over `modules` + `apps` is green in both.

**Please watch the macOS and Windows jobs**: those runners have a native window server, so the window tests will actually run there rather than skip. If they turn out to be unhappy, the gate in `tests/gui_test_common.h` is the single place to restrict them to Linux.

## Bugs found and fixed

* **`CTicTac` over-alignment → segfault in every optimized build.** `alignas(16)` on storage that is only ever reinterpreted as `struct timespec`/`LARGE_INTEGER` propagated through `CTimeLogger` up to `CRegistrationDeciderOrOptimizer`, which is used as a *virtual base*. GCC then compiled its members assuming a 16-byte-aligned `this` and emitted `movdqa`, while the virtual-base subobject inside a derived class sits at an 8-byte-aligned offset — so merely constructing a `CFixedIntervalsNRD` crashed in Release, i.e. `graphslam-engine` was broken. Same failure mode already documented in `mrpt::math::CMatrixFixed`; a `static_assert` now pins it.
* **Root node placed at the wrong pose.** `CNodeRegistrationDecider::registerNewNodeAtEnd()` seeded the root with `getCurrentRobotPosEstimation()` instead of the origin, applying the pre-registration motion twice (node 1 landed at 2× the travelled distance).
* **Uninitialized registration thresholds** in all three decider `TParams` (`CFixedIntervalsNRD`, `CIncrementalNodeRegistrationDecider`, `CICPCriteriaNRD`): the documented defaults existed only inside `loadFromConfigFile()`, so a decider used without `loadParams()` compared against garbage.
* **Two templates that could not be instantiated at all**: `CIncrementalNodeRegistrationDecider` (undefined `report_sep`, unqualified `INVALID_NODEID`) and `TUncertaintyPath::hasLowerUncertaintyThan()` (a `const` method calling the non-`const` `getDeterminant()`; the cache is now `mutable`).
* **`CDisplayWindow3D::getLastMousePosition()` always returned pixel (0,0)** — and so did `getLastMousePositionRay()` and all 3D picking. `CGlCanvasBase::updateLastPos()` was declared but never defined after the 3.x camera refactor, and `CWxGLCanvasBase`'s mouse handlers never recorded the pointer position. Also defines `CGlCanvasBaseHeadless::renderError()`, whose absence made that documented class unlinkable; the two dead click setters (superseded by `COrbitCameraController`) are removed.
* **`wxImage2MRPTImage()` swapped red and blue** — a leftover from MRPT 2.x when `CImage` stored BGR. In 3.x both sides are RGB.
* **`CWindowObserver` missed Ctrl+C** whenever another modifier was held (`key_modifiers == 8192` instead of masking `MRPTKMOD_CONTROL`).
* **`using namespace std;` at global scope in a public header** (`CNodeRegistrationDecider_impl.h`), leaking into every TU that included any NRD.

`agents.md` is updated with the new numbers, the Xvfb recipe and the gotchas.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved 3D mouse-position tracking for more reliable picking.
  - Corrected image conversions to preserve RGB channel order.
  - Added safe default registration thresholds for graph-slam components.
  - Ensured newly created graph roots start at the origin.
  - Improved Ctrl+C handling and diagnostic logging.
  - Prevented potential alignment issues in timing utilities.

- **Tests**
  - Expanded GUI and graph-slam test coverage, including headless GUI execution in CI.
  - Added coverage for window behavior, image conversion, registration, uncertainty paths, and event handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->