### PR TITLE
Coverage pass on mrpt_math, mrpt_maps, mrpt_obs and mrpt_slam

### DIFF
--- a/agents.md
+++ b/agents.md
@@ -201,10 +201,10 @@ files needed changes.
 A full rebuild of all 33 `modules/*` packages was done with coverage
 instrumentation, followed by a full `colcon test` run (all tests passed) and a
 `gcovr` line/branch report. **Goal: 90% line coverage per module.** Current
-overall (2026-09-06, deduplicated the same way as
-`scripts/coverage_module_report.py`): **76.4% lines**
-- still short of goal, dominated by the hardware modules below.
-The whole table below was re-measured on 2026-09-06; the date tags on some
+overall (2026-09-07, deduplicated the same way as
+`scripts/coverage_module_report.py`): **77.8% lines**
+- still short of goal, dominated by the hardware/GUI modules below.
+The whole table below was re-measured on 2026-09-07; the date tags on some
 rows mark when that module last had a dedicated unit-test pass, and point at
 the footnote describing it.
 
@@ -308,31 +308,31 @@ and accurate path — pick two.
 | mrpt_opengl | 2323/4234 | 54.9% | 35.7% |
 | mrpt_libapps_cli | 1129/1910 | 59.1% | 38.0% |
 | mrpt_libapps_gui | 803/1288 | 62.3% | 45.8% |
-| mrpt_viz (2026-08-02) | 6600/9440 | 69.9% | 51.4% |
+| mrpt_viz (2026-08-02) | 6617/9440 | 70.1% | 51.5% |
 | mrpt_common | 5/7 | 71.4% | 0.0% |
-| mrpt_graphslam (2026-09-06)@ | 814/997 | 81.6% | 64.4% |
 | mrpt_comms (2026-08-29)» | 687/906 | 75.8% | 54.4% |
 | mrpt_examples_cpp | 99/128 | 77.3% | 46.3% |
-| mrpt_system (2026-08-29)» | 1625/1963 | 82.8% | 58.5% |
-| mrpt_rtti (2026-08-29)» | 151/176 | 85.8% | 77.4% |
-| mrpt_maps (2026-08-03)§ | 10118/11698 | 86.5% | 62.8% |
-| mrpt_io (2026-08-29)» | 1133/1310 | 86.5% | 69.7% |
-| mrpt_containers (2026-07-11) | 1633/1848 | 88.4% | 54.4%‡ |
-| mrpt_obs (2026-07-10) | 6066/6856 | 88.5% | 61.0% |
-| mrpt_math (2026-07-05) | 6816/7674 | 88.8% | 60.3% |
-| mrpt_core | 571/636 | 89.8% | 69.9% |
-| mrpt_slam (2026-08-31)× | 3921/4346 | 90.2% | 62.3% |
-| mrpt_nav (2026-08-28)¶ | 5683/6287 | 90.4% | 68.9% |
-| mrpt_graphs (2026-07-06) | 1023/1112 | 92.0% | 76.5% |
-| mrpt_poses | 6279/6787 | 92.5% | 60.9% |
-| mrpt_img (2026-07-10)† | 2839/3061 | 92.7% | 71.0% |
+| mrpt_graphslam (2026-09-06)@ | 814/997 | 81.6% | 64.4% |
+| mrpt_system (2026-08-29)» | 1637/1964 | 83.4% | 59.0% |
+| mrpt_rtti (2026-08-29)» | 151/176 | 85.8% | 78.1% |
+| mrpt_io (2026-08-29)» | 1133/1310 | 86.5% | 70.4% |
+| mrpt_maps (2026-09-07)★ | 10631/11789 | 90.2% | 66.4% |
+| mrpt_containers (2026-07-11) | 1803/1999 | 90.2% | 55.6%‡ |
+| mrpt_nav (2026-08-28)¶ | 5683/6287 | 90.4% | 69.0% |
+| mrpt_core | 579/638 | 90.8% | 71.9% |
+| mrpt_obs (2026-09-07)★ | 6282/6857 | 91.6% | 63.1% |
+| mrpt_graphs (2026-07-06) | 1030/1113 | 92.5% | 76.8% |
+| mrpt_poses | 6282/6788 | 92.5% | 61.4% |
 | mrpt_expr | 93/100 | 93.0% | 60.2% |
-| mrpt_bayes (2026-07-09) | 1049/1090 | 96.2% | 80.2% |
-| mrpt_serialization (2026-08-29)» | 728/754 | 96.6% | 74.7% |
+| mrpt_img (2026-07-10)† | 2856/3060 | 93.3% | 71.7% |
+| mrpt_slam (2026-09-07)★ | 4065/4348 | 93.5% | 65.3% |
+| mrpt_math (2026-09-07)★ | 7472/7867 | 95.0% | 64.4% |
+| mrpt_bayes (2026-07-09) | 1049/1090 | 96.2% | 80.3% |
+| mrpt_serialization (2026-08-29)» | 728/754 | 96.6% | 75.2% |
 | mrpt_random | 162/167 | 97.0% | 88.4% |
-| mrpt_tfest (2026-07-07) | 635/654 | 97.1% | 73.1% |
+| mrpt_tfest (2026-07-07) | 635/654 | 97.1% | 72.9% |
 | mrpt_kinematics (2026-08-28)¶ | 503/518 | 97.1% | 81.2% |
-| mrpt_config (2026-07-09) | 536/548 | 97.8% | 84.6% |
+| mrpt_config (2026-07-09) | 536/548 | 97.8% | 84.7% |
 | mrpt_topography (2026-07-10) | 414/417 | 99.3% | 83.2% |
 | mrpt_typemeta | 57/57 | 100.0% | 80.9% |
 
@@ -937,6 +937,98 @@ from outside the module. `mrpt_gui`'s is `CDisplayWindowGUI.cpp` (nanogui /
 GLFW), `CQtGlCanvasBase.cpp` (Qt), `CAboutBox*`/`error_box.cpp` (modal dialogs
 that would block a test run) and the rest of `mathplot.cpp`.
 
+★ Coverage pass of 2026-09-07 on the four core algorithmic modules:
+`mrpt_math` (88.8% -> 95.0%), `mrpt_maps` (86.5% -> 90.2%), `mrpt_obs`
+(88.5% -> 91.6%) and `mrpt_slam` (90.2% -> 93.5%). All four are now at or
+above the 90% goal.
+
+The single most productive technique here was a ~30-line test helper that
+writes an MRPT object frame (`[len|0x80][class name][version byte][payload]
+[0x88]`) with an **arbitrary streaming version**, so the backwards-compatible
+branches of `serializeFrom()` can be driven without shipping binary fixture
+files. It lives as `tests/legacy_serialization.h` in both `mrpt_math` and
+`mrpt_obs` (duplicated rather than shared, since modules are independent CMake
+projects) and covers the legacy formats of `CPolygon` (v0/v1),
+`CActionRobotMovement2D` (v0..v7, both the odometry and the streamed-PDF
+paths), `CObservationStereoImages` (v0..v6), `CObservationImage` (v0..v4),
+`CObservationBeaconRanges`, `CObservationIMU`, `CObservationGasSensors` and
+`CObservation3DRangeScan` (v0..v10) - together several hundred lines that no
+test had ever reached.
+
+Real bugs found and fixed:
+
+* `mrpt::math::TLine3D::TLine3D(const TLine2D&)` computed the base point of a
+  *horizontal* 2D line (`A ~ 0`) as `-B/A`, dividing by the coefficient it had
+  just tested for zero; it should be `-C/B`, as in `TLine2D::getAsPose2D()`.
+  Every 2D->3D line conversion of a horizontal line yielded an infinite/NaN
+  base point.
+* `mrpt::math::getAngleBisector(TLine2D, TLine2D)`'s parallel-lines branch
+  normalized the second line with `sqrt(A^2 + C^2)` instead of
+  `sqrt(A^2 + B^2)`, and then added the two offsets without halving them. The
+  two errors cancelled for a line whose normalization factor happened to equal
+  `|C|`, which is exactly the case the pre-existing test used; for anything
+  else the "bisector" was one of the two input lines.
+* `mrpt::math::intersect(vector<T>, vector<U>, CSparseMatrixTemplate<O>&)`
+  (geometry.h) iterated the inner loop up to `v1.size()` instead of
+  `v2.size()`, reading out of bounds whenever the second set was smaller; its
+  `std::vector<O>` sibling took the output container **by value**, so results
+  never reached the caller. Both templates were uninstantiated dead code.
+* `KDTreeCapable`'s radius-limited k-NN searches (`kdTreeNClosestPoint2D`,
+  `kdTreeNClosestPoint3D`, `kdTreeNClosestPoint3DWithIdx`) trimmed the index
+  and distance vectors to the number of points actually found but left the
+  coordinate vectors at the requested `knn`, handing back stale entries; the
+  `TPoint2D`/`TPoint3D` overloads then sized their output from those, so
+  `pOut.size() != outDistSqr.size()`.
+* `mrpt::math::CHistogram::createWithFixedWidth()` was declared as a
+  non-static member, so the documented `CHistogram::createWithFixedWidth(...)`
+  usage did not compile - which made `mrpt::math::CMonteCarlo`'s
+  `getDistribution()` (its only caller) uninstantiable. Now `static`.
+* `mrpt::math::KLD_Gaussians()` called the non-existent
+  `inverse_LLt(out)` overload and `multiply_HCHt_scalar()` (row-vector form)
+  on a column vector; it was likewise uninstantiable dead code.
+* `CGasConcentrationGridMap2D::simulateAdvection()` indexes `m_stackedCov`,
+  which only exists for the `mrKalmanApproximate` representation, so calling
+  it on any other map type read past the end of an empty matrix and
+  segfaulted. It now returns false with an error log instead.
+
+Worth knowing for future tests here:
+
+* `CObservationVelodyneScan`'s per-ray timestamps are derived from
+  `CObservation::timestamp`, not from `getOriginalReceivedTimeStamp()` (which
+  is left at `INVALID_TIMESTAMP` in a synthetically-built scan), so the
+  `CPose3DInterpolator` fed to `generatePointCloudAlongSE3Trajectory()` must
+  be built around the former, densely enough that every query has neighbors on
+  both sides.
+* Only the **auxiliary** particle filters go through
+  `PF_SLAM_implementation_gatherActionsCheckBothActObs()`, which is what
+  accumulates actions across steps; `pfStandardProposal` reads the action
+  directly. And `PF_SLAM_implementation_doWeHaveValidObservations()` defaults
+  to `true`, so an *empty* sensory frame is still "valid" - passing a null
+  `sf` is the way to leave a movement accumulated for the next step.
+* `CObservationGPS`'s `TIMECONV_IsALeapYear()` and
+  `TIMECONV_GetNumberOfDaysInMonth()` are only ever called from the
+  `seconds >= 60.0` rollover fix-up inside
+  `TIMECONV_GetUTCTimeFromJulianDate()`. A sweep over ~2400 GPS weeks never
+  gets the accumulated floating-point error above 59.999999 s, so that branch
+  (and hence those two helpers) is unreachable in practice.
+* `CRandomFieldGridMap2D`'s largest single block of untested code was
+  `internal_clear()`'s `GMRF_use_occupancy_information` path, which builds the
+  factor-graph prior by region growing over an occupancy gridmap. Pointing
+  `insertionOptions.GMRF_gridmap_image_file` at the module's own
+  `tests/map_pgm_32.pgm` fixture is enough to drive it end to end.
+* `CGasConcentrationGridMap2D::build_Gaussian_Wind_Grid()` caches its look-up
+  table in a file named after the grid parameters **in the current working
+  directory**, and also writes a `simple_LUT.txt` debug dump. A test that
+  wants to cover both the "generate + save" and the "found, load" branches
+  must `chdir` into a scratch directory first (and restore it afterwards).
+
+`mrpt_maps`' remaining gap is concentrated in
+`CVoxelMapOccupancyBase.h`/`CVoxelMapBase.h` (voxel types other than the two
+instantiated ones), `COccupancyGridMap2D_voronoi.cpp` and
+`COccupancyGridMap3D.cpp`; `mrpt_slam`'s is `CMultiMetricMapPDF_RBPF.cpp`'s
+landmark-map and no-odometry RO-SLAM branches of
+`prediction_and_update_pfOptimalProposal()`.
+
 ### Weak areas, grouped by root cause
 
 1. **Hardware drivers - `mrpt_hwdrivers` (13.9%)**: inherently hard to
@@ -984,9 +1076,12 @@ that would block a test run) and the rest of `mathplot.cpp`.
 
 5. **Biggest single-file impact (most uncovered lines, worth prioritizing for
    raw percentage gains)**:
-   `mrpt_maps/src/maps/COccupancyGridMap2D_io.cpp` (85, 56.0%),
    `mrpt_nav/src/reactive/CAbstractPTGBasedReactive.cpp` (123, 82.1%),
-   `mrpt_maps/src/maps/COccupancyGridMap2D_simulate.cpp` (49, 53.3%).
+   `mrpt_maps/include/mrpt/maps/CVoxelMapOccupancyBase.h` (92, 62.0%),
+   `mrpt_maps/src/maps/CGenericPointsMap.cpp` (75, 84.5%),
+   `mrpt_maps/src/maps/COccupancyGridMap2D_common.cpp` (72, 84.6%).
+   (`mrpt_maps/src/maps/COccupancyGridMap2D_io.cpp` and `_simulate.cpp`
+   cleared this bucket as of 2026-08-03.)
    (`mrpt_viz/src/CPolyhedron.cpp`, formerly the single biggest uncovered file
    in the whole repo at 1420 uncovered lines, cleared this bucket as of
    2026-08-02, now at 91.6%.)
@@ -997,20 +1092,18 @@ that would block a test run) and the rest of `mathplot.cpp`.
    2026-07-17 — see § above.)
 
 6. **Near-target modules (75-90%), smallest remaining gap to close first**:
-   `mrpt_system` (82.6%; `CTimeLogger.cpp`, `COutputLogger.cpp` and
+   `mrpt_system` (83.4%; `CTimeLogger.cpp`, `COutputLogger.cpp` and
    `filesystem.cpp` are what is left), `mrpt_rtti` (85.8%, but see the dead
    registration queue noted in » above), `mrpt_io` (86.5%; `CPipe.cpp` needs
    child processes), `mrpt_comms` (75.8%; the rest is `CInterfaceFTDI`, which
-   needs a real FTDI device).
-   (`mrpt_slam` cleared this bucket as of 2026-08-31, now at 90.2%; what is
-   left there is `PF_implementations.h` (60.6%, mostly the auxiliary-PF
-   sub-variants and the KLD adaptive-sampling paths), `CICP.cpp` (87.9%) and
-   `data_association.cpp` (84.5%).)
+   needs a real FTDI device), `mrpt_graphslam` (81.6%, needs a live
+   `CDisplayWindow3D`).
+   (`mrpt_math`, `mrpt_maps`, `mrpt_obs` and `mrpt_slam` cleared this bucket
+   as of 2026-09-07 — see ★ above.)
    (`mrpt_serialization` cleared this bucket as of 2026-08-29, now at 96.6%;
    `mrpt_graphs` and `mrpt_random` cleared it as of 2026-07-06;
    `mrpt_bayes` and `mrpt_config` cleared it as of 2026-07-09, both now >96%;
-   `mrpt_obs` improved to 87.0% as of 2026-07-10 but is still within this
-   range; `mrpt_containers` cleared it as of 2026-07-11, now at 92.9%,
+   `mrpt_containers` cleared it as of 2026-07-11, now at 90.2%,
    remaining gaps being mostly defensive "should never happen" throws and
    libfyaml parser error paths that are difficult to trigger without a
    malformed internal parser state.)

--- a/modules/mrpt_maps/CMakeLists.txt
+++ b/modules/mrpt_maps/CMakeLists.txt
@@ -83,6 +83,7 @@ set(LIB_UNIT_TEST_SOURCES
   tests/CPointCloudFilterByDistance_unittest.cpp
   tests/CGenericPointsMap_unittest.cpp
   tests/CPointsMap_unittest.cpp
+  tests/CPointsMap_insertObs_unittest.cpp
   tests/CPointsMapXYZIRT_unittest.cpp
   tests/CRandomFieldGridMap2D_unittest.cpp
   tests/CRandomFieldGridMap3D_unittest.cpp
@@ -93,6 +94,7 @@ set(LIB_UNIT_TEST_SOURCES
   tests/CWirelessPowerGridMap2D_unittest.cpp
   tests/customizable_obs_viz_unittest.cpp
   tests/CPlanarLaserScan_unittest.cpp
+  tests/maps_coverage2_unittest.cpp
 )
 
 set(LIB_PUBLIC_HEADERS

--- a/modules/mrpt_maps/src/maps/CGasConcentrationGridMap2D.cpp
+++ b/modules/mrpt_maps/src/maps/CGasConcentrationGridMap2D.cpp
@@ -606,6 +606,17 @@ bool CGasConcentrationGridMap2D::simulateAdvection(double STD_increase_value)
     return false;
   }
 
+  // The transition model below reads the per-cell variances from the
+  // compressed covariance (m_stackedCov), which only exists for the
+  // approximate Kalman representation:
+  if (m_mapType != mrKalmanApproximate)
+  {
+    MRPT_LOG_ERROR(
+        "simulateAdvection() is only implemented for the mrKalmanApproximate "
+        "map representation.");
+    return false;
+  }
+
   // Get time since last simulation
   double At = mrpt::system::timeDifference(timeLastSimulated, mrpt::Clock::now());
   std::cout << endl

--- a/modules/mrpt_maps/tests/CGasConcentrationGridMap2D_unittest.cpp
+++ b/modules/mrpt_maps/tests/CGasConcentrationGridMap2D_unittest.cpp
@@ -23,6 +23,7 @@
 #include <mrpt/system/filesystem.h>
 #include <mrpt/viz/CSetOfObjects.h>
 
+#include <filesystem>
 #include <sstream>
 
 const double xMin = -4.0, xMax = 4.0, yMin = -4.0, yMax = 4.0;
@@ -376,4 +377,58 @@ gasSensorLabel=Full_MCEnose
   const auto createdMap = mrpt::maps::CGasConcentrationGridMap2D::CreateFromMapDefinition(def);
   ASSERT_NE(createdMap, nullptr);
   EXPECT_GT(createdMap->getSizeX(), 0u);
+}
+
+// =========================================================================
+//  Wind-advection look-up table
+// =========================================================================
+
+TEST(CGasConcentrationGridMap2D, GaussianWindLUTBuildSaveAndReload)
+{
+  // build_Gaussian_Wind_Grid() caches the generated table in a file in the
+  // current working directory, so run this from a scratch directory.
+  const auto prevDir = std::filesystem::current_path();
+  const auto tmpDir = std::filesystem::path(mrpt::system::getTempFileName() + "_windlut");
+  std::filesystem::create_directories(tmpDir);
+  std::filesystem::current_path(tmpDir);
+
+  try
+  {
+    mrpt::maps::CGasConcentrationGridMap2D grid(
+        mrpt::maps::CRandomFieldGridMap2D::mrKalmanApproximate, -0.5f, 0.5f, -0.5f, 0.5f, 0.1f);
+    grid.insertionOptions.useWindInformation = true;
+    grid.insertionOptions.advectionFreq = 1.0f;
+
+    // The first clear() generates the table from scratch and saves it:
+    grid.clear();
+    EXPECT_FALSE(std::filesystem::is_empty(tmpDir));
+
+    // A second map with the same parameters must find and load the cached one:
+    mrpt::maps::CGasConcentrationGridMap2D grid2(
+        mrpt::maps::CRandomFieldGridMap2D::mrKalmanApproximate, -0.5f, 0.5f, -0.5f, 0.5f, 0.1f);
+    grid2.insertionOptions.useWindInformation = true;
+    grid2.insertionOptions.advectionFreq = 1.0f;
+    grid2.clear();
+
+    // The advection simulation now has a usable look-up table:
+    grid2.insertIndividualReading(0.5, {0.0, 0.0}, true, true, 1.0);
+    EXPECT_TRUE(grid2.simulateAdvection(0.01));
+
+    // ...but only the approximate-Kalman representation supports it:
+    mrpt::maps::CGasConcentrationGridMap2D dmGrid(
+        mrpt::maps::CRandomFieldGridMap2D::mrKernelDM, -0.5f, 0.5f, -0.5f, 0.5f, 0.1f);
+    dmGrid.insertionOptions.useWindInformation = true;
+    dmGrid.insertionOptions.advectionFreq = 1.0f;
+    dmGrid.clear();
+    EXPECT_FALSE(dmGrid.simulateAdvection(0.01));
+  }
+  catch (...)
+  {
+    std::filesystem::current_path(prevDir);
+    std::filesystem::remove_all(tmpDir);
+    throw;
+  }
+
+  std::filesystem::current_path(prevDir);
+  std::filesystem::remove_all(tmpDir);
 }

--- a/modules/mrpt_maps/tests/CPointsMap_insertObs_unittest.cpp
+++ b/modules/mrpt_maps/tests/CPointsMap_insertObs_unittest.cpp
@@ -17,6 +17,8 @@
 // point-accessor and nearest-neighbor overloads.
 
 #include <gtest/gtest.h>
+#include <mrpt/core/bits_math.h>  // M_PI on MSVC
+#include <mrpt/core/common.h>     // M_PIf on MSVC
 #include <mrpt/maps/CSimplePointsMap.h>
 #include <mrpt/obs/CObservation2DRangeScan.h>
 #include <mrpt/obs/CObservation3DRangeScan.h>

--- a/modules/mrpt_maps/tests/CPointsMap_insertObs_unittest.cpp
+++ b/modules/mrpt_maps/tests/CPointsMap_insertObs_unittest.cpp
@@ -248,28 +248,34 @@ TEST(CPointsMapInsertObs, insertWithFuseWithExisting)
   const size_t nAfterFirst = map.size();
   ASSERT_GT(nAfterFirst, 0U);
 
-  // Re-inserting the same scan with fusion enabled must not double the cloud:
+  // Re-inserting the same scan with fusion enabled must not double the cloud
+  // (without fusion the size would be exactly 2*nAfterFirst):
   map.insertionOptions.fuseWithExisting = true;
   map.insertionOptions.minDistBetweenLaserPoints = 0.05f;
   EXPECT_TRUE(map.insertObservation(*scan));
-  EXPECT_LE(map.size(), 2 * nAfterFirst);
+  EXPECT_LT(map.size(), 2 * nAfterFirst);
 
-  // The same for a 3D range scan:
+  // The same for a 3D range scan. Note that a point at exactly (0,0,0) is
+  // treated as an invalid reading and dropped, so all coordinates are
+  // non-zero here to keep the count predictable:
   auto obs3D = CObservation3DRangeScan::Create();
   obs3D->timestamp = mrpt::Clock::now();
   obs3D->hasPoints3D = true;
   obs3D->resizePoints3DVectors(3);
   for (int i = 0; i < 3; i++)
   {
-    obs3D->points3D_x[i] = static_cast<float>(i);
-    obs3D->points3D_y[i] = 0.0f;
-    obs3D->points3D_z[i] = 0.0f;
+    obs3D->points3D_x[i] = static_cast<float>(i + 1);
+    obs3D->points3D_y[i] = 1.0f;
+    obs3D->points3D_z[i] = 1.0f;
   }
   CSimplePointsMap map3d;
   map3d.insertObservation(*obs3D);
+  const size_t n3dAfterFirst = map3d.size();
+  ASSERT_EQ(n3dAfterFirst, 3U);
+
   map3d.insertionOptions.fuseWithExisting = true;
   EXPECT_TRUE(map3d.insertObservation(*obs3D));
-  EXPECT_LE(map3d.size(), 6U);
+  EXPECT_LT(map3d.size(), 2 * n3dAfterFirst);
 }
 
 TEST(CPointsMapInsertObs, getAllPointsWithDecimation)

--- a/modules/mrpt_maps/tests/CPointsMap_insertObs_unittest.cpp
+++ b/modules/mrpt_maps/tests/CPointsMap_insertObs_unittest.cpp
@@ -1,0 +1,408 @@
+/*                    _
+                     | |    Mobile Robot Programming Toolkit (MRPT)
+ _ __ ___  _ __ _ __ | |_
+| '_ ` _ \| '__| '_ \| __|          https://www.mrpt.org/
+| | | | | | |  | |_) | |_
+|_| |_| |_|_|  | .__/ \__|     https://github.com/MRPT/mrpt/
+               | |
+               |_|
+
+ Copyright (c) 2005-2026, Individual contributors, see AUTHORS file
+ See: https://www.mrpt.org/Authors - All rights reserved.
+ SPDX-License-Identifier: BSD-3-Clause
+*/
+
+// Covers the observation types accepted by CPointsMap::insertObservation() that
+// the main CPointsMap test file does not reach, plus the remaining
+// point-accessor and nearest-neighbor overloads.
+
+#include <gtest/gtest.h>
+#include <mrpt/maps/CSimplePointsMap.h>
+#include <mrpt/obs/CObservation2DRangeScan.h>
+#include <mrpt/obs/CObservation3DRangeScan.h>
+#include <mrpt/obs/CObservationPointCloud.h>
+#include <mrpt/obs/CObservationRange.h>
+#include <mrpt/obs/CObservationRotatingScan.h>
+#include <mrpt/obs/CObservationVelodyneScan.h>
+#include <mrpt/poses/CPose3D.h>
+#include <mrpt/viz/CSetOfObjects.h>
+
+#include <sstream>
+
+using namespace mrpt;
+using namespace mrpt::maps;
+using namespace mrpt::obs;
+
+namespace
+{
+CSimplePointsMap makeGrid(int n = 5, float step = 1.0f)
+{
+  CSimplePointsMap m;
+  for (int i = 0; i < n; i++)
+    for (int j = 0; j < n; j++) m.insertPoint(i * step, j * step, 0.0f);
+  return m;
+}
+
+CObservation2DRangeScan::Ptr makeScan2D()
+{
+  auto scan = CObservation2DRangeScan::Create();
+  scan->timestamp = mrpt::Clock::now();
+  scan->aperture = M_PIf;
+  scan->rightToLeft = true;
+  scan->maxRange = 20.0f;
+  scan->resizeScan(60);
+  for (size_t i = 0; i < 60; i++)
+  {
+    scan->setScanRange(i, 5.0f);
+    scan->setScanRangeValidity(i, true);
+  }
+  return scan;
+}
+}  // namespace
+
+TEST(CPointsMapInsertObs, insertObservationRange)
+{
+  // A sonar-like observation: each cone is inserted as a single point at the
+  // measured distance along the sensor's X axis.
+  auto obs = CObservationRange::Create();
+  obs->timestamp = mrpt::Clock::now();
+  obs->minSensorDistance = 0.1f;
+  obs->maxSensorDistance = 10.0f;
+  obs->sensorConeAperture = 0.2f;
+
+  CObservationRange::TMeasurement m;
+  m.sensorID = 0;
+  m.sensorPose = mrpt::math::TPose3D(0, 0, 0, 0, 0, 0);
+  m.sensedDistance = 3.0f;
+  obs->sensedData.push_back(m);
+
+  m.sensorPose = mrpt::math::TPose3D(0, 0, 0, M_PI / 2, 0, 0);
+  m.sensedDistance = 4.0f;
+  obs->sensedData.push_back(m);
+
+  CSimplePointsMap map;
+  EXPECT_TRUE(map.insertObservation(*obs));
+  // Each cone is discretized into a patch of points at the sensed distance:
+  ASSERT_GT(map.size(), 2U);
+
+  size_t nAt3m = 0, nAt4m = 0;
+  for (size_t i = 0; i < map.size(); i++)
+  {
+    mrpt::math::TPoint3D p;
+    map.getPoint(i, p);
+    const double r = p.norm();
+    if (std::abs(r - 3.0) < 1e-4) nAt3m++;
+    if (std::abs(r - 4.0) < 1e-4) nAt4m++;
+  }
+  EXPECT_GT(nAt3m, 0U);
+  EXPECT_GT(nAt4m, 0U);
+  EXPECT_EQ(nAt3m + nAt4m, map.size());
+
+  // Out-of-range readings are dropped:
+  CSimplePointsMap map2;
+  obs->sensedData[0].sensedDistance = 100.0f;
+  obs->sensedData[1].sensedDistance = 0.01f;
+  EXPECT_TRUE(map2.insertObservation(*obs));
+  EXPECT_EQ(map2.size(), 0U);
+}
+
+TEST(CPointsMapInsertObs, insertObservationPointCloud)
+{
+  auto obs = CObservationPointCloud::Create();
+  obs->timestamp = mrpt::Clock::now();
+  obs->sensorPose = mrpt::poses::CPose3D(10, 0, 0, 0, 0, 0);
+  obs->pointcloud = CSimplePointsMap::Create();
+  obs->pointcloud->insertPoint(1.0f, 2.0f, 3.0f);
+  obs->pointcloud->insertPoint(-1.0f, 0.0f, 0.0f);
+
+  CSimplePointsMap map;
+  EXPECT_TRUE(map.insertObservation(*obs));
+  ASSERT_EQ(map.size(), 2U);
+
+  // Points come back in the map frame, i.e. shifted by the sensor pose:
+  mrpt::math::TPoint3D p;
+  map.getPoint(0, p);
+  EXPECT_NEAR(p.x, 11.0, 1e-4);
+
+  // An observation without a point cloud is rejected:
+  auto emptyObs = CObservationPointCloud::Create();
+  emptyObs->timestamp = mrpt::Clock::now();
+  CSimplePointsMap map2;
+  EXPECT_THROW(map2.insertObservation(*emptyObs), std::exception);
+}
+
+TEST(CPointsMapInsertObs, insertObservationRotatingScan)
+{
+  auto obs = CObservationRotatingScan::Create();
+  obs->timestamp = mrpt::Clock::now();
+  obs->rowCount = 2;
+  obs->columnCount = 8;
+  obs->rangeResolution = 0.01;
+  obs->sensorPose = mrpt::poses::CPose3D(0, 0, 0.5, 0, 0, 0);
+  obs->rangeImage.setZero(obs->rowCount, obs->columnCount);
+  obs->intensityImage.setZero(obs->rowCount, obs->columnCount);
+  obs->azimuthSpan = 2 * M_PI;
+  obs->minRange = 0.1;
+  obs->maxRange = 50.0;
+  for (size_t r = 0; r < obs->rowCount; r++)
+    for (size_t c = 0; c < obs->columnCount; c++) obs->rangeImage(r, c) = 500;  // 5 m
+
+  CSimplePointsMap map;
+  EXPECT_TRUE(map.insertObservation(*obs));
+  EXPECT_GT(map.size(), 0U);
+
+  // The likelihood of the same observation against the map it built must be
+  // finite (and better than against an empty map):
+  const double lik = map.computeObservationLikelihood(*obs, mrpt::poses::CPose3D());
+  EXPECT_TRUE(std::isfinite(lik));
+
+  CSimplePointsMap emptyMap;
+  EXPECT_NEAR(emptyMap.computeObservationLikelihood(*obs, mrpt::poses::CPose3D()), -100.0, 1e-9);
+}
+
+TEST(CPointsMapInsertObs, insertObservationVelodyneScan)
+{
+  // A minimal, already-decoded Velodyne observation:
+  auto obs = CObservationVelodyneScan::Create();
+  obs->timestamp = mrpt::Clock::now();
+  obs->sensorPose = mrpt::poses::CPose3D(0, 0, 1.0, 0, 0, 0);
+  for (int i = 0; i < 10; i++)
+  {
+    obs->point_cloud.x.push_back(static_cast<float>(i));
+    obs->point_cloud.y.push_back(0.0f);
+    obs->point_cloud.z.push_back(0.0f);
+    obs->point_cloud.intensity.push_back(100);
+    obs->point_cloud.laser_id.push_back(0);
+    obs->point_cloud.azimuth.push_back(0.0f);
+  }
+
+  CSimplePointsMap map;
+  EXPECT_TRUE(map.insertObservation(*obs));
+  ASSERT_EQ(map.size(), 10U);
+
+  mrpt::math::TPoint3D p;
+  map.getPoint(3, p);
+  EXPECT_NEAR(p.z, 1.0, 1e-4);
+
+  const double lik = map.computeObservationLikelihood(*obs, mrpt::poses::CPose3D());
+  EXPECT_TRUE(std::isfinite(lik));
+}
+
+TEST(CPointsMapInsertObs, insertObservationPointCloudLikelihood)
+{
+  CSimplePointsMap map = makeGrid();
+
+  auto obs = CObservationPointCloud::Create();
+  obs->timestamp = mrpt::Clock::now();
+  obs->pointcloud = CSimplePointsMap::Create();
+  obs->pointcloud->insertPoint(1.0f, 1.0f, 0.0f);
+  obs->pointcloud->insertPoint(2.0f, 2.0f, 0.0f);
+
+  const double lik = map.computeObservationLikelihood(*obs, mrpt::poses::CPose3D());
+  EXPECT_TRUE(std::isfinite(lik));
+
+  // A point cloud far away must be less likely:
+  auto farObs = CObservationPointCloud::Create();
+  farObs->timestamp = mrpt::Clock::now();
+  farObs->pointcloud = CSimplePointsMap::Create();
+  farObs->pointcloud->insertPoint(100.0f, 100.0f, 0.0f);
+  EXPECT_LT(map.computeObservationLikelihood(*farObs, mrpt::poses::CPose3D()), lik);
+}
+
+TEST(CPointsMapInsertObs, insertPlanarMapRejectsNonHorizontalScans)
+{
+  auto scan = makeScan2D();
+  // A sensor looking downwards is not a planar (horizontal) scan:
+  scan->setSensorPose(mrpt::poses::CPose3D(0, 0, 1.0, 0, M_PI / 4, 0));
+
+  CSimplePointsMap map;
+  map.insertionOptions.isPlanarMap = true;
+  map.insertionOptions.horizontalTolerance = mrpt::DEG2RAD(1.0);
+  EXPECT_FALSE(map.insertObservation(*scan));
+  EXPECT_EQ(map.size(), 0U);
+
+  // A horizontal one is accepted:
+  scan->setSensorPose(mrpt::poses::CPose3D(0, 0, 1.0, 0, 0, 0));
+  EXPECT_TRUE(map.insertObservation(*scan));
+  EXPECT_GT(map.size(), 0U);
+
+  // 3D range scans are never inserted into a planar map:
+  auto obs3D = CObservation3DRangeScan::Create();
+  obs3D->timestamp = mrpt::Clock::now();
+  obs3D->hasPoints3D = true;
+  obs3D->resizePoints3DVectors(1);
+  obs3D->points3D_x[0] = 1.0f;
+  obs3D->points3D_y[0] = 0.0f;
+  obs3D->points3D_z[0] = 0.0f;
+  const size_t before = map.size();
+  EXPECT_FALSE(map.insertObservation(*obs3D));
+  EXPECT_EQ(map.size(), before);
+}
+
+TEST(CPointsMapInsertObs, insertWithFuseWithExisting)
+{
+  auto scan = makeScan2D();
+
+  CSimplePointsMap map;
+  map.insertObservation(*scan);
+  const size_t nAfterFirst = map.size();
+  ASSERT_GT(nAfterFirst, 0U);
+
+  // Re-inserting the same scan with fusion enabled must not double the cloud:
+  map.insertionOptions.fuseWithExisting = true;
+  map.insertionOptions.minDistBetweenLaserPoints = 0.05f;
+  EXPECT_TRUE(map.insertObservation(*scan));
+  EXPECT_LE(map.size(), 2 * nAfterFirst);
+
+  // The same for a 3D range scan:
+  auto obs3D = CObservation3DRangeScan::Create();
+  obs3D->timestamp = mrpt::Clock::now();
+  obs3D->hasPoints3D = true;
+  obs3D->resizePoints3DVectors(3);
+  for (int i = 0; i < 3; i++)
+  {
+    obs3D->points3D_x[i] = static_cast<float>(i);
+    obs3D->points3D_y[i] = 0.0f;
+    obs3D->points3D_z[i] = 0.0f;
+  }
+  CSimplePointsMap map3d;
+  map3d.insertObservation(*obs3D);
+  map3d.insertionOptions.fuseWithExisting = true;
+  EXPECT_TRUE(map3d.insertObservation(*obs3D));
+  EXPECT_LE(map3d.size(), 6U);
+}
+
+TEST(CPointsMapInsertObs, getAllPointsWithDecimation)
+{
+  CSimplePointsMap map;
+  for (int i = 0; i < 20; i++) map.insertPoint(i, 2 * i, 3 * i);
+
+  std::vector<float> xs, ys;
+  map.getAllPoints(xs, ys);
+  EXPECT_EQ(xs.size(), 20U);
+  EXPECT_EQ(ys.size(), 20U);
+  EXPECT_NEAR(ys[3], 6.0f, 1e-5f);
+
+  map.getAllPoints(xs, ys, 4);
+  EXPECT_EQ(xs.size(), 5U);
+  EXPECT_NEAR(xs[1], 4.0f, 1e-5f);
+
+  std::vector<mrpt::math::TPoint2D> pts;
+  map.getAllPoints(pts, 5);
+  EXPECT_EQ(pts.size(), 4U);
+
+  std::vector<float> zs;
+  map.getAllPoints(xs, ys, zs, 2);
+  EXPECT_EQ(zs.size(), 10U);
+  EXPECT_NEAR(zs[1], 6.0f, 1e-5f);
+
+  EXPECT_THROW(map.getAllPoints(xs, ys, 0), std::exception);
+}
+
+TEST(CPointsMapInsertObs, setAllPoints)
+{
+  CSimplePointsMap map;
+
+  const std::vector<float> X{1.0f, 2.0f, 3.0f};
+  const std::vector<float> Y{4.0f, 5.0f, 6.0f};
+  const std::vector<float> Z{7.0f, 8.0f, 9.0f};
+
+  map.setAllPoints(X, Y, Z);
+  ASSERT_EQ(map.size(), 3U);
+  mrpt::math::TPoint3D p;
+  map.getPoint(2, p);
+  EXPECT_NEAR(p.z, 9.0, 1e-5);
+
+  // The 2D overload zeroes z:
+  map.setAllPoints(X, Y);
+  ASSERT_EQ(map.size(), 3U);
+  map.getPoint(2, p);
+  EXPECT_NEAR(p.z, 0.0, 1e-5);
+
+  const std::vector<float> shorter{1.0f};
+  EXPECT_THROW(map.setAllPoints(X, shorter), std::exception);
+  EXPECT_THROW(map.setAllPoints(X, Y, shorter), std::exception);
+}
+
+TEST(CPointsMapInsertObs, save2DToTextStream)
+{
+  CSimplePointsMap map;
+  map.insertPoint(1.0f, 2.0f, 3.0f);
+  map.insertPoint(4.0f, 5.0f, 6.0f);
+
+  std::ostringstream ss;
+  EXPECT_TRUE(map.save2D_to_text_stream(ss));
+
+  // Two lines, each with the x,y pair only:
+  const std::string s = ss.str();
+  EXPECT_NE(s.find("1.000000 2.000000"), std::string::npos);
+  EXPECT_NE(s.find("4.000000 5.000000"), std::string::npos);
+  EXPECT_EQ(s.find("3.000000"), std::string::npos);
+}
+
+TEST(CPointsMapInsertObs, nnSearchOverloads)
+{
+  const CSimplePointsMap map = makeGrid();
+
+  // 2D multiple search:
+  {
+    std::vector<mrpt::math::TPoint2Df> results;
+    std::vector<float> dists;
+    std::vector<uint64_t> ids;
+    map.nn_multiple_search({0.1f, 0.1f}, 3, results, dists, ids);
+    EXPECT_EQ(results.size(), 3U);
+    EXPECT_EQ(ids.size(), 3U);
+  }
+  // 3D multiple search:
+  {
+    std::vector<mrpt::math::TPoint3Df> results;
+    std::vector<float> dists;
+    std::vector<uint64_t> ids;
+    map.nn_multiple_search({0.1f, 0.1f, 0.0f}, 4, results, dists, ids);
+    EXPECT_EQ(results.size(), 4U);
+  }
+  // 2D radius search, both the unbounded and the maxPoints variants:
+  {
+    std::vector<mrpt::math::TPoint2Df> results;
+    std::vector<float> dists;
+    std::vector<uint64_t> ids;
+    map.nn_radius_search({0.0f, 0.0f}, 1.1f * 1.1f, results, dists, ids, 0);
+    EXPECT_EQ(results.size(), 3U);  // itself + the two neighbors at 1 m
+
+    map.nn_radius_search({0.0f, 0.0f}, 1.1f * 1.1f, results, dists, ids, 2);
+    EXPECT_EQ(results.size(), 2U);
+    EXPECT_EQ(dists.size(), 2U);
+  }
+  // 3D radius search with a maximum number of points:
+  {
+    std::vector<mrpt::math::TPoint3Df> results;
+    std::vector<float> dists;
+    std::vector<uint64_t> ids;
+    map.nn_radius_search({0.0f, 0.0f, 0.0f}, 1.1f * 1.1f, results, dists, ids, 2);
+    EXPECT_EQ(results.size(), 2U);
+
+    map.nn_radius_search({0.0f, 0.0f, 0.0f}, 1.1f * 1.1f, results, dists, ids, 0);
+    EXPECT_EQ(results.size(), 3U);
+  }
+}
+
+TEST(CPointsMapInsertObs, getVisualizationIntoColorFromZ)
+{
+  CSimplePointsMap map;
+  for (int i = 0; i < 10; i++) map.insertPoint(i, 0, i * 0.1f);
+
+  // Flat color:
+  {
+    map.renderOptions.colormap = mrpt::img::cmNONE;
+    mrpt::viz::CSetOfObjects o;
+    map.getVisualizationInto(o);
+    EXPECT_EQ(o.size(), 1U);
+  }
+  // Colorized by height:
+  {
+    map.renderOptions.colormap = mrpt::img::cmJET;
+    mrpt::viz::CSetOfObjects o;
+    map.getVisualizationInto(o);
+    EXPECT_EQ(o.size(), 1U);
+  }
+}

--- a/modules/mrpt_maps/tests/CRandomFieldGridMap2D_unittest.cpp
+++ b/modules/mrpt_maps/tests/CRandomFieldGridMap2D_unittest.cpp
@@ -22,6 +22,7 @@
 #include <mrpt/poses/CPose3D.h>
 #include <mrpt/system/filesystem.h>
 #include <mrpt/viz/CSetOfObjects.h>
+#include <test_mrpt_common.h>
 
 #include <cmath>
 #include <filesystem>
@@ -709,4 +710,77 @@ TEST(CRandomFieldGridMap2D, Compute3DMatchingRatioAlwaysZero)
   mrpt::maps::TMatchingRatioParams params;
   const float ratio = grid.compute3DMatchingRatio(&other, mrpt::poses::CPose3D(), params);
   EXPECT_FLOAT_EQ(ratio, 0.0f);
+}
+
+// =========================================================================
+//  GMRF prior built from an occupancy gridmap
+// =========================================================================
+
+TEST(CRandomFieldGridMap2D, GMRF_PriorFromOccupancyGridmapImage)
+{
+  using namespace std::string_literals;
+
+  // internal_clear() dumps a debug bitmap of the occupancy map into the
+  // current working directory, so run this from a scratch one.
+  const auto prevDir = std::filesystem::current_path();
+  const auto tmpDir = std::filesystem::path(mrpt::system::getTempFileName() + "_gmrf");
+  std::filesystem::create_directories(tmpDir);
+  std::filesystem::current_path(tmpDir);
+  struct DirRestorer
+  {
+    std::filesystem::path prev, tmp;
+    ~DirRestorer()
+    {
+      std::filesystem::current_path(prev);
+      std::filesystem::remove_all(tmp);
+    }
+  } restorer{prevDir, tmpDir};
+
+  CGasConcentrationGridMap2D grid(
+      CRandomFieldGridMap2D::mrGMRF_SD, -1.0f, 1.0f, -1.0f, 1.0f, 0.20f);
+
+  auto* opts = &grid.insertionOptions;
+  opts->GMRF_use_occupancy_information = true;
+  opts->GMRF_gridmap_image_file = mrpt::UNITTEST_BASEDIR() + "/tests/map_pgm_32.pgm"s;
+  opts->GMRF_gridmap_image_res = 0.10f;
+  opts->GMRF_gridmap_image_cx = 15;
+  opts->GMRF_gridmap_image_cy = 33;
+
+  // clear() rebuilds the factor graph, this time deriving the cell
+  // connectivity from the occupancy map through region growing:
+  grid.clear();
+
+  // The map must have been resized to match the occupancy gridmap:
+  EXPECT_GT(grid.getSizeX(), 0U);
+  EXPECT_GT(grid.getSizeY(), 0U);
+
+  grid.insertIndividualReading(0.5, {0.0, 0.0}, true, true, 1.0);
+
+  const TRandomFieldCell* cell = grid.cellByPos(0.0, 0.0);
+  ASSERT_NE(cell, nullptr);
+  EXPECT_TRUE(std::isfinite(cell->gmrf_mean()));
+}
+
+TEST(CRandomFieldGridMap2D, GMRF_OccupancyWithoutAnySourceThrows)
+{
+  CGasConcentrationGridMap2D grid(CRandomFieldGridMap2D::mrGMRF_SD, -1.0f, 1.0f, -1.0f, 1.0f, 0.5f);
+
+  auto* opts = &grid.insertionOptions;
+  opts->GMRF_use_occupancy_information = true;
+  opts->GMRF_simplemap_file.clear();
+  opts->GMRF_gridmap_image_file.clear();
+
+  EXPECT_THROW(grid.clear(), std::exception);
+}
+
+TEST(CRandomFieldGridMap2D, GMRF_OccupancyFromMissingImageThrows)
+{
+  CGasConcentrationGridMap2D grid(CRandomFieldGridMap2D::mrGMRF_SD, -1.0f, 1.0f, -1.0f, 1.0f, 0.5f);
+
+  auto* opts = &grid.insertionOptions;
+  opts->GMRF_use_occupancy_information = true;
+  opts->GMRF_gridmap_image_file = "/nonexistent-dir/does_not_exist.png";
+  opts->GMRF_gridmap_image_res = 0.1f;
+
+  EXPECT_THROW(grid.clear(), std::exception);
 }

--- a/modules/mrpt_maps/tests/maps_coverage2_unittest.cpp
+++ b/modules/mrpt_maps/tests/maps_coverage2_unittest.cpp
@@ -1,0 +1,207 @@
+/*                    _
+                     | |    Mobile Robot Programming Toolkit (MRPT)
+ _ __ ___  _ __ _ __ | |_
+| '_ ` _ \| '__| '_ \| __|          https://www.mrpt.org/
+| | | | | | |  | |_) | |_
+|_| |_| |_|_|  | .__/ \__|     https://github.com/MRPT/mrpt/
+               | |
+               |_|
+
+ Copyright (c) 2005-2026, Individual contributors, see AUTHORS file
+ See: https://www.mrpt.org/Authors - All rights reserved.
+ SPDX-License-Identifier: BSD-3-Clause
+*/
+
+// Assorted gaps left by the per-class test files: the generic point-field
+// accessors of CPointsMap, the voxel-map visualization coloring schemes and
+// the textual description of a CObservationPointCloud.
+
+#include <gtest/gtest.h>
+#include <mrpt/maps/CSimplePointsMap.h>
+#include <mrpt/maps/CVoxelMap.h>
+#include <mrpt/maps/CVoxelMapRGB.h>
+#include <mrpt/obs/CObservationPointCloud.h>
+#include <mrpt/viz/COctoMapVoxels.h>
+
+#include <limits>
+#include <sstream>
+
+using namespace mrpt::maps;
+using mrpt::obs::CObservationPointCloud;
+
+TEST(CPointsMapFields, genericFieldAccessors)
+{
+  CSimplePointsMap m;
+  m.insertPoint(1.0f, 2.0f, 3.0f);
+  m.insertPoint(4.0f, 5.0f, 6.0f);
+
+  // The three built-in float fields:
+  EXPECT_NEAR(m.getPointField_float(0, "x"), 1.0f, 1e-6f);
+  EXPECT_NEAR(m.getPointField_float(0, "y"), 2.0f, 1e-6f);
+  EXPECT_NEAR(m.getPointField_float(0, "z"), 3.0f, 1e-6f);
+  // Any other field name yields zero rather than throwing:
+  EXPECT_NEAR(m.getPointField_float(0, "intensity"), 0.0f, 1e-6f);
+
+  // A plain points map has no non-float fields at all:
+  EXPECT_NEAR(m.getPointField_double(0, "anything"), 0.0, 1e-12);
+  EXPECT_EQ(m.getPointField_uint16(0, "anything"), 0);
+  EXPECT_EQ(m.getPointField_uint8(0, "anything"), 0);
+  EXPECT_EQ(m.getPointField_uint32(0, "anything"), 0u);
+
+  // Setters for the built-in fields:
+  m.setPointField_float(1, "x", 40.0f);
+  m.setPointField_float(1, "y", 50.0f);
+  m.setPointField_float(1, "z", 60.0f);
+  EXPECT_NEAR(m.getPointField_float(1, "z"), 60.0f, 1e-6f);
+  // Unknown names are silently ignored:
+  EXPECT_NO_THROW(m.setPointField_float(1, "intensity", 1.0f));
+  EXPECT_NO_THROW(m.setPointField_double(1, "anything", 1.0));
+  EXPECT_NO_THROW(m.setPointField_uint16(1, "anything", 1));
+  EXPECT_NO_THROW(m.setPointField_uint8(1, "anything", 1));
+  EXPECT_NO_THROW(m.setPointField_uint32(1, "anything", 1));
+
+  // Out-of-bounds indices are rejected:
+  EXPECT_THROW(m.getPointField_float(10, "x"), std::exception);
+  EXPECT_THROW(m.setPointField_float(10, "x", 0.0f), std::exception);
+}
+
+TEST(CPointsMapFields, bufferRefsByFieldName)
+{
+  CSimplePointsMap m;
+  m.insertPoint(1.0f, 2.0f, 3.0f);
+
+  const CSimplePointsMap& cm = m;
+
+  ASSERT_NE(cm.getPointsBufferRef_float_field("x"), nullptr);
+  ASSERT_NE(cm.getPointsBufferRef_float_field("y"), nullptr);
+  ASSERT_NE(cm.getPointsBufferRef_float_field("z"), nullptr);
+  EXPECT_EQ(cm.getPointsBufferRef_float_field("intensity"), nullptr);
+  EXPECT_EQ(cm.getPointsBufferRef_double_field("anything"), nullptr);
+  EXPECT_EQ(cm.getPointsBufferRef_uint16_field("anything"), nullptr);
+  EXPECT_EQ(cm.getPointsBufferRef_uint8_field("anything"), nullptr);
+  EXPECT_EQ(cm.getPointsBufferRef_uint32_field("anything"), nullptr);
+
+  // Non-const overloads allow modifying the buffer in place:
+  auto* xs = m.getPointsBufferRef_float_field("x");
+  ASSERT_NE(xs, nullptr);
+  (*xs)[0] = 11.0f;
+  EXPECT_NEAR(m.getPointField_float(0, "x"), 11.0f, 1e-6f);
+  EXPECT_NE(m.getPointsBufferRef_float_field("y"), nullptr);
+  EXPECT_NE(m.getPointsBufferRef_float_field("z"), nullptr);
+  EXPECT_EQ(m.getPointsBufferRef_float_field("intensity"), nullptr);
+  EXPECT_EQ(m.getPointsBufferRef_double_field("anything"), nullptr);
+  EXPECT_EQ(m.getPointsBufferRef_uint16_field("anything"), nullptr);
+  EXPECT_EQ(m.getPointsBufferRef_uint8_field("anything"), nullptr);
+  EXPECT_EQ(m.getPointsBufferRef_uint32_field("anything"), nullptr);
+}
+
+namespace
+{
+CVoxelMap makeVoxelMap()
+{
+  CVoxelMap m(0.25);
+  // A few occupied voxels and a few free ones:
+  // Repeat the updates so the log-odds get well past both thresholds:
+  for (int rep = 0; rep < 10; rep++)
+  {
+    for (int i = 0; i < 3; i++) m.updateVoxel(i * 0.25, 0, i * 0.25, true);
+    for (int i = 3; i < 6; i++) m.updateVoxel(i * 0.25, 0, i * 0.25, false);
+  }
+  return m;
+}
+}  // namespace
+
+TEST(CVoxelMapViz, getAsOctoMapVoxelsAllColoringModes)
+{
+  auto m = makeVoxelMap();
+
+  using mrpt::viz::COctoMapVoxels;
+  const COctoMapVoxels::visualization_mode_t modes[] = {
+      COctoMapVoxels::FIXED, COctoMapVoxels::COLOR_FROM_HEIGHT,
+      COctoMapVoxels::COLOR_FROM_OCCUPANCY, COctoMapVoxels::TRANSPARENCY_FROM_OCCUPANCY,
+      COctoMapVoxels::TRANS_AND_COLOR_FROM_OCCUPANCY};
+
+  for (const auto mode : modes)
+  {
+    COctoMapVoxels vx;
+    vx.setVisualizationMode(mode);
+    m.getAsOctoMapVoxels(vx);
+    EXPECT_GT(vx.getVoxelCount(mrpt::viz::VOXEL_SET_OCCUPIED), 0U)
+        << "mode " << static_cast<int>(mode);
+  }
+
+  // Unsupported schemes for this map class:
+  {
+    COctoMapVoxels vx;
+    vx.setVisualizationMode(COctoMapVoxels::MIXED);
+    EXPECT_THROW(m.getAsOctoMapVoxels(vx), std::exception);
+  }
+  {
+    // A voxel type without colour cannot be colored from RGB data:
+    COctoMapVoxels vx;
+    vx.setVisualizationMode(COctoMapVoxels::COLOR_FROM_RGB_DATA);
+    EXPECT_THROW(m.getAsOctoMapVoxels(vx), std::exception);
+  }
+}
+
+TEST(CVoxelMapViz, renderingOptionsFilterVoxelSets)
+{
+  auto m = makeVoxelMap();
+
+  using mrpt::viz::COctoMapVoxels;
+
+  // Only free voxels:
+  {
+    COctoMapVoxels vx;
+    vx.setVisualizationMode(COctoMapVoxels::FIXED);
+    m.renderingOptions.generateOccupiedVoxels = false;
+    m.renderingOptions.generateFreeVoxels = true;
+    m.getAsOctoMapVoxels(vx);
+    EXPECT_EQ(vx.getVoxelCount(mrpt::viz::VOXEL_SET_OCCUPIED), 0U);
+    EXPECT_GT(vx.getVoxelCount(mrpt::viz::VOXEL_SET_FREESPACE), 0U);
+  }
+  // Only occupied voxels:
+  {
+    COctoMapVoxels vx;
+    vx.setVisualizationMode(COctoMapVoxels::FIXED);
+    m.renderingOptions.generateOccupiedVoxels = true;
+    m.renderingOptions.generateFreeVoxels = false;
+    m.getAsOctoMapVoxels(vx);
+    EXPECT_GT(vx.getVoxelCount(mrpt::viz::VOXEL_SET_OCCUPIED), 0U);
+    EXPECT_EQ(vx.getVoxelCount(mrpt::viz::VOXEL_SET_FREESPACE), 0U);
+  }
+}
+
+TEST(CObservationPointCloudDescription, getDescriptionAsText)
+{
+  auto obs = CObservationPointCloud::Create();
+  obs->timestamp = mrpt::Clock::now();
+  obs->sensorLabel = "lidar";
+  obs->sensorPose = mrpt::poses::CPose3D(1, 2, 3, 0, 0, 0);
+  obs->pointcloud = CSimplePointsMap::Create();
+  for (int i = 0; i < 10; i++) obs->pointcloud->insertPoint(i * 1.0f, i * 2.0f, i * 0.5f);
+
+  std::ostringstream ss;
+  obs->getDescriptionAsText(ss);
+  const std::string s = ss.str();
+  EXPECT_NE(s.find("lidar"), std::string::npos);
+  EXPECT_FALSE(s.empty());
+
+  // The same, on an observation with no point cloud at all:
+  auto empty = CObservationPointCloud::Create();
+  empty->timestamp = mrpt::Clock::now();
+  std::ostringstream ss2;
+  EXPECT_NO_THROW(empty->getDescriptionAsText(ss2));
+  EXPECT_FALSE(ss2.str().empty());
+
+  // ...and on one whose coordinates include NaNs, which the min/max helper
+  // must skip:
+  auto withNaN = CObservationPointCloud::Create();
+  withNaN->timestamp = mrpt::Clock::now();
+  withNaN->pointcloud = CSimplePointsMap::Create();
+  withNaN->pointcloud->insertPoint(1.0f, 1.0f, 1.0f);
+  withNaN->pointcloud->insertPoint(std::numeric_limits<float>::quiet_NaN(), 2.0f, 2.0f);
+  std::ostringstream ss3;
+  EXPECT_NO_THROW(withNaN->getDescriptionAsText(ss3));
+  EXPECT_FALSE(ss3.str().empty());
+}

--- a/modules/mrpt_math/CMakeLists.txt
+++ b/modules/mrpt_math/CMakeLists.txt
@@ -100,6 +100,7 @@ set(LIB_UNIT_TEST_SOURCES
   tests/CMatrixFixed_unittest.cpp
   tests/container_ops_unittest.cpp
   tests/CPolygon_unittest.cpp
+  tests/CHistogram_unittest.cpp
   tests/CSparseMatrixTemplate_unittest.cpp
   tests/CSplineInterpolator1D_unittest.cpp
   tests/distributions_unittest.cpp
@@ -108,9 +109,11 @@ set(LIB_UNIT_TEST_SOURCES
   tests/fresnel_unittest.cpp
   tests/geometry_dispatch_unittest.cpp
   tests/geometry_extra_unittest.cpp
+  tests/geometry_sets_unittest.cpp
   tests/geometry_unittest.cpp
   tests/interp_fit_unittest.cpp
   tests/KDTreeCapable_unittest.cpp
+  tests/matrix_api_unittest.cpp
   tests/matrix_ops_unittest.cpp
   tests/matrix_ops1_unittest.cpp
   tests/matrix_ops2_unittest.cpp
@@ -121,6 +124,8 @@ set(LIB_UNIT_TEST_SOURCES
   tests/math_unittest.cpp
   tests/ModelSearch_unittest.cpp
   tests/poly_roots_unittest.cpp
+  tests/ops_vectors_unittest.cpp
+  tests/poly_roots_extra_unittest.cpp
   tests/ransac_applications_unittest.cpp
   tests/ransac_unittest.cpp
   tests/robust_kernels_unittest.cpp
@@ -130,6 +135,8 @@ set(LIB_UNIT_TEST_SOURCES
   tests/TObject3D_unittest.cpp
   tests/TOrientedBox_unittest.cpp
   tests/TPlane_unittest.cpp
+  tests/TLine2D_TSegment2D_unittest.cpp
+  tests/TPoint2D_unittest.cpp
   tests/TPoint3D_unittest.cpp
   tests/TPolygon2D_unittest.cpp
   tests/TPolygon3D_unittest.cpp
@@ -137,6 +144,7 @@ set(LIB_UNIT_TEST_SOURCES
   tests/TPose3DQuat_unittest.cpp
   tests/TPoseOrPoint_unittest.cpp
   tests/TSegment3D_unittest.cpp
+  tests/TTwist2D_unittest.cpp
   tests/TTwist3D_unittest.cpp
   tests/wrap2pi_unittest.cpp
 )

--- a/modules/mrpt_math/include/mrpt/math/CHistogram.h
+++ b/modules/mrpt_math/include/mrpt/math/CHistogram.h
@@ -57,7 +57,7 @@ class CHistogram
   /** Constructor with a fixed bin width.
    * \exception std::exception On max<=min or width<=0
    */
-  CHistogram createWithFixedWidth(double min, double max, double binWidth);
+  [[nodiscard]] static CHistogram createWithFixedWidth(double min, double max, double binWidth);
 
   /** Clear the histogram:
    */

--- a/modules/mrpt_math/include/mrpt/math/CMatrixDynamic.h
+++ b/modules/mrpt_math/include/mrpt/math/CMatrixDynamic.h
@@ -137,14 +137,14 @@ class CMatrixDynamic : public MatrixBase<T, CMatrixDynamic<T>>
         }
       }
     }
-    // New rows to zero?
+    // New rows to zero? (whole rows beyond the old row count)
     if (newElementsToZero && m_Rows > old_rows)
     {
       if constexpr (std::is_trivial_v<T>)
       {
         ::memset(
             &newData[static_cast<std::size_t>(old_rows * m_Cols)], 0,
-            sizeof(T) * static_cast<std::size_t>(m_Rows - old_rows));
+            sizeof(T) * static_cast<std::size_t>((m_Rows - old_rows) * m_Cols));
       }
       else
       {
@@ -157,10 +157,12 @@ class CMatrixDynamic : public MatrixBase<T, CMatrixDynamic<T>>
         }
       }
     }
-    // New cols to zero?
+    // New cols to zero? (only within the rows that actually survived; note
+    // that nRowsToCopy is min(old_rows, m_Rows), so a matrix that loses rows
+    // while gaining columns stays inside the new buffer)
     if (newElementsToZero && m_Cols > old_cols)
     {
-      for (Index r = 0; r < old_rows; r++)
+      for (Index r = 0; r < nRowsToCopy; r++)
       {
         if constexpr (std::is_trivial_v<T>)
         {

--- a/modules/mrpt_math/include/mrpt/math/KDTreeCapable.h
+++ b/modules/mrpt_math/include/mrpt/math/KDTreeCapable.h
@@ -376,6 +376,10 @@ class KDTreeCapable
 #endif
     }
 
+    // A radius-limited search may return fewer than knn points:
+    out_x.resize(ret_indexes.size());
+    out_y.resize(ret_indexes.size());
+
     for (size_t i = 0; i < ret_indexes.size(); i++)
     {
       out_x[i] = derived().kdtree_get_pt(ret_indexes[i], 0);
@@ -619,6 +623,11 @@ class KDTreeCapable
 #endif
     }
 
+    // A radius-limited search may return fewer than knn points:
+    out_x.resize(ret_indexes.size());
+    out_y.resize(ret_indexes.size());
+    out_z.resize(ret_indexes.size());
+
     for (size_t i = 0; i < ret_indexes.size(); i++)
     {
       out_x[i] = derived().kdtree_get_pt(ret_indexes[i], 0);
@@ -695,6 +704,11 @@ class KDTreeCapable
       THROW_EXCEPTION("RKNN search requires nanoflann>=1.5.1");
 #endif
     }
+
+    // A radius-limited search may return fewer than knn points:
+    out_x.resize(out_idx.size());
+    out_y.resize(out_idx.size());
+    out_z.resize(out_idx.size());
 
     for (size_t i = 0; i < out_idx.size(); i++)
     {

--- a/modules/mrpt_math/include/mrpt/math/KDTreeCapable.h
+++ b/modules/mrpt_math/include/mrpt/math/KDTreeCapable.h
@@ -361,6 +361,8 @@ class KDTreeCapable
       resultSet.init(&ret_indexes[0], &out_dist_sqr[0]);
 
       m_kdtree2d_data.index->findNeighbors(resultSet, &query_point[0], {});
+      ret_indexes.resize(resultSet.size());
+      out_dist_sqr.resize(resultSet.size());
     }
     else
     {
@@ -376,7 +378,8 @@ class KDTreeCapable
 #endif
     }
 
-    // A radius-limited search may return fewer than knn points:
+    // Fewer than knn points may be returned (a small cloud, or a
+    // radius-limited search):
     out_x.resize(ret_indexes.size());
     out_y.resize(ret_indexes.size());
 
@@ -450,6 +453,8 @@ class KDTreeCapable
       resultSet.init(&out_idx[0], &out_dist_sqr[0]);
 
       m_kdtree2d_data.index->findNeighbors(resultSet, &query_point[0], {});
+      out_idx.resize(resultSet.size());
+      out_dist_sqr.resize(resultSet.size());
     }
     else
     {
@@ -609,6 +614,8 @@ class KDTreeCapable
       nanoflann::KNNResultSet<num_t> resultSet(knn);
       resultSet.init(&ret_indexes[0], &out_dist_sqr[0]);
       m_kdtree3d_data.index->findNeighbors(resultSet, &query_point[0], {});
+      ret_indexes.resize(resultSet.size());
+      out_dist_sqr.resize(resultSet.size());
     }
     else
     {
@@ -623,7 +630,8 @@ class KDTreeCapable
 #endif
     }
 
-    // A radius-limited search may return fewer than knn points:
+    // Fewer than knn points may be returned (a small cloud, or a
+    // radius-limited search):
     out_x.resize(ret_indexes.size());
     out_y.resize(ret_indexes.size());
     out_z.resize(ret_indexes.size());
@@ -691,6 +699,8 @@ class KDTreeCapable
       resultSet.init(&out_idx[0], &out_dist_sqr[0]);
 
       m_kdtree3d_data.index->findNeighbors(resultSet, &query_point[0], {});
+      out_idx.resize(resultSet.size());
+      out_dist_sqr.resize(resultSet.size());
     }
     else
     {
@@ -705,7 +715,8 @@ class KDTreeCapable
 #endif
     }
 
-    // A radius-limited search may return fewer than knn points:
+    // Fewer than knn points may be returned (a small cloud, or a
+    // radius-limited search):
     out_x.resize(out_idx.size());
     out_y.resize(out_idx.size());
     out_z.resize(out_idx.size());
@@ -849,6 +860,8 @@ class KDTreeCapable
       nanoflann::KNNResultSet<num_t> resultSet(knn);
       resultSet.init(&out_idx[0], &out_dist_sqr[0]);
       m_kdtree3d_data.index->findNeighbors(resultSet, &query_point[0], {});
+      out_idx.resize(resultSet.size());
+      out_dist_sqr.resize(resultSet.size());
     }
     else
     {

--- a/modules/mrpt_math/include/mrpt/math/distributions.h
+++ b/modules/mrpt_math/include/mrpt/math/distributions.h
@@ -116,11 +116,10 @@ double KLD_Gaussians(
       size_t(mu0.size()) == size_t(mu1.size()) && size_t(mu0.size()) == size_t(cov0.rows()) &&
       size_t(mu0.size()) == size_t(cov1.cols()) && cov0.isSquare() && cov1.isSquare());
   const size_t N = mu0.size();
-  MATRIXLIKE2 cov1_inv;
-  cov1.inverse_LLt(cov1_inv);
+  const MATRIXLIKE2 cov1_inv = cov1.inverse_LLt();
   const VECTORLIKE1 mu_difs = mu0 - mu1;
   return 0.5 * (log(cov1.det() / cov0.det()) + (cov1_inv * cov0).trace() +
-                multiply_HCHt_scalar(mu_difs, cov1_inv) - N);
+                multiply_HtCH_scalar(mu_difs, cov1_inv) - N);
   MRPT_END
 }
 

--- a/modules/mrpt_math/include/mrpt/math/geometry.h
+++ b/modules/mrpt_math/include/mrpt/math/geometry.h
@@ -499,7 +499,7 @@ size_t intersect(const std::vector<T>& v1, const std::vector<U>& v2, CSparseMatr
   objs.resize(M, N);
   for (size_t i = 0; i < M; i++)
   {
-    for (size_t j = 0; j < M; j++)
+    for (size_t j = 0; j < N; j++)
     {
       if (intersect(v1[i], v2[j], obj))
       {
@@ -514,7 +514,7 @@ size_t intersect(const std::vector<T>& v1, const std::vector<U>& v2, CSparseMatr
  * a vector of either TObject2D or TObject3D.
  * \sa TObject2D,TObject3D */
 template <class T, class U, class O>
-size_t intersect(const std::vector<T>& v1, const std::vector<U>& v2, std::vector<O> objs)
+size_t intersect(const std::vector<T>& v1, const std::vector<U>& v2, std::vector<O>& objs)
 {
   objs.resize(0);
   O obj;

--- a/modules/mrpt_math/src/TLine3D.cpp
+++ b/modules/mrpt_math/src/TLine3D.cpp
@@ -147,7 +147,7 @@ TLine3D::TLine3D(const TLine2D& l)
   else
   {
     pBase.x = 0;
-    pBase.y = -l.coefs[1] / l.coefs[0];
+    pBase.y = -l.coefs[2] / l.coefs[1];
   }
   pBase.z = 0;
 }

--- a/modules/mrpt_math/src/geometry.cpp
+++ b/modules/mrpt_math/src/geometry.cpp
@@ -2225,7 +2225,7 @@ void math::getAngleBisector(const TLine2D& l1, const TLine2D& l2, TLine2D& bis)
   {
     // Both lines are parallel
     double mod1 = sqrt(square(l1.coefs[0]) + square(l1.coefs[1]));
-    double mod2 = sqrt(square(l2.coefs[0]) + square(l2.coefs[2]));
+    double mod2 = sqrt(square(l2.coefs[0]) + square(l2.coefs[1]));
     bis.coefs[0] = l1.coefs[0] / mod1;
     bis.coefs[1] = l1.coefs[1] / mod1;
     bool sameSign;
@@ -2233,10 +2233,11 @@ void math::getAngleBisector(const TLine2D& l1, const TLine2D& l2, TLine2D& bis)
       sameSign = (l1.coefs[1] * l2.coefs[1]) > 0;
     else
       sameSign = (l1.coefs[0] * l2.coefs[0]) > 0;
+    // Midway between both normalized lines:
     if (sameSign)
-      bis.coefs[2] = (l1.coefs[2] / mod1) + (l2.coefs[2] / mod2);
+      bis.coefs[2] = 0.5 * ((l1.coefs[2] / mod1) + (l2.coefs[2] / mod2));
     else
-      bis.coefs[2] = (l1.coefs[2] / mod1) - (l2.coefs[2] / mod2);
+      bis.coefs[2] = 0.5 * ((l1.coefs[2] / mod1) - (l2.coefs[2] / mod2));
   }
   else if (obj.getPoint(p))
   {

--- a/modules/mrpt_math/tests/CHistogram_unittest.cpp
+++ b/modules/mrpt_math/tests/CHistogram_unittest.cpp
@@ -1,0 +1,111 @@
+/*                    _
+                     | |    Mobile Robot Programming Toolkit (MRPT)
+ _ __ ___  _ __ _ __ | |_
+| '_ ` _ \| '__| '_ \| __|          https://www.mrpt.org/
+| | | | | | |  | |_) | |_
+|_| |_| |_|_|  | .__/ \__|     https://github.com/MRPT/mrpt/
+               | |
+               |_|
+
+ Copyright (c) 2005-2026, Individual contributors, see AUTHORS file
+ See: https://www.mrpt.org/Authors - All rights reserved.
+ SPDX-License-Identifier: BSD-3-Clause
+*/
+
+#include <gtest/gtest.h>
+#include <mrpt/math/CHistogram.h>
+#include <mrpt/math/CVectorDynamic.h>
+
+#include <vector>
+
+using mrpt::math::CHistogram;
+
+TEST(CHistogram, constructorChecks)
+{
+  EXPECT_THROW(CHistogram(0.0, 100.0, 0), std::exception);
+  EXPECT_THROW(CHistogram(100.0, 0.0, 10), std::exception);
+  EXPECT_NO_THROW(CHistogram(0.0, 100.0, 10));
+}
+
+TEST(CHistogram, addAndCount)
+{
+  CHistogram h(0.0, 100.0, 10);
+
+  h.add(86);
+  h.add(7);
+  h.add(45);
+
+  EXPECT_EQ(h.getBinCount(0), 1U);
+  EXPECT_EQ(h.getBinCount(4), 1U);
+  EXPECT_EQ(h.getBinCount(8), 1U);
+  EXPECT_EQ(h.getBinCount(9), 0U);
+  EXPECT_NEAR(h.getBinRatio(0), 1.0 / 3.0, 1e-9);
+  EXPECT_NEAR(h.getBinRatio(9), 0.0, 1e-9);
+
+  // Values out of [min,max] are silently ignored:
+  h.add(-1);
+  h.add(101);
+  EXPECT_NEAR(h.getBinRatio(0), 1.0 / 3.0, 1e-9);
+
+  // The upper limit itself falls in the last bin:
+  h.add(100);
+  EXPECT_EQ(h.getBinCount(9), 1U);
+
+  EXPECT_THROW(h.getBinCount(10), std::exception);
+  EXPECT_THROW(h.getBinRatio(10), std::exception);
+
+  h.clear();
+  EXPECT_EQ(h.getBinCount(0), 0U);
+  // With no elements added, the ratio is defined to be zero:
+  EXPECT_EQ(h.getBinRatio(0), 0.0);
+}
+
+TEST(CHistogram, addContainers)
+{
+  CHistogram h(0.0, 10.0, 5);
+
+  // Bins are [0,2), [2,4), ... so only 1.0 falls in the first one:
+  const std::vector<double> v{1.0, 2.0, 3.0, 4.0, 5.0};
+  h.add(v);
+  EXPECT_EQ(h.getBinCount(0), 1U);
+
+  mrpt::math::CVectorDouble cv(3);
+  cv[0] = 1.0;
+  cv[1] = 1.5;
+  cv[2] = 9.0;
+  h.add(cv);
+  EXPECT_EQ(h.getBinCount(0), 3U);
+  EXPECT_EQ(h.getBinCount(4), 1U);
+}
+
+TEST(CHistogram, getHistogram)
+{
+  CHistogram h(0.0, 10.0, 5);
+  for (int i = 0; i < 10; i++) h.add(i + 0.5);
+
+  std::vector<double> x, hits;
+  h.getHistogram(x, hits);
+  ASSERT_EQ(x.size(), 5U);
+  ASSERT_EQ(hits.size(), 5U);
+  for (const auto v : hits) EXPECT_NEAR(v, 2.0, 1e-9);
+
+  std::vector<double> xn, hitsn;
+  h.getHistogramNormalized(xn, hitsn);
+  ASSERT_EQ(hitsn.size(), 5U);
+  // The normalized histogram must integrate to 1:
+  double integral = 0;
+  const double binWidth = 10.0 / 5;
+  for (const auto v : hitsn) integral += v * binWidth;
+  EXPECT_NEAR(integral, 1.0, 1e-9);
+}
+
+TEST(CHistogram, createWithFixedWidth)
+{
+  const CHistogram h = CHistogram::createWithFixedWidth(0.0, 10.0, 2.0);
+  std::vector<double> x, hits;
+  h.getHistogram(x, hits);
+  EXPECT_EQ(hits.size(), 5U);
+
+  EXPECT_THROW(CHistogram::createWithFixedWidth(10.0, 0.0, 2.0), std::exception);
+  EXPECT_THROW(CHistogram::createWithFixedWidth(0.0, 10.0, 0.0), std::exception);
+}

--- a/modules/mrpt_math/tests/CPolygon_unittest.cpp
+++ b/modules/mrpt_math/tests/CPolygon_unittest.cpp
@@ -17,6 +17,8 @@
 #include <mrpt/math/CPolygon.h>
 #include <mrpt/serialization/CArchive.h>
 
+#include "legacy_serialization.h"
+
 using namespace mrpt::math;
 
 TEST(CPolygon, SetGetVerticesDouble)
@@ -88,4 +90,79 @@ TEST(CPolygon, SerializationRoundTripEmpty)
   CPolygon p2;
   arch >> p2;
   EXPECT_EQ(p2.size(), 0u);
+}
+
+// Writes the payload of the pre-v2 (float/double, explicit bounding box)
+// polygon format, shared by streaming versions 0 and 1.
+namespace
+{
+void writeLegacyPolygonPayload(
+    mrpt::serialization::CArchive& arch,
+    const std::vector<double>& xs,
+    const std::vector<double>& ys)
+{
+  const auto n = static_cast<uint32_t>(xs.size());
+  arch << n;
+  // max_x, max_y, min_x, min_y, cx, cy: read but discarded by the loader
+  for (int i = 0; i < 6; i++) arch << double(0);
+  for (const auto v : xs) arch << v;
+  for (const auto v : ys) arch << v;
+}
+}  // namespace
+
+TEST(CPolygon, DeserializeLegacyVersion0)
+{
+  const std::vector<double> xs{0, 1, 1, 0};
+  const std::vector<double> ys{0, 0, 1, 1};
+
+  mrpt::io::CMemoryStream buf;
+  mrpt_test::writeLegacyObjectFrame(
+      buf, "CPolygon", 0,
+      [&](mrpt::serialization::CArchive& a) { writeLegacyPolygonPayload(a, xs, ys); });
+
+  auto arch = mrpt::serialization::archiveFrom(buf);
+  const auto obj = arch.ReadObject();
+  const auto p = std::dynamic_pointer_cast<CPolygon>(obj);
+  ASSERT_TRUE(p);
+  ASSERT_EQ(p->size(), 4U);
+  EXPECT_NEAR(p->get_vertex_x(2), 1.0, 1e-9);
+  EXPECT_NEAR(p->get_vertex_y(3), 1.0, 1e-9);
+}
+
+TEST(CPolygon, DeserializeLegacyVersion1)
+{
+  const std::vector<double> xs{0, 2, 2};
+  const std::vector<double> ys{0, 0, 3};
+
+  mrpt::io::CMemoryStream buf;
+  mrpt_test::writeLegacyObjectFrame(
+      buf, "CPolygon", 1,
+      [&](mrpt::serialization::CArchive& a) { writeLegacyPolygonPayload(a, xs, ys); });
+
+  auto arch = mrpt::serialization::archiveFrom(buf);
+  const auto obj = arch.ReadObject();
+  const auto p = std::dynamic_pointer_cast<CPolygon>(obj);
+  ASSERT_TRUE(p);
+  ASSERT_EQ(p->size(), 3U);
+  EXPECT_NEAR(p->get_vertex_x(1), 2.0, 1e-9);
+  EXPECT_NEAR(p->get_vertex_y(2), 3.0, 1e-9);
+}
+
+TEST(CPolygon, DeserializeUnknownVersionThrows)
+{
+  mrpt::io::CMemoryStream buf;
+  mrpt_test::writeLegacyObjectFrame(buf, "CPolygon", 99, [](mrpt::serialization::CArchive&) {});
+
+  auto arch = mrpt::serialization::archiveFrom(buf);
+  EXPECT_THROW(arch.ReadObject(), std::exception);
+}
+
+TEST(CPolygon, VertexAccessorsCheckBounds)
+{
+  CPolygon p;
+  p.add_vertex(1.0, 2.0);
+  EXPECT_NEAR(p.get_vertex_x(0), 1.0, 1e-9);
+  EXPECT_NEAR(p.get_vertex_y(0), 2.0, 1e-9);
+  EXPECT_THROW(p.get_vertex_x(1), std::exception);
+  EXPECT_THROW(p.get_vertex_y(1), std::exception);
 }

--- a/modules/mrpt_math/tests/KDTreeCapable_unittest.cpp
+++ b/modules/mrpt_math/tests/KDTreeCapable_unittest.cpp
@@ -396,6 +396,8 @@ TEST(KDTreeCapable, kNNRequestLargerThanCloud)
 
   cloud3d.kdTreeNClosestPoint3DWithIdx(0.f, 0.f, 0.f, 10, xs, ys, zs, idxs, dists);
   EXPECT_EQ(xs.size(), 2U);
+  EXPECT_EQ(ys.size(), 2U);
+  EXPECT_EQ(zs.size(), 2U);
   EXPECT_EQ(idxs.size(), 2U);
   EXPECT_EQ(dists.size(), 2U);
 

--- a/modules/mrpt_math/tests/KDTreeCapable_unittest.cpp
+++ b/modules/mrpt_math/tests/KDTreeCapable_unittest.cpp
@@ -167,3 +167,188 @@ TEST(KDTreeCapable, radiusSearch2D)
     EXPECT_LT(r.first, 3u);  // index should be 0, 1, or 2 (not the far point)
   }
 }
+
+namespace
+{
+PointCloud2D makeGrid2D()
+{
+  PointCloud2D cloud;
+  for (int i = 0; i < 5; i++)
+    for (int j = 0; j < 5; j++) cloud.pts.emplace_back(i, j);
+  return cloud;
+}
+
+PointCloud3D makeGrid3D()
+{
+  PointCloud3D cloud;
+  for (int i = 0; i < 4; i++)
+    for (int j = 0; j < 4; j++)
+      for (int k = 0; k < 4; k++) cloud.pts.emplace_back(i, j, k);
+  return cloud;
+}
+}  // namespace
+
+TEST(KDTreeCapable, closestPoint2DOverloads)
+{
+  auto cloud = makeGrid2D();
+
+  float distSqr = 0;
+  const size_t idx = cloud.kdTreeClosestPoint2D(1.1f, 2.1f, distSqr);
+  EXPECT_EQ(cloud.pts[idx], mrpt::math::TPoint2D(1, 2));
+
+  mrpt::math::TPoint2D pOut;
+  const size_t idx2 = cloud.kdTreeClosestPoint2D({1.1, 2.1}, pOut, distSqr);
+  EXPECT_EQ(idx2, idx);
+  EXPECT_NEAR(pOut.x, 1.0, 1e-4);
+
+  EXPECT_NEAR(cloud.kdTreeClosestPoint2DsqrError(1.0f, 2.0f), 0.0, 1e-6);
+  EXPECT_NEAR(cloud.kdTreeClosestPoint2DsqrError(mrpt::math::TPoint2D(1.0, 2.0)), 0.0, 1e-6);
+
+  PointCloud2D empty;
+  EXPECT_THROW(empty.kdTreeClosestPoint2D(0.f, 0.f, distSqr), std::exception);
+}
+
+TEST(KDTreeCapable, twoClosestPoint2D)
+{
+  auto cloud = makeGrid2D();
+
+  float x1 = 0, y1 = 0, x2 = 0, y2 = 0, d1 = 0, d2 = 0;
+  cloud.kdTreeTwoClosestPoint2D(0.1f, 0.0f, x1, y1, x2, y2, d1, d2);
+  EXPECT_NEAR(x1, 0.0f, 1e-4f);
+  EXPECT_NEAR(y1, 0.0f, 1e-4f);
+  EXPECT_LE(d1, d2);
+
+  mrpt::math::TPoint2D p1, p2;
+  cloud.kdTreeTwoClosestPoint2D({0.1, 0.0}, p1, p2, d1, d2);
+  EXPECT_NEAR(p1.x, 0.0, 1e-4);
+  EXPECT_LE(d1, d2);
+}
+
+TEST(KDTreeCapable, nClosestPoint2DWithMaxDistance)
+{
+  auto cloud = makeGrid2D();
+
+  std::vector<size_t> idxs;
+  std::vector<float> dists;
+
+  // Without a radius limit, exactly `knn` neighbors come back:
+  cloud.kdTreeNClosestPoint2DIdx(0.f, 0.f, 5, idxs, dists);
+  EXPECT_EQ(idxs.size(), 5U);
+
+  // With a radius smaller than the grid step, only the query point itself:
+  cloud.kdTreeNClosestPoint2DIdx(0.f, 0.f, 5, idxs, dists, 0.5f);
+  EXPECT_EQ(idxs.size(), 1U);
+  EXPECT_EQ(dists.size(), 1U);
+
+  // The same, through the TPoint2D overload:
+  cloud.kdTreeNClosestPoint2DIdx(mrpt::math::TPoint2D(0, 0), 5, idxs, dists);
+  EXPECT_EQ(idxs.size(), 5U);
+
+  std::vector<float> xs, ys;
+  auto found = cloud.kdTreeNClosestPoint2D(0.f, 0.f, 5, xs, ys, dists, 0.5f);
+  EXPECT_EQ(found.size(), 1U);
+  // All the output vectors must be trimmed to the number of points found:
+  EXPECT_EQ(xs.size(), 1U);
+  EXPECT_EQ(ys.size(), 1U);
+  EXPECT_EQ(dists.size(), 1U);
+
+  std::vector<mrpt::math::TPoint2D> limitedPts;
+  found = cloud.kdTreeNClosestPoint2D(mrpt::math::TPoint2D(0, 0), 5, limitedPts, dists, 0.5f);
+  EXPECT_EQ(limitedPts.size(), 1U);
+
+  std::vector<mrpt::math::TPoint2D> pts;
+  found = cloud.kdTreeNClosestPoint2D(mrpt::math::TPoint2D(0, 0), 3, pts, dists);
+  EXPECT_EQ(found.size(), 3U);
+  EXPECT_EQ(pts.size(), 3U);
+}
+
+TEST(KDTreeCapable, closestPoint3DOverloads)
+{
+  auto cloud = makeGrid3D();
+
+  float distSqr = 0;
+  const size_t idx = cloud.kdTreeClosestPoint3D(1.1f, 2.1f, 3.1f, distSqr);
+  EXPECT_EQ(cloud.pts[idx], mrpt::math::TPoint3D(1, 2, 3));
+
+  mrpt::math::TPoint3D pOut;
+  const size_t idx2 = cloud.kdTreeClosestPoint3D({1.1, 2.1, 3.1}, pOut, distSqr);
+  EXPECT_EQ(idx2, idx);
+  EXPECT_NEAR(pOut.z, 3.0, 1e-4);
+
+  PointCloud3D empty;
+  EXPECT_THROW(empty.kdTreeClosestPoint3D(0.f, 0.f, 0.f, distSqr), std::exception);
+}
+
+TEST(KDTreeCapable, nClosestPoint3DWithMaxDistance)
+{
+  auto cloud = makeGrid3D();
+
+  std::vector<size_t> idxs;
+  std::vector<float> dists;
+
+  cloud.kdTreeNClosestPoint3DIdx(0.f, 0.f, 0.f, 4, idxs, dists);
+  EXPECT_EQ(idxs.size(), 4U);
+
+  cloud.kdTreeNClosestPoint3DIdx(0.f, 0.f, 0.f, 4, idxs, dists, 0.5f);
+  EXPECT_EQ(idxs.size(), 1U);
+
+  cloud.kdTreeNClosestPoint3DIdx(mrpt::math::TPoint3D(0, 0, 0), 4, idxs, dists);
+  EXPECT_EQ(idxs.size(), 4U);
+
+  std::vector<float> xs, ys, zs;
+  cloud.kdTreeNClosestPoint3D(0.f, 0.f, 0.f, 4, xs, ys, zs, dists, 0.5f);
+  EXPECT_EQ(xs.size(), 1U);
+  EXPECT_EQ(ys.size(), 1U);
+  EXPECT_EQ(zs.size(), 1U);
+
+  std::vector<size_t> limitedIdx;
+  cloud.kdTreeNClosestPoint3DWithIdx(0.f, 0.f, 0.f, 4, xs, ys, zs, limitedIdx, dists, 0.5f);
+  EXPECT_EQ(xs.size(), 1U);
+  EXPECT_EQ(limitedIdx.size(), 1U);
+
+  std::vector<mrpt::math::TPoint3D> pts;
+  cloud.kdTreeNClosestPoint3D(mrpt::math::TPoint3D(0, 0, 0), 3, pts, dists);
+  EXPECT_EQ(pts.size(), 3U);
+}
+
+TEST(KDTreeCapable, radiusSearch3DAndEmptyClouds)
+{
+  auto cloud = makeGrid3D();
+
+  std::vector<nanoflann::ResultItem<size_t, float>> results;
+  const size_t n = cloud.kdTreeRadiusSearch3D(0.f, 0.f, 0.f, 1.1f, results);
+  EXPECT_EQ(n, results.size());
+  EXPECT_GE(n, 4U);  // itself plus the 3 axis neighbors at distance 1
+
+  // Radius searches on an empty cloud return zero results instead of throwing:
+  PointCloud3D empty3d;
+  EXPECT_EQ(empty3d.kdTreeRadiusSearch3D(0.f, 0.f, 0.f, 10.f, results), 0U);
+
+  PointCloud2D empty2d;
+  std::vector<nanoflann::ResultItem<size_t, float>> results2d;
+  EXPECT_EQ(empty2d.kdTreeRadiusSearch2D(0.f, 0.f, 10.f, results2d), 0U);
+}
+
+// Exposes the protected invalidation hook, as any real map class does when
+// its contents change.
+namespace
+{
+struct MutablePointCloud2D : public PointCloud2D
+{
+  void markOutdated() { this->kdtree_mark_as_outdated(); }
+};
+}  // namespace
+
+TEST(KDTreeCapable, treeIsRebuiltWhenCloudChanges)
+{
+  MutablePointCloud2D cloud;
+  cloud.pts.emplace_back(0, 0);
+
+  float distSqr = 0;
+  EXPECT_EQ(cloud.kdTreeClosestPoint2D(5.f, 5.f, distSqr), 0U);
+
+  cloud.pts.emplace_back(5, 5);
+  cloud.markOutdated();
+  EXPECT_EQ(cloud.kdTreeClosestPoint2D(5.f, 5.f, distSqr), 1U);
+  EXPECT_NEAR(distSqr, 0.0f, 1e-6f);
+}

--- a/modules/mrpt_math/tests/KDTreeCapable_unittest.cpp
+++ b/modules/mrpt_math/tests/KDTreeCapable_unittest.cpp
@@ -352,3 +352,55 @@ TEST(KDTreeCapable, treeIsRebuiltWhenCloudChanges)
   EXPECT_EQ(cloud.kdTreeClosestPoint2D(5.f, 5.f, distSqr), 1U);
   EXPECT_NEAR(distSqr, 0.0f, 1e-6f);
 }
+
+TEST(KDTreeCapable, kNNRequestLargerThanCloud)
+{
+  // Asking for more neighbors than the cloud holds must return only as many
+  // as exist, in *every* output vector, rather than leaving stale entries.
+  PointCloud2D cloud2d;
+  cloud2d.pts.emplace_back(0, 0);
+  cloud2d.pts.emplace_back(1, 0);
+  cloud2d.pts.emplace_back(0, 1);
+
+  std::vector<size_t> idxs;
+  std::vector<float> dists, xs, ys, zs;
+
+  cloud2d.kdTreeNClosestPoint2DIdx(0.f, 0.f, 10, idxs, dists);
+  EXPECT_EQ(idxs.size(), 3U);
+  EXPECT_EQ(dists.size(), 3U);
+
+  auto found = cloud2d.kdTreeNClosestPoint2D(0.f, 0.f, 10, xs, ys, dists);
+  EXPECT_EQ(found.size(), 3U);
+  EXPECT_EQ(xs.size(), 3U);
+  EXPECT_EQ(ys.size(), 3U);
+  EXPECT_EQ(dists.size(), 3U);
+
+  std::vector<mrpt::math::TPoint2D> pts2d;
+  found = cloud2d.kdTreeNClosestPoint2D(mrpt::math::TPoint2D(0, 0), 10, pts2d, dists);
+  EXPECT_EQ(pts2d.size(), 3U);
+  EXPECT_EQ(pts2d.size(), dists.size());
+
+  PointCloud3D cloud3d;
+  cloud3d.pts.emplace_back(0, 0, 0);
+  cloud3d.pts.emplace_back(1, 0, 0);
+
+  cloud3d.kdTreeNClosestPoint3DIdx(0.f, 0.f, 0.f, 10, idxs, dists);
+  EXPECT_EQ(idxs.size(), 2U);
+  EXPECT_EQ(dists.size(), 2U);
+
+  cloud3d.kdTreeNClosestPoint3D(0.f, 0.f, 0.f, 10, xs, ys, zs, dists);
+  EXPECT_EQ(xs.size(), 2U);
+  EXPECT_EQ(ys.size(), 2U);
+  EXPECT_EQ(zs.size(), 2U);
+  EXPECT_EQ(dists.size(), 2U);
+
+  cloud3d.kdTreeNClosestPoint3DWithIdx(0.f, 0.f, 0.f, 10, xs, ys, zs, idxs, dists);
+  EXPECT_EQ(xs.size(), 2U);
+  EXPECT_EQ(idxs.size(), 2U);
+  EXPECT_EQ(dists.size(), 2U);
+
+  std::vector<mrpt::math::TPoint3D> pts3d;
+  cloud3d.kdTreeNClosestPoint3D(mrpt::math::TPoint3D(0, 0, 0), 10, pts3d, dists);
+  EXPECT_EQ(pts3d.size(), 2U);
+  EXPECT_EQ(pts3d.size(), dists.size());
+}

--- a/modules/mrpt_math/tests/TLine2D_TSegment2D_unittest.cpp
+++ b/modules/mrpt_math/tests/TLine2D_TSegment2D_unittest.cpp
@@ -1,0 +1,202 @@
+/*                    _
+                     | |    Mobile Robot Programming Toolkit (MRPT)
+ _ __ ___  _ __ _ __ | |_
+| '_ ` _ \| '__| '_ \| __|          https://www.mrpt.org/
+| | | | | | |  | |_) | |_
+|_| |_| |_|_|  | .__/ \__|     https://github.com/MRPT/mrpt/
+               | |
+               |_|
+
+ Copyright (c) 2005-2026, Individual contributors, see AUTHORS file
+ See: https://www.mrpt.org/Authors - All rights reserved.
+ SPDX-License-Identifier: BSD-3-Clause
+*/
+
+#include <gtest/gtest.h>
+#include <mrpt/io/CMemoryStream.h>
+#include <mrpt/math/TLine2D.h>
+#include <mrpt/math/TLine3D.h>
+#include <mrpt/math/TPose2D.h>
+#include <mrpt/math/TSegment2D.h>
+#include <mrpt/math/TSegment3D.h>
+#include <mrpt/serialization/CArchive.h>
+
+#include <sstream>
+
+using namespace mrpt::math;
+
+TEST(TLine2D, factories)
+{
+  // A*x + B*y + C = 0 <=> the horizontal line y=1
+  const auto l = TLine2D::FromCoefficientsABC(0, 1, -1);
+  EXPECT_NEAR(l.evaluatePoint({5.0, 1.0}), 0.0, 1e-12);
+  EXPECT_TRUE(l.contains({5.0, 1.0}));
+  EXPECT_FALSE(l.contains({5.0, 2.0}));
+
+  const auto l2 = TLine2D::FromTwoPoints({0.0, 0.0}, {1.0, 1.0});
+  EXPECT_TRUE(l2.contains({2.0, 2.0}));
+
+  // Two identical points do not define a line:
+  EXPECT_THROW(TLine2D::FromTwoPoints({1.0, 1.0}, {1.0, 1.0}), std::logic_error);
+}
+
+TEST(TLine2D, distances)
+{
+  // The line y=0
+  const auto l = TLine2D::FromCoefficientsABC(0, 1, 0);
+
+  EXPECT_NEAR(l.distance({3.0, 2.0}), 2.0, 1e-12);
+  EXPECT_NEAR(l.distance({3.0, -2.0}), 2.0, 1e-12);
+  EXPECT_NEAR(l.signedDistance({3.0, 2.0}), 2.0, 1e-12);
+  EXPECT_NEAR(l.signedDistance({3.0, -2.0}), -2.0, 1e-12);
+}
+
+TEST(TLine2D, vectorsAndUnitarize)
+{
+  auto l = TLine2D::FromCoefficientsABC(0, 2, -4);
+
+  double n[2] = {0, 0};
+  l.getNormalVector(n);
+  EXPECT_NEAR(n[0], 0.0, 1e-12);
+  EXPECT_NEAR(n[1], 2.0, 1e-12);
+
+  double d[2] = {0, 0};
+  l.getDirectorVector(d);
+  EXPECT_NEAR(d[0], -2.0, 1e-12);
+  EXPECT_NEAR(d[1], 0.0, 1e-12);
+
+  l.unitarize();
+  l.getNormalVector(n);
+  EXPECT_NEAR(std::hypot(n[0], n[1]), 1.0, 1e-12);
+  // Still the same line (y=2):
+  EXPECT_TRUE(l.contains({7.0, 2.0}));
+}
+
+TEST(TLine2D, getAsPose2D)
+{
+  // Vertical line x=3: coefs[0]!=0, so the "force y=0" branch applies
+  {
+    const auto l = TLine2D::FromCoefficientsABC(1, 0, -3);
+    TPose2D p;
+    l.getAsPose2D(p);
+    EXPECT_NEAR(p.x, 3.0, 1e-12);
+    EXPECT_NEAR(p.y, 0.0, 1e-12);
+  }
+  // Horizontal line y=2: coefs[0]==0, so the "force x=0" branch applies
+  {
+    const auto l = TLine2D::FromCoefficientsABC(0, 1, -2);
+    TPose2D p;
+    l.getAsPose2D(p);
+    EXPECT_NEAR(p.x, 0.0, 1e-12);
+    EXPECT_NEAR(p.y, 2.0, 1e-12);
+  }
+  // Forcing the origin, which must lie on the line:
+  {
+    const auto l = TLine2D::FromCoefficientsABC(0, 1, -2);
+    TPose2D p;
+    l.getAsPose2DForcingOrigin({5.0, 2.0}, p);
+    EXPECT_NEAR(p.x, 5.0, 1e-12);
+    EXPECT_NEAR(p.y, 2.0, 1e-12);
+    EXPECT_THROW(l.getAsPose2DForcingOrigin({5.0, 3.0}, p), std::logic_error);
+  }
+}
+
+TEST(TLine2D, conversions3D)
+{
+  const auto l = TLine2D::FromCoefficientsABC(0, 1, -2);
+
+  TLine3D l3;
+  l.generate3DObject(l3);
+  EXPECT_NEAR(l3.director[2], 0.0, 1e-12);
+  // A horizontal 2D line uses x as the free coordinate for its base point:
+  EXPECT_NEAR(l3.pBase.x, 0.0, 1e-12);
+  EXPECT_NEAR(l3.pBase.y, 2.0, 1e-12);
+
+  // Back to 2D:
+  const TLine2D lBack(l3);
+  EXPECT_TRUE(lBack.contains({9.0, 2.0}));
+
+  // A line normal to the XY plane cannot be projected onto it:
+  const TLine3D vertical(TPoint3D(0, 0, 0), TPoint3D(0, 0, 1));
+  EXPECT_THROW(TLine2D{vertical}, std::logic_error);
+}
+
+TEST(TLine2D, serializationAndPrint)
+{
+  const auto l = TLine2D::FromCoefficientsABC(1, 2, 3);
+
+  mrpt::io::CMemoryStream buf;
+  auto arch = mrpt::serialization::archiveFrom(buf);
+  arch << l;
+  buf.Seek(0);
+  TLine2D l2;
+  arch >> l2;
+  EXPECT_NEAR(l2.coefs[0], 1.0, 1e-12);
+  EXPECT_NEAR(l2.coefs[2], 3.0, 1e-12);
+
+  EXPECT_FALSE(l.asString().empty());
+  std::stringstream ss;
+  ss << l;
+  EXPECT_FALSE(ss.str().empty());
+}
+
+TEST(TSegment2D, basics)
+{
+  const TSegment2D s({0.0, 0.0}, {10.0, 0.0});
+
+  EXPECT_NEAR(s.length(), 10.0, 1e-12);
+  EXPECT_TRUE(s.contains({5.0, 0.0}));
+  EXPECT_FALSE(s.contains({5.0, 1.0}));
+  EXPECT_FALSE(s.contains({15.0, 0.0}));
+
+  EXPECT_NEAR(s.distance({5.0, 3.0}), 3.0, 1e-12);
+  EXPECT_NEAR(std::abs(s.signedDistance({5.0, 3.0})), 3.0, 1e-12);
+  EXPECT_NEAR(s.signedDistance({5.0, 3.0}), -s.signedDistance({5.0, -3.0}), 1e-12);
+}
+
+TEST(TSegment2D, ordering)
+{
+  const TSegment2D a({0.0, 0.0}, {1.0, 0.0});
+  const TSegment2D b({0.0, 0.0}, {2.0, 0.0});
+  const TSegment2D c({1.0, 0.0}, {2.0, 0.0});
+
+  EXPECT_TRUE(a < b);  // same first point, second decides
+  EXPECT_FALSE(b < a);
+  EXPECT_TRUE(a < c);  // first point decides
+  EXPECT_FALSE(c < a);
+}
+
+TEST(TSegment2D, conversions3D)
+{
+  const TSegment2D s({0.0, 0.0}, {10.0, 0.0});
+
+  TSegment3D s3;
+  s.generate3DObject(s3);
+  EXPECT_NEAR(s3.point2.x, 10.0, 1e-12);
+
+  const TSegment2D sBack(s3);
+  EXPECT_NEAR(sBack.length(), 10.0, 1e-12);
+
+  // A segment normal to the XY plane projects onto a single point:
+  const TSegment3D vertical(TPoint3D(1, 2, 0), TPoint3D(1, 2, 5));
+  EXPECT_THROW(TSegment2D{vertical}, std::logic_error);
+}
+
+TEST(TSegment2D, serializationAndPrint)
+{
+  const TSegment2D s({1.0, 2.0}, {3.0, 4.0});
+
+  mrpt::io::CMemoryStream buf;
+  auto arch = mrpt::serialization::archiveFrom(buf);
+  arch << s;
+  buf.Seek(0);
+  TSegment2D s2;
+  arch >> s2;
+  EXPECT_EQ(s2.point1, s.point1);
+  EXPECT_EQ(s2.point2, s.point2);
+
+  EXPECT_FALSE(s.asString().empty());
+  std::stringstream ss;
+  ss << s;
+  EXPECT_FALSE(ss.str().empty());
+}

--- a/modules/mrpt_math/tests/TOrientedBox_unittest.cpp
+++ b/modules/mrpt_math/tests/TOrientedBox_unittest.cpp
@@ -184,3 +184,47 @@ TEST(TOrientedBox, SerializationRoundTripFloat)
   EXPECT_TRUE(box2.pose() == pose);
   EXPECT_TRUE(box2.size() == size);
 }
+
+TEST(TOrientedBox, copyAssignmentAndComparison)
+{
+  using mrpt::literals::operator""_deg;
+
+  const mrpt::math::TOrientedBox a{
+      mrpt::math::TPose3D(1, 2, 3, 30.0_deg, 0.0_deg, 0.0_deg),
+      mrpt::math::TPoint3D(1.0, 2.0, 3.0)};
+
+  // Copy assignment (it also invalidates the cached vertices):
+  mrpt::math::TOrientedBox b;
+  b = a;
+  EXPECT_TRUE(a == b);
+  EXPECT_FALSE(a != b);
+  EXPECT_EQ(b.vertices().size(), 8U);
+
+  b.setSize(mrpt::math::TPoint3D(9.0, 9.0, 9.0));
+  EXPECT_FALSE(a == b);
+  EXPECT_TRUE(a != b);
+
+  mrpt::math::TOrientedBox c;
+  c = a;
+  c.setPose(mrpt::math::TPose3D(9, 9, 9, 0.0_deg, 0.0_deg, 0.0_deg));
+  EXPECT_TRUE(a != c);
+
+  // Self-assignment must leave the box unchanged:
+  mrpt::math::TOrientedBox d = a;
+  const auto& dRef = d;
+  d = dRef;
+  EXPECT_TRUE(d == a);
+}
+
+TEST(TOrientedBox, castFloatComparison)
+{
+  const mrpt::math::TOrientedBoxf a{
+      mrpt::math::TPose3D::Identity(), mrpt::math::TPoint3Df(1.0f, 2.0f, 3.0f)};
+  const mrpt::math::TOrientedBoxf b = a;
+
+  EXPECT_TRUE(a == b);
+  EXPECT_FALSE(a != b);
+
+  const auto asDouble = a.cast<double>();
+  EXPECT_NEAR(asDouble.size().z, 3.0, 1e-6);
+}

--- a/modules/mrpt_math/tests/TPoint2D_unittest.cpp
+++ b/modules/mrpt_math/tests/TPoint2D_unittest.cpp
@@ -1,0 +1,201 @@
+/*                    _
+                     | |    Mobile Robot Programming Toolkit (MRPT)
+ _ __ ___  _ __ _ __ | |_
+| '_ ` _ \| '__| '_ \| __|          https://www.mrpt.org/
+| | | | | | |  | |_) | |_
+|_| |_| |_|_|  | .__/ \__|     https://github.com/MRPT/mrpt/
+               | |
+               |_|
+
+ Copyright (c) 2005-2026, Individual contributors, see AUTHORS file
+ See: https://www.mrpt.org/Authors - All rights reserved.
+ SPDX-License-Identifier: BSD-3-Clause
+*/
+
+#include <gtest/gtest.h>
+#include <mrpt/math/TPoint2D.h>
+#include <mrpt/math/TPoint3D.h>
+#include <mrpt/math/TPose2D.h>
+#include <mrpt/math/TPose3D.h>
+
+#include <sstream>
+#include <stdexcept>
+#include <vector>
+
+using namespace mrpt::math;
+
+template <typename T>
+class TPoint2DTests : public ::testing::Test
+{
+};
+
+using PointTypes = ::testing::Types<float, double>;
+TYPED_TEST_SUITE(TPoint2DTests, PointTypes);
+
+TYPED_TEST(TPoint2DTests, constructorsAndAccessors)
+{
+  using P = TPoint2D_<TypeParam>;
+
+  const P zero;
+  EXPECT_EQ(zero.x, TypeParam(0));
+  EXPECT_EQ(zero.y, TypeParam(0));
+  EXPECT_EQ(zero.rows(), 2U);
+  EXPECT_EQ(zero.cols(), 1U);
+  EXPECT_EQ(zero.size(), 2U);
+
+  P p(1, 2);
+  EXPECT_EQ(p[0], TypeParam(1));
+  EXPECT_EQ(p[1], TypeParam(2));
+  p[0] = 10;
+  p[1] = 20;
+  EXPECT_EQ(p.x, TypeParam(10));
+  EXPECT_EQ(p.y, TypeParam(20));
+
+  const P cp = p;
+  EXPECT_EQ(cp[0], TypeParam(10));
+  EXPECT_EQ(cp[1], TypeParam(20));
+
+  EXPECT_THROW(p[2], std::out_of_range);
+  EXPECT_THROW(cp[2], std::out_of_range);
+
+  // data() gives contiguous (x,y) access:
+  EXPECT_EQ(p.data()[0], p.x);
+  EXPECT_EQ(cp.data()[1], cp.y);
+
+  // resize() only accepts the static size:
+  P q;
+  q.resize(2);
+  EXPECT_THROW(q.resize(3), std::exception);
+}
+
+TYPED_TEST(TPoint2DTests, conversionConstructors)
+{
+  using P = TPoint2D_<TypeParam>;
+
+  const P fromPose2D(TPose2D(1.0, 2.0, 0.5));
+  EXPECT_NEAR(double(fromPose2D.x), 1.0, 1e-6);
+  EXPECT_NEAR(double(fromPose2D.y), 2.0, 1e-6);
+
+  const P fromPoint3D(TPoint3D_<TypeParam>(1, 2, 3));
+  EXPECT_NEAR(double(fromPoint3D.x), 1.0, 1e-6);
+  EXPECT_NEAR(double(fromPoint3D.y), 2.0, 1e-6);
+
+  const P fromPose3D(TPose3D(1.0, 2.0, 3.0, 0.1, 0.2, 0.3));
+  EXPECT_NEAR(double(fromPose3D.x), 1.0, 1e-6);
+  EXPECT_NEAR(double(fromPose3D.y), 2.0, 1e-6);
+
+  // cast<> between float and double variants:
+  const auto asFloat = P(3, 4).template cast<float>();
+  EXPECT_NEAR(asFloat.x, 3.0f, 1e-6f);
+  const auto asDouble = P(3, 4).template cast<double>();
+  EXPECT_NEAR(asDouble.y, 4.0, 1e-6);
+}
+
+TYPED_TEST(TPoint2DTests, vectorInterop)
+{
+  using P = TPoint2D_<TypeParam>;
+
+  const std::vector<double> v{7.0, 8.0};
+  const P p = P::FromVector(v);
+  EXPECT_NEAR(double(p.x), 7.0, 1e-6);
+  EXPECT_NEAR(double(p.y), 8.0, 1e-6);
+
+  std::vector<double> out;
+  p.asVector(out);
+  ASSERT_EQ(out.size(), 2U);
+  EXPECT_NEAR(out[1], 8.0, 1e-6);
+
+  const auto out2 = p.template asVector<std::vector<double>>();
+  EXPECT_NEAR(out2[0], 7.0, 1e-6);
+}
+
+TYPED_TEST(TPoint2DTests, arithmetic)
+{
+  using P = TPoint2D_<TypeParam>;
+
+  P a(1, 2);
+  const P b(10, 20);
+
+  a += b;
+  EXPECT_EQ(a, P(11, 22));
+  a -= b;
+  EXPECT_EQ(a, P(1, 2));
+  a *= 3;
+  EXPECT_EQ(a, P(3, 6));
+  a /= 3;
+  EXPECT_EQ(a, P(1, 2));
+  EXPECT_THROW(a /= 0, std::exception);
+
+  EXPECT_EQ(a + b, P(11, 22));
+  EXPECT_EQ(b - a, P(9, 18));
+  EXPECT_EQ(a * 2, P(2, 4));
+  EXPECT_EQ(b / 2, P(5, 10));
+  EXPECT_THROW((void)(b / 0), std::exception);
+  EXPECT_EQ(-a, P(-1, -2));
+  EXPECT_EQ(TypeParam(2) * a, P(2, 4));
+
+  EXPECT_TRUE(a != b);
+  EXPECT_FALSE(a == b);
+
+  // Strict weak ordering: x first, then y
+  EXPECT_TRUE(P(1, 2) < P(2, 0));
+  EXPECT_FALSE(P(2, 0) < P(1, 2));
+  EXPECT_TRUE(P(1, 2) < P(1, 3));
+  EXPECT_FALSE(P(1, 3) < P(1, 2));
+}
+
+TYPED_TEST(TPoint2DTests, norms)
+{
+  using P = TPoint2D_<TypeParam>;
+
+  const P p(3, 4);
+  EXPECT_NEAR(double(p.sqrNorm()), 25.0, 1e-4);
+  EXPECT_NEAR(double(p.norm()), 5.0, 1e-4);
+
+  const P u = p.unitarize();
+  EXPECT_NEAR(double(u.norm()), 1.0, 1e-5);
+  EXPECT_NEAR(double(u.x), 0.6, 1e-5);
+
+  EXPECT_THROW(P(0, 0).unitarize(), std::exception);
+}
+
+TYPED_TEST(TPoint2DTests, stringConversion)
+{
+  using P = TPoint2D_<TypeParam>;
+
+  const P p(1.5, -2.25);
+  const std::string s = p.asString();
+  EXPECT_FALSE(s.empty());
+
+  const P q = P::FromString(s);
+  EXPECT_NEAR(double(q.x), 1.5, 1e-4);
+  EXPECT_NEAR(double(q.y), -2.25, 1e-4);
+
+  P r;
+  r.fromString("[3.0 4.0]");
+  EXPECT_NEAR(double(r.x), 3.0, 1e-4);
+
+  EXPECT_THROW(r.fromString("not a matrix"), std::exception);
+  EXPECT_THROW(r.fromString("[1 2 3]"), std::exception);
+
+  std::stringstream ss;
+  ss << p;
+  EXPECT_FALSE(ss.str().empty());
+}
+
+TYPED_TEST(TPoint2DTests, tupleInterface)
+{
+  using P = TPoint2D_<TypeParam>;
+
+  const P p(5, 6);
+  EXPECT_EQ(p.template get<0>(), TypeParam(5));
+  EXPECT_EQ(p.template get<1>(), TypeParam(6));
+
+  const auto t = p.as_tuple();
+  EXPECT_EQ(std::get<0>(t), TypeParam(5));
+
+  TypeParam x = 0, y = 0;
+  std::tie(x, y) = p.as_tuple();
+  EXPECT_EQ(x, TypeParam(5));
+  EXPECT_EQ(y, TypeParam(6));
+}

--- a/modules/mrpt_math/tests/TTwist2D_unittest.cpp
+++ b/modules/mrpt_math/tests/TTwist2D_unittest.cpp
@@ -1,0 +1,125 @@
+/*                    _
+                     | |    Mobile Robot Programming Toolkit (MRPT)
+ _ __ ___  _ __ _ __ | |_
+| '_ ` _ \| '__| '_ \| __|          https://www.mrpt.org/
+| | | | | | |  | |_) | |_
+|_| |_| |_|_|  | .__/ \__|     https://github.com/MRPT/mrpt/
+               | |
+               |_|
+
+ Copyright (c) 2005-2026, Individual contributors, see AUTHORS file
+ See: https://www.mrpt.org/Authors - All rights reserved.
+ SPDX-License-Identifier: BSD-3-Clause
+*/
+
+#include <gtest/gtest.h>
+#include <mrpt/core/bits_math.h>
+#include <mrpt/io/CMemoryStream.h>
+#include <mrpt/math/TPose2D.h>
+#include <mrpt/math/TTwist2D.h>
+#include <mrpt/serialization/CArchive.h>
+
+#include <stdexcept>
+#include <vector>
+
+using mrpt::math::TTwist2D;
+
+TEST(TTwist2D, componentAccess)
+{
+  TTwist2D t(1.0, 2.0, 3.0);
+  EXPECT_EQ(t[0], 1.0);
+  EXPECT_EQ(t[1], 2.0);
+  EXPECT_EQ(t[2], 3.0);
+  t[0] = 10.0;
+  EXPECT_EQ(t.vx, 10.0);
+  EXPECT_THROW(t[3], std::out_of_range);
+
+  const TTwist2D ct(1.0, 2.0, 3.0);
+  EXPECT_EQ(ct[2], 3.0);
+  EXPECT_THROW(ct[3], std::out_of_range);
+}
+
+TEST(TTwist2D, vectorConversions)
+{
+  const std::vector<double> v{1.0, 2.0, 3.0};
+  const TTwist2D t = TTwist2D::FromVector(v);
+  EXPECT_EQ(t.omega, 3.0);
+
+  std::vector<double> out;
+  t.asVector(out);
+  ASSERT_EQ(out.size(), 3U);
+  EXPECT_EQ(out[1], 2.0);
+
+  const auto out2 = t.asVector<std::vector<double>>();
+  EXPECT_EQ(out2[2], 3.0);
+}
+
+TEST(TTwist2D, comparisonAndScaling)
+{
+  const TTwist2D a(1.0, 2.0, 3.0);
+  TTwist2D b(1.0, 2.0, 3.0);
+
+  EXPECT_TRUE(a == b);
+  EXPECT_FALSE(a != b);
+
+  b.omega = 4.0;
+  EXPECT_FALSE(a == b);
+  EXPECT_TRUE(a != b);
+
+  TTwist2D c = a;
+  c *= 2.0;
+  EXPECT_EQ(c.vx, 2.0);
+  EXPECT_EQ(c.omega, 6.0);
+
+  // A twist times a time increment is a pose increment:
+  const auto p = a * 0.5;
+  EXPECT_NEAR(p.x, 0.5, 1e-12);
+  EXPECT_NEAR(p.y, 1.0, 1e-12);
+  EXPECT_NEAR(p.phi, 1.5, 1e-12);
+}
+
+TEST(TTwist2D, rotate)
+{
+  const TTwist2D t(1.0, 0.0, 0.5);
+
+  const auto r90 = t.rotated(mrpt::DEG2RAD(90.0));
+  EXPECT_NEAR(r90.vx, 0.0, 1e-12);
+  EXPECT_NEAR(r90.vy, 1.0, 1e-12);
+  // The angular velocity is not affected by a planar rotation:
+  EXPECT_NEAR(r90.omega, 0.5, 1e-12);
+
+  TTwist2D t2 = t;
+  t2.rotate(0.0);
+  EXPECT_NEAR(t2.vx, 1.0, 1e-12);
+  EXPECT_NEAR(t2.vy, 0.0, 1e-12);
+}
+
+TEST(TTwist2D, stringConversion)
+{
+  const TTwist2D t(1.0, 2.0, mrpt::DEG2RAD(45.0));
+
+  const std::string s = t.asString();
+  EXPECT_FALSE(s.empty());
+
+  const TTwist2D t2 = TTwist2D::FromString(s);
+  EXPECT_NEAR(t2.vx, 1.0, 1e-4);
+  EXPECT_NEAR(t2.vy, 2.0, 1e-4);
+  EXPECT_NEAR(t2.omega, mrpt::DEG2RAD(45.0), 1e-4);
+
+  TTwist2D t3;
+  EXPECT_THROW(t3.fromString("not a matrix"), std::exception);
+  EXPECT_THROW(t3.fromString("[1 2]"), std::exception);
+}
+
+TEST(TTwist2D, serialization)
+{
+  const TTwist2D t(1.0, 2.0, 3.0);
+
+  mrpt::io::CMemoryStream buf;
+  auto arch = mrpt::serialization::archiveFrom(buf);
+  arch << t;
+  buf.Seek(0);
+  TTwist2D t2;
+  arch >> t2;
+  EXPECT_TRUE(t == t2);
+}

--- a/modules/mrpt_math/tests/distributions_unittest.cpp
+++ b/modules/mrpt_math/tests/distributions_unittest.cpp
@@ -154,3 +154,89 @@ TEST(data_utils, mahalanobisDistanceSqAndLogPDF)
   EXPECT_NEAR(out_maha2, 0.388264, 1e-4);
   EXPECT_NEAR(out_ml, 9.14118, 1e-4);
 }
+
+TEST(distributions, normalPDFInf)
+{
+  const double cov_vals[3 * 3] = {4.0, 2.0, 1.0, 2.0, 3.0, 0.5, 1.0, 0.5, 1.0};
+  const CMatrixDouble33 COV(cov_vals);
+  const CMatrixDouble33 COV_inv = COV.inverse_LLt();
+
+  const double x1_vals[3] = {1.0, 0.0, 0.0};
+  const CMatrixFixed<double, 3, 1> x0;
+  const CMatrixFixed<double, 3, 1> x1(x1_vals);
+
+  // The unscaled version must match the plain covariance-based evaluation:
+  EXPECT_NEAR(normalPDFInf(x1, x0, COV_inv), normalPDF(x1, x0, COV), 1e-12);
+
+  // The scaled version peaks at 1 for x==mu:
+  EXPECT_NEAR(normalPDFInf(x0, x0, COV_inv, true), 1.0, 1e-12);
+  EXPECT_LT(normalPDFInf(x1, x0, COV_inv, true), 1.0);
+}
+
+TEST(distributions, KLD_Gaussians)
+{
+  CMatrixDouble cov0(2, 2);
+  cov0.setIdentity();
+  CMatrixDouble cov1(2, 2);
+  cov1.setIdentity();
+
+  CVectorDouble mu0(2);
+  mu0.fill(0);
+  CVectorDouble mu1(2);
+  mu1.fill(0);
+
+  // Identical distributions => zero divergence
+  EXPECT_NEAR(KLD_Gaussians(mu0, cov0, mu1, cov1), 0.0, 1e-12);
+
+  // Shifting the mean by 1 sigma in one axis adds 0.5:
+  mu1[0] = 1.0;
+  EXPECT_NEAR(KLD_Gaussians(mu0, cov0, mu1, cov1), 0.5, 1e-12);
+
+  // Doubling the variance of one axis:
+  cov1(0, 0) = 4.0;
+  mu1[0] = 0.0;
+  EXPECT_NEAR(KLD_Gaussians(mu0, cov0, mu1, cov1), 0.5 * (std::log(4.0) + 0.25 - 1.0), 1e-12);
+
+  // Mismatched dimensions are rejected:
+  CMatrixDouble cov3(3, 3);
+  cov3.setIdentity();
+  CVectorDouble mu3(3);
+  mu3.fill(0);
+  EXPECT_THROW(KLD_Gaussians(mu0, cov0, mu3, cov3), std::exception);
+}
+
+TEST(distributions, confidenceIntervals)
+{
+  // A uniform ramp of samples in [0,100]: the 10%-90% interval must be close
+  // to [10,90] and the mean to 50.
+  CVectorDouble data(1001);
+  for (int i = 0; i < 1001; i++) data[i] = i * 0.1;
+
+  double mean = 0, lower = 0, upper = 0;
+  confidenceIntervals(data, mean, lower, upper, 0.1, 100);
+
+  EXPECT_NEAR(mean, 50.0, 1e-6);
+  EXPECT_NEAR(lower, 10.0, 2.0);
+  EXPECT_NEAR(upper, 90.0, 2.0);
+
+  // Invalid arguments:
+  CVectorDouble empty(0);
+  EXPECT_THROW(confidenceIntervals(empty, mean, lower, upper), std::exception);
+  EXPECT_THROW(confidenceIntervals(data, mean, lower, upper, 0.0), std::exception);
+  EXPECT_THROW(confidenceIntervals(data, mean, lower, upper, 1.0), std::exception);
+}
+
+TEST(distributions, confidenceIntervalsFromHistogram)
+{
+  // A flat histogram over [0,100) in 100 bins:
+  std::vector<double> coords(100), hits(100, 0.01);
+  for (int i = 0; i < 100; i++) coords[i] = i;
+
+  double lower = 0, upper = 0;
+  confidenceIntervalsFromHistogram(coords, hits, lower, upper, 0.1);
+
+  EXPECT_NEAR(lower, 9.9, 2.0);
+  EXPECT_NEAR(upper, 89.1, 2.0);
+
+  EXPECT_THROW(confidenceIntervalsFromHistogram(coords, hits, lower, upper, 0.0), std::exception);
+}

--- a/modules/mrpt_math/tests/fresnel_unittest.cpp
+++ b/modules/mrpt_math/tests/fresnel_unittest.cpp
@@ -71,3 +71,59 @@ TEST(fresnel, fresnels)
         << " x: " << x << "\n val_good: " << val_good << "\n val: " << val << "\n";
   }
 }
+
+namespace
+{
+// Reference values by direct numerical integration of the definitions
+//   C(x) = int_0^x cos(pi/2 * t^2) dt,  S(x) = int_0^x sin(pi/2 * t^2) dt
+// using composite Simpson's rule, so that no hard-coded table is needed.
+double simpson(double x, bool sine)
+{
+  const int n = 2000000;  // even
+  const double h = x / n;
+  auto f = [sine](double t)
+  {
+    const double a = M_PI * 0.5 * t * t;
+    return sine ? std::sin(a) : std::cos(a);
+  };
+  double s = f(0) + f(x);
+  for (int i = 1; i < n; i++) s += f(i * h) * ((i & 1) ? 4.0 : 2.0);
+  return s * h / 3.0;
+}
+}  // namespace
+
+TEST(fresnel, matchesNumericalIntegration)
+{
+  // Values spanning every internal branch: the power series (|x| < ~0.4), the
+  // Chebyshev expansions for each sub-range, and the asymptotic series.
+  const double xs[] = {0.05, 0.2, 0.3, 0.39, 0.5, 1.0,   2.0,   3.5,
+                       4.2,  5.0, 5.5, 6.5,  9.0, -0.25, -0.35, -5.2};
+
+  for (const double x : xs)
+  {
+    const double refC = simpson(x, false);
+    const double refS = simpson(x, true);
+
+    EXPECT_NEAR(mrpt::math::fresnel_cos_integral(x), refC, 1e-6) << "x=" << x;
+    EXPECT_NEAR(mrpt::math::fresnel_sin_integral(x), refS, 1e-6) << "x=" << x;
+
+    // The long-double entry points must agree with the double ones:
+    EXPECT_NEAR(
+        static_cast<double>(mrpt::math::lfresnel_cos_integral(static_cast<long double>(x))), refC,
+        1e-6)
+        << "x=" << x;
+    EXPECT_NEAR(
+        static_cast<double>(mrpt::math::lfresnel_sin_integral(static_cast<long double>(x))), refS,
+        1e-6)
+        << "x=" << x;
+  }
+}
+
+TEST(fresnel, oddSymmetry)
+{
+  for (const double x : {0.2, 1.0, 4.5, 6.0, 20.0})
+  {
+    EXPECT_NEAR(mrpt::math::fresnel_cos_integral(-x), -mrpt::math::fresnel_cos_integral(x), 1e-12);
+    EXPECT_NEAR(mrpt::math::fresnel_sin_integral(-x), -mrpt::math::fresnel_sin_integral(x), 1e-12);
+  }
+}

--- a/modules/mrpt_math/tests/fresnel_unittest.cpp
+++ b/modules/mrpt_math/tests/fresnel_unittest.cpp
@@ -79,7 +79,9 @@ namespace
 // using composite Simpson's rule, so that no hard-coded table is needed.
 double simpson(double x, bool sine)
 {
-  const int n = 2000000;  // even
+  // Even; the Simpson error stays far below the 1e-6 tolerance used below,
+  // while keeping the whole test in the low milliseconds.
+  const int n = 20000;
   const double h = x / n;
   auto f = [sine](double t)
   {

--- a/modules/mrpt_math/tests/fresnel_unittest.cpp
+++ b/modules/mrpt_math/tests/fresnel_unittest.cpp
@@ -13,6 +13,7 @@
 */
 
 #include <gtest/gtest.h>
+#include <mrpt/core/bits_math.h>  // M_PI on MSVC
 #include <mrpt/math/fresnel.h>
 #include <mrpt/system/os.h>
 

--- a/modules/mrpt_math/tests/geometry_sets_unittest.cpp
+++ b/modules/mrpt_math/tests/geometry_sets_unittest.cpp
@@ -1,0 +1,333 @@
+/*                    _
+                     | |    Mobile Robot Programming Toolkit (MRPT)
+ _ __ ___  _ __ _ __ | |_
+| '_ ` _ \| '__| '_ \| __|          https://www.mrpt.org/
+| | | | | | |  | |_) | |_
+|_| |_| |_|_|  | .__/ \__|     https://github.com/MRPT/mrpt/
+               | |
+               |_|
+
+ Copyright (c) 2005-2026, Individual contributors, see AUTHORS file
+ See: https://www.mrpt.org/Authors - All rights reserved.
+ SPDX-License-Identifier: BSD-3-Clause
+*/
+
+#include <gtest/gtest.h>
+#include <mrpt/math/CSparseMatrixTemplate.h>
+#include <mrpt/math/TLine2D.h>
+#include <mrpt/math/TLine3D.h>
+#include <mrpt/math/TObject2D.h>
+#include <mrpt/math/TObject3D.h>
+#include <mrpt/math/TPolygon2D.h>
+#include <mrpt/math/TPolygon3D.h>
+#include <mrpt/math/TSegment2D.h>
+#include <mrpt/math/TSegment3D.h>
+#include <mrpt/math/geometry.h>
+
+#include <vector>
+
+using namespace mrpt::math;
+
+namespace
+{
+// The unit square in the XY plane, at height z
+TPolygon3D squareAtZ(double z)
+{
+  TPolygon3D p;
+  p.emplace_back(0, 0, z);
+  p.emplace_back(1, 0, z);
+  p.emplace_back(1, 1, z);
+  p.emplace_back(0, 1, z);
+  return p;
+}
+}  // namespace
+
+TEST(GeometrySets, getRectangleBounds)
+{
+  const std::vector<TPoint2D> poly{
+      {-1.0,  2.0},
+      { 3.0, -4.0},
+      { 0.5,  0.5}
+  };
+
+  TPoint2D pMin, pMax;
+  getRectangleBounds(poly, pMin, pMax);
+  EXPECT_NEAR(pMin.x, -1.0, 1e-12);
+  EXPECT_NEAR(pMin.y, -4.0, 1e-12);
+  EXPECT_NEAR(pMax.x, 3.0, 1e-12);
+  EXPECT_NEAR(pMax.y, 2.0, 1e-12);
+
+  const std::vector<TPoint2D> empty;
+  EXPECT_THROW(getRectangleBounds(empty, pMin, pMax), std::logic_error);
+}
+
+TEST(GeometrySets, getPrismBounds)
+{
+  const std::vector<TPoint3D> poly{
+      {-1.0,  2.0,  5.0},
+      { 3.0, -4.0, -2.0},
+      { 0.5,  0.5,  0.0}
+  };
+
+  TPoint3D pMin, pMax;
+  getPrismBounds(poly, pMin, pMax);
+  EXPECT_NEAR(pMin.z, -2.0, 1e-12);
+  EXPECT_NEAR(pMax.z, 5.0, 1e-12);
+
+  const std::vector<TPoint3D> empty;
+  EXPECT_THROW(getPrismBounds(empty, pMin, pMax), std::logic_error);
+}
+
+TEST(GeometrySets, intersectPolygonSetsSparse)
+{
+  // Two identical squares plus one far away: only the coincident pair overlaps
+  const std::vector<TPolygon3D> v1{squareAtZ(0), squareAtZ(100)};
+  const std::vector<TPolygon3D> v2{squareAtZ(0)};
+
+  CSparseMatrixTemplate<TObject3D> objs;
+  const size_t n = intersect(v1, v2, objs);
+  EXPECT_EQ(n, 1U);
+  EXPECT_EQ(objs.rows(), 2U);
+  EXPECT_EQ(objs.cols(), 1U);
+}
+
+TEST(GeometrySets, intersectPolygonSetsVector)
+{
+  const std::vector<TPolygon3D> v1{squareAtZ(0), squareAtZ(100)};
+  const std::vector<TPolygon3D> v2{squareAtZ(0)};
+
+  std::vector<TObject3D> objs;
+  const size_t n = intersect(v1, v2, objs);
+  EXPECT_EQ(n, 1U);
+  EXPECT_EQ(objs.size(), 1U);
+}
+
+TEST(GeometrySets, intersectGenericVectors)
+{
+  // The generic template over any pair of intersectable object types:
+  const std::vector<TSegment2D> v1{
+      TSegment2D({0.0, 0.0}, {10.0, 0.0}), TSegment2D({0.0, 5.0}, {10.0, 5.0})};
+  const std::vector<TSegment2D> v2{TSegment2D({5.0, -1.0}, {5.0, 1.0})};
+
+  CSparseMatrixTemplate<TObject2D> sparse;
+  EXPECT_EQ(intersect(v1, v2, sparse), 1U);
+
+  std::vector<TObject2D> objs;
+  EXPECT_EQ(intersect(v1, v2, objs), 1U);
+  ASSERT_EQ(objs.size(), 1U);
+  EXPECT_TRUE(objs[0].isPoint());
+}
+
+TEST(GeometrySets, assemblePolygonsWithBothRemainders)
+{
+  // A closed triangle (assembled into a polygon), one dangling segment and one
+  // point (neither of which can take part in any polygon):
+  std::vector<TObject3D> objs;
+  objs.push_back(TObject3D::From(TSegment3D({0, 0, 0}, {1, 0, 0})));
+  objs.push_back(TObject3D::From(TSegment3D({1, 0, 0}, {0, 1, 0})));
+  objs.push_back(TObject3D::From(TSegment3D({0, 1, 0}, {0, 0, 0})));
+  objs.push_back(TObject3D::From(TSegment3D({5, 5, 5}, {6, 5, 5})));
+  objs.push_back(TObject3D::From(TPoint3D(9, 9, 9)));
+
+  std::vector<TPolygon3D> polys;
+  std::vector<TSegment3D> remainderSegments;
+  std::vector<TObject3D> remainderObjects;
+  assemblePolygons(objs, polys, remainderSegments, remainderObjects);
+
+  EXPECT_EQ(polys.size(), 1U);
+  EXPECT_EQ(remainderSegments.size(), 1U);
+  ASSERT_EQ(remainderObjects.size(), 1U);
+  EXPECT_TRUE(remainderObjects[0].isPoint());
+}
+
+TEST(GeometrySets, distanceBetweenSkewLines)
+{
+  // Two perpendicular, non-intersecting lines 3 units apart in z
+  const TLine3D l1(TPoint3D(0, 0, 0), TPoint3D(1, 0, 0));
+  const TLine3D l2(TPoint3D(0, 0, 3), TPoint3D(0, 1, 3));
+
+  EXPECT_NEAR(distance(l1, l2), 3.0, 1e-9);
+}
+
+TEST(GeometrySets, splitInConvexComponents3D)
+{
+  // An L-shaped (concave) polygon lying on the plane z=1
+  TPolygon3D poly;
+  poly.emplace_back(0, 0, 1);
+  poly.emplace_back(2, 0, 1);
+  poly.emplace_back(2, 1, 1);
+  poly.emplace_back(1, 1, 1);
+  poly.emplace_back(1, 2, 1);
+  poly.emplace_back(0, 2, 1);
+
+  std::vector<TPolygon3D> comps;
+  EXPECT_TRUE(splitInConvexComponents(poly, comps));
+  EXPECT_GE(comps.size(), 2U);
+  for (const auto& c : comps)
+    for (const auto& pt : c) EXPECT_NEAR(pt.z, 1.0, 1e-6);
+
+  // A triangle is already convex, so no split takes place:
+  TPolygon3D tri;
+  tri.emplace_back(0, 0, 1);
+  tri.emplace_back(1, 0, 1);
+  tri.emplace_back(0, 1, 1);
+  EXPECT_FALSE(splitInConvexComponents(tri, comps));
+}
+
+TEST(GeometrySets, intersectPolygonsInPerpendicularPlanes)
+{
+  // A square in the XY plane and a square in the XZ plane, crossing it:
+  TPolygon3D pXY;
+  pXY.emplace_back(-1, -1, 0);
+  pXY.emplace_back(1, -1, 0);
+  pXY.emplace_back(1, 1, 0);
+  pXY.emplace_back(-1, 1, 0);
+
+  TPolygon3D pXZ;
+  pXZ.emplace_back(-0.5, 0, -1);
+  pXZ.emplace_back(0.5, 0, -1);
+  pXZ.emplace_back(0.5, 0, 1);
+  pXZ.emplace_back(-0.5, 0, 1);
+
+  TObject3D obj;
+  ASSERT_TRUE(intersect(pXY, pXZ, obj));
+
+  // The two faces cross along a segment of the line y=z=0:
+  TSegment3D s;
+  ASSERT_TRUE(obj.getSegment(s));
+  EXPECT_NEAR(s.point1.z, 0.0, 1e-9);
+  EXPECT_NEAR(s.point2.z, 0.0, 1e-9);
+  EXPECT_NEAR(s.point1.y, 0.0, 1e-9);
+  EXPECT_NEAR(std::abs(s.point2.x - s.point1.x), 1.0, 1e-9);
+}
+
+TEST(GeometrySets, intersectPolygonsInParallelPlanes)
+{
+  // Parallel but distinct planes never intersect:
+  TObject3D obj;
+  EXPECT_FALSE(intersect(squareAtZ(0), squareAtZ(1), obj));
+}
+
+TEST(GeometrySets, getAngleBisectorParallelOppositeSigns)
+{
+  // y=0 and -y+2=0: parallel lines whose normals point in opposite directions
+  const auto l1 = TLine2D::FromCoefficientsABC(0, 1, 0);
+  const auto l2 = TLine2D::FromCoefficientsABC(0, -1, 2);
+
+  TLine2D bis;
+  getAngleBisector(l1, l2, bis);
+
+  // The bisector must be the line y=1, i.e. equidistant from both:
+  EXPECT_NEAR(bis.distance({0.0, 1.0}), 0.0, 1e-9);
+  EXPECT_NEAR(bis.distance({5.0, 1.0}), 0.0, 1e-9);
+}
+
+TEST(GeometrySets, intersectPolygonSetsInDifferentPlanes)
+{
+  // A square in the XY plane and one in the XZ plane crossing it: their
+  // supporting planes meet along a line, which is the branch of the
+  // polygon-vs-polygon intersection that the coplanar case never reaches.
+  TPolygon3D pXY;
+  pXY.emplace_back(-1, -1, 0);
+  pXY.emplace_back(1, -1, 0);
+  pXY.emplace_back(1, 1, 0);
+  pXY.emplace_back(-1, 1, 0);
+
+  TPolygon3D pXZ;
+  pXZ.emplace_back(-0.5, 0, -1);
+  pXZ.emplace_back(0.5, 0, -1);
+  pXZ.emplace_back(0.5, 0, 1);
+  pXZ.emplace_back(-0.5, 0, 1);
+
+  // A third one, parallel to the first but far away, which must not match:
+  const TPolygon3D far = squareAtZ(50);
+
+  const std::vector<TPolygon3D> v1{pXY, far};
+  const std::vector<TPolygon3D> v2{pXZ};
+
+  CSparseMatrixTemplate<TObject3D> objs;
+  EXPECT_EQ(intersect(v1, v2, objs), 1U);
+  ASSERT_TRUE(objs.exists(0, 0));
+
+  TSegment3D s;
+  ASSERT_TRUE(objs(0, 0).getSegment(s));
+  EXPECT_NEAR(std::abs(s.point2.x - s.point1.x), 1.0, 1e-9);
+
+  std::vector<TObject3D> objsVec;
+  EXPECT_EQ(intersect(v1, v2, objsVec), 1U);
+  ASSERT_EQ(objsVec.size(), 1U);
+}
+
+TEST(GeometrySets, intersectPolygon3DWithLine)
+{
+  TPolygon3D poly;
+  poly.emplace_back(-1, -1, 0);
+  poly.emplace_back(1, -1, 0);
+  poly.emplace_back(1, 1, 0);
+  poly.emplace_back(-1, 1, 0);
+
+  TObject3D obj;
+
+  // A line crossing the polygon's plane inside it: a single point
+  {
+    const TLine3D l(TPoint3D(0, 0, -1), TPoint3D(0, 0, 1));
+    ASSERT_TRUE(intersect(poly, l, obj));
+    TPoint3D p;
+    ASSERT_TRUE(obj.getPoint(p));
+    EXPECT_NEAR(p.z, 0.0, 1e-9);
+  }
+  // A line crossing the plane outside the polygon: no intersection
+  {
+    const TLine3D l(TPoint3D(10, 10, -1), TPoint3D(10, 10, 1));
+    EXPECT_FALSE(intersect(poly, l, obj));
+  }
+  // A line contained in the polygon's plane and crossing it: a segment
+  {
+    const TLine3D l(TPoint3D(-5, 0, 0), TPoint3D(5, 0, 0));
+    ASSERT_TRUE(intersect(poly, l, obj));
+    TSegment3D s;
+    ASSERT_TRUE(obj.getSegment(s));
+    EXPECT_NEAR(std::abs(s.point2.x - s.point1.x), 2.0, 1e-9);
+  }
+  // A line parallel to the plane but off it: no intersection
+  {
+    const TLine3D l(TPoint3D(-5, 0, 1), TPoint3D(5, 0, 1));
+    EXPECT_FALSE(intersect(poly, l, obj));
+  }
+}
+
+TEST(GeometrySets, areAlignedDegenerateInputs)
+{
+  // Two points are always aligned, and the line through them is returned:
+  TLine2D l2;
+  EXPECT_TRUE(areAligned(
+      std::vector<TPoint2D>{
+          {0.0, 0.0},
+          {1.0, 1.0}
+  },
+      l2));
+  EXPECT_TRUE(l2.contains({2.0, 2.0}));
+
+  TLine3D l3;
+  EXPECT_TRUE(areAligned(
+      std::vector<TPoint3D>{
+          {0, 0, 0},
+          {1, 1, 1}
+  },
+      l3));
+  EXPECT_TRUE(l3.contains({2, 2, 2}));
+
+  // Coincident points do not define a line:
+  EXPECT_FALSE(areAligned(
+      std::vector<TPoint2D>{
+          {1.0, 1.0},
+          {1.0, 1.0}
+  },
+      l2));
+  EXPECT_FALSE(areAligned(
+      std::vector<TPoint3D>{
+          {1, 1, 1},
+          {1, 1, 1}
+  },
+      l3));
+}

--- a/modules/mrpt_math/tests/geometry_sets_unittest.cpp
+++ b/modules/mrpt_math/tests/geometry_sets_unittest.cpp
@@ -210,16 +210,21 @@ TEST(GeometrySets, intersectPolygonsInParallelPlanes)
 
 TEST(GeometrySets, getAngleBisectorParallelOppositeSigns)
 {
-  // y=0 and -y+2=0: parallel lines whose normals point in opposite directions
+  // y=0 and y=3, the latter written with a non-unit normal and the opposite
+  // orientation. The un-normalized coefficients matter: with A=0 the old,
+  // buggy normalization `sqrt(A^2+C^2)` equals |C|, which for C=2 happened to
+  // cancel the (also missing) factor of 2 and gave the right answer anyway.
+  // C=6 breaks that coincidence, so this pins both halves of the fix.
   const auto l1 = TLine2D::FromCoefficientsABC(0, 1, 0);
-  const auto l2 = TLine2D::FromCoefficientsABC(0, -1, 2);
+  const auto l2 = TLine2D::FromCoefficientsABC(0, -2, 6);
 
   TLine2D bis;
   getAngleBisector(l1, l2, bis);
 
-  // The bisector must be the line y=1, i.e. equidistant from both:
-  EXPECT_NEAR(bis.distance({0.0, 1.0}), 0.0, 1e-9);
-  EXPECT_NEAR(bis.distance({5.0, 1.0}), 0.0, 1e-9);
+  // The bisector must be y=1.5, i.e. equidistant from both:
+  EXPECT_NEAR(bis.distance({0.0, 1.5}), 0.0, 1e-9);
+  EXPECT_NEAR(bis.distance({5.0, 1.5}), 0.0, 1e-9);
+  EXPECT_NEAR(bis.distance({0.0, 0.0}), bis.distance({0.0, 3.0}), 1e-9);
 }
 
 TEST(GeometrySets, intersectPolygonSetsInDifferentPlanes)

--- a/modules/mrpt_math/tests/legacy_serialization.h
+++ b/modules/mrpt_math/tests/legacy_serialization.h
@@ -1,0 +1,52 @@
+/*                    _
+                     | |    Mobile Robot Programming Toolkit (MRPT)
+ _ __ ___  _ __ _ __ | |_
+| '_ ` _ \| '__| '_ \| __|          https://www.mrpt.org/
+| | | | | | |  | |_) | |_
+|_| |_| |_|_|  | .__/ \__|     https://github.com/MRPT/mrpt/
+               | |
+               |_|
+
+ Copyright (c) 2005-2026, Individual contributors, see AUTHORS file
+ See: https://www.mrpt.org/Authors - All rights reserved.
+ SPDX-License-Identifier: BSD-3-Clause
+*/
+#pragma once
+
+#include <mrpt/io/CMemoryStream.h>
+#include <mrpt/serialization/CArchive.h>
+#include <mrpt/serialization/CSerializable.h>
+
+#include <cstdint>
+#include <functional>
+#include <string>
+
+namespace mrpt_test
+{
+/** Writes an MRPT object frame (class name, streaming version, payload and end
+ *  flag) with an arbitrary version number, so that the backwards-compatibility
+ *  branches of serializeFrom() can be exercised without shipping binary
+ *  fixture files. The stream is left rewound and ready to be read back.
+ */
+inline void writeLegacyObjectFrame(
+    mrpt::io::CMemoryStream& buf,
+    const std::string& className,
+    uint8_t version,
+    const std::function<void(mrpt::serialization::CArchive&)>& writePayload)
+{
+  auto arch = mrpt::serialization::archiveFrom(buf);
+
+  // Class name, length with the "new format" flag in its MSB:
+  const auto lenAndFlag = static_cast<int8_t>(className.size() | 0x80);
+  arch << lenAndFlag;
+  buf.Write(className.data(), className.size());
+
+  arch << version;
+  writePayload(arch);
+
+  const uint8_t endFlag = 0x88;
+  arch << endFlag;
+
+  buf.Seek(0);
+}
+}  // namespace mrpt_test

--- a/modules/mrpt_math/tests/matrix_api_unittest.cpp
+++ b/modules/mrpt_math/tests/matrix_api_unittest.cpp
@@ -76,6 +76,9 @@ TEST(CMatrixDynamic, resizeOverloads)
   EXPECT_EQ(m.rows(), 5U);
   EXPECT_EQ(m.cols(), 1U);
 
+  // Shrinking the rows while growing the columns, asking for the new cells to
+  // be zeroed: the "zero the new columns" pass must stay within the *new*
+  // buffer (2x4 = 8 cells), not iterate over the 5 old rows.
   matrix_size_t siz;
   siz[0] = 2;
   siz[1] = 4;

--- a/modules/mrpt_math/tests/matrix_api_unittest.cpp
+++ b/modules/mrpt_math/tests/matrix_api_unittest.cpp
@@ -1,0 +1,293 @@
+/*                    _
+                     | |    Mobile Robot Programming Toolkit (MRPT)
+ _ __ ___  _ __ _ __ | |_
+| '_ ` _ \| '__| '_ \| __|          https://www.mrpt.org/
+| | | | | | |  | |_) | |_
+|_| |_| |_|_|  | .__/ \__|     https://github.com/MRPT/mrpt/
+               | |
+               |_|
+
+ Copyright (c) 2005-2026, Individual contributors, see AUTHORS file
+ See: https://www.mrpt.org/Authors - All rights reserved.
+ SPDX-License-Identifier: BSD-3-Clause
+*/
+
+#include <gtest/gtest.h>
+#include <mrpt/math/CMatrixDynamic.h>
+#include <mrpt/math/CMatrixFixed.h>
+#include <mrpt/math/CVectorDynamic.h>
+#include <mrpt/math/CVectorFixed.h>
+#include <mrpt/math/ops_matrices.h>
+
+#include <Eigen/Dense>
+#include <sstream>
+
+using namespace mrpt::math;
+
+TEST(CMatrixDynamic, cropConstructorAndSwap)
+{
+  CMatrixDouble m(3, 3);
+  for (int r = 0; r < 3; r++)
+    for (int c = 0; c < 3; c++) m(r, c) = 10 * r + c;
+
+  // Crop to the top-left 2x2 block:
+  const CMatrixDouble cropped(m, 2, 2);
+  EXPECT_EQ(cropped.rows(), 2U);
+  EXPECT_EQ(cropped.cols(), 2U);
+  EXPECT_NEAR(cropped(1, 1), 11.0, 1e-12);
+
+  // Cropping to a larger size is rejected:
+  EXPECT_THROW(CMatrixDouble(m, 4, 2), std::exception);
+  EXPECT_THROW(CMatrixDouble(m, 2, 4), std::exception);
+
+  CMatrixDouble a(1, 1), b(2, 2);
+  a(0, 0) = 7.0;
+  a.swap(b);
+  EXPECT_EQ(a.rows(), 2U);
+  EXPECT_EQ(b.rows(), 1U);
+  EXPECT_NEAR(b(0, 0), 7.0, 1e-12);
+}
+
+TEST(CMatrixDynamic, moveSemanticsAndSizes)
+{
+  CMatrixDouble m(2, 3);
+  m.fill(4.0);
+
+  const CMatrixDouble moved(std::move(m));
+  EXPECT_EQ(moved.rows(), 2U);
+  EXPECT_EQ(moved.cols(), 3U);
+  EXPECT_NEAR(moved(1, 2), 4.0, 1e-12);
+
+  CMatrixDouble m2(1, 1);
+  m2 = CMatrixDouble(4, 5);
+  EXPECT_EQ(m2.rows(), 4U);
+
+  const auto dims = moved.size();
+  EXPECT_EQ(dims[0], 2U);
+  EXPECT_EQ(dims[1], 3U);
+}
+
+TEST(CMatrixDynamic, resizeOverloads)
+{
+  CMatrixDouble m;
+
+  // Nx1 vector-like resize:
+  m.resize(5U);
+  EXPECT_EQ(m.rows(), 5U);
+  EXPECT_EQ(m.cols(), 1U);
+
+  matrix_size_t siz;
+  siz[0] = 2;
+  siz[1] = 4;
+  m.resize(siz, true);
+  EXPECT_EQ(m.rows(), 2U);
+  EXPECT_EQ(m.cols(), 4U);
+  // Zeroed new elements:
+  EXPECT_NEAR(m(1, 3), 0.0, 1e-12);
+
+  // Growing with zeroNewElements keeps old content and zeroes the rest:
+  CMatrixDouble g(1, 1);
+  g(0, 0) = 9.0;
+  g.setSize(2, 2, true);
+  EXPECT_NEAR(g(0, 0), 9.0, 1e-12);
+  EXPECT_NEAR(g(0, 1), 0.0, 1e-12);
+  EXPECT_NEAR(g(1, 1), 0.0, 1e-12);
+
+  // Shrinking keeps the top-left block:
+  g.setSize(1, 1);
+  EXPECT_EQ(g.rows(), 1U);
+  EXPECT_NEAR(g(0, 0), 9.0, 1e-12);
+
+  // Setting the same size is a no-op:
+  g.setSize(1, 1);
+  EXPECT_EQ(g.rows(), 1U);
+}
+
+TEST(CMatrixDynamic, arrayConstructorSizeMismatch)
+{
+  double values[6] = {1, 2, 3, 4, 5, 6};
+  const CMatrixDouble ok(2, 3, values);
+  EXPECT_NEAR(ok(1, 2), 6.0, 1e-12);
+
+  EXPECT_THROW(CMatrixDouble(2, 2, values), std::exception);
+}
+
+TEST(CMatrixDynamic, constIterationAndIndexing)
+{
+  CMatrixDouble m(1, 3);
+  m(0, 0) = 1.0;
+  m(0, 1) = 2.0;
+  m(0, 2) = 3.0;
+
+  const CMatrixDouble& cm = m;
+  EXPECT_NEAR(cm[2], 3.0, 1e-12);
+  EXPECT_EQ(std::distance(cm.cbegin(), cm.cend()), 3);
+  EXPECT_EQ(std::distance(cm.begin(), cm.end()), 3);
+}
+
+TEST(CMatrixFixed, assignmentsFromOtherTypes)
+{
+  CMatrixDouble dyn(2, 2);
+  dyn(0, 0) = 1.0;
+  dyn(1, 1) = 2.0;
+
+  CMatrixDouble22 fixed;
+  fixed = dyn;
+  EXPECT_NEAR(fixed(1, 1), 2.0, 1e-12);
+
+  // From a plain Eigen expression:
+  Eigen::MatrixXd e(2, 2);
+  e.setZero();
+  e(1, 1) = 4.0;
+  fixed = e;
+  EXPECT_NEAR(fixed(1, 1), 4.0, 1e-12);
+
+  // The (rows, cols) constructor only accepts the compile-time size:
+  EXPECT_NO_THROW(CMatrixDouble22(2, 2));
+  EXPECT_THROW(CMatrixDouble22(3, 2), std::exception);
+  EXPECT_THROW(CMatrixDouble22(2, 3), std::exception);
+}
+
+TEST(CMatrixFixed, resizeChecksAndSize)
+{
+  CMatrixDouble22 m;
+  EXPECT_NO_THROW(m.resize(2, 2));
+  EXPECT_THROW(m.resize(3, 2), std::exception);
+
+  matrix_size_t siz;
+  siz[0] = 2;
+  siz[1] = 2;
+  EXPECT_NO_THROW(m.resize(siz));
+
+  // The 1-argument resize() is only meaningful for row/column matrices:
+  EXPECT_THROW(m.resize(size_t(2)), std::exception);
+
+  CVectorFixedDouble<3> v;
+  EXPECT_NO_THROW(v.resize(size_t(3)));
+  EXPECT_THROW(v.resize(size_t(4)), std::exception);
+
+  const auto dims = m.size();
+  EXPECT_EQ(dims[0], 2U);
+  EXPECT_EQ(dims[1], 2U);
+}
+
+TEST(CMatrixFixed, linearIndexingAndSwap)
+{
+  CMatrixDouble22 m;
+  m(0, 0) = 1.0;
+  m(0, 1) = 2.0;
+  m(1, 0) = 3.0;
+  m(1, 1) = 4.0;
+
+  // Row-major linear access:
+  EXPECT_NEAR(m(2), 3.0, 1e-12);
+  const CMatrixDouble22& cm = m;
+  EXPECT_NEAR(cm(3), 4.0, 1e-12);
+  EXPECT_EQ(std::distance(cm.begin(), cm.end()), 4);
+
+  CMatrixDouble22 other;
+  other.fill(9.0);
+  m.swap(other);
+  EXPECT_NEAR(m(0, 0), 9.0, 1e-12);
+  EXPECT_NEAR(other(0, 0), 1.0, 1e-12);
+}
+
+TEST(CMatrixFixed, sum_At)
+{
+  CMatrixDouble22 m;
+  m.fill(0);
+  CMatrixDouble22 a;
+  a(0, 0) = 1.0;
+  a(0, 1) = 2.0;
+  a(1, 0) = 3.0;
+  a(1, 1) = 4.0;
+
+  m.sum_At(a);
+  EXPECT_NEAR(m(0, 1), 3.0, 1e-12);
+  EXPECT_NEAR(m(1, 0), 2.0, 1e-12);
+
+  // Non-square matrices have no in-place transpose sum:
+  CMatrixFixed<double, 2, 3> nonSquare;
+  nonSquare.fill(0);
+  EXPECT_THROW(nonSquare.sum_At(nonSquare), std::runtime_error);
+}
+
+TEST(MatrixVectorBase, minMaxCoeffWithIndices)
+{
+  CVectorDouble v(4);
+  v[0] = 3.0;
+  v[1] = -1.0;
+  v[2] = 7.0;
+  v[3] = 0.0;
+
+  matrix_index_t idx = 0;
+  EXPECT_NEAR(v.minCoeff(idx), -1.0, 1e-12);
+  EXPECT_EQ(idx, 1U);
+  EXPECT_NEAR(v.maxCoeff(idx), 7.0, 1e-12);
+  EXPECT_EQ(idx, 2U);
+
+  CMatrixDouble m(2, 2);
+  m(0, 0) = 5.0;
+  m(0, 1) = -2.0;
+  m(1, 0) = 1.0;
+  m(1, 1) = 3.0;
+
+  matrix_index_t r = 0, c = 0;
+  EXPECT_NEAR(m.minCoeff(r, c), -2.0, 1e-12);
+  EXPECT_EQ(r, 0U);
+  EXPECT_EQ(c, 1U);
+  EXPECT_NEAR(m.maxCoeff(r, c), 5.0, 1e-12);
+  EXPECT_EQ(r, 0U);
+  EXPECT_EQ(c, 0U);
+
+  // The 1-index signatures are only valid for column vectors:
+  EXPECT_THROW(m.minCoeff(idx), std::runtime_error);
+  EXPECT_THROW(m.maxCoeff(idx), std::runtime_error);
+}
+
+TEST(MatrixVectorBase, scalarInPlaceAddAndDot)
+{
+  CVectorDouble v(3);
+  v.fill(1.0);
+  v += 2.0;
+  EXPECT_NEAR(v[0], 3.0, 1e-12);
+  EXPECT_NEAR(v[2], 3.0, 1e-12);
+
+  CVectorDouble w(3);
+  w.fill(2.0);
+  EXPECT_NEAR(v.dot(w), 18.0, 1e-12);
+
+  // dot() is only defined for column vectors:
+  CMatrixDouble m(2, 2);
+  m.fill(1.0);
+  CMatrixDouble m2(2, 2);
+  m2.fill(1.0);
+  EXPECT_THROW(m.dot(m2), std::exception);
+}
+
+TEST(MatrixVectorBase, fromMatlabStringFormatErrors)
+{
+  CMatrixDouble m;
+
+  EXPECT_TRUE(m.fromMatlabStringFormat("[1 2 3; 4 5 6]"));
+  EXPECT_EQ(m.rows(), 2U);
+  EXPECT_EQ(m.cols(), 3U);
+
+  // Rows of different length:
+  std::stringstream errs;
+  EXPECT_FALSE(m.fromMatlabStringFormat("[1 2 3; 4 5]", errs));
+  EXPECT_FALSE(errs.str().empty());
+
+  // Not a matrix at all:
+  EXPECT_FALSE(m.fromMatlabStringFormat("hello"));
+
+  // A fixed-size matrix rejects a mismatched number of rows/columns:
+  CMatrixDouble22 f;
+  std::stringstream errs2;
+  EXPECT_FALSE(f.fromMatlabStringFormat("[1 2 3; 4 5 6; 7 8 9]", errs2));
+  EXPECT_FALSE(errs2.str().empty());
+
+  std::stringstream errs3;
+  EXPECT_FALSE(f.fromMatlabStringFormat("[1 2]", errs3));
+  EXPECT_FALSE(errs3.str().empty());
+}

--- a/modules/mrpt_math/tests/ops_vectors_unittest.cpp
+++ b/modules/mrpt_math/tests/ops_vectors_unittest.cpp
@@ -1,0 +1,89 @@
+/*                    _
+                     | |    Mobile Robot Programming Toolkit (MRPT)
+ _ __ ___  _ __ _ __ | |_
+| '_ ` _ \| '__| '_ \| __|          https://www.mrpt.org/
+| | | | | | |  | |_) | |_
+|_| |_| |_|_|  | .__/ \__|     https://github.com/MRPT/mrpt/
+               | |
+               |_|
+
+ Copyright (c) 2005-2026, Individual contributors, see AUTHORS file
+ See: https://www.mrpt.org/Authors - All rights reserved.
+ SPDX-License-Identifier: BSD-3-Clause
+*/
+
+#include <gtest/gtest.h>
+#include <mrpt/io/CMemoryStream.h>
+#include <mrpt/math/CVectorFixed.h>
+#include <mrpt/math/ops_vectors.h>
+#include <mrpt/serialization/CArchive.h>
+
+#include <sstream>
+#include <vector>
+
+using namespace mrpt::math;
+
+TEST(ops_vectors, elementWiseOperators)
+{
+  std::vector<double> a{1.0, 2.0, 3.0};
+  const std::vector<double> b{10.0, 20.0, 30.0};
+
+  EXPECT_EQ(a * b, (std::vector<double>{10.0, 40.0, 90.0}));
+  EXPECT_EQ(a + b, (std::vector<double>{11.0, 22.0, 33.0}));
+  EXPECT_EQ(b - a, (std::vector<double>{9.0, 18.0, 27.0}));
+
+  a *= b;
+  EXPECT_EQ(a, (std::vector<double>{10.0, 40.0, 90.0}));
+  a += b;
+  EXPECT_EQ(a, (std::vector<double>{20.0, 60.0, 120.0}));
+  a *= 0.5;
+  EXPECT_EQ(a, (std::vector<double>{10.0, 30.0, 60.0}));
+  a += 1.0;
+  EXPECT_EQ(a, (std::vector<double>{11.0, 31.0, 61.0}));
+
+  // Mismatched sizes are rejected:
+  const std::vector<double> shorter{1.0};
+  EXPECT_THROW(a *= shorter, std::exception);
+  EXPECT_THROW(a += shorter, std::exception);
+  EXPECT_THROW((void)(a * shorter), std::exception);
+  EXPECT_THROW((void)(a + shorter), std::exception);
+  EXPECT_THROW((void)(a - shorter), std::exception);
+}
+
+TEST(ops_vectors, streamPrinting)
+{
+  std::vector<double> v{1.0, 2.5};
+
+  std::stringstream ss;
+  ss << v;
+  EXPECT_EQ(ss.str(), "[1.0000 2.5000 ]");
+  // The stream flags/precision must be restored after printing:
+  EXPECT_EQ(ss.precision(), std::stringstream().precision());
+
+  std::stringstream ss2;
+  ss2 << &v;
+  EXPECT_EQ(ss2.str(), "[1.0000 2.5000 ]");
+}
+
+TEST(ops_vectors, cvectorFixedSerialization)
+{
+  CVectorFixedDouble<3> v;
+  v[0] = 1.0;
+  v[1] = 2.0;
+  v[2] = 3.0;
+
+  mrpt::io::CMemoryStream buf;
+  auto arch = mrpt::serialization::archiveFrom(buf);
+  arch << v;
+
+  buf.Seek(0);
+  CVectorFixedDouble<3> v2;
+  arch >> v2;
+  EXPECT_NEAR(v2[0], 1.0, 1e-12);
+  EXPECT_NEAR(v2[2], 3.0, 1e-12);
+
+  // A type-name mismatch must be detected:
+  buf.Seek(0);
+  CVectorFixedFloat<3> vf;
+  EXPECT_THROW(arch >> vf, std::exception);
+}

--- a/modules/mrpt_math/tests/poly_roots_extra_unittest.cpp
+++ b/modules/mrpt_math/tests/poly_roots_extra_unittest.cpp
@@ -1,0 +1,168 @@
+/*                    _
+                     | |    Mobile Robot Programming Toolkit (MRPT)
+ _ __ ___  _ __ _ __ | |_
+| '_ ` _ \| '__| '_ \| __|          https://www.mrpt.org/
+| | | | | | |  | |_) | |_
+|_| |_| |_|_|  | .__/ \__|     https://github.com/MRPT/mrpt/
+               | |
+               |_|
+
+ Copyright (c) 2005-2026, Individual contributors, see AUTHORS file
+ See: https://www.mrpt.org/Authors - All rights reserved.
+ SPDX-License-Identifier: BSD-3-Clause
+*/
+
+#include <gtest/gtest.h>
+#include <mrpt/core/format.h>
+#include <mrpt/math/poly_roots.h>
+
+#include <cmath>
+#include <complex>
+
+namespace
+{
+using cplx = std::complex<double>;
+
+// Evaluates x^4 + a*x^3 + b*x^2 + c*x + d
+cplx evalQuartic(const cplx& x, double a, double b, double c, double d)
+{
+  return (((x + a) * x + b) * x + c) * x + d;
+}
+
+// Evaluates x^5 + a*x^4 + b*x^3 + c*x^2 + d*x + e
+cplx evalQuintic(const cplx& x, double a, double b, double c, double d, double e)
+{
+  return ((((x + a) * x + b) * x + c) * x + d) * x + e;
+}
+
+// Checks that the roots reported by solve_poly4() are actual roots, taking into
+// account the meaning of each returned value (see the API docs).
+void checkQuartic(double a, double b, double c, double d, int expectedNumRealRoots)
+{
+  const std::string sMsg = mrpt::format("x^4 + %g*x^3 + %g*x^2 + %g*x + %g = 0", a, b, c, d);
+
+  double x[4] = {0, 0, 0, 0};
+  const int res = mrpt::math::solve_poly4(x, a, b, c, d);
+  ASSERT_EQ(res, expectedNumRealRoots) << sMsg;
+
+  const double tol = 1e-6;
+  switch (res)
+  {
+    case 4:
+      for (int i = 0; i < 4; i++)
+      {
+        EXPECT_NEAR(std::abs(evalQuartic(cplx(x[i], 0), a, b, c, d)), 0.0, tol)
+            << sMsg << " root #" << i;
+      }
+      break;
+    case 2:
+      // x[0], x[1] real; x[2] +- i*x[3] complex:
+      EXPECT_NEAR(std::abs(evalQuartic(cplx(x[0], 0), a, b, c, d)), 0.0, tol) << sMsg;
+      EXPECT_NEAR(std::abs(evalQuartic(cplx(x[1], 0), a, b, c, d)), 0.0, tol) << sMsg;
+      EXPECT_NEAR(std::abs(evalQuartic(cplx(x[2], x[3]), a, b, c, d)), 0.0, tol) << sMsg;
+      break;
+    case 0:
+      // x[0] +- i*x[1] and x[2] +- i*x[3]:
+      EXPECT_NEAR(std::abs(evalQuartic(cplx(x[0], x[1]), a, b, c, d)), 0.0, tol) << sMsg;
+      EXPECT_NEAR(std::abs(evalQuartic(cplx(x[2], x[3]), a, b, c, d)), 0.0, tol) << sMsg;
+      break;
+    default:
+      FAIL() << "Unexpected return value " << res << " for " << sMsg;
+  }
+}
+}  // namespace
+
+TEST(poly_roots, solve_poly3_doubleRoot)
+{
+  // (x-1)^2 * (x+2) = x^3 - 3*x + 2
+  double r[3] = {0, 0, 0};
+  const int n = mrpt::math::solve_poly3(r, 0.0, -3.0, 2.0);
+  // The solver reports the "two distinct real roots" case for a double root:
+  EXPECT_EQ(n, 2);
+  for (int i = 0; i < n; i++)
+  {
+    const double v = ((r[i] + 0.0) * r[i] - 3.0) * r[i] + 2.0;
+    EXPECT_NEAR(v, 0.0, 1e-9);
+  }
+}
+
+TEST(poly_roots, solve_poly4_biquadratic)
+{
+  // (x^2-1)*(x^2-4): 4 real roots, and c==0 routes through the biquadratic solver
+  checkQuartic(0, -5, 0, 4, 4);
+
+  // (x^2+1)*(x^2+4): no real roots, biquadratic solver with a positive discriminant
+  checkQuartic(0, 5, 0, 4, 0);
+
+  // x^4 + 1: biquadratic solver with a negative discriminant (complex sqrt)
+  checkQuartic(0, 0, 0, 1, 0);
+
+  // (x^2-1)*(x^2+4): 2 real + 2 complex roots
+  checkQuartic(0, 3, 0, -4, 2);
+}
+
+TEST(poly_roots, solve_poly4_generalCases)
+{
+  // (x-1)(x-2)(x-3)(x-4), shifted so that the resolvent has three positive roots
+  checkQuartic(-10, 35, -50, 24, 4);
+
+  // Mirrored version, exercises the opposite sign of the linear coefficient
+  checkQuartic(10, 35, 50, 24, 4);
+
+  // (x^2+1)*(x-1)*(x-2) = x^4 -3x^3 +3x^2 -3x +2
+  checkQuartic(-3, 3, -3, 2, 2);
+
+  // (x^2+2x+2)*(x^2-2x+5): two pairs of complex roots
+  checkQuartic(0, 3, 6, 10, 0);
+
+  // Quadruple root at x=1: the solver cannot tell the four coincident roots
+  // apart and reports them as two complex conjugate pairs sitting on the root.
+  checkQuartic(-4, 6, -4, 1, 0);
+}
+
+TEST(poly_roots, solve_poly5)
+{
+  struct TestCase
+  {
+    double a, b, c, d, e;
+  };
+  // Each case is a monic quintic; only the real root returned in x[0] is
+  // checked here, plus whatever solve_poly4() reports for the deflated quartic.
+  const TestCase cases[] = {
+      {-15, 85, -225, 274, -120}, // (x-1)(x-2)(x-3)(x-4)(x-5)
+      {  0,  0,    0,   0,   -1}, // x^5 = 1
+      {  0,  0,    0,   0,    1}, // x^5 = -1
+      {  0,  1,    0,   1,    0}, // e==0 => trivial real root at x=0
+      {  2,  3,    4,   5,    6},
+  };
+
+  for (const auto& tc : cases)
+  {
+    double x[5] = {0, 0, 0, 0, 0};
+    const int n = mrpt::math::solve_poly5(x, tc.a, tc.b, tc.c, tc.d, tc.e);
+    const std::string sMsg = mrpt::format(
+        "x^5 + %g*x^4 + %g*x^3 + %g*x^2 + %g*x + %g = 0", tc.a, tc.b, tc.c, tc.d, tc.e);
+
+    // At least the one real root found by the quintic-specific solver:
+    EXPECT_GE(n, 1) << sMsg;
+    EXPECT_NEAR(std::abs(evalQuintic(cplx(x[0], 0), tc.a, tc.b, tc.c, tc.d, tc.e)), 0.0, 1e-5)
+        << sMsg;
+  }
+}
+
+TEST(poly_roots, solve_poly2_degenerate)
+{
+  double r1 = 0, r2 = 0;
+
+  // a==0 and b==0: no solution at all
+  EXPECT_EQ(mrpt::math::solve_poly2(0, 0, 1, r1, r2), 0);
+
+  // a==0: degenerates into the linear equation b*x+c=0
+  EXPECT_EQ(mrpt::math::solve_poly2(0, 2, -4, r1, r2), 1);
+  EXPECT_NEAR(r1, 2.0, 1e-12);
+
+  // Double root
+  EXPECT_EQ(mrpt::math::solve_poly2(1, -2, 1, r1, r2), 2);
+  EXPECT_NEAR(r1, 1.0, 1e-12);
+  EXPECT_NEAR(r2, 1.0, 1e-12);
+}

--- a/modules/mrpt_obs/CMakeLists.txt
+++ b/modules/mrpt_obs/CMakeLists.txt
@@ -95,6 +95,7 @@ set(LIB_UNIT_TEST_SOURCES
   tests/CSerializable_unittest.cpp
   tests/CSimpleMap_unittest.cpp
   tests/gnss_messages_unittest.cpp
+  tests/legacy_serialization_unittest.cpp
   tests/TPixelLabelInfo_unittest.cpp
 )
 

--- a/modules/mrpt_obs/tests/CObservationGPS_unittest.cpp
+++ b/modules/mrpt_obs/tests/CObservationGPS_unittest.cpp
@@ -372,3 +372,66 @@ TEST(CObservationGPS, DeserializeLegacyVersion9SatsThrows)
   CObservationGPS obs;
   EXPECT_THROW(arch >> obs, std::exception);
 }
+
+namespace
+{
+// Reference conversion: UTC = GPS epoch (1980-01-06 00:00:00) + week*604800 +
+// seconds - leap seconds. Comparing against that linear expression exercises
+// the whole calendar decomposition (leap years, month lengths) without
+// hard-coded dates.
+void checkGpsToUtc(uint16_t week, double sec, int leapSeconds)
+{
+  mrpt::system::TTimeParts parts;
+  ASSERT_TRUE(mrpt::obs::CObservationGPS::GPS_time_to_UTC(week, sec, leapSeconds, parts));
+
+  mrpt::system::TTimeParts epochParts;
+  epochParts.year = 1980;
+  epochParts.month = 1;
+  epochParts.day = 6;
+  const auto gpsEpoch = mrpt::system::buildTimestampFromParts(epochParts);
+  const auto expected = mrpt::system::timestampAdd(
+      gpsEpoch, week * 604800.0 + sec - static_cast<double>(leapSeconds));
+  const auto got = mrpt::system::buildTimestampFromParts(parts);
+
+  EXPECT_NEAR(mrpt::system::timeDifference(expected, got), 0.0, 1e-3)
+      << "week=" << week << " sec=" << sec << " leap=" << leapSeconds;
+
+  // The dedicated timestamp overload must agree:
+  mrpt::system::TTimeStamp ts;
+  ASSERT_TRUE(mrpt::obs::CObservationGPS::GPS_time_to_UTC(week, sec, leapSeconds, ts));
+  EXPECT_NEAR(mrpt::system::timeDifference(expected, ts), 0.0, 1e-3);
+}
+}  // namespace
+
+TEST(CObservationGPS, GPS_time_to_UTC)
+{
+  // The GPS epoch itself:
+  mrpt::system::TTimeParts utc;
+  ASSERT_TRUE(mrpt::obs::CObservationGPS::GPS_time_to_UTC(0, 0.0, 0, utc));
+  EXPECT_EQ(static_cast<int>(utc.year), 1980);
+  EXPECT_EQ(static_cast<int>(utc.month), 1);
+  EXPECT_EQ(static_cast<int>(utc.day), 6);
+
+  checkGpsToUtc(0, 0.0, 0);
+  checkGpsToUtc(1000, 86400.0 + 3600.0 + 30.5, 0);
+  checkGpsToUtc(1000, 86400.0, 18);  // leap seconds shift the instant back
+  checkGpsToUtc(2200, 604799.0, 18);
+
+  // Out-of-range seconds-of-week are rejected by both overloads:
+  EXPECT_FALSE(mrpt::obs::CObservationGPS::GPS_time_to_UTC(1000, -1.0, 0, utc));
+  EXPECT_FALSE(mrpt::obs::CObservationGPS::GPS_time_to_UTC(1000, 604801.0, 0, utc));
+  mrpt::system::TTimeStamp ts;
+  EXPECT_FALSE(mrpt::obs::CObservationGPS::GPS_time_to_UTC(1000, -1.0, 0, ts));
+}
+
+TEST(CObservationGPS, GPS_time_to_UTC_acrossCalendar)
+{
+  // Sweep several years' worth of weeks so that every month length, and the
+  // leap-year rules for 1984/2000 (divisible by 4, by 100 and by 400), are
+  // crossed at least once.
+  for (uint16_t week = 0; week < 2400; week += 3)
+  {
+    checkGpsToUtc(week, 12345.0, 0);
+    if (::testing::Test::HasFailure()) return;
+  }
+}

--- a/modules/mrpt_obs/tests/CObservationVelodyneScan_unittest.cpp
+++ b/modules/mrpt_obs/tests/CObservationVelodyneScan_unittest.cpp
@@ -20,6 +20,7 @@
 #include <mrpt/obs/CObservationRotatingScan.h>
 #include <mrpt/obs/CObservationVelodyneScan.h>
 #include <mrpt/obs/VelodyneCalibration.h>
+#include <mrpt/poses/CPose3DInterpolator.h>
 #include <mrpt/serialization/CArchive.h>
 #include <mrpt/system/filesystem.h>
 
@@ -504,4 +505,92 @@ TEST(CObservationRotatingScan, ExternalStorageMRPTSerializationRoundtrip)
   EXPECT_EQ(rot1.rangeImage.rows(), 16);
 
   mrpt::system::deleteFile(mrpt::io::lazy_load_absolute_path(tmpFile));
+}
+
+TEST(CObservationVelodyneScan, GeneratePointCloudAlongSE3Trajectory)
+{
+  auto obs = buildSyntheticVLP16Scan(3);
+
+  // A densely-sampled vehicle path generously spanning the scan's time range
+  // (the interpolator needs neighbors on both sides of every query):
+  mrpt::poses::CPose3DInterpolator path;
+  path.setInterpolationMethod(mrpt::poses::TInterpolatorMethod::imLinearSlerp);
+  // Ray timestamps are derived from the observation timestamp:
+  const auto t0 = obs->timestamp;
+  for (int i = -20; i <= 20; i++)
+  {
+    path.insert(
+        mrpt::system::timestampAdd(t0, i * 0.01), mrpt::poses::CPose3D(i * 0.1, 0, 0, 0, 0, 0));
+  }
+
+  std::vector<mrpt::math::TPointXYZIu8> pts;
+  CObservationVelodyneScan::TGeneratePointCloudSE3Results stats;
+  obs->generatePointCloudAlongSE3Trajectory(path, pts, stats);
+
+  EXPECT_GT(stats.num_points, 0U);
+  EXPECT_EQ(stats.num_correctly_inserted_points, pts.size());
+  EXPECT_GT(pts.size(), 0U);
+
+  // An empty path yields no valid interpolated poses at all:
+  mrpt::poses::CPose3DInterpolator emptyPath;
+  std::vector<mrpt::math::TPointXYZIu8> pts2;
+  CObservationVelodyneScan::TGeneratePointCloudSE3Results stats2;
+  obs->generatePointCloudAlongSE3Trajectory(emptyPath, pts2, stats2);
+  EXPECT_GT(stats2.num_points, 0U);
+  EXPECT_EQ(stats2.num_correctly_inserted_points, 0U);
+  EXPECT_TRUE(pts2.empty());
+}
+
+TEST(CObservationVelodyneScan, GeneratePointCloudHDL32)
+{
+  // The HDL-32 has its own per-firing timestamp adjustment and block layout:
+  auto obs = CObservationVelodyneScan::Create();
+  obs->calibration = loadDefaultCal("HDL32");
+  obs->minRange = 0.5;
+  obs->maxRange = 100.0;
+  obs->timestamp = mrpt::Clock::now();
+
+  obs->scan_packets.resize(2);
+  for (size_t p = 0; p < obs->scan_packets.size(); p++)
+  {
+    RawPacket raw{};
+    raw.gps_timestamp = static_cast<uint32_t>(2000 + p * 553);
+    raw.laser_return_mode = CObservationVelodyneScan::RETMODE_STRONGEST;
+    raw.velodyne_model_ID = 0x21;  // HDL-32E
+    for (int b = 0; b < 12; b++)
+    {
+      raw.blocks[b].header = CObservationVelodyneScan::UPPER_BANK;
+      raw.blocks[b].rotation = static_cast<uint16_t>(
+          (static_cast<int>(p) * 12 * 100 + b * 100) %
+          CObservationVelodyneScan::ROTATION_MAX_UNITS);
+      for (int k = 0; k < 32; k++)
+      {
+        raw.blocks[b].returns[k].distance = 3000;
+        raw.blocks[b].returns[k].intensity = static_cast<uint8_t>(50 + k);
+      }
+    }
+    std::memcpy(
+        static_cast<void*>(&obs->scan_packets[p]), static_cast<const void*>(&raw), sizeof(raw));
+  }
+
+  obs->generatePointCloud();
+  EXPECT_GT(obs->point_cloud.size(), 0U);
+}
+
+TEST(CObservationVelodyneScan, GeneratePointCloudOutOfRangeReturnsAreDropped)
+{
+  auto obs = buildSyntheticVLP16Scan();
+
+  // Zero distance means "no return" and must never produce a point:
+  for (auto& pkt : obs->scan_packets)
+  {
+    RawPacket raw{};
+    std::memcpy(static_cast<void*>(&raw), static_cast<const void*>(&pkt), sizeof(raw));
+    for (int b = 0; b < 12; b++)
+      for (int k = 0; k < 32; k++) raw.blocks[b].returns[k].distance = 0;
+    std::memcpy(static_cast<void*>(&pkt), static_cast<const void*>(&raw), sizeof(raw));
+  }
+
+  obs->generatePointCloud();
+  EXPECT_EQ(obs->point_cloud.size(), 0U);
 }

--- a/modules/mrpt_obs/tests/CRawlog_content_unittest.cpp
+++ b/modules/mrpt_obs/tests/CRawlog_content_unittest.cpp
@@ -484,7 +484,7 @@ TEST(CRawlogContent, LoadTruncatedRawlogStopsGracefully)
   // Chop the file in half: the loader must keep whatever it could read
   {
     const auto sz = mrpt::system::getFileSize(tmpFile);
-    ASSERT_GT(sz, 20);
+    ASSERT_GT(sz, 20U);
     std::vector<uint8_t> data(static_cast<size_t>(sz));
     {
       mrpt::io::CFileInputStream fi(tmpFile);

--- a/modules/mrpt_obs/tests/CRawlog_content_unittest.cpp
+++ b/modules/mrpt_obs/tests/CRawlog_content_unittest.cpp
@@ -15,6 +15,8 @@
 #include <gtest/gtest.h>
 #include <mrpt/config/CConfigFileMemory.h>
 #include <mrpt/io/CFileGZOutputStream.h>
+#include <mrpt/io/CFileInputStream.h>
+#include <mrpt/io/CFileOutputStream.h>
 #include <mrpt/io/CMemoryStream.h>
 #include <mrpt/obs/CActionCollection.h>
 #include <mrpt/obs/CActionRobotMovement2D.h>
@@ -22,6 +24,7 @@
 #include <mrpt/obs/CObservationOdometry.h>
 #include <mrpt/obs/CRawlog.h>
 #include <mrpt/obs/CSensoryFrame.h>
+#include <mrpt/poses/CPose3D.h>
 #include <mrpt/serialization/CArchive.h>
 #include <mrpt/system/filesystem.h>
 
@@ -407,4 +410,223 @@ TEST(CRawlogContent, DetectImagesDirectoryFallback)
 {
   const std::string result = CRawlog::detectImagesDirectory("/tmp/nonexistent_rawlog_xyz.rawlog");
   EXPECT_FALSE(result.empty());
+}
+
+TEST(CRawlogContent, GetTypeOther)
+{
+  CRawlog rawlog;
+  // Any serializable object that is neither an observation, an action
+  // collection nor a sensory frame:
+  rawlog.insert(mrpt::poses::CPose3D::Create());
+
+  EXPECT_EQ(rawlog.getType(0), CRawlog::TEntryType::etOther);
+  EXPECT_THROW(rawlog.getType(1), std::exception);
+}
+
+TEST(CRawlogContent, LoadRawlogWithCommentObservation)
+{
+  // A loose CObservationComment in the stream is picked up as the rawlog
+  // comment text rather than added as one more entry:
+  const std::string tmpFile = mrpt::system::getTempFileName() + "_comment.rawlog";
+  {
+    mrpt::io::CFileGZOutputStream fo(tmpFile);
+    auto arch = mrpt::serialization::archiveFrom(fo);
+    CObservationComment c;
+    c.text = "the comment";
+    arch << c;
+    auto sf = buildSensoryFrame();
+    arch << sf;
+  }
+
+  CRawlog rawlog;
+  ASSERT_TRUE(rawlog.loadFromRawLogFile(tmpFile));
+  EXPECT_EQ(rawlog.size(), 1U);
+  EXPECT_EQ(rawlog.getCommentText(), "the comment");
+
+  mrpt::system::deleteFile(tmpFile);
+}
+
+TEST(CRawlogContent, LoadRawlogWithNonObservationObjects)
+{
+  const std::string tmpFile = mrpt::system::getTempFileName() + "_other.rawlog";
+  {
+    mrpt::io::CFileGZOutputStream fo(tmpFile);
+    auto arch = mrpt::serialization::archiveFrom(fo);
+    auto sf = buildSensoryFrame();
+    arch << sf;
+    arch << mrpt::poses::CPose3D();  // not an observation/action/SF
+    arch << sf;
+  }
+
+  // By default, reading stops at the first unexpected class:
+  CRawlog strict;
+  ASSERT_TRUE(strict.loadFromRawLogFile(tmpFile));
+  EXPECT_EQ(strict.size(), 1U);
+
+  // ...unless such objects are explicitly declared legal:
+  CRawlog lenient;
+  ASSERT_TRUE(lenient.loadFromRawLogFile(tmpFile, true));
+  EXPECT_EQ(lenient.size(), 3U);
+
+  mrpt::system::deleteFile(tmpFile);
+}
+
+TEST(CRawlogContent, LoadTruncatedRawlogStopsGracefully)
+{
+  const std::string tmpFile = mrpt::system::getTempFileName() + "_trunc.rawlog";
+  {
+    CRawlog r;
+    auto sf = buildSensoryFrame();
+    r.insert(sf);
+    r.insert(sf);
+    ASSERT_TRUE(r.saveToRawLogFile(tmpFile));
+  }
+  // Chop the file in half: the loader must keep whatever it could read
+  {
+    const auto sz = mrpt::system::getFileSize(tmpFile);
+    ASSERT_GT(sz, 20);
+    std::vector<uint8_t> data(static_cast<size_t>(sz));
+    {
+      mrpt::io::CFileInputStream fi(tmpFile);
+      fi.Read(data.data(), data.size());
+    }
+    mrpt::io::CFileOutputStream fo(tmpFile);
+    fo.Write(data.data(), data.size() / 2);
+  }
+
+  CRawlog rawlog;
+  EXPECT_TRUE(rawlog.loadFromRawLogFile(tmpFile));
+
+  mrpt::system::deleteFile(tmpFile);
+}
+
+TEST(CRawlogContent, SaveToUnwritablePathReturnsFalse)
+{
+  CRawlog rawlog;
+  auto sf = buildSensoryFrame();
+  rawlog.insert(sf);
+
+  EXPECT_FALSE(rawlog.saveToRawLogFile("/nonexistent-dir-for-mrpt-tests/out.rawlog"));
+}
+
+TEST(CRawlogContent, ReadActionObservationPairSkipsUnrelatedObjects)
+{
+  // action, <unrelated object>, sensory frame: the loose object in between is
+  // skipped while looking for the sensory frame.
+  mrpt::io::CMemoryStream buf;
+  {
+    auto arch = mrpt::serialization::archiveFrom(buf);
+    auto ac = buildActionCollection();
+    arch << ac;
+    arch << mrpt::poses::CPose3D();
+    auto sf = buildSensoryFrame();
+    arch << sf;
+  }
+  buf.Seek(0);
+
+  auto arch = mrpt::serialization::archiveFrom(buf);
+  CActionCollection::Ptr action;
+  CSensoryFrame::Ptr observations;
+  size_t entry = 0;
+  ASSERT_TRUE(CRawlog::readActionObservationPair(arch, action, observations, entry));
+  ASSERT_TRUE(action);
+  ASSERT_TRUE(observations);
+  EXPECT_EQ(entry, 3U);
+}
+
+TEST(CRawlogContent, ReadActionObservationPairOnCorruptStream)
+{
+  // Random bytes: the reader must report failure rather than propagate
+  mrpt::io::CMemoryStream buf;
+  const uint8_t garbage[64] = {0x81, 'X', 0x00, 0x01, 0x02, 0x03};
+  buf.Write(garbage, sizeof(garbage));
+  buf.Seek(0);
+
+  auto arch = mrpt::serialization::archiveFrom(buf);
+  CActionCollection::Ptr action;
+  CSensoryFrame::Ptr observations;
+  size_t entry = 0;
+  EXPECT_FALSE(CRawlog::readActionObservationPair(arch, action, observations, entry));
+}
+
+TEST(CRawlogContent, GetActionObservationPairOrObservationOnCorruptStream)
+{
+  mrpt::io::CMemoryStream buf;
+  const uint8_t garbage[64] = {0x81, 'X', 0x00, 0x01, 0x02, 0x03};
+  buf.Write(garbage, sizeof(garbage));
+  buf.Seek(0);
+
+  auto arch = mrpt::serialization::archiveFrom(buf);
+  CActionCollection::Ptr action;
+  CSensoryFrame::Ptr observations;
+  CObservation::Ptr observation;
+  size_t entry = 0;
+  EXPECT_FALSE(CRawlog::getActionObservationPairOrObservation(
+      arch, action, observations, observation, entry));
+}
+
+TEST(CRawlogContent, GetActionObservationPairSkipsUnrelatedEntries)
+{
+  CRawlog rawlog;
+  rawlog.insert(mrpt::poses::CPose3D::Create());
+  auto ac = buildActionCollection();
+  rawlog.insert(ac);
+  rawlog.insert(mrpt::poses::CPose3D::Create());
+  auto sf = buildSensoryFrame();
+  rawlog.insert(sf);
+
+  CActionCollection::ConstPtr action;
+  CSensoryFrame::ConstPtr observations;
+  size_t entry = 0;
+  ASSERT_TRUE(rawlog.getActionObservationPair(action, observations, entry));
+  ASSERT_TRUE(action);
+  ASSERT_TRUE(observations);
+  EXPECT_EQ(entry, 4U);
+}
+
+TEST(CRawlogContent, FindObservationsByClassInRangeBinarySearch)
+{
+  // Enough entries to make the internal lower-bound search iterate:
+  CRawlog rawlog;
+  const auto t0 = mrpt::Clock::now();
+  for (int i = 0; i < 64; i++)
+  {
+    auto obs = CObservationOdometry::Create();
+    obs->timestamp = mrpt::system::timestampAdd(t0, i * 1.0);
+    obs->sensorLabel = "ODO";
+    rawlog.insert(obs);
+  }
+
+  const auto tStart = mrpt::system::timestampAdd(t0, 10.0);
+  const auto tEnd = mrpt::system::timestampAdd(t0, 20.0);
+
+  mrpt::obs::TListTimeAndObservations found;
+  rawlog.findObservationsByClassInRange(tStart, tEnd, CLASS_ID(CObservationOdometry), found);
+
+  // 10 or 11 depending on how the interval ends are rounded:
+  EXPECT_GE(found.size(), 10U);
+  EXPECT_LE(found.size(), 11U);
+  for (const auto& [t, obs] : found)
+  {
+    EXPECT_GE(mrpt::system::timeDifference(tStart, t), -1e-3);
+    EXPECT_LE(mrpt::system::timeDifference(tEnd, t), 1e-3);
+  }
+
+  // A class that is not present yields nothing:
+  mrpt::obs::TListTimeAndObservations none;
+  rawlog.findObservationsByClassInRange(
+      t0, mrpt::system::timestampAdd(t0, 100.0), CLASS_ID(CObservationComment), none);
+  EXPECT_TRUE(none.empty());
+}
+
+TEST(CRawlogContent, FindObservationsByClassInRangeRejectsNonObservations)
+{
+  CRawlog rawlog;
+  for (int i = 0; i < 4; i++) rawlog.insert(mrpt::poses::CPose3D::Create());
+
+  mrpt::obs::TListTimeAndObservations found;
+  EXPECT_THROW(
+      rawlog.findObservationsByClassInRange(
+          mrpt::Clock::now(), mrpt::Clock::now(), CLASS_ID(CObservationOdometry), found),
+      std::exception);
 }

--- a/modules/mrpt_obs/tests/legacy_serialization.h
+++ b/modules/mrpt_obs/tests/legacy_serialization.h
@@ -1,0 +1,52 @@
+/*                    _
+                     | |    Mobile Robot Programming Toolkit (MRPT)
+ _ __ ___  _ __ _ __ | |_
+| '_ ` _ \| '__| '_ \| __|          https://www.mrpt.org/
+| | | | | | |  | |_) | |_
+|_| |_| |_|_|  | .__/ \__|     https://github.com/MRPT/mrpt/
+               | |
+               |_|
+
+ Copyright (c) 2005-2026, Individual contributors, see AUTHORS file
+ See: https://www.mrpt.org/Authors - All rights reserved.
+ SPDX-License-Identifier: BSD-3-Clause
+*/
+#pragma once
+
+#include <mrpt/io/CMemoryStream.h>
+#include <mrpt/serialization/CArchive.h>
+#include <mrpt/serialization/CSerializable.h>
+
+#include <cstdint>
+#include <functional>
+#include <string>
+
+namespace mrpt_test
+{
+/** Writes an MRPT object frame (class name, streaming version, payload and end
+ *  flag) with an arbitrary version number, so that the backwards-compatibility
+ *  branches of serializeFrom() can be exercised without shipping binary
+ *  fixture files. The stream is left rewound and ready to be read back.
+ */
+inline void writeLegacyObjectFrame(
+    mrpt::io::CMemoryStream& buf,
+    const std::string& className,
+    uint8_t version,
+    const std::function<void(mrpt::serialization::CArchive&)>& writePayload)
+{
+  auto arch = mrpt::serialization::archiveFrom(buf);
+
+  // Class name, length with the "new format" flag in its MSB:
+  const auto lenAndFlag = static_cast<int8_t>(className.size() | 0x80);
+  arch << lenAndFlag;
+  buf.Write(className.data(), className.size());
+
+  arch << version;
+  writePayload(arch);
+
+  const uint8_t endFlag = 0x88;
+  arch << endFlag;
+
+  buf.Seek(0);
+}
+}  // namespace mrpt_test

--- a/modules/mrpt_obs/tests/legacy_serialization_unittest.cpp
+++ b/modules/mrpt_obs/tests/legacy_serialization_unittest.cpp
@@ -1,0 +1,645 @@
+/*                    _
+                     | |    Mobile Robot Programming Toolkit (MRPT)
+ _ __ ___  _ __ _ __ | |_
+| '_ ` _ \| '__| '_ \| __|          https://www.mrpt.org/
+| | | | | | |  | |_) | |_
+|_| |_| |_|_|  | .__/ \__|     https://github.com/MRPT/mrpt/
+               | |
+               |_|
+
+ Copyright (c) 2005-2026, Individual contributors, see AUTHORS file
+ See: https://www.mrpt.org/Authors - All rights reserved.
+ SPDX-License-Identifier: BSD-3-Clause
+*/
+
+// Exercises the backwards-compatibility branches of serializeFrom() for the
+// observation/action classes that still support older streaming versions.
+
+#include "legacy_serialization.h"
+
+#include <gtest/gtest.h>
+#include <mrpt/img/CImage.h>
+#include <mrpt/math/CMatrixF.h>
+#include <mrpt/obs/CActionRobotMovement2D.h>
+#include <mrpt/obs/CObservation3DRangeScan.h>
+#include <mrpt/obs/CObservationBeaconRanges.h>
+#include <mrpt/obs/CObservationGasSensors.h>
+#include <mrpt/obs/CObservationIMU.h>
+#include <mrpt/obs/CObservationImage.h>
+#include <mrpt/obs/CObservationStereoImages.h>
+#include <mrpt/poses/CPoint3D.h>
+#include <mrpt/poses/CPose2D.h>
+#include <mrpt/poses/CPose3D.h>
+#include <mrpt/poses/CPose3DQuat.h>
+#include <mrpt/poses/CPosePDFGaussian.h>
+
+using namespace mrpt::obs;
+using namespace mrpt::serialization;
+using mrpt_test::writeLegacyObjectFrame;
+
+namespace
+{
+template <class T>
+std::shared_ptr<T> readBackAs(mrpt::io::CMemoryStream& buf)
+{
+  auto arch = mrpt::serialization::archiveFrom(buf);
+  return std::dynamic_pointer_cast<T>(arch.ReadObject());
+}
+
+// Common tail of the version 2..3 CActionRobotMovement2D payload
+void writeVelocitiesAndEncodersV2V3(CArchive& a)
+{
+  a << bool(true);    // hasVelocities
+  a << float(1.5f);   // linear velocity
+  a << float(0.25f);  // angular velocity
+  a << bool(true);    // hasEncodersInfo
+  a << int32_t(100);  // left ticks
+  a << int32_t(200);  // right ticks
+}
+
+void writeOdometryModelConfigV4Plus(CArchive& a, uint8_t version)
+{
+  a << mrpt::poses::CPose2D(1.0, 0.5, 0.1);  // rawOdometryIncrementReading
+  a << int32_t(0);                           // modelSelection == mmGaussian
+  a << float(0.02f) << float(0.03f) << float(0.04f) << float(0.05f);  // a1..a4
+  a << float(0.01f) << float(0.02f);                                  // minStdXY, minStdPHI
+  a << int32_t(50);                                                   // nParticlesCount
+  a << float(0.1f) << float(0.2f) << float(0.3f) << float(0.4f);      // alfa1..alfa4
+  if (version >= 5) a << float(0.001f) << float(0.002f);              // additional_std_XY / _phi
+}
+}  // namespace
+
+TEST(LegacySerialization, CActionRobotMovement2D_v7_odometry)
+{
+  mrpt::io::CMemoryStream buf;
+  writeLegacyObjectFrame(
+      buf, "CActionRobotMovement2D", 7,
+      [](CArchive& a)
+      {
+        a << int32_t(CActionRobotMovement2D::emOdometry);
+        writeOdometryModelConfigV4Plus(a, 7);
+        a << bool(true);
+        a << mrpt::math::TTwist2D(1.0, 0.0, 0.5);
+        a << bool(true);
+        a << int32_t(10) << int32_t(20);
+        a << mrpt::Clock::now();
+      });
+
+  const auto act = readBackAs<CActionRobotMovement2D>(buf);
+  ASSERT_TRUE(act);
+  EXPECT_EQ(act->estimationMethod, CActionRobotMovement2D::emOdometry);
+  EXPECT_NEAR(act->rawOdometryIncrementReading.x(), 1.0, 1e-6);
+  EXPECT_TRUE(act->hasVelocities);
+  EXPECT_NEAR(act->velocityLocal.vx, 1.0, 1e-6);
+  EXPECT_TRUE(act->hasEncodersInfo);
+  EXPECT_EQ(act->encoderLeftTicks, 10);
+  EXPECT_EQ(act->motionModelConfiguration.thrunModel.nParticlesCount, 50U);
+}
+
+TEST(LegacySerialization, CActionRobotMovement2D_v7_noVelocitiesNoEncoders)
+{
+  mrpt::io::CMemoryStream buf;
+  writeLegacyObjectFrame(
+      buf, "CActionRobotMovement2D", 7,
+      [](CArchive& a)
+      {
+        a << int32_t(CActionRobotMovement2D::emScan2DMatching);
+        // The PDF is streamed directly for any method other than odometry:
+        const mrpt::poses::CPosePDFGaussian pdf(mrpt::poses::CPose2D(2.0, 3.0, 0.0));
+        a << static_cast<const mrpt::serialization::CSerializable&>(pdf);
+        a << bool(false);  // hasVelocities
+        a << bool(false);  // hasEncodersInfo
+        a << mrpt::Clock::now();
+      });
+
+  const auto act = readBackAs<CActionRobotMovement2D>(buf);
+  ASSERT_TRUE(act);
+  EXPECT_EQ(act->estimationMethod, CActionRobotMovement2D::emScan2DMatching);
+  EXPECT_FALSE(act->hasVelocities);
+  EXPECT_FALSE(act->hasEncodersInfo);
+  EXPECT_EQ(act->encoderLeftTicks, 0);
+  mrpt::poses::CPose2D mean;
+  act->poseChange->getMean(mean);
+  EXPECT_NEAR(mean.x(), 2.0, 1e-6);
+}
+
+TEST(LegacySerialization, CActionRobotMovement2D_v4_v5_v6)
+{
+  for (const uint8_t version : {uint8_t(4), uint8_t(5), uint8_t(6)})
+  {
+    mrpt::io::CMemoryStream buf;
+    writeLegacyObjectFrame(
+        buf, "CActionRobotMovement2D", version,
+        [version](CArchive& a)
+        {
+          a << int32_t(CActionRobotMovement2D::emOdometry);
+          writeOdometryModelConfigV4Plus(a, version);
+          a << bool(true);
+          a << float(1.0f) << float(0.5f);  // pre-v7: separate linear/angular
+          a << bool(true);
+          a << int32_t(3) << int32_t(4);
+          if (version >= 6) a << mrpt::Clock::now();
+        });
+
+    const auto act = readBackAs<CActionRobotMovement2D>(buf);
+    ASSERT_TRUE(act) << "version " << int(version);
+    EXPECT_NEAR(act->velocityLocal.vx, 1.0, 1e-6);
+    EXPECT_NEAR(act->velocityLocal.vy, 0.0, 1e-6);
+    EXPECT_NEAR(act->velocityLocal.omega, 0.5, 1e-6);
+    EXPECT_EQ(act->encoderRightTicks, 4);
+    if (version < 6) EXPECT_EQ(act->timestamp, INVALID_TIMESTAMP);
+    // The additional Thrun std devs default to zero before version 5:
+    if (version < 5)
+      EXPECT_NEAR(act->motionModelConfiguration.thrunModel.additional_std_XY, 0.0f, 1e-9f);
+  }
+}
+
+TEST(LegacySerialization, CActionRobotMovement2D_v3)
+{
+  mrpt::io::CMemoryStream buf;
+  writeLegacyObjectFrame(
+      buf, "CActionRobotMovement2D", 3,
+      [](CArchive& a)
+      {
+        a << int32_t(CActionRobotMovement2D::emOdometry);
+        a << mrpt::poses::CPose2D(1.0, 0.0, 0.0);
+        a << int32_t(0);  // modelSelection
+        // 3 discarded floats + minStdXY + minStdPHI (as doubles)
+        a << float(0) << float(0) << float(0);
+        a << double(0.01) << double(0.02);
+        a << int32_t(70);  // nParticlesCount
+        a << float(0.1f) << float(0.2f) << float(0.3f) << float(0.4f);
+        writeVelocitiesAndEncodersV2V3(a);
+      });
+
+  const auto act = readBackAs<CActionRobotMovement2D>(buf);
+  ASSERT_TRUE(act);
+  EXPECT_EQ(act->motionModelConfiguration.thrunModel.nParticlesCount, 70U);
+  EXPECT_NEAR(act->velocityLocal.vx, 1.5, 1e-6);
+  EXPECT_EQ(act->encoderRightTicks, 200);
+}
+
+TEST(LegacySerialization, CActionRobotMovement2D_v2)
+{
+  mrpt::io::CMemoryStream buf;
+  writeLegacyObjectFrame(
+      buf, "CActionRobotMovement2D", 2,
+      [](CArchive& a)
+      {
+        a << int32_t(CActionRobotMovement2D::emOdometry);
+        a << mrpt::poses::CPose2D(0.5, 0.25, 0.0);
+        // A 44-byte blob of obsolete options, read and discarded:
+        const uint8_t dummy[44] = {0};
+        a.WriteBuffer(dummy, sizeof(dummy));
+        writeVelocitiesAndEncodersV2V3(a);
+      });
+
+  const auto act = readBackAs<CActionRobotMovement2D>(buf);
+  ASSERT_TRUE(act);
+  EXPECT_NEAR(act->rawOdometryIncrementReading.x(), 0.5, 1e-6);
+  // The options are reset to their defaults:
+  EXPECT_EQ(act->motionModelConfiguration.thrunModel.nParticlesCount, 300U);
+}
+
+TEST(LegacySerialization, CActionRobotMovement2D_v0_v1)
+{
+  for (const uint8_t version : {uint8_t(0), uint8_t(1)})
+  {
+    mrpt::io::CMemoryStream buf;
+    writeLegacyObjectFrame(
+        buf, "CActionRobotMovement2D", version,
+        [version](CArchive& a)
+        {
+          const mrpt::poses::CPosePDFGaussian pdf(mrpt::poses::CPose2D(1.0, 2.0, 0.0));
+          a << static_cast<const mrpt::serialization::CSerializable&>(pdf);
+          a << int32_t(CActionRobotMovement2D::emOdometry);
+          if (version >= 1) writeVelocitiesAndEncodersV2V3(a);
+        });
+
+    const auto act = readBackAs<CActionRobotMovement2D>(buf);
+    ASSERT_TRUE(act) << "version " << int(version);
+    // The raw odometry is reconstructed as the mean of the stored PDF:
+    EXPECT_NEAR(act->rawOdometryIncrementReading.x(), 1.0, 1e-6);
+    if (version == 0)
+    {
+      EXPECT_FALSE(act->hasVelocities);
+      EXPECT_FALSE(act->hasEncodersInfo);
+      EXPECT_EQ(act->encoderLeftTicks, 0);
+    }
+    else
+    {
+      EXPECT_TRUE(act->hasEncodersInfo);
+      EXPECT_EQ(act->encoderLeftTicks, 100);
+    }
+  }
+}
+
+TEST(LegacySerialization, CActionRobotMovement2D_unknownVersion)
+{
+  mrpt::io::CMemoryStream buf;
+  writeLegacyObjectFrame(buf, "CActionRobotMovement2D", 200, [](CArchive&) {});
+
+  auto arch = mrpt::serialization::archiveFrom(buf);
+  EXPECT_THROW(arch.ReadObject(), std::exception);
+}
+
+TEST(LegacySerialization, CObservationStereoImages_v5)
+{
+  mrpt::io::CMemoryStream buf;
+  writeLegacyObjectFrame(
+      buf, "CObservationStereoImages", 5,
+      [](CArchive& a)
+      {
+        a << mrpt::poses::CPose3DQuat(mrpt::poses::CPose3D(1, 2, 3, 0, 0, 0));
+        mrpt::img::TCamera cam;
+        a << cam;                                          // leftCamera
+        a << cam;                                          // rightCamera
+        a << mrpt::img::CImage(8, 8, mrpt::img::CH_GRAY);  // imageLeft
+        a << mrpt::img::CImage(8, 8, mrpt::img::CH_GRAY);  // imageRight
+        a << mrpt::Clock::now();
+        a << mrpt::poses::CPose3DQuat(mrpt::poses::CPose3D(0.12, 0, 0, 0, 0, 0));
+        a << std::string("stereo_v5");
+      });
+
+  const auto obs = readBackAs<CObservationStereoImages>(buf);
+  ASSERT_TRUE(obs);
+  EXPECT_TRUE(obs->hasImageRight);
+  EXPECT_FALSE(obs->hasImageDisparity);
+  EXPECT_EQ(obs->sensorLabel, "stereo_v5");
+  EXPECT_NEAR(obs->rightCameraPose.x(), 0.12, 1e-6);
+}
+
+TEST(LegacySerialization, CObservationStereoImages_v0_to_v4)
+{
+  for (const uint8_t version : {uint8_t(0), uint8_t(1), uint8_t(2), uint8_t(3), uint8_t(4)})
+  {
+    mrpt::io::CMemoryStream buf;
+    writeLegacyObjectFrame(
+        buf, "CObservationStereoImages", version,
+        [version](CArchive& a)
+        {
+          a << mrpt::poses::CPose3D(1, 2, 3, 0, 0, 0);  // cameraPose (as CPose3D)
+          mrpt::math::CMatrixF intParams(3, 3);
+          intParams.setIdentity();
+          a << intParams;
+          a << mrpt::img::CImage(8, 8, mrpt::img::CH_GRAY);
+          a << mrpt::img::CImage(8, 8, mrpt::img::CH_GRAY);
+          if (version >= 1) a << mrpt::Clock::now();
+          if (version >= 2) a << mrpt::poses::CPose3D(0.2, 0, 0, 0, 0, 0);
+          if (version >= 3) a << double(0.004);  // focal length in meters
+          if (version >= 4) a << std::string("stereo_old");
+        });
+
+    const auto obs = readBackAs<CObservationStereoImages>(buf);
+    ASSERT_TRUE(obs) << "version " << int(version);
+    EXPECT_TRUE(obs->hasImageRight);
+    EXPECT_NEAR(obs->cameraPose.x(), 1.0, 1e-6);
+
+    if (version < 1) EXPECT_EQ(obs->timestamp, INVALID_TIMESTAMP);
+    if (version < 2) EXPECT_NEAR(obs->rightCameraPose.x(), 0.10, 1e-5);
+    if (version >= 2) EXPECT_NEAR(obs->rightCameraPose.x(), 0.2, 1e-5);
+    if (version >= 3) EXPECT_NEAR(obs->leftCamera.focalLengthMeters, 0.004, 1e-9);
+    if (version < 3) EXPECT_NEAR(obs->leftCamera.focalLengthMeters, 0.002, 1e-9);
+    EXPECT_EQ(obs->sensorLabel, version >= 4 ? "stereo_old" : "");
+  }
+}
+
+TEST(LegacySerialization, CObservationStereoImages_unknownVersion)
+{
+  mrpt::io::CMemoryStream buf;
+  writeLegacyObjectFrame(buf, "CObservationStereoImages", 200, [](CArchive&) {});
+
+  auto arch = mrpt::serialization::archiveFrom(buf);
+  EXPECT_THROW(arch.ReadObject(), std::exception);
+}
+
+TEST(LegacySerialization, CObservationImage_v0_to_v3)
+{
+  for (const uint8_t version : {uint8_t(0), uint8_t(1), uint8_t(2), uint8_t(3)})
+  {
+    mrpt::io::CMemoryStream buf;
+    writeLegacyObjectFrame(
+        buf, "CObservationImage", version,
+        [version](CArchive& a)
+        {
+          a << mrpt::poses::CPose3D(1, 2, 3, 0, 0, 0);
+          // Before v4, the distortion and intrinsic matrices were streamed:
+          mrpt::math::CMatrixF dist(1, 5);
+          dist.fill(0.1f);
+          mrpt::math::CMatrixF intr(3, 3);
+          intr.setIdentity();
+          a << dist << intr;
+          a << mrpt::img::CImage(4, 4, mrpt::img::CH_GRAY);
+          if (version >= 1) a << mrpt::Clock::now();
+          if (version >= 2) a << double(0.005);
+          if (version >= 3) a << std::string("cam_old");
+        });
+
+    const auto obs = readBackAs<CObservationImage>(buf);
+    ASSERT_TRUE(obs) << "version " << int(version);
+    EXPECT_NEAR(obs->cameraPose.x(), 1.0, 1e-6);
+    EXPECT_NEAR(obs->cameraParams.dist[0], 0.1, 1e-5);
+    EXPECT_NEAR(obs->cameraParams.intrinsicParams(1, 1), 1.0, 1e-9);
+    EXPECT_NEAR(obs->cameraParams.focalLengthMeters, version >= 2 ? 0.005 : 0.002, 1e-9);
+    EXPECT_EQ(obs->sensorLabel, version >= 3 ? "cam_old" : "");
+  }
+}
+
+TEST(LegacySerialization, CObservationImage_v0_wrongSizedDistortion)
+{
+  // A distortion matrix that is not 1x5 leaves the parameters at zero:
+  mrpt::io::CMemoryStream buf;
+  writeLegacyObjectFrame(
+      buf, "CObservationImage", 0,
+      [](CArchive& a)
+      {
+        a << mrpt::poses::CPose3D();
+        mrpt::math::CMatrixF dist(1, 4);
+        dist.fill(0.5f);
+        mrpt::math::CMatrixF intr(3, 3);
+        intr.setIdentity();
+        a << dist << intr;
+        a << mrpt::img::CImage(4, 4, mrpt::img::CH_GRAY);
+      });
+
+  const auto obs = readBackAs<CObservationImage>(buf);
+  ASSERT_TRUE(obs);
+  for (int i = 0; i < 5; i++) EXPECT_NEAR(obs->cameraParams.dist[i], 0.0, 1e-12);
+}
+
+TEST(LegacySerialization, CObservationImage_unknownVersion)
+{
+  mrpt::io::CMemoryStream buf;
+  writeLegacyObjectFrame(buf, "CObservationImage", 200, [](CArchive&) {});
+  auto arch = mrpt::serialization::archiveFrom(buf);
+  EXPECT_THROW(arch.ReadObject(), std::exception);
+}
+
+TEST(LegacySerialization, CObservationBeaconRanges_v0_to_v2)
+{
+  for (const uint8_t version : {uint8_t(0), uint8_t(1), uint8_t(2)})
+  {
+    mrpt::io::CMemoryStream buf;
+    writeLegacyObjectFrame(
+        buf, "CObservationBeaconRanges", version,
+        [version](CArchive& a)
+        {
+          a << float(0.1f) << float(30.0f) << float(0.05f);  // min/max/stdError
+          a << uint32_t(2);                                  // number of readings
+          for (uint32_t i = 0; i < 2; i++)
+          {
+            a << mrpt::poses::CPoint3D(0.1 * i, 0, 0);
+            a << float(5.0f + i);
+            a << uint32_t(100 + i);
+          }
+          if (version >= 1) a << mrpt::poses::CPose2D(1, 2, 0);
+          if (version >= 2) a << std::string("beacons_old");
+        });
+
+    const auto obs = readBackAs<CObservationBeaconRanges>(buf);
+    ASSERT_TRUE(obs) << "version " << int(version);
+    ASSERT_EQ(obs->sensedData.size(), 2U);
+    EXPECT_EQ(obs->sensedData[1].beaconID, 101U);
+    EXPECT_NEAR(obs->sensedData[1].sensedDistance, 6.0f, 1e-5f);
+    if (version >= 1) EXPECT_NEAR(obs->auxEstimatePose.y(), 2.0, 1e-6);
+    EXPECT_EQ(obs->sensorLabel, version >= 2 ? "beacons_old" : "");
+    EXPECT_EQ(obs->timestamp, INVALID_TIMESTAMP);
+  }
+}
+
+TEST(LegacySerialization, CObservationBeaconRanges_unknownVersion)
+{
+  mrpt::io::CMemoryStream buf;
+  writeLegacyObjectFrame(buf, "CObservationBeaconRanges", 200, [](CArchive&) {});
+  auto arch = mrpt::serialization::archiveFrom(buf);
+  EXPECT_THROW(arch.ReadObject(), std::exception);
+}
+
+TEST(LegacySerialization, CObservationIMU_v0_to_v3)
+{
+  for (const uint8_t version : {uint8_t(0), uint8_t(1), uint8_t(2), uint8_t(3)})
+  {
+    mrpt::io::CMemoryStream buf;
+    writeLegacyObjectFrame(
+        buf, "CObservationIMU", version,
+        [version](CArchive& a)
+        {
+          a << mrpt::poses::CPose3D(0, 0, 1, 0, 0, 0);
+          const std::vector<bool> present(mrpt::obs::COUNT_IMU_DATA_FIELDS, true);
+          a << present;
+          a << mrpt::Clock::now();
+          if (version < 1)
+          {
+            mrpt::math::CVectorFloat v(mrpt::obs::COUNT_IMU_DATA_FIELDS);
+            for (int i = 0; i < v.size(); i++) v[i] = static_cast<float>(i);
+            a << v;
+          }
+          else
+          {
+            std::vector<double> v(mrpt::obs::COUNT_IMU_DATA_FIELDS);
+            for (size_t i = 0; i < v.size(); i++) v[i] = static_cast<double>(i);
+            a << v;
+          }
+          a << std::string("imu_old");
+        });
+
+    const auto obs = readBackAs<CObservationIMU>(buf);
+    ASSERT_TRUE(obs) << "version " << int(version);
+    EXPECT_EQ(obs->sensorLabel, "imu_old");
+    EXPECT_NEAR(obs->sensorPose.z(), 1.0, 1e-6);
+    EXPECT_TRUE(obs->dataIsPresent[mrpt::obs::IMU_X_ACC]);
+    EXPECT_NEAR(obs->rawMeasurements[mrpt::obs::IMU_X_ACC], 0.0, 1e-9);
+
+    // Before v2 the yaw and roll rates were stored swapped and are fixed up:
+    if (version < 2)
+    {
+      EXPECT_NEAR(
+          obs->rawMeasurements[mrpt::obs::IMU_YAW_VEL],
+          static_cast<double>(mrpt::obs::IMU_ROLL_VEL), 1e-9);
+    }
+    else
+    {
+      EXPECT_NEAR(
+          obs->rawMeasurements[mrpt::obs::IMU_YAW_VEL], static_cast<double>(mrpt::obs::IMU_YAW_VEL),
+          1e-9);
+    }
+  }
+}
+
+TEST(LegacySerialization, CObservationGasSensors_v2_to_v4)
+{
+  for (const uint8_t version : {uint8_t(2), uint8_t(3), uint8_t(4)})
+  {
+    mrpt::io::CMemoryStream buf;
+    writeLegacyObjectFrame(
+        buf, "CObservationGasSensors", version,
+        [version](CArchive& a)
+        {
+          a << uint32_t(1);  // one e-nose
+          a << mrpt::poses::CPose3D(0.2, -0.15, 0.1, 0, 0, 0);
+          mrpt::math::CVectorFloat volts(2);
+          volts[0] = 1.0f;
+          volts[1] = 2.0f;
+          a << volts;
+          a << std::vector<int>{10, 20};
+          if (version >= 3)
+          {
+            a << bool(true);
+            a << float(25.5f);
+          }
+          if (version >= 4) a << std::string("enose_old");
+        });
+
+    const auto obs = readBackAs<CObservationGasSensors>(buf);
+    ASSERT_TRUE(obs) << "version " << int(version);
+    ASSERT_EQ(obs->m_readings.size(), 1U);
+    EXPECT_EQ(obs->m_readings[0].readingsVoltage.size(), 2U);
+    EXPECT_EQ(obs->m_readings[0].sensorTypes[1], 20);
+    if (version >= 3)
+    {
+      EXPECT_TRUE(obs->m_readings[0].hasTemperature);
+      EXPECT_NEAR(obs->m_readings[0].temperature, 25.5f, 1e-5f);
+    }
+    else
+    {
+      EXPECT_FALSE(obs->m_readings[0].hasTemperature);
+    }
+    EXPECT_EQ(obs->sensorLabel, version >= 4 ? "enose_old" : "");
+    EXPECT_EQ(obs->timestamp, INVALID_TIMESTAMP);
+  }
+}
+
+TEST(LegacySerialization, CObservationGasSensors_v0_v1)
+{
+  for (const uint8_t version : {uint8_t(0), uint8_t(1)})
+  {
+    mrpt::io::CMemoryStream buf;
+    writeLegacyObjectFrame(
+        buf, "CObservationGasSensors", version,
+        [](CArchive& a)
+        {
+          // The oldest format: a single block of 16 raw values
+          mrpt::math::CVectorFloat readings(16);
+          for (int i = 0; i < readings.size(); i++) readings[i] = static_cast<float>(i);
+          a << readings;
+        });
+
+    const auto obs = readBackAs<CObservationGasSensors>(buf);
+    ASSERT_TRUE(obs) << "version " << int(version);
+    // The 16 raw values are split into the two e-noses of that setup:
+    EXPECT_EQ(obs->m_readings.size(), 2U);
+  }
+}
+
+namespace
+{
+// Payload of the pre-v9 CObservation3DRangeScan format (range image as a
+// float matrix, no extra layers).
+void write3DScanLegacyPayload(CArchive& a, uint8_t version)
+{
+  a << float(10.0f);                            // maxRange
+  a << mrpt::poses::CPose3D(0, 0, 1, 0, 0, 0);  // sensorPose
+
+  if (version > 0) a << bool(true);  // hasPoints3D
+  const uint32_t N = 3;
+  a << N;
+  const float xs[N] = {1.0f, 2.0f, 3.0f};
+  const float ys[N] = {0.0f, 0.0f, 0.0f};
+  const float zs[N] = {0.5f, 0.5f, 0.5f};
+  a.WriteBufferFixEndianness(xs, N);
+  a.WriteBufferFixEndianness(ys, N);
+  a.WriteBufferFixEndianness(zs, N);
+  if (version == 0)
+  {
+    const char validRange[N] = {1, 1, 1};
+    a.WriteBuffer(validRange, sizeof(validRange));
+  }
+  if (version >= 8)
+  {
+    const uint16_t idxs[N] = {0, 1, 2};
+    a.WriteBufferFixEndianness(idxs, N);
+    a.WriteBufferFixEndianness(idxs, N);
+  }
+
+  if (version >= 1)
+  {
+    a << bool(true);  // hasRangeImage
+    // Pre-v9: a plain float matrix of ranges
+    mrpt::math::CMatrixF ri(2, 2);
+    ri(0, 0) = 1.0f;
+    ri(0, 1) = 2.0f;
+    ri(1, 0) = 3.0f;
+    ri(1, 1) = 4.0f;
+    a << ri;
+
+    a << bool(false);  // hasIntensityImage
+    a << bool(false);  // hasConfidenceImage
+
+    if (version >= 2)
+    {
+      mrpt::img::TCamera cam;
+      a << cam;
+      if (version >= 4)
+      {
+        a << cam;
+        a << mrpt::poses::CPose3D();
+      }
+    }
+  }
+
+  a << float(0.01f);          // stdError
+  a << mrpt::Clock::now();    // timestamp
+  a << std::string("depth");  // sensorLabel
+
+  if (version >= 3)
+  {
+    a << bool(false) << std::string();  // points3D external storage
+    a << bool(false) << std::string();  // rangeImage external storage
+  }
+  if (version >= 5) a << bool(true);   // range_is_depth
+  if (version >= 6) a << int8_t(0);    // intensityImageChannel
+  if (version >= 7) a << bool(false);  // no pixel labels
+}
+}  // namespace
+
+TEST(LegacySerialization, CObservation3DRangeScan_v0_to_v8)
+{
+  for (const uint8_t version :
+       {uint8_t(0), uint8_t(1), uint8_t(2), uint8_t(3), uint8_t(4), uint8_t(5), uint8_t(6),
+        uint8_t(7), uint8_t(8)})
+  {
+    mrpt::io::CMemoryStream buf;
+    writeLegacyObjectFrame(
+        buf, "CObservation3DRangeScan", version,
+        [version](CArchive& a) { write3DScanLegacyPayload(a, version); });
+
+    const auto obs = readBackAs<mrpt::obs::CObservation3DRangeScan>(buf);
+    ASSERT_TRUE(obs) << "version " << int(version);
+    EXPECT_TRUE(obs->hasPoints3D);
+    EXPECT_EQ(obs->points3D_x.size(), 3U);
+    EXPECT_NEAR(obs->points3D_x[2], 3.0f, 1e-5f);
+
+    if (version >= 1)
+    {
+      EXPECT_TRUE(obs->hasRangeImage);
+      EXPECT_EQ(obs->rangeImage.rows(), 2);
+      EXPECT_EQ(obs->rangeImage.cols(), 2);
+      // Pre-v9 files stored ranges in meters, converted to the fixed-point
+      // representation with the default 1mm units:
+      EXPECT_NEAR(obs->rangeImage(0, 1) * obs->rangeUnits, 2.0f, 1e-3f);
+      // The camera resolution is auto-fixed to match the range image:
+      EXPECT_EQ(obs->cameraParams.ncols, 2U);
+      EXPECT_EQ(obs->cameraParams.nrows, 2U);
+    }
+    EXPECT_EQ(obs->sensorLabel, "depth");
+    if (version < 5) EXPECT_TRUE(obs->range_is_depth);
+  }
+}
+
+TEST(LegacySerialization, CObservation3DRangeScan_unknownVersion)
+{
+  mrpt::io::CMemoryStream buf;
+  writeLegacyObjectFrame(buf, "CObservation3DRangeScan", 200, [](CArchive&) {});
+  auto arch = mrpt::serialization::archiveFrom(buf);
+  EXPECT_THROW(arch.ReadObject(), std::exception);
+}

--- a/modules/mrpt_slam/tests/CICP_unittest.cpp
+++ b/modules/mrpt_slam/tests/CICP_unittest.cpp
@@ -17,7 +17,9 @@
 #include <mrpt/obs/CObservation2DRangeScan.h>
 #include <mrpt/obs/stock_observations.h>
 #include <mrpt/poses/CPose3DPDF.h>
+#include <mrpt/poses/CPose3DPDFGaussian.h>
 #include <mrpt/poses/CPosePDF.h>
+#include <mrpt/poses/CPosePDFGaussian.h>
 #include <mrpt/slam/CICP.h>
 
 #include <Eigen/Dense>
@@ -126,4 +128,136 @@ TEST_F(ICPTests, SyntheticICP3D)
   EXPECT_NEAR(0, (mean.asVectorVal() - SCAN2_POSE_ERROR.asVectorVal()).array().abs().mean(), 0.02)
       << "ICP output: mean= " << mean << "\n"
       << "Real displacement: " << SCAN2_POSE_ERROR << "\n";
+}
+
+TEST_F(ICPTests, CovarianceMethods)
+{
+  CSimplePointsMap m1, m2;
+  CObservation2DRangeScan scan1, scan2;
+  stock_observations::example2DRangeScan(scan1, 0);
+  stock_observations::example2DRangeScan(scan2, 1);
+  m1.insertObservation(scan1);
+  m2.insertObservation(scan2);
+
+  const CPose2D initialPose(0.8, 0.0, 0.0);
+
+  for (const auto method : {icpCovLinealMSE, icpCovFiniteDifferences})
+  {
+    CICP icp;
+    CICP::TReturnInfo info;
+    icp.options.ICP_algorithm = icpClassic;
+    icp.options.maxIterations = 40;
+    icp.options.thresholdDist = 0.75f;
+    icp.options.thresholdAng = DEG2RAD(10.0f);
+    icp.options.ALFA = 0.5f;
+    icp.options.smallestThresholdDist = 0.05f;
+    icp.options.skip_cov_calculation = false;
+    icp.options.ICP_covariance_method = method;
+
+    CPosePDF::Ptr pdf = icp.Align(&m1, &m2, initialPose, info);
+    ASSERT_TRUE(pdf);
+
+    const auto gauss = std::dynamic_pointer_cast<CPosePDFGaussian>(pdf);
+    ASSERT_TRUE(gauss);
+    // A valid, positive-definite covariance:
+    EXPECT_GT(gauss->cov(0, 0), 0.0);
+    EXPECT_GT(gauss->cov(1, 1), 0.0);
+    EXPECT_GT(gauss->cov(2, 2), 0.0);
+  }
+}
+
+TEST_F(ICPTests, InvalidCovarianceMethodThrows)
+{
+  CSimplePointsMap m1, m2;
+  CObservation2DRangeScan scan1, scan2;
+  stock_observations::example2DRangeScan(scan1, 0);
+  stock_observations::example2DRangeScan(scan2, 1);
+  m1.insertObservation(scan1);
+  m2.insertObservation(scan2);
+
+  CICP icp;
+  CICP::TReturnInfo info;
+  icp.options.ICP_algorithm = icpClassic;
+  icp.options.maxIterations = 10;
+  icp.options.skip_cov_calculation = false;
+  icp.options.ICP_covariance_method = static_cast<TICPCovarianceMethod>(99);
+
+  EXPECT_THROW(icp.Align(&m1, &m2, CPose2D(0.8, 0, 0), info), std::exception);
+}
+
+TEST_F(ICPTests, SkipQualityAndCovarianceCalculations)
+{
+  CSimplePointsMap m1, m2;
+  CObservation2DRangeScan scan1, scan2;
+  stock_observations::example2DRangeScan(scan1, 0);
+  stock_observations::example2DRangeScan(scan2, 1);
+  m1.insertObservation(scan1);
+  m2.insertObservation(scan2);
+
+  CICP icp;
+  CICP::TReturnInfo info;
+  icp.options.ICP_algorithm = icpClassic;
+  icp.options.maxIterations = 20;
+  icp.options.skip_cov_calculation = true;
+  icp.options.skip_quality_calculation = true;
+
+  CPosePDF::Ptr pdf = icp.Align(&m1, &m2, CPose2D(0.8, 0, 0), info);
+  ASSERT_TRUE(pdf);
+  // With the quality estimation skipped, it equals the correspondences ratio:
+  EXPECT_NEAR(info.quality, info.goodness, 1e-9);
+}
+
+TEST_F(ICPTests, AlignPDFWithGaussianInitialGuess)
+{
+  CSimplePointsMap m1, m2;
+  CObservation2DRangeScan scan1, scan2;
+  stock_observations::example2DRangeScan(scan1, 0);
+  stock_observations::example2DRangeScan(scan2, 1);
+  m1.insertObservation(scan1);
+  m2.insertObservation(scan2);
+
+  CICP icp;
+  CICP::TReturnInfo info;
+  icp.options.ICP_algorithm = icpClassic;
+  icp.options.maxIterations = 40;
+  icp.options.thresholdDist = 0.75f;
+  icp.options.thresholdAng = DEG2RAD(10.0f);
+  icp.options.ALFA = 0.5f;
+  icp.options.smallestThresholdDist = 0.05f;
+
+  CPosePDFGaussian init;
+  init.mean = CPose2D(0.8, 0.0, 0.0);
+  init.cov.setDiagonal(0.01);
+
+  CPosePDF::Ptr pdf = icp.AlignPDF(&m1, &m2, init, info);
+  ASSERT_TRUE(pdf);
+
+  const CPose2D good_pose(0.820, 0.084, 8.73_deg);
+  EXPECT_NEAR(good_pose.distanceTo(pdf->getMeanVal()), 0, 0.05);
+}
+
+TEST_F(ICPTests, Align3DPDFWithGaussianInitialGuess)
+{
+  const CPose3D poseError(0.05, -0.03, 0.02, 0.01, 0.02, 0.02);
+
+  CSimplePointsMap M1, M2;
+  generateSyntheticCloud(M1, CPose3D());
+  generateSyntheticCloud(M2, CPose3D());
+
+  CSimplePointsMap M2_noisy = M2;
+  M2_noisy.changeCoordinatesReference(poseError);
+
+  CICP icp;
+  CICP::TReturnInfo info;
+  icp.options.thresholdDist = 0.40f;
+  icp.options.thresholdAng = 0;
+
+  mrpt::poses::CPose3DPDFGaussian init;
+  init.cov.setDiagonal(0.01);
+
+  CPose3DPDF::Ptr pdf = icp.Align3DPDF(&M2_noisy, &M1, init, info);
+  ASSERT_TRUE(pdf);
+
+  const CPose3D mean = pdf->getMeanVal();
+  EXPECT_NEAR(0, (mean.asVectorVal() - poseError.asVectorVal()).array().abs().mean(), 0.03);
 }

--- a/modules/mrpt_slam/tests/CMonteCarloLocalization_unittest.cpp
+++ b/modules/mrpt_slam/tests/CMonteCarloLocalization_unittest.cpp
@@ -21,6 +21,7 @@
 #include <gtest/gtest.h>
 #include <mrpt/bayes/CParticleFilter.h>
 #include <mrpt/maps/COccupancyGridMap2D.h>
+#include <mrpt/obs/CActionRobotMovement3D.h>
 #include <mrpt/random.h>
 #include <mrpt/slam/CMonteCarloLocalization2D.h>
 #include <mrpt/slam/CMonteCarloLocalization3D.h>
@@ -225,4 +226,142 @@ TEST(CMonteCarloLocalization3DSynthetic, auxiliaryPFStandard)
   const auto gt =
       runLocalization(pdf, pfOptions(mrpt::bayes::CParticleFilter::pfAuxiliaryPFStandard), 3);
   EXPECT_NEAR(pdf.getMeanVal().x(), gt.x(), 1.0);
+}
+
+TEST(CMonteCarloLocalization2DSynthetic, adaptiveSampleSizeWithAuxiliaryPFs)
+{
+  // The KLD adaptive-sampling code path of the auxiliary particle filters is
+  // a separate implementation from the fixed-sample-size one:
+  const std::vector<mrpt::bayes::CParticleFilter::TParticleFilterAlgorithm> algos = {
+      mrpt::bayes::CParticleFilter::pfAuxiliaryPFStandard,
+      mrpt::bayes::CParticleFilter::pfAuxiliaryPFOptimal};
+
+  auto map = referenceMap();
+
+  for (const auto algo : algos)
+  {
+    mrpt::random::getRandomGenerator().randomize(200 + static_cast<int>(algo));
+
+    CMonteCarloLocalization2D pdf(50);
+    pdf.options.metricMap = map;
+    pdf.options.KLD_params.KLD_minSampleSize = 20;
+    pdf.options.KLD_params.KLD_maxSampleSize = 200;
+    pdf.resetUniform(-2.5, -1.5, -0.5, 0.5, -mrpt::DEG2RAD(20.0), mrpt::DEG2RAD(20.0));
+
+    runLocalization(pdf, pfOptions(algo, true), 3);
+
+    EXPECT_GE(pdf.particlesCount(), 20U) << "PF algorithm #" << static_cast<int>(algo);
+    EXPECT_LE(pdf.particlesCount(), 200U) << "PF algorithm #" << static_cast<int>(algo);
+  }
+}
+
+TEST(CMonteCarloLocalization2DSynthetic, accumulates3DOdometryActions)
+{
+  // Both the standard proposal (which reads the action directly) and the
+  // auxiliary variants (which accumulate actions across steps) accept a
+  // CActionRobotMovement3D instead of the usual 2D one.
+  for (const auto algo :
+       {mrpt::bayes::CParticleFilter::pfStandardProposal,
+        mrpt::bayes::CParticleFilter::pfAuxiliaryPFStandard})
+  {
+    mrpt::random::getRandomGenerator().randomize(6);
+
+    auto map = referenceMap();
+
+    CMonteCarloLocalization2D pdf(20);
+    pdf.options.metricMap = map;
+    pdf.resetUniform(-2.5, -1.5, -0.5, 0.5, -mrpt::DEG2RAD(20.0), mrpt::DEG2RAD(20.0));
+
+    mrpt::bayes::CParticleFilter pf;
+    pf.m_options = pfOptions(algo);
+
+    mrpt::poses::CPose2D gtPose(-2.0, 0.0, 0.0);
+    for (int i = 0; i < 3; i++)
+    {
+      const mrpt::poses::CPose2D incr(0.3, 0, 0);
+      gtPose = gtPose + incr;
+      const auto t = mrpt::test::nextTimestamp();
+
+      // A 3D action instead of the usual 2D one:
+      auto acts = mrpt::obs::CActionCollection::Create();
+      mrpt::obs::CActionRobotMovement3D act3D;
+      act3D.timestamp = t;
+      act3D.poseChange.mean = mrpt::poses::CPose3D(incr);
+      act3D.poseChange.cov.setDiagonal(1e-4);
+      acts->insert(act3D);
+
+      auto sf = simulateSF(gtPose, t);
+      pf.executeOn(pdf, acts.get(), sf.get());
+    }
+
+    EXPECT_EQ(pdf.particlesCount(), 20U);
+    EXPECT_TRUE(std::isfinite(pdf.getMeanVal().x()));
+  }
+}
+
+TEST(CMonteCarloLocalization2DSynthetic, mixing2DAnd3DActionsThrows)
+{
+  mrpt::random::getRandomGenerator().randomize(7);
+
+  auto map = referenceMap();
+
+  CMonteCarloLocalization2D pdf(10);
+  pdf.options.metricMap = map;
+  pdf.resetUniform(-2.5, -1.5, -0.5, 0.5, -mrpt::DEG2RAD(20.0), mrpt::DEG2RAD(20.0));
+
+  // Only the auxiliary variants accumulate actions across steps, and hence
+  // are the ones that can end up mixing a 2D and a 3D one:
+  mrpt::bayes::CParticleFilter pf;
+  pf.m_options = pfOptions(mrpt::bayes::CParticleFilter::pfAuxiliaryPFStandard);
+
+  const mrpt::poses::CPose2D gtPose(-2.0, 0.0, 0.0);
+
+  // A first step with a 3D action and no observations, so the movement is
+  // only accumulated and not consumed:
+  {
+    auto acts = mrpt::obs::CActionCollection::Create();
+    mrpt::obs::CActionRobotMovement3D act3D;
+    act3D.timestamp = mrpt::test::nextTimestamp();
+    act3D.poseChange.mean = mrpt::poses::CPose3D(mrpt::poses::CPose2D(0.3, 0, 0));
+    act3D.poseChange.cov.setDiagonal(1e-4);
+    acts->insert(act3D);
+
+    // With no observations at all the movement is only accumulated:
+    pf.executeOn(pdf, acts.get(), nullptr);
+  }
+
+  // ...and now a 2D one, which cannot be mixed with the accumulated 3D:
+  {
+    const auto t = mrpt::test::nextTimestamp();
+    auto acts = makeOdometryAction(mrpt::poses::CPose2D(0.3, 0, 0), t);
+    auto sf = simulateSF(gtPose, t);
+    EXPECT_THROW(pf.executeOn(pdf, acts.get(), sf.get()), std::exception);
+  }
+}
+
+TEST(CMonteCarloLocalization3DSynthetic, auxiliaryPFOptimalAndAdaptiveSampling)
+{
+  auto map = referenceMap();
+
+  for (const auto algo :
+       {mrpt::bayes::CParticleFilter::pfAuxiliaryPFOptimal,
+        mrpt::bayes::CParticleFilter::pfAuxiliaryPFStandard})
+  {
+    mrpt::random::getRandomGenerator().randomize(300 + static_cast<int>(algo));
+
+    CMonteCarloLocalization3D pdf(40);
+    pdf.options.metricMap = map;
+    // The 3D KLD binning uses its own TPoseBin3D specialization:
+    pdf.options.KLD_params.KLD_minSampleSize = 20;
+    pdf.options.KLD_params.KLD_maxSampleSize = 150;
+    pdf.resetUniform(
+        mrpt::math::TPose3D(-2.5, -0.5, 0, -mrpt::DEG2RAD(20.0), 0, 0),
+        mrpt::math::TPose3D(-1.5, 0.5, 0, mrpt::DEG2RAD(20.0), 0, 0));
+
+    runLocalization(pdf, pfOptions(algo, true), 3);
+
+    EXPECT_GE(pdf.particlesCount(), 20U) << "PF algorithm #" << static_cast<int>(algo);
+    EXPECT_LE(pdf.particlesCount(), 150U) << "PF algorithm #" << static_cast<int>(algo);
+    EXPECT_TRUE(std::isfinite(pdf.getMeanVal().x()));
+  }
 }

--- a/modules/mrpt_slam/tests/data_association_unittest.cpp
+++ b/modules/mrpt_slam/tests/data_association_unittest.cpp
@@ -15,6 +15,9 @@
 #include <gtest/gtest.h>
 #include <mrpt/slam/data_association.h>
 
+#include <map>
+#include <string>
+
 using namespace mrpt;
 using namespace mrpt::slam;
 using namespace mrpt::math;
@@ -105,9 +108,20 @@ TEST(DataAssociation, FullCovarianceAllMethodsAndMetrics)
             z, y, y_cov, r, method, metric, 0.99, useKdTree, std::vector<prediction_index_t>(),
             metricMaha, 0.0);
 
-        EXPECT_EQ(r.associations.size(), 3U)
-            << "method=" << static_cast<int>(method) << " metric=" << static_cast<int>(metric)
-            << " kdtree=" << useKdTree;
+        const std::string sMsg = "method=" + std::to_string(static_cast<int>(method)) +
+                                 " metric=" + std::to_string(static_cast<int>(metric)) +
+                                 " kdtree=" + std::to_string(useKdTree);
+
+        ASSERT_EQ(r.associations.size(), 3U) << sMsg;
+        // Each observation matches the prediction it was built from, so the
+        // pairing is the identity; a mere size check would also accept any
+        // permutation of it:
+        for (size_t i = 0; i < 3; i++)
+        {
+          const auto it = r.associations.find(i);
+          ASSERT_NE(it, r.associations.end()) << sMsg << " obs #" << i;
+          EXPECT_EQ(it->second, i) << sMsg << " obs #" << i;
+        }
         EXPECT_EQ(r.indiv_distances.rows(), 3);
         EXPECT_EQ(r.indiv_distances.cols(), 3);
       }
@@ -142,10 +156,17 @@ TEST(DataAssociation, FullCovarianceRemapsPredictionIDs)
       z, y, y_cov, r, assocNN, metricMaha, 0.99, false, ids, metricMaha, 0.0);
 
   ASSERT_EQ(r.associations.size(), 3U);
-  for (const auto& [obsIdx, predId] : r.associations)
+  // The identity pairing, with the prediction indices replaced by their IDs:
+  const std::map<observation_index_t, prediction_index_t> expected{
+      {0, 100},
+      {1, 200},
+      {2, 300}
+  };
+  for (const auto& [obsIdx, expectedId] : expected)
   {
-    (void)obsIdx;
-    EXPECT_TRUE(predId == 100 || predId == 200 || predId == 300);
+    const auto it = r.associations.find(obsIdx);
+    ASSERT_NE(it, r.associations.end()) << "obs #" << obsIdx;
+    EXPECT_EQ(it->second, expectedId) << "obs #" << obsIdx;
   }
 
   // A mismatched ID vector is rejected:

--- a/modules/mrpt_slam/tests/data_association_unittest.cpp
+++ b/modules/mrpt_slam/tests/data_association_unittest.cpp
@@ -57,3 +57,123 @@ TEST(DataAssociation, TestNoICs)
     }
   }
 }
+
+namespace
+{
+// Three predicted landmarks and three observations that match them almost
+// exactly, so every association method must find all three pairings.
+void buildEasyProblem(CMatrixDouble& z, CMatrixDouble& y, CMatrixDouble& y_cov)
+{
+  const size_t nPred = 3, lenO = 2;
+
+  y.setSize(nPred, lenO);
+  y(0, 0) = 0.0;
+  y(0, 1) = 0.0;
+  y(1, 0) = 10.0;
+  y(1, 1) = 0.0;
+  y(2, 0) = 0.0;
+  y(2, 1) = 10.0;
+
+  // Block-diagonal covariance: one 2x2 block per prediction
+  y_cov.setSize(nPred * lenO, nPred * lenO);
+  y_cov.setZero();
+  for (size_t i = 0; i < nPred * lenO; i++) y_cov(i, i) = 0.25;
+
+  z.setSize(nPred, lenO);
+  z(0, 0) = 0.05;
+  z(0, 1) = 0.0;
+  z(1, 0) = 10.05;
+  z(1, 1) = 0.0;
+  z(2, 0) = 0.0;
+  z(2, 1) = 9.95;
+}
+}  // namespace
+
+TEST(DataAssociation, FullCovarianceAllMethodsAndMetrics)
+{
+  CMatrixDouble z, y, y_cov;
+  buildEasyProblem(z, y, y_cov);
+
+  for (const auto method : {assocNN, assocJCBB})
+  {
+    for (const auto metric : {metricMaha, metricML})
+    {
+      for (const bool useKdTree : {true, false})
+      {
+        TDataAssociationResults r;
+        data_association_full_covariance(
+            z, y, y_cov, r, method, metric, 0.99, useKdTree, std::vector<prediction_index_t>(),
+            metricMaha, 0.0);
+
+        EXPECT_EQ(r.associations.size(), 3U)
+            << "method=" << static_cast<int>(method) << " metric=" << static_cast<int>(metric)
+            << " kdtree=" << useKdTree;
+        EXPECT_EQ(r.indiv_distances.rows(), 3);
+        EXPECT_EQ(r.indiv_distances.cols(), 3);
+      }
+    }
+  }
+}
+
+TEST(DataAssociation, FullCovarianceWithMLCompatibilityTest)
+{
+  CMatrixDouble z, y, y_cov;
+  buildEasyProblem(z, y, y_cov);
+
+  // Individual compatibility judged by the matching likelihood instead of the
+  // chi2 test on the Mahalanobis distance:
+  TDataAssociationResults r;
+  data_association_full_covariance(
+      z, y, y_cov, r, assocJCBB, metricML, 0.99, false, std::vector<prediction_index_t>(), metricML,
+      -20.0);
+
+  EXPECT_EQ(r.associations.size(), 3U);
+}
+
+TEST(DataAssociation, FullCovarianceRemapsPredictionIDs)
+{
+  CMatrixDouble z, y, y_cov;
+  buildEasyProblem(z, y, y_cov);
+
+  const std::vector<prediction_index_t> ids{100, 200, 300};
+
+  TDataAssociationResults r;
+  data_association_full_covariance(
+      z, y, y_cov, r, assocNN, metricMaha, 0.99, false, ids, metricMaha, 0.0);
+
+  ASSERT_EQ(r.associations.size(), 3U);
+  for (const auto& [obsIdx, predId] : r.associations)
+  {
+    (void)obsIdx;
+    EXPECT_TRUE(predId == 100 || predId == 200 || predId == 300);
+  }
+
+  // A mismatched ID vector is rejected:
+  TDataAssociationResults r2;
+  const std::vector<prediction_index_t> badIds{1, 2};
+  EXPECT_THROW(
+      data_association_full_covariance(
+          z, y, y_cov, r2, assocNN, metricMaha, 0.99, false, badIds, metricMaha, 0.0),
+      std::exception);
+}
+
+TEST(DataAssociation, FullCovarianceArgumentChecks)
+{
+  CMatrixDouble z, y, y_cov;
+  buildEasyProblem(z, y, y_cov);
+
+  TDataAssociationResults r;
+
+  // Out-of-range chi2 quantile:
+  EXPECT_THROW(
+      data_association_full_covariance(z, y, y_cov, r, assocNN, metricMaha, 0.0), std::exception);
+  EXPECT_THROW(
+      data_association_full_covariance(z, y, y_cov, r, assocNN, metricMaha, 1.0), std::exception);
+
+  // No predictions / no observations:
+  CMatrixDouble empty(0, 2);
+  EXPECT_THROW(
+      data_association_full_covariance(z, empty, y_cov, r, assocNN, metricMaha), std::exception);
+  EXPECT_THROW(
+      data_association_full_covariance(empty, y, y_cov, r, assocNN, metricMaha), std::exception);
+}


### PR DESCRIPTION
Raises line coverage above the 90% goal in all four core algorithmic modules:

| Module | Before | After | Branch % |
|---|---|---|---|
| mrpt_math | 88.8% | **95.0%** | 60.3% → 64.4% |
| mrpt_maps | 86.5% | **90.2%** | 62.8% → 66.4% |
| mrpt_obs | 88.5% | **91.6%** | 61.0% → 63.1% |
| mrpt_slam | 90.2% | **93.5%** | 62.3% → 65.3% |

Whole-repo overall: 76.4% → 77.8%.

## Technique

A ~30-line test helper (`tests/legacy_serialization.h`, duplicated in `mrpt_math` and `mrpt_obs` since modules are independent CMake projects) writes an MRPT object frame with an **arbitrary streaming version**, so the backwards-compatibility branches of `serializeFrom()` can be driven without shipping binary fixture files. It covers the legacy formats of `CPolygon` (v0/v1), `CActionRobotMovement2D` (v0..v7), `CObservationStereoImages` (v0..v6), `CObservationImage` (v0..v4), `CObservationBeaconRanges`, `CObservationIMU`, `CObservationGasSensors` and `CObservation3DRangeScan` (v0..v10) — several hundred lines that no test had ever reached.

Other large previously-untested blocks now covered: `CRandomFieldGridMap2D::internal_clear()`'s occupancy-gridmap GMRF prior, the wind-advection look-up table build/save/load, `CPointsMap::internal_insertObservation()`'s Range/Velodyne/PointCloud/RotatingScan branches, the auxiliary-PF and KLD adaptive-sampling paths, `solve_poly5()`, and `KDTreeCapable`'s radius-limited searches.

## Bugs found and fixed

1. `TLine3D::TLine3D(const TLine2D&)` computed the base point of a *horizontal* 2D line (`A ≈ 0`) as `-B/A`, dividing by the coefficient it had just tested for zero. Every 2D→3D conversion of a horizontal line yielded an infinite/NaN base point.
2. `getAngleBisector(TLine2D, TLine2D)`'s parallel-lines branch normalized the second line with `sqrt(A² + C²)` instead of `sqrt(A² + B²)`, and never halved the resulting offset. The two errors cancelled for a line whose normalization factor happened to equal `|C|` — exactly the case the pre-existing test used; for anything else the "bisector" was one of the two input lines.
3. The templated `intersect(vector<T>, vector<U>, ...)` in `geometry.h` iterated the inner loop up to `v1.size()` instead of `v2.size()` (out-of-bounds read when the second set is smaller), and its `std::vector<O>` sibling took the output container **by value**. Both were uninstantiated dead code.
4. `KDTreeCapable`'s radius-limited k-NN searches (`kdTreeNClosestPoint2D`, `kdTreeNClosestPoint3D`, `kdTreeNClosestPoint3DWithIdx`) trimmed the index/distance vectors to the number of points found but left the coordinate vectors at the requested `knn`, handing back stale entries; the `TPoint2D`/`TPoint3D` overloads then sized their output from those.
5. `CHistogram::createWithFixedWidth()` was declared non-static, so the documented `CHistogram::createWithFixedWidth(...)` usage did not compile — which made `mrpt::math::CMonteCarlo::getDistribution()` (its only caller) uninstantiable.
6. `KLD_Gaussians()` called a non-existent `inverse_LLt(out)` overload and `multiply_HCHt_scalar()` (row-vector form) on a column vector; likewise uninstantiable dead code.
7. `CGasConcentrationGridMap2D::simulateAdvection()` indexes `m_stackedCov`, which only exists for the `mrKalmanApproximate` representation, so calling it on any other map type read past the end of an empty matrix and segfaulted. It now returns false with an error log.

## Notes

`agents.md` section 10 is updated: refreshed coverage table, plus a new ★ footnote recording the techniques, the bug list, and the gotchas found (Velodyne per-ray timestamps come from `CObservation::timestamp`, only the auxiliary PFs accumulate actions across steps, `CObservationGPS`'s leap-year helpers are unreachable in practice, and `build_Gaussian_Wind_Grid()` writes cache/debug files into the CWD).

Full `colcon test` under `xvfb-run`: 82 packages, 0 failures.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved geometric calculations for line conversion, angle bisectors, and polygon intersections.
  - Corrected nearest-neighbor result sizing, matrix resizing initialization, and covariance calculations.
  - Added validation for unsupported gas-map advection simulations.

- **Improvements**
  - Histogram creation can be called directly, with warnings when results are ignored.
  - Improved reliability across mapping, point-cloud, SLAM, serialization, and mathematical operations.

- **Tests**
  - Expanded automated coverage across maps, math, observations, and SLAM, including legacy compatibility scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->