### PR TITLE
hwdrivers: mocked-stream coverage pass (13.9% -> 29.0%), reviving dead pcap support and fixing 7 defects

### DIFF
--- a/agents.md
+++ b/agents.md
@@ -202,7 +202,7 @@ A full rebuild of all 33 `modules/*` packages was done with coverage
 instrumentation, followed by a full `colcon test` run (all tests passed) and a
 `gcovr` line/branch report. **Goal: 90% line coverage per module.** Current
 overall (2026-09-07, deduplicated the same way as
-`scripts/coverage_module_report.py`): **79.8% lines**
+`scripts/coverage_module_report.py`): **80.9% lines**
 - still short of goal, dominated by the hardware/GUI modules below.
 The whole table below was re-measured on 2026-09-07; the date tags on some
 rows mark when that module last had a dedicated unit-test pass, and point at
@@ -303,7 +303,7 @@ and accurate path — pick two.
 | Module | Covered/Total lines | Line % | Branch % |
 |---|---|---|---|
 | mrpt_imgui | 0/53 | 0.0% | 0.0% |
-| mrpt_hwdrivers | 913/6592 | 13.9% | 9.7% |
+| mrpt_hwdrivers (2026-09-07)§ | 1957/6746 | 29.0% | 20.5% |
 | mrpt_gui (2026-09-06)@ | 1888/4655 | 40.6% | 30.4% |
 | mrpt_opengl | 2323/4234 | 54.9% | 35.7% |
 | mrpt_libapps_cli | 1129/1910 | 59.1% | 38.0% |
@@ -1031,14 +1031,16 @@ landmark-map and no-odometry RO-SLAM branches of
 
 ### Weak areas, grouped by root cause
 
-1. **Hardware drivers - `mrpt_hwdrivers` (13.9%)**: inherently hard to
-   unit-test since they talk to real serial ports/USB/GPS/LIDAR/cameras
-   (`CHokuyoURG`, `CSickLaserSerial`, `COpenNI2Generic`, `CVelodyneScanner`,
-   `CNTRIPClient`, `CKinect`, etc., all at 0%). Improving this needs a
-   mockable transport layer (inject a fake `CStream`/socket) rather than
-   plain unit tests against hardware. `mrpt_comms` cleared this bucket on
-   2026-08-29 (see » above): everything but `CInterfaceFTDI` turned out to be
-   testable over loopback sockets and a pseudo-terminal.
+1. **Hardware drivers - `mrpt_hwdrivers` (29.0%)**: hard to unit-test since
+   they talk to real serial ports/USB/GPS/LIDAR/cameras. The mockable-transport
+   approach this entry used to call for was applied on 2026-09-07 (see § below)
+   and works well for any driver that reads through an injectable `CStream`.
+   What is still at 0% are the drivers that own their transport instead
+   (`COpenNI2Generic`, `CKinect`, `CCameraSensor`, `CNTRIPClient`, `CLMS100eth`,
+   `CSICKTim561Eth`, `CCANBusReader`, `CTaoboticsIMU`, ...); reaching them needs
+   the same `bindIO()`/`bindStream()` treatment first. `mrpt_comms` cleared this
+   bucket on 2026-08-29 (see » above): everything but `CInterfaceFTDI` turned
+   out to be testable over loopback sockets and a pseudo-terminal.
 
 2. **GUI/rendering — `mrpt_imgui` (0%) and the GUI-only files still left in
    `mrpt_gui` (40.6%)**: `CDisplayWindowGUI.cpp` (nanogui/GLFW),
@@ -1237,3 +1239,62 @@ indicating error-handling and edge-case branches are the norm left untested
 even in files with decent line coverage — prioritize adding failure-path
 tests, not just more happy-path calls.
 
+§ Coverage pass of 2026-09-07 (third pass of the day) on `mrpt_hwdrivers`
+(13.9% -> 29.0%).
+
+`mrpt_hwdrivers/tests/mock_stream.h` is the lever for all of it: a `CStream`
+that records everything the driver writes and replays scripted answers keyed
+on the command received, which is what request/response sensor protocols need.
+Any driver reachable through `C2DRangeFinderAbstract::bindIO()` or
+`CGPSInterface::bindStream()` becomes testable with it; the covered ones are
+`C2DRangeFinderAbstract` (0% -> 99%), `CHokuyoURG` (0% -> 62%, the whole
+SCIP2.0 handshake and scan decoder), `CSickLaserSerial` (0% -> 33%) and
+`CGPSInterface` (19% -> 47%).
+
+The pcap half of `CVelodyneScanner` (0% -> 40%) was dead code, not untested
+code, and it took four separate fixes to revive: there was no `FindPCAP.cmake`
+in the repo so `find_package(PCAP)` always failed; `MRPT_HAS_LIBPCAP` was never
+emitted into `config.h`; `CVelodyneScanner.cpp` never included that `config.h`;
+and the unit test guarded on `MRPT_HAS_TINYXML2` without including
+`mrpt/obs/config.h`. Both Velodyne tests had therefore been compiling to
+nothing on every platform, sample `.pcap` datasets and all.
+
+Warning for anyone extending this: several `MRPT_HAS_*` macros that hwdrivers
+sources still guard on are never defined anywhere in the 3.x build
+(`MRPT_HAS_OPENCV`, `MRPT_HAS_LIBDC1394_2`, `MRPT_HAS_ROBOPEAK_LIDAR`,
+`MRPT_HAS_NIDAQMX*`, `MRPT_HAS_PGR_FLYCAPTURE2`, `MRPT_HAS_KINECT_CL_NUI`), so
+those code paths are unconditionally compiled out. Do not "fix" one by adding
+the define alone: enabling `MRPT_HAS_LIBDC1394_2` was tried here and
+`CImageGrabber_dc1394.cpp` no longer compiles against current `mrpt::img`
+(6 errors), having rotted unnoticed for as long as the macro was missing.
+Several sources also fail to include `mrpt/hwdrivers/config.h` at all
+(`COpenNI2*`, `CNationalInstrumentsDAQ`, `CImageGrabber_FlyCapture2`,
+`CPhidgetInterfaceKitProximitySensors`), so even their defined macros read 0.
+
+Seven defects were found by the new tests, five of them crashes:
+
+ - `C2DRangeFinderAbstract::getObservation()` could never return anything:
+   `m_lastObservation`/`m_lastObservationIsNew`/`m_hardwareError` were read but
+   written nowhere in the class.
+ - `CHokuyoURG::parseResponse()` validated the device status code only on
+   replies carrying data, so an error answer to a status-only command (`BM`,
+   `QT`, `CR`, ...) counted as success.
+ - `CGPSInterface::OnConnectionShutdown()`, called from the destructor,
+   dereferenced a null stream when shutdown commands were configured but
+   nothing was ever opened.
+ - `CGPSInterface` setup commands were sent only from the serial-open path, so
+   with an externally bound stream they were dropped while the matching
+   shutdown commands were still sent.
+ - `~CIbeoLuxETH()` joined a never-started thread, `~CRoboPeakLidar()` called a
+   `turnOff()` that throws without the SDK, `~CImpinjRFID()` wrote to a null
+   socket and `~CGyroKVHDSP3000()` closed a null serial port -- each aborting
+   the process when a sensor was created by the factory and destroyed before
+   `initialize()`, which is precisely what `rawlog-grabber` does between
+   `createSensor()` and configuring it. `CGenericSensor_unittest.cpp` walks
+   every registered driver to keep that path honest.
+
+`CSickLaserSerial` advertised `bindIO()` but its frame reader, ACK waiter and
+command sender each `dynamic_cast`ed to `CSerialPort` and asserted on it, so
+any other stream aborted on the first read. Those four functions only ever call
+`Read()`/`Write()`, so they now use the bound stream; `open`/`setConfig`/
+`purgeBuffers` are genuinely serial-specific and were left alone.

--- a/modules/mrpt_hwdrivers/CMakeLists.txt
+++ b/modules/mrpt_hwdrivers/CMakeLists.txt
@@ -147,8 +147,11 @@ set(LIB_SOURCES
 )
 
 set(LIB_UNIT_TEST_SOURCES
+  tests/C2DRangeFinderAbstract_unittest.cpp
   tests/CGPSInterface_unittest.cpp
+  tests/CHokuyoURG_unittest.cpp
   tests/CVelodyneScanner_unittest.cpp
+  tests/mock_stream.h
 )
 
 set(LIB_PUBLIC_HEADERS

--- a/modules/mrpt_hwdrivers/CMakeLists.txt
+++ b/modules/mrpt_hwdrivers/CMakeLists.txt
@@ -9,6 +9,8 @@ find_package(mrpt_viz REQUIRED)
 find_package(Threads REQUIRED)
 find_package(PkgConfig QUIET)
 
+list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake")
+
 # Optional dependency detection scripts:
 include(${CMAKE_CURRENT_SOURCE_DIR}/cmake/script_ffmpeg.cmake REQUIRED)
 include(${CMAKE_CURRENT_SOURCE_DIR}/cmake/script_flycapture2.cmake REQUIRED)

--- a/modules/mrpt_hwdrivers/CMakeLists.txt
+++ b/modules/mrpt_hwdrivers/CMakeLists.txt
@@ -149,6 +149,7 @@ set(LIB_SOURCES
 set(LIB_UNIT_TEST_SOURCES
   tests/C2DRangeFinderAbstract_unittest.cpp
   tests/CGPSInterface_stream_unittest.cpp
+  tests/CGenericSensor_unittest.cpp
   tests/CGPSInterface_unittest.cpp
   tests/CHokuyoURG_unittest.cpp
   tests/CSickLaserSerial_unittest.cpp

--- a/modules/mrpt_hwdrivers/CMakeLists.txt
+++ b/modules/mrpt_hwdrivers/CMakeLists.txt
@@ -148,6 +148,7 @@ set(LIB_SOURCES
 
 set(LIB_UNIT_TEST_SOURCES
   tests/C2DRangeFinderAbstract_unittest.cpp
+  tests/CGPSInterface_stream_unittest.cpp
   tests/CGPSInterface_unittest.cpp
   tests/CHokuyoURG_unittest.cpp
   tests/CVelodyneScanner_unittest.cpp

--- a/modules/mrpt_hwdrivers/CMakeLists.txt
+++ b/modules/mrpt_hwdrivers/CMakeLists.txt
@@ -151,6 +151,7 @@ set(LIB_UNIT_TEST_SOURCES
   tests/CGPSInterface_stream_unittest.cpp
   tests/CGPSInterface_unittest.cpp
   tests/CHokuyoURG_unittest.cpp
+  tests/CSickLaserSerial_unittest.cpp
   tests/CVelodyneScanner_unittest.cpp
   tests/mock_stream.h
 )

--- a/modules/mrpt_hwdrivers/cmake/FindPCAP.cmake
+++ b/modules/mrpt_hwdrivers/cmake/FindPCAP.cmake
@@ -1,0 +1,44 @@
+# - Try to find libpcap include dirs and libraries
+#
+# Usage of this module as follows:
+#
+#     find_package(PCAP)
+#
+# Variables used by this module, they can change the default behaviour and need
+# to be set before calling find_package:
+#
+#  PCAP_ROOT_DIR             Set this variable to the root installation of
+#                            libpcap if the module has problems finding the
+#                            proper installation path.
+#
+# Variables defined by this module:
+#
+#  PCAP_FOUND                System has libpcap, include and library dirs found
+#  PCAP_INCLUDE_DIR          The libpcap include directories.
+#  PCAP_LIBRARY              The libpcap library.
+
+find_path(PCAP_ROOT_DIR
+    NAMES include/pcap.h
+)
+
+find_path(PCAP_INCLUDE_DIR
+    NAMES pcap.h
+    HINTS ${PCAP_ROOT_DIR}/include
+)
+
+find_library(PCAP_LIBRARY
+    NAMES pcap
+    HINTS ${PCAP_ROOT_DIR}/lib
+)
+
+include(FindPackageHandleStandardArgs)
+find_package_handle_standard_args(PCAP DEFAULT_MSG
+    PCAP_LIBRARY
+    PCAP_INCLUDE_DIR
+)
+
+mark_as_advanced(
+    PCAP_ROOT_DIR
+    PCAP_INCLUDE_DIR
+    PCAP_LIBRARY
+)

--- a/modules/mrpt_hwdrivers/config.h.in
+++ b/modules/mrpt_hwdrivers/config.h.in
@@ -36,4 +36,7 @@
 /** MYNTEYE-Depth SDK is available */
 #define MRPT_HAS_MYNTEYE_D          ${CMAKE_MRPT_HAS_MYNTEYE_D}
 
+/** libpcap, used to replay Velodyne captures from a .pcap file */
+#define MRPT_HAS_LIBPCAP            ${CMAKE_MRPT_HAS_LIBPCAP}
+
 // clang-format on

--- a/modules/mrpt_hwdrivers/include/mrpt/hwdrivers/CGPSInterface.h
+++ b/modules/mrpt_hwdrivers/include/mrpt/hwdrivers/CGPSInterface.h
@@ -289,6 +289,8 @@ class CGPSInterface : public mrpt::system::COutputLogger, public CGenericSensor
   std::shared_ptr<std::mutex> m_data_stream_cs;
   std::shared_ptr<std::mutex> m_data_stream_mine_cs = std::make_shared<std::mutex>();
   bool m_data_stream_is_external{false};
+  /** Setup commands already sent over an externally-bound stream. */
+  bool m_setup_cmds_sent{false};
 
   poses::CPose3D m_sensorPose;
   std::string m_customInit;

--- a/modules/mrpt_hwdrivers/src/C2DRangeFinderAbstract.cpp
+++ b/modules/mrpt_hwdrivers/src/C2DRangeFinderAbstract.cpp
@@ -50,14 +50,17 @@ void C2DRangeFinderAbstract::getObservation(
     mrpt::obs::CObservation2DRangeScan& outObservation,
     bool& hardwareError)
 {
-  m_csLastObservation.lock();
+  std::lock_guard<std::mutex> lck(m_csLastObservation);
 
   hardwareError = m_hardwareError;
   outThereIsObservation = m_lastObservationIsNew;
 
-  if (outThereIsObservation) outObservation = m_lastObservation;
-
-  m_csLastObservation.unlock();
+  if (outThereIsObservation)
+  {
+    outObservation = m_lastObservation;
+    // Consumed: a new scan must arrive before this reports one again.
+    m_lastObservationIsNew = false;
+  }
 }
 
 /*-------------------------------------------------------------
@@ -65,9 +68,13 @@ void C2DRangeFinderAbstract::getObservation(
 -------------------------------------------------------------*/
 void C2DRangeFinderAbstract::doProcess()
 {
-  bool thereIs, hwError;
+  bool thereIs = false;
+  bool hwError = false;
 
-  if (!m_nextObservation) m_nextObservation = std::make_shared<CObservation2DRangeScan>();
+  if (!m_nextObservation)
+  {
+    m_nextObservation = std::make_shared<CObservation2DRangeScan>();
+  }
 
   doProcessSimple(thereIs, *m_nextObservation, hwError);
 
@@ -75,6 +82,17 @@ void C2DRangeFinderAbstract::doProcess()
   {
     m_state = ssError;
     MRPT_LOG_THROTTLE_ERROR(5.0, "Error reading from the sensor hardware. Will retry.");
+  }
+
+  // Keep the latest result available to getObservation() as well:
+  {
+    std::lock_guard<std::mutex> lck(m_csLastObservation);
+    m_hardwareError = hwError;
+    if (thereIs)
+    {
+      m_lastObservation = *m_nextObservation;
+      m_lastObservationIsNew = true;
+    }
   }
 
   if (thereIs)

--- a/modules/mrpt_hwdrivers/src/CGPSInterface.cpp
+++ b/modules/mrpt_hwdrivers/src/CGPSInterface.cpp
@@ -248,8 +248,11 @@ bool CGPSInterface::tryToOpenTheCOM()
   // are always sent from the destructor).
   if (!m_setup_cmds_sent)
   {
-    m_setup_cmds_sent = true;
-    return OnConnectionEstablished();
+    // Only latch on success, so a failed attempt is retried on the next call,
+    // as the serial-port path above already does by reopening the port.
+    const bool setup_ok = OnConnectionEstablished();
+    m_setup_cmds_sent = setup_ok;
+    return setup_ok;
   }
 
   return true;  // All OK

--- a/modules/mrpt_hwdrivers/src/CGPSInterface.cpp
+++ b/modules/mrpt_hwdrivers/src/CGPSInterface.cpp
@@ -243,6 +243,15 @@ bool CGPSInterface::tryToOpenTheCOM()
     }
   }  // end of this is a serial port
 
+  // Externally-bound stream: there is nothing to open, but the user-provided
+  // setup commands still have to be sent once (their shutdown counterparts
+  // are always sent from the destructor).
+  if (!m_setup_cmds_sent)
+  {
+    m_setup_cmds_sent = true;
+    return OnConnectionEstablished();
+  }
+
   return true;  // All OK
 }
 
@@ -543,6 +552,12 @@ void CGPSInterface::JAVAD_sendMessage(const char* str, bool waitForAnswer)
 
 bool CGPSInterface::OnConnectionShutdown()
 {
+  // Nothing was ever connected (e.g. destroyed right after loadConfig()):
+  if (!m_data_stream || !m_data_stream_cs)
+  {
+    return false;
+  }
+
   auto* stream_serial = dynamic_cast<CSerialPort*>(m_data_stream.get());
 
   if (stream_serial && !stream_serial->isOpen())

--- a/modules/mrpt_hwdrivers/src/CGyroKVHDSP3000.cpp
+++ b/modules/mrpt_hwdrivers/src/CGyroKVHDSP3000.cpp
@@ -36,7 +36,14 @@ CGyroKVHDSP3000::CGyroKVHDSP3000() : m_com_port(), m_sensorPose()
   m_sensorLabel = "KVH_DSP3000";
 }
 
-CGyroKVHDSP3000::~CGyroKVHDSP3000() { m_serialPort->close(); }
+CGyroKVHDSP3000::~CGyroKVHDSP3000()
+{
+  // The port only exists after initialize():
+  if (m_serialPort)
+  {
+    m_serialPort->close();
+  }
+}
 
 /*-------------------------------------------------------------
           doProcess

--- a/modules/mrpt_hwdrivers/src/CHokuyoURG.cpp
+++ b/modules/mrpt_hwdrivers/src/CHokuyoURG.cpp
@@ -579,6 +579,16 @@ bool CHokuyoURG::parseResponse(bool additionalWaitForData)
         m_rcv_status1 = tmp_rcv_status1;
         // Empty read bytes so far:
         for (size_t k = 0; k < peekIdx; k++) m_rx_buffer.pop();
+
+        // Status-only replies carry the error code too, so check it here
+        // as well and not just in the with-data case below:
+        if (m_rcv_status0 != '0' && (m_rcv_status0 != '9' && m_rcv_status1 != '9'))
+        {
+          MRPT_LOG_ERROR_STREAM(
+              "[Hokuyo] Error LIDAR status: " << static_cast<int>(m_rcv_status0)
+                                              << " after command: `" << m_lastSentMeasCmd << "`");
+          return false;
+        }
         return true;
       }
 

--- a/modules/mrpt_hwdrivers/src/CIbeoLuxETH.cpp
+++ b/modules/mrpt_hwdrivers/src/CIbeoLuxETH.cpp
@@ -48,11 +48,16 @@ CIbeoLuxETH::CIbeoLuxETH(string _ip, unsigned int _port) :
 CIbeoLuxETH::~CIbeoLuxETH()
 {
   m_run = false;
-  dataCollectionThread.join();
-  // Wait a little for the thread to come down
-  // Don't ask why, it just works
-  // TODO: Try without the delay
-  std::this_thread::sleep_for(10ms);
+  // The thread only exists after initialize(); joining a non-started thread
+  // would throw from a destructor and abort the process.
+  if (dataCollectionThread.joinable())
+  {
+    dataCollectionThread.join();
+    // Wait a little for the thread to come down
+    // Don't ask why, it just works
+    // TODO: Try without the delay
+    std::this_thread::sleep_for(10ms);
+  }
 }
 
 void CIbeoLuxETH::dataCollection()

--- a/modules/mrpt_hwdrivers/src/CImpinjRFID.cpp
+++ b/modules/mrpt_hwdrivers/src/CImpinjRFID.cpp
@@ -189,6 +189,12 @@ bool CImpinjRFID::getObservation(mrpt::obs::CObservationRFID& obs)
  ---------------------------------------------------------------*/
 void CImpinjRFID::closeReader()
 {
+  // The socket only exists after initialize():
+  if (!client)
+  {
+    return;
+  }
+
   char cmd[20];
   // send a kill command to the device interface program
   strcpy(cmd, "END\0");

--- a/modules/mrpt_hwdrivers/src/CRoboPeakLidar.cpp
+++ b/modules/mrpt_hwdrivers/src/CRoboPeakLidar.cpp
@@ -40,7 +40,15 @@ CRoboPeakLidar::CRoboPeakLidar() : m_com_port("") { m_sensorLabel = "RPLidar"; }
 -------------------------------------------------------------*/
 CRoboPeakLidar::~CRoboPeakLidar()
 {
-  turnOff();
+  // turnOff() throws when built without RPLidar support: letting that escape
+  // a destructor would abort the process.
+  try
+  {
+    turnOff();
+  }
+  catch (const std::exception&)
+  {
+  }
   disconnect();
 }
 

--- a/modules/mrpt_hwdrivers/src/CSickLaserSerial.cpp
+++ b/modules/mrpt_hwdrivers/src/CSickLaserSerial.cpp
@@ -280,8 +280,7 @@ bool CSickLaserSerial::tryToOpenComms(std::string* err_msg)
 bool CSickLaserSerial::waitContinuousSampleFrame(
     vector<float>& out_ranges_meters, unsigned char& LMS_status, bool& is_mm_mode)
 {
-  auto* COM = dynamic_cast<CSerialPort*>(m_stream.get());
-  ASSERTMSG_(COM != nullptr, "No I/O channel bound to this object");
+  ASSERTMSG_(m_stream, "No I/O channel bound to this object");
 
   size_t nRead, nBytesToRead;
   size_t nFrameBytes = 0;
@@ -305,7 +304,7 @@ bool CSickLaserSerial::waitContinuousSampleFrame(
 
     try
     {
-      nRead = COM->Read(buf + nFrameBytes, nBytesToRead);
+      nRead = m_stream->Read(buf + nFrameBytes, nBytesToRead);
     }
     catch (const std::exception& e)
     {
@@ -545,8 +544,7 @@ bool CSickLaserSerial::LMS_statusQuery()
 // Returns false if timeout
 bool CSickLaserSerial::LMS_waitACK(uint16_t timeout_ms)
 {
-  auto* COM = dynamic_cast<CSerialPort*>(m_stream.get());
-  ASSERT_(COM);
+  ASSERTMSG_(m_stream, "No I/O channel bound to this object");
 
   uint8_t b = 0;
   CTicTac tictac;
@@ -554,7 +552,7 @@ bool CSickLaserSerial::LMS_waitACK(uint16_t timeout_ms)
 
   do
   {
-    if (COM->Read(&b, 1))
+    if (m_stream->Read(&b, 1))
     {  // Byte rx:
       if (b == 0x06)
       {
@@ -574,8 +572,7 @@ bool CSickLaserSerial::LMS_waitACK(uint16_t timeout_ms)
 // Returns false if timeout
 bool CSickLaserSerial::LMS_waitIncomingFrame(uint16_t timeout)
 {
-  auto* COM = dynamic_cast<CSerialPort*>(m_stream.get());
-  ASSERT_(COM);
+  ASSERTMSG_(m_stream, "No I/O channel bound to this object");
 
   uint8_t b;
   unsigned int nBytes = 0;
@@ -587,7 +584,7 @@ bool CSickLaserSerial::LMS_waitIncomingFrame(uint16_t timeout)
   while (nBytes < 6 || (nBytes < (6U + m_received_frame_buffer[2] +
                                   static_cast<uint16_t>(m_received_frame_buffer[3] << 8))))
   {
-    if (COM->Read(&b, 1))
+    if (m_stream->Read(&b, 1))
     {
       // First byte must be STX:
       if (nBytes > 1 || (!nBytes && b == 0x02) || (nBytes == 1 && b == 0x80))
@@ -784,8 +781,7 @@ bool CSickLaserSerial::SendCommandToSICK(const uint8_t* cmd, const uint16_t cmd_
   uint8_t cmd_full[1024];
   ASSERT_(sizeof(cmd_full) > cmd_len + 4U + 2U);
 
-  auto* COM = dynamic_cast<CSerialPort*>(m_stream.get());
-  ASSERT_(COM);
+  ASSERTMSG_(m_stream, "No I/O channel bound to this object");
 
   // Create header
   cmd_full[0] = 0x02;  // STX
@@ -812,7 +808,7 @@ bool CSickLaserSerial::SendCommandToSICK(const uint8_t* cmd, const uint16_t cmd_
 
   for (int k = 0; k < NTRIES; k++)
   {
-    if (toWrite != COM->Write(cmd_full, toWrite))
+    if (toWrite != m_stream->Write(cmd_full, toWrite))
     {
       std::cout << "[CSickLaserSerial::SendCommandToSICK] Error writing data "
                    "to serial port."

--- a/modules/mrpt_hwdrivers/src/CVelodyneScanner.cpp
+++ b/modules/mrpt_hwdrivers/src/CVelodyneScanner.cpp
@@ -16,6 +16,7 @@
 #include <mrpt/core/reverse_bytes.h>
 #include <mrpt/hwdrivers/CGPSInterface.h>
 #include <mrpt/hwdrivers/CVelodyneScanner.h>
+#include <mrpt/hwdrivers/config.h>
 #include <mrpt/serialization/CArchive.h>
 #include <mrpt/system/datetime.h>  // timeDifference
 #include <mrpt/system/filesystem.h>

--- a/modules/mrpt_hwdrivers/tests/C2DRangeFinderAbstract_unittest.cpp
+++ b/modules/mrpt_hwdrivers/tests/C2DRangeFinderAbstract_unittest.cpp
@@ -184,20 +184,24 @@ TEST(C2DRangeFinderAbstract, repeatedMissingScansEventuallyReportAFailure)
 
   // Feed a burst of scans so the estimated scan period (which starts at 1 s)
   // converges down to the millisecond range this test can wait out:
+  // (the filter is a 90/10 average of the measured inter-scan time, so how
+  // many iterations this takes depends on how fast the machine is)
   laser.stageScan(makeScan(4, 1.0f));
-  for (int i = 0; i < 80; i++)
+  for (int i = 0; i < 5000 && laser.getEstimatedScanPeriod() >= 0.01; i++)
   {
     laser.doProcess();
   }
   const double period = laser.getEstimatedScanPeriod();
   EXPECT_GT(period, 0.0);
-  EXPECT_LT(period, 0.01);
+  ASSERT_LT(period, 0.01);
 
-  // Now go quiet for clearly longer than that period, `maxMissed` times:
+  // Now go quiet for clearly longer than the 1.5*period the driver tolerates,
+  // `maxMissed` times:
   laser.stageNothing();
+  const auto quiet = std::chrono::duration<double>(2.0 * period);
   for (int i = 0; i < maxMissed; i++)
   {
-    std::this_thread::sleep_for(std::chrono::milliseconds(20));
+    std::this_thread::sleep_for(quiet);
     laser.doProcess();
   }
   EXPECT_FALSE(laser.lastNoScanWasOk());

--- a/modules/mrpt_hwdrivers/tests/C2DRangeFinderAbstract_unittest.cpp
+++ b/modules/mrpt_hwdrivers/tests/C2DRangeFinderAbstract_unittest.cpp
@@ -1,0 +1,314 @@
+/*                    _
+                     | |    Mobile Robot Programming Toolkit (MRPT)
+ _ __ ___  _ __ _ __ | |_
+| '_ ` _ \| '__| '_ \| __|          https://www.mrpt.org/
+| | | | | | |  | |_) | |_
+|_| |_| |_|_|  | .__/ \__|     https://github.com/MRPT/mrpt/
+               | |
+               |_|
+
+ Copyright (c) 2005-2026, Individual contributors, see AUTHORS file
+ See: https://www.mrpt.org/Authors - All rights reserved.
+ SPDX-License-Identifier: BSD-3-Clause
+*/
+
+#include <gtest/gtest.h>
+#include <mrpt/config/CConfigFileMemory.h>
+#include <mrpt/hwdrivers/C2DRangeFinderAbstract.h>
+
+#include <chrono>
+#include <thread>
+
+#include "mock_stream.h"
+
+using namespace mrpt::hwdrivers;
+using mrpt::hwdrivers::testing::MockStream;
+
+namespace mrpt::hwdrivers
+{
+/** A minimal 2D scanner driver: it returns whatever scan the test stages,
+ *  so that the generic machinery of the base class can be exercised without
+ *  any real device protocol in the way. */
+class FakeLaser : public C2DRangeFinderAbstract
+{
+  DEFINE_GENERIC_SENSOR(FakeLaser)
+
+ public:
+  FakeLaser() = default;
+
+  void doProcessSimple(
+      bool& outThereIsObservation,
+      mrpt::obs::CObservation2DRangeScan& outObservation,
+      bool& hardwareError) override
+  {
+    hardwareError = m_stagedHwError;
+    outThereIsObservation = m_stagedThereIs;
+    if (m_stagedThereIs)
+    {
+      outObservation = m_stagedScan;
+      // Exercise the base class filters, as real drivers do:
+      filterByExclusionAreas(outObservation);
+      filterByExclusionAngles(outObservation);
+      internal_notifyGoodScanNow();
+    }
+    else
+    {
+      m_lastNoScanWasOk = internal_notifyNoScanReceived();
+    }
+  }
+
+  bool turnOn() override { return true; }
+  bool turnOff() override { return true; }
+
+  void stageScan(const mrpt::obs::CObservation2DRangeScan& s)
+  {
+    m_stagedScan = s;
+    m_stagedThereIs = true;
+    m_stagedHwError = false;
+  }
+  void stageNothing() { m_stagedThereIs = false; }
+  void stageHardwareError()
+  {
+    m_stagedThereIs = false;
+    m_stagedHwError = true;
+  }
+  bool lastNoScanWasOk() const { return m_lastNoScanWasOk; }
+
+  // Expose the protected config loader for the tests:
+  void loadCommon(const mrpt::config::CConfigFileBase& c, const std::string& s)
+  {
+    loadCommonParams(c, s);
+  }
+
+ protected:
+  void loadConfig_sensorSpecific(
+      const mrpt::config::CConfigFileBase& c, const std::string& s) override
+  {
+    loadCommonParams(c, s);
+  }
+
+ private:
+  mrpt::obs::CObservation2DRangeScan m_stagedScan;
+  bool m_stagedThereIs = false;
+  bool m_stagedHwError = false;
+  bool m_lastNoScanWasOk = true;
+};
+}  // namespace mrpt::hwdrivers
+
+IMPLEMENTS_GENERIC_SENSOR(FakeLaser, mrpt::hwdrivers)
+
+namespace
+{
+using mrpt::hwdrivers::FakeLaser;
+
+/** A scan of `n` rays spanning 180 deg, all valid at `range` meters. */
+mrpt::obs::CObservation2DRangeScan makeScan(size_t n, float range)
+{
+  mrpt::obs::CObservation2DRangeScan scan;
+  scan.aperture = M_PIf;
+  scan.rightToLeft = true;
+  scan.maxRange = 30.0f;
+  scan.sensorPose = mrpt::poses::CPose3D();
+  scan.resizeScan(n);
+  for (size_t i = 0; i < n; i++)
+  {
+    scan.setScanRange(i, range);
+    scan.setScanRangeValidity(i, true);
+  }
+  return scan;
+}
+}  // namespace
+
+TEST(C2DRangeFinderAbstract, bindIOAndGetObservation)
+{
+  FakeLaser laser;
+  auto s = std::make_shared<MockStream>();
+  laser.bindIO(s);
+
+  // Nothing staged yet -> nothing to hand out:
+  bool thereIs = true;
+  bool hwError = false;
+  mrpt::obs::CObservation2DRangeScan obs;
+  laser.getObservation(thereIs, obs, hwError);
+  EXPECT_FALSE(thereIs);
+
+  laser.stageScan(makeScan(10, 2.0f));
+  laser.doProcess();
+
+  laser.getObservation(thereIs, obs, hwError);
+  EXPECT_FALSE(hwError);
+  ASSERT_TRUE(thereIs);
+  EXPECT_EQ(obs.getScanSize(), 10U);
+
+  // getObservation() consumes it: a second call finds nothing new.
+  laser.getObservation(thereIs, obs, hwError);
+  EXPECT_FALSE(thereIs);
+}
+
+TEST(C2DRangeFinderAbstract, doProcessQueuesObservations)
+{
+  FakeLaser laser;
+  laser.stageScan(makeScan(4, 1.0f));
+
+  laser.doProcess();
+  laser.doProcess();
+
+  auto obss = laser.getObservations();
+  EXPECT_EQ(obss.size(), 2U);
+  EXPECT_EQ(laser.getState(), CGenericSensor::ssWorking);
+}
+
+TEST(C2DRangeFinderAbstract, hardwareErrorSetsErrorState)
+{
+  FakeLaser laser;
+  laser.stageHardwareError();
+
+  laser.doProcess();
+
+  EXPECT_EQ(laser.getState(), CGenericSensor::ssError);
+  EXPECT_TRUE(laser.getObservations().empty());
+}
+
+TEST(C2DRangeFinderAbstract, repeatedMissingScansEventuallyReportAFailure)
+{
+  FakeLaser laser;
+  const int maxMissed = 3;
+  mrpt::config::CConfigFileMemory cfg;
+  cfg.write("LASER", "maxMissedScansToDeclareError", maxMissed);
+  laser.loadCommon(cfg, "LASER");
+
+  // Before any good scan, a missing scan is not yet an error:
+  laser.stageNothing();
+  laser.doProcess();
+  EXPECT_TRUE(laser.lastNoScanWasOk());
+
+  // Feed a burst of scans so the estimated scan period (which starts at 1 s)
+  // converges down to the millisecond range this test can wait out:
+  laser.stageScan(makeScan(4, 1.0f));
+  for (int i = 0; i < 80; i++)
+  {
+    laser.doProcess();
+  }
+  const double period = laser.getEstimatedScanPeriod();
+  EXPECT_GT(period, 0.0);
+  EXPECT_LT(period, 0.01);
+
+  // Now go quiet for clearly longer than that period, `maxMissed` times:
+  laser.stageNothing();
+  for (int i = 0; i < maxMissed; i++)
+  {
+    std::this_thread::sleep_for(std::chrono::milliseconds(20));
+    laser.doProcess();
+  }
+  EXPECT_FALSE(laser.lastNoScanWasOk());
+}
+
+TEST(C2DRangeFinderAbstract, exclusionAreaInvalidatesEnclosedRays)
+{
+  FakeLaser laser;
+
+  // A square covering everything in front of the sensor up to 5 m:
+  mrpt::config::CConfigFileMemory cfg;
+  cfg.write("LASER", "exclusionZone1_x", "[-5 5 5 -5]");
+  cfg.write("LASER", "exclusionZone1_y", "[-5 -5 5 5]");
+  laser.loadCommon(cfg, "LASER");
+
+  // Rays at 2 m fall inside the zone; rays at 20 m do not.
+  laser.stageScan(makeScan(20, 2.0f));
+  bool thereIs = false;
+  bool hwError = false;
+  mrpt::obs::CObservation2DRangeScan obs;
+  laser.doProcessSimple(thereIs, obs, hwError);
+  ASSERT_TRUE(thereIs);
+  for (size_t i = 0; i < obs.getScanSize(); i++)
+  {
+    EXPECT_FALSE(obs.getScanRangeValidity(i)) << "at i=" << i;
+  }
+
+  laser.stageScan(makeScan(20, 20.0f));
+  laser.doProcessSimple(thereIs, obs, hwError);
+  ASSERT_TRUE(thereIs);
+  size_t nValid = 0;
+  for (size_t i = 0; i < obs.getScanSize(); i++)
+  {
+    if (obs.getScanRangeValidity(i))
+    {
+      nValid++;
+    }
+  }
+  EXPECT_GT(nValid, 0U);
+}
+
+TEST(C2DRangeFinderAbstract, exclusionAreaWithZRangeIsParsed)
+{
+  FakeLaser laser;
+  mrpt::config::CConfigFileMemory cfg;
+  cfg.write("LASER", "exclusionZone1_x", "[-5 5 5 -5]");
+  cfg.write("LASER", "exclusionZone1_y", "[-5 -5 5 5]");
+  cfg.write("LASER", "exclusionZone1_z", "[-1.0 1.0]");
+  EXPECT_NO_THROW(laser.loadCommon(cfg, "LASER"));
+
+  // A malformed z range must be rejected:
+  mrpt::config::CConfigFileMemory bad;
+  bad.write("LASER", "exclusionZone1_x", "[-5 5 5 -5]");
+  bad.write("LASER", "exclusionZone1_y", "[-5 -5 5 5]");
+  bad.write("LASER", "exclusionZone1_z", "[1.0 -1.0]");
+  EXPECT_THROW(laser.loadCommon(bad, "LASER"), std::exception);
+}
+
+TEST(C2DRangeFinderAbstract, exclusionAnglesInvalidateTheirSector)
+{
+  FakeLaser laser;
+  // The scan spans [-90, +90] deg; block the left half:
+  mrpt::config::CConfigFileMemory cfg;
+  cfg.write("LASER", "exclusionAngles1_ini", 0.0);
+  cfg.write("LASER", "exclusionAngles1_end", 90.0);
+  laser.loadCommon(cfg, "LASER");
+
+  laser.stageScan(makeScan(180, 10.0f));
+
+  bool thereIs = false;
+  bool hwError = false;
+  mrpt::obs::CObservation2DRangeScan obs;
+  laser.doProcessSimple(thereIs, obs, hwError);
+  ASSERT_TRUE(thereIs);
+
+  size_t nValid = 0;
+  size_t nInvalid = 0;
+  for (size_t i = 0; i < obs.getScanSize(); i++)
+  {
+    if (obs.getScanRangeValidity(i))
+    {
+      nValid++;
+    }
+    else
+    {
+      nInvalid++;
+    }
+  }
+  // Roughly half the scan must have been discarded:
+  EXPECT_GT(nInvalid, 0U);
+  EXPECT_GT(nValid, 0U);
+}
+
+TEST(C2DRangeFinderAbstract, multipleExclusionZonesAreAllLoaded)
+{
+  FakeLaser laser;
+  mrpt::config::CConfigFileMemory cfg;
+  cfg.write("LASER", "exclusionZone1_x", "[-1 1 1 -1]");
+  cfg.write("LASER", "exclusionZone1_y", "[-1 -1 1 1]");
+  cfg.write("LASER", "exclusionZone2_x", "[3 5 5 3]");
+  cfg.write("LASER", "exclusionZone2_y", "[3 3 5 5]");
+  cfg.write("LASER", "exclusionAngles1_ini", -10.0);
+  cfg.write("LASER", "exclusionAngles1_end", 10.0);
+  cfg.write("LASER", "exclusionAngles2_ini", 20.0);
+  cfg.write("LASER", "exclusionAngles2_end", 30.0);
+
+  EXPECT_NO_THROW(laser.loadCommon(cfg, "LASER"));
+
+  // Mismatched vertex counts are an error:
+  mrpt::config::CConfigFileMemory bad;
+  bad.write("LASER", "exclusionZone1_x", "[-1 1 1 -1]");
+  bad.write("LASER", "exclusionZone1_y", "[-1 -1 1]");
+  EXPECT_THROW(laser.loadCommon(bad, "LASER"), std::exception);
+}

--- a/modules/mrpt_hwdrivers/tests/CGPSInterface_stream_unittest.cpp
+++ b/modules/mrpt_hwdrivers/tests/CGPSInterface_stream_unittest.cpp
@@ -1,0 +1,249 @@
+/*                    _
+                     | |    Mobile Robot Programming Toolkit (MRPT)
+ _ __ ___  _ __ _ __ | |_
+| '_ ` _ \| '__| '_ \| __|          https://www.mrpt.org/
+| | | | | | |  | |_) | |_
+|_| |_| |_|_|  | .__/ \__|     https://github.com/MRPT/mrpt/
+               | |
+               |_|
+
+ Copyright (c) 2005-2026, Individual contributors, see AUTHORS file
+ See: https://www.mrpt.org/Authors - All rights reserved.
+ SPDX-License-Identifier: BSD-3-Clause
+*/
+
+// Driver-level tests for CGPSInterface: the framing/dispatch layer around the
+// NMEA and NOVATEL parsers, driven through a mocked I/O stream.
+
+#include <gtest/gtest.h>
+#include <mrpt/config/CConfigFileMemory.h>
+#include <mrpt/hwdrivers/CGPSInterface.h>
+#include <mrpt/obs/CObservationGPS.h>
+
+#include <string>
+
+#include "mock_stream.h"
+
+using namespace mrpt::hwdrivers;
+using mrpt::hwdrivers::testing::MockStream;
+using mrpt::obs::CObservationGPS;
+
+namespace
+{
+// A short, valid NMEA burst: position fix + recommended minimum data.
+const char* nmeaBurst =
+    "$GPGGA,101830.00,3649.76162994,N,00224.53709052,W,2,08,1.1,9.3,M,47.4,M,5.0,0120*58\n"
+    "$GPRMC,161229.487,A,3723.2475,N,12158.3416,W,0.13,309.62,120598, ,*10\n";
+}  // namespace
+
+TEST(CGPSInterfaceStream, parsesFramesFromABoundStream)
+{
+  auto s = std::make_shared<MockStream>();
+  s->pushRx(nmeaBurst);
+
+  CGPSInterface gps;
+  gps.bindStream(s);
+  EXPECT_TRUE(gps.useExternalStream());
+
+  gps.initialize();
+  gps.doProcess();
+
+  const auto obss = gps.getObservations();
+  ASSERT_FALSE(obss.empty());
+
+  bool sawGGA = false;
+  for (const auto& [t, o] : obss)
+  {
+    auto obs = mrpt::ptr_cast<CObservationGPS>::from(o);
+    ASSERT_TRUE(obs);
+    if (obs->getMsgByClassPtr<mrpt::obs::gnss::Message_NMEA_GGA>() != nullptr)
+    {
+      sawGGA = true;
+    }
+  }
+  EXPECT_TRUE(sawGGA);
+}
+
+TEST(CGPSInterfaceStream, cachesTheLastGGAFrame)
+{
+  auto s = std::make_shared<MockStream>();
+  s->pushRx(nmeaBurst);
+
+  CGPSInterface gps;
+  gps.bindStream(s);
+  gps.initialize();
+  gps.doProcess();
+
+  const std::string gga = gps.getLastGGA(false);
+  EXPECT_NE(gga.find("$GPGGA"), std::string::npos);
+
+  // Reading with reset empties the cache:
+  EXPECT_FALSE(gps.getLastGGA(true).empty());
+  EXPECT_TRUE(gps.getLastGGA(true).empty());
+}
+
+TEST(CGPSInterfaceStream, garbageBetweenFramesIsSkipped)
+{
+  auto s = std::make_shared<MockStream>();
+  s->pushRx(std::string("\x01\x02\x03 not a frame at all \xFF\xFE\n") + nmeaBurst);
+
+  CGPSInterface gps;
+  gps.bindStream(s);
+  gps.initialize();
+  gps.doProcess();
+
+  // The valid frames after the noise must still be recovered:
+  EXPECT_FALSE(gps.getObservations().empty());
+}
+
+TEST(CGPSInterfaceStream, setupAndShutdownCommandsGoOutOnTheWire)
+{
+  auto s = std::make_shared<MockStream>();
+
+  {
+    CGPSInterface gps;
+    gps.bindStream(s);
+    gps.setSetupCommandsDelay(0);
+    gps.enableSetupCommandsAppendCRLF(true);
+    gps.setSetupCommands({"LOG BESTPOSA ONTIME 1", "LOG RANGEA ONTIME 1"});
+    gps.setShutdownCommands({"UNLOGALL"});
+
+    EXPECT_EQ(gps.getSetupCommands().size(), 2U);
+    EXPECT_EQ(gps.getShutdownCommands().size(), 1U);
+    EXPECT_TRUE(gps.isEnabledSetupCommandsAppendCRLF());
+    EXPECT_EQ(gps.getSetupCommandsDelay(), 0.0);
+
+    gps.initialize();
+    gps.doProcess();
+
+    EXPECT_NE(s->tx().find("LOG BESTPOSA ONTIME 1\r\n"), std::string::npos);
+    EXPECT_NE(s->tx().find("LOG RANGEA ONTIME 1\r\n"), std::string::npos);
+    // Shutdown commands are sent by the destructor.
+  }
+
+  EXPECT_NE(s->tx().find("UNLOGALL\r\n"), std::string::npos);
+}
+
+TEST(CGPSInterfaceStream, setupCommandsCanSkipTheCRLF)
+{
+  auto s = std::make_shared<MockStream>();
+  CGPSInterface gps;
+  gps.bindStream(s);
+  gps.setSetupCommandsDelay(0);
+  gps.enableSetupCommandsAppendCRLF(false);
+  gps.setSetupCommands({"ABC"});
+
+  gps.initialize();
+  gps.doProcess();
+
+  EXPECT_NE(s->tx().find("ABC"), std::string::npos);
+  EXPECT_EQ(s->tx().find("ABC\r\n"), std::string::npos);
+}
+
+TEST(CGPSInterfaceStream, sendCustomCommandWritesToTheStream)
+{
+  auto s = std::make_shared<MockStream>();
+  CGPSInterface gps;
+  gps.bindStream(s);
+
+  const std::string cmd = "$PUBX,40,GLL,0,0,0,0*5C\r\n";
+  EXPECT_TRUE(gps.sendCustomCommand(cmd.data(), cmd.size()));
+  EXPECT_NE(s->tx().find(cmd), std::string::npos);
+
+  // I/O failures are reported, not thrown:
+  s->setWritesThrow(true);
+  EXPECT_FALSE(gps.sendCustomCommand(cmd.data(), cmd.size()));
+}
+
+TEST(CGPSInterfaceStream, parserSelectionRoundTrips)
+{
+  CGPSInterface gps;
+  // AUTO is the default:
+  EXPECT_EQ(gps.getParser(), CGPSInterface::AUTO);
+
+  gps.setParser(CGPSInterface::NMEA);
+  EXPECT_EQ(gps.getParser(), CGPSInterface::NMEA);
+
+  gps.setParser(CGPSInterface::NOVATEL_OEM6);
+  EXPECT_EQ(gps.getParser(), CGPSInterface::NOVATEL_OEM6);
+}
+
+TEST(CGPSInterfaceStream, appendMsgTypeToSensorLabel)
+{
+  auto s = std::make_shared<MockStream>();
+  s->pushRx(nmeaBurst);
+
+  CGPSInterface gps;
+  gps.bindStream(s);
+  gps.setSensorLabel("gps1");
+  gps.enableAppendMsgTypeToSensorLabel(true);
+  gps.initialize();
+  gps.doProcess();
+
+  const auto obss = gps.getObservations();
+  ASSERT_FALSE(obss.empty());
+  for (const auto& [t, o] : obss)
+  {
+    auto obs = mrpt::ptr_cast<CObservationGPS>::from(o);
+    ASSERT_TRUE(obs);
+    // The message class name is appended after the base label:
+    EXPECT_EQ(obs->sensorLabel.rfind("gps1_", 0), 0U) << "label: " << obs->sensorLabel;
+  }
+}
+
+TEST(CGPSInterfaceStream, loadConfigReadsDriverSettings)
+{
+  mrpt::config::CConfigFileMemory cfg;
+  const std::string sec = "GPS";
+  cfg.write(sec, "parser", "NMEA");
+  // COM port and baud rate are mandatory entries:
+#ifdef _WIN32
+  cfg.write(sec, "COM_port_WIN", "COM1");
+#else
+  cfg.write(sec, "COM_port_LIN", "/dev/ttyUSB0");
+#endif
+  cfg.write(sec, "baudRate", 115200);
+  cfg.write(sec, "custom_cmds_delay", 0.0);
+  cfg.write(sec, "custom_cmds_append_CRLF", true);
+  cfg.write(sec, "setup_cmd1", "CMD_ONE");
+  cfg.write(sec, "setup_cmd2", "CMD_TWO");
+  cfg.write(sec, "shutdown_cmd1", "CMD_BYE");
+  cfg.write(sec, "sensor_label_append_msg_type", true);
+  cfg.write(sec, "pose_x", 1.0);
+  cfg.write(sec, "pose_y", 2.0);
+  cfg.write(sec, "pose_z", 3.0);
+
+  CGPSInterface gps;
+  gps.loadConfig(cfg, sec);
+
+  EXPECT_EQ(gps.getParser(), CGPSInterface::NMEA);
+  ASSERT_EQ(gps.getSetupCommands().size(), 2U);
+  EXPECT_EQ(gps.getSetupCommands()[0], "CMD_ONE");
+  EXPECT_EQ(gps.getSetupCommands()[1], "CMD_TWO");
+  ASSERT_EQ(gps.getShutdownCommands().size(), 1U);
+  EXPECT_EQ(gps.getShutdownCommands()[0], "CMD_BYE");
+  EXPECT_TRUE(gps.isEnabledSetupCommandsAppendCRLF());
+}
+
+TEST(CGPSInterfaceStream, destroyingAnUnconnectedDriverIsSafe)
+{
+  // Shutdown commands are sent from the destructor: doing so with a driver
+  // that never opened a stream must not dereference a null stream.
+  CGPSInterface gps;
+  gps.setShutdownCommands({"UNLOGALL"});
+  SUCCEED();
+}
+
+TEST(CGPSInterfaceStream, forcedParserIgnoresTheOtherFormat)
+{
+  auto s = std::make_shared<MockStream>();
+  s->pushRx(nmeaBurst);
+
+  CGPSInterface gps;
+  gps.bindStream(s);
+  gps.setParser(CGPSInterface::NMEA);
+  gps.initialize();
+  gps.doProcess();
+
+  EXPECT_FALSE(gps.getObservations().empty());
+}

--- a/modules/mrpt_hwdrivers/tests/CGPSInterface_stream_unittest.cpp
+++ b/modules/mrpt_hwdrivers/tests/CGPSInterface_stream_unittest.cpp
@@ -124,6 +124,28 @@ TEST(CGPSInterfaceStream, setupAndShutdownCommandsGoOutOnTheWire)
   EXPECT_NE(s->tx().find("UNLOGALL\r\n"), std::string::npos);
 }
 
+TEST(CGPSInterfaceStream, failedSetupIsRetriedOnTheNextCall)
+{
+  auto s = std::make_shared<MockStream>();
+  CGPSInterface gps;
+  gps.bindStream(s);
+  gps.setSetupCommandsDelay(0);
+  gps.setSetupCommands({"LOG BESTPOSA ONTIME 1"});
+
+  // The link is down for the first attempt. As on the serial-port path, a
+  // stream that cannot be brought up is reported by doProcess() throwing, and
+  // the setup must not be marked as done.
+  s->setWritesThrow(true);
+  gps.initialize();
+  EXPECT_THROW(gps.doProcess(), std::exception);
+  EXPECT_TRUE(s->tx().empty());
+
+  // Once the link recovers, the setup commands are sent after all:
+  s->setWritesThrow(false);
+  gps.doProcess();
+  EXPECT_NE(s->tx().find("LOG BESTPOSA ONTIME 1"), std::string::npos);
+}
+
 TEST(CGPSInterfaceStream, setupCommandsCanSkipTheCRLF)
 {
   auto s = std::make_shared<MockStream>();

--- a/modules/mrpt_hwdrivers/tests/CGenericSensor_unittest.cpp
+++ b/modules/mrpt_hwdrivers/tests/CGenericSensor_unittest.cpp
@@ -1,0 +1,137 @@
+/*                    _
+                     | |    Mobile Robot Programming Toolkit (MRPT)
+ _ __ ___  _ __ _ __ | |_
+| '_ ` _ \| '__| '_ \| __|          https://www.mrpt.org/
+| | | | | | |  | |_) | |_
+|_| |_| |_|_|  | .__/ \__|     https://github.com/MRPT/mrpt/
+               | |
+               |_|
+
+ Copyright (c) 2005-2026, Individual contributors, see AUTHORS file
+ See: https://www.mrpt.org/Authors - All rights reserved.
+ SPDX-License-Identifier: BSD-3-Clause
+*/
+
+#include <gtest/gtest.h>
+#include <mrpt/config/CConfigFileMemory.h>
+#include <mrpt/hwdrivers/CGenericSensor.h>
+#include <mrpt/hwdrivers/registerAllClasses.h>
+
+#include <memory>
+#include <string>
+
+using namespace mrpt::hwdrivers;
+
+TEST(CGenericSensor, factoryKnowsTheRegisteredDrivers)
+{
+  mrpt::hwdrivers::registerAllClasses_mrpt_hwdrivers();
+
+  // A few drivers that are always built, whatever the optional deps:
+  for (const char* name : {"CHokuyoURG", "CGPSInterface", "CSickLaserSerial", "CVelodyneScanner"})
+  {
+    std::unique_ptr<CGenericSensor> s(CGenericSensor::createSensor(name));
+    ASSERT_TRUE(s) << "createSensor failed for: " << name;
+    EXPECT_EQ(std::string(s->GetRuntimeClass()->className), std::string(name));
+  }
+}
+
+TEST(CGenericSensor, factoryReturnsNullForUnknownClasses)
+{
+  EXPECT_EQ(CGenericSensor::createSensor("NoSuchSensorClass"), nullptr);
+  EXPECT_EQ(CGenericSensor::createSensor(""), nullptr);
+}
+
+TEST(CGenericSensor, everyRegisteredClassIsConstructible)
+{
+  mrpt::hwdrivers::registerAllClasses_mrpt_hwdrivers();
+
+  // Every driver registered by registerAllClasses_mrpt_hwdrivers(). They are
+  // all registered whether or not their optional SDK is available, so a few
+  // of them refuse to be built at all in a stripped-down configuration; the
+  // rest must construct *and* destruct cleanly without initialize() having
+  // been called, which is what rawlog-grabber does before configuring them.
+  const char* allClasses[] = {"CSickLaserUSB",    "CIbeoLuxETH",
+                              "CHokuyoURG",       "CRoboPeakLidar",
+                              "CGPSInterface",    "CIMUXSens_MT4",
+                              "CCameraSensor",    "CWirelessPower",
+                              "CRaePID",          "CImpinjRFID",
+                              "CSickLaserSerial", "CEnoseModular",
+                              "CGillAnemometer",  "CNTRIPEmitter",
+                              "CLMS100Eth",       "CPhidgetInterfaceKitProximitySensors",
+                              "CGyroKVHDSP3000",  "CKinect",
+                              "COpenNI2Sensor",   "COpenNI2_RGBD360",
+                              "CCANBusReader",    "CNationalInstrumentsDAQ",
+                              "CGPS_NTRIP",       "CVelodyneScanner",
+                              "CSICKTim561Eth",   "CTaoboticsIMU"};
+
+  size_t nBuilt = 0;
+  for (const char* name : allClasses)
+  {
+    std::unique_ptr<CGenericSensor> s;
+    try
+    {
+      s.reset(CGenericSensor::createSensor(name));
+    }
+    catch (const std::exception&)
+    {
+      // Built without the SDK this driver needs: it says so and refuses.
+      continue;
+    }
+    ASSERT_TRUE(s) << "createSensor failed for registered class: " << name;
+    nBuilt++;
+    EXPECT_EQ(std::string(s->GetRuntimeClass()->className), std::string(name));
+    // A freshly built sensor is idle and holds nothing:
+    EXPECT_TRUE(s->getObservations().empty()) << name;
+    EXPECT_EQ(s->getState(), CGenericSensor::ssInitializing) << name;
+  }
+  EXPECT_GT(nBuilt, 15U);
+}
+
+TEST(CGenericSensor, loadConfigReadsTheCommonParameters)
+{
+  mrpt::hwdrivers::registerAllClasses_mrpt_hwdrivers();
+  std::unique_ptr<CGenericSensor> s(CGenericSensor::createSensor("CGPSInterface"));
+  ASSERT_TRUE(s);
+
+  mrpt::config::CConfigFileMemory cfg;
+  const std::string sec = "SENSOR";
+  cfg.write(sec, "process_rate", 25.0);
+  cfg.write(sec, "max_queue_len", 500);
+  cfg.write(sec, "grab_decimation", 3);
+  cfg.write(sec, "sensorLabel", "my_sensor");
+  // Mandatory for this particular driver:
+#ifdef _WIN32
+  cfg.write(sec, "COM_port_WIN", "COM1");
+#else
+  cfg.write(sec, "COM_port_LIN", "/dev/ttyUSB0");
+#endif
+  cfg.write(sec, "baudRate", 4800);
+
+  s->loadConfig(cfg, sec);
+
+  EXPECT_NEAR(s->getProcessRate(), 25.0, 1e-9);
+  EXPECT_EQ(s->getSensorLabel(), "my_sensor");
+}
+
+TEST(CGenericSensor, sensorLabelRoundTrips)
+{
+  mrpt::hwdrivers::registerAllClasses_mrpt_hwdrivers();
+  std::unique_ptr<CGenericSensor> s(CGenericSensor::createSensor("CHokuyoURG"));
+  ASSERT_TRUE(s);
+
+  s->setSensorLabel("laser_front");
+  EXPECT_EQ(s->getSensorLabel(), "laser_front");
+  EXPECT_EQ(s->getState(), CGenericSensor::ssInitializing);
+}
+
+TEST(CGenericSensor, missingMandatoryEntryThrows)
+{
+  mrpt::hwdrivers::registerAllClasses_mrpt_hwdrivers();
+  std::unique_ptr<CGenericSensor> s(CGenericSensor::createSensor("CGPSInterface"));
+  ASSERT_TRUE(s);
+
+  // No COM port given, which this driver requires:
+  mrpt::config::CConfigFileMemory cfg;
+  cfg.write("SENSOR", "process_rate", 10.0);
+  EXPECT_THROW(s->loadConfig(cfg, "SENSOR"), std::exception);
+}

--- a/modules/mrpt_hwdrivers/tests/CHokuyoURG_unittest.cpp
+++ b/modules/mrpt_hwdrivers/tests/CHokuyoURG_unittest.cpp
@@ -1,0 +1,354 @@
+/*                    _
+                     | |    Mobile Robot Programming Toolkit (MRPT)
+ _ __ ___  _ __ _ __ | |_
+| '_ ` _ \| '__| '_ \| __|          https://www.mrpt.org/
+| | | | | | |  | |_) | |_
+|_| |_| |_|_|  | .__/ \__|     https://github.com/MRPT/mrpt/
+               | |
+               |_|
+
+ Copyright (c) 2005-2026, Individual contributors, see AUTHORS file
+ See: https://www.mrpt.org/Authors - All rights reserved.
+ SPDX-License-Identifier: BSD-3-Clause
+*/
+
+#include <gtest/gtest.h>
+#include <mrpt/config/CConfigFileMemory.h>
+#include <mrpt/hwdrivers/CHokuyoURG.h>
+
+#include <string>
+
+#include "mock_stream.h"
+
+using namespace mrpt::hwdrivers;
+using mrpt::hwdrivers::testing::MockStream;
+
+namespace
+{
+// SCIP2.0 replies are: <command echo><status0><status1><sum><LF>, optionally
+// followed by data lines "<payload><sum><LF>", and closed by a final LF.
+// The driver strips the per-line sum char, so its value is irrelevant here.
+std::string scipReply(const std::string& cmdEcho, const std::string& status = "00")
+{
+  return cmdEcho + status + "P" + "\x0A" + "\x0A";
+}
+
+std::string scipReplyWithData(
+    const std::string& cmdEcho, const std::string& payload, const std::string& status = "00")
+{
+  return cmdEcho + status + "P" + "\x0A" + payload + "P" + "\x0A" + "\x0A";
+}
+
+/** A URG-04LX-like answer to the "PP" (sensor parameters) command, reporting
+ *  the scan window [first,last] out of 1024 steps per 360 deg. */
+std::string sensorParamsPayload(unsigned int first, unsigned int last)
+{
+  char buf[256];
+  ::snprintf(
+      buf, sizeof(buf),
+      "MODL:URG-04LX;DMIN:20;DMAX:5600;ARES:1024;AMIN:%u;AMAX:%u;AFRT:384;SCAN:600;", first, last);
+  return buf;
+}
+
+/** The continuous-scan command the driver issues for a given window. */
+std::string measCommandFor(unsigned int first, unsigned int last, bool intensity = false)
+{
+  char cmd[64];
+  ::snprintf(cmd, sizeof(cmd), "M%c%04u%04u01000\x0A", intensity ? 'E' : 'D', first, last);
+  return cmd;
+}
+
+/** Scripts a mock stream with the whole turnOn() handshake. */
+void scriptTurnOnSession(MockStream& s, unsigned int first, unsigned int last)
+{
+  s.replyTo("SCIP2.0\x0A", scipReply("SCIP2.0\x0A"));
+  s.replyTo("BM\x0A", scipReply("BM\x0A"));
+  s.replyTo("QT\x0A", scipReply("QT\x0A"));
+  s.replyTo("HS0\x0A", scipReply("HS0\x0A"));
+  s.replyTo("HS1\x0A", scipReply("HS1\x0A"));
+  s.replyTo("PP\x0A", scipReplyWithData("PP\x0A", sensorParamsPayload(first, last)));
+  s.replyTo("VV\x0A", scipReplyWithData("VV\x0A", "VEND:Hokuyo;PROD:URG-04LX;FIRM:3.3.00;"));
+
+  for (bool intensity : {false, true})
+  {
+    const std::string cmd = measCommandFor(first, last, intensity);
+    s.replyTo(cmd, scipReply(cmd));
+  }
+}
+
+/** Builds one continuous-mode MD scan reply: a 4-char timestamp followed by
+ *  `nRanges` 3-char encoded ranges, all reading `range_mm`. */
+std::string makeScanReply(
+    const std::string& mdCmd, int nRanges, int range_mm, unsigned int timestamp = 0)
+{
+  std::string payload;
+  payload += static_cast<char>(0x30 + ((timestamp >> 18) & 0x3F));
+  payload += static_cast<char>(0x30 + ((timestamp >> 12) & 0x3F));
+  payload += static_cast<char>(0x30 + ((timestamp >> 6) & 0x3F));
+  payload += static_cast<char>(0x30 + (timestamp & 0x3F));
+
+  for (int i = 0; i < nRanges; i++)
+  {
+    payload += static_cast<char>(0x30 + ((range_mm >> 12) & 0x3F));
+    payload += static_cast<char>(0x30 + ((range_mm >> 6) & 0x3F));
+    payload += static_cast<char>(0x30 + (range_mm & 0x3F));
+  }
+  return scipReplyWithData(mdCmd, payload, "99");
+}
+
+// Scan window kept small so the expected byte counts stay easy to follow.
+constexpr unsigned int FIRST_STEP = 44;
+constexpr unsigned int LAST_STEP = 143;
+constexpr int N_RANGES = static_cast<int>(LAST_STEP - FIRST_STEP + 1);
+}  // namespace
+
+TEST(CHokuyoURG, turnOnRunsTheWholeSCIP20Handshake)
+{
+  auto s = std::make_shared<MockStream>();
+  scriptTurnOnSession(*s, 44, 725);
+
+  CHokuyoURG laser;
+  laser.bindIO(s);
+
+  EXPECT_TRUE(laser.turnOn());
+
+  const std::string& sent = s->tx();
+  EXPECT_NE(sent.find("SCIP2.0\x0A"), std::string::npos);
+  EXPECT_NE(sent.find("BM\x0A"), std::string::npos);
+  EXPECT_NE(sent.find("PP\x0A"), std::string::npos);
+  EXPECT_NE(sent.find("VV\x0A"), std::string::npos);
+  // The scan window must be the one reported by the "PP" reply (AMIN/AMAX):
+  EXPECT_NE(sent.find("MD00440725"), std::string::npos);
+}
+
+TEST(CHokuyoURG, decodeScanOverMockedStream)
+{
+  auto s = std::make_shared<MockStream>();
+  scriptTurnOnSession(*s, FIRST_STEP, LAST_STEP);
+
+  CHokuyoURG laser;
+  laser.bindIO(s);
+  ASSERT_TRUE(laser.turnOn());
+
+  s->pushRx(makeScanReply(measCommandFor(FIRST_STEP, LAST_STEP), N_RANGES, 1234));
+
+  bool thereIs = false;
+  bool hwError = false;
+  mrpt::obs::CObservation2DRangeScan obs;
+  laser.doProcessSimple(thereIs, obs, hwError);
+
+  EXPECT_FALSE(hwError);
+  ASSERT_TRUE(thereIs);
+  ASSERT_EQ(obs.getScanSize(), static_cast<size_t>(N_RANGES));
+  EXPECT_TRUE(obs.rightToLeft);
+  // maxRange comes from the DMAX:5600 field of the "PP" reply:
+  EXPECT_NEAR(obs.maxRange, 5.6f, 1e-4f);
+  for (size_t i = 0; i < obs.getScanSize(); i++)
+  {
+    EXPECT_NEAR(obs.getScanRange(i), 1.234f, 1e-4f) << "at i=" << i;
+    EXPECT_TRUE(obs.getScanRangeValidity(i)) << "at i=" << i;
+  }
+  // aperture = nRanges * 2*pi / ARES
+  EXPECT_NEAR(obs.aperture, N_RANGES * 2 * M_PI / 1024.0, 1e-4);
+}
+
+TEST(CHokuyoURG, truncatedScanIsReportedAsHardwareError)
+{
+  auto s = std::make_shared<MockStream>();
+  scriptTurnOnSession(*s, FIRST_STEP, LAST_STEP);
+
+  CHokuyoURG laser;
+  laser.bindIO(s);
+  ASSERT_TRUE(laser.turnOn());
+
+  // One range short of what the driver asked for:
+  s->pushRx(makeScanReply(measCommandFor(FIRST_STEP, LAST_STEP), N_RANGES - 1, 1000));
+
+  bool thereIs = false;
+  bool hwError = false;
+  mrpt::obs::CObservation2DRangeScan obs;
+  laser.doProcessSimple(thereIs, obs, hwError);
+
+  EXPECT_FALSE(thereIs);
+  EXPECT_TRUE(hwError);
+}
+
+TEST(CHokuyoURG, readingsBelowMinimumRangeAreMarkedInvalid)
+{
+  auto s = std::make_shared<MockStream>();
+  scriptTurnOnSession(*s, FIRST_STEP, LAST_STEP);
+
+  CHokuyoURG laser;
+  laser.bindIO(s);
+  ASSERT_TRUE(laser.turnOn());
+
+  // 10 mm is below the 20 mm the driver treats as the valid minimum:
+  s->pushRx(makeScanReply(measCommandFor(FIRST_STEP, LAST_STEP), N_RANGES, 10));
+
+  bool thereIs = false;
+  bool hwError = false;
+  mrpt::obs::CObservation2DRangeScan obs;
+  laser.doProcessSimple(thereIs, obs, hwError);
+
+  ASSERT_TRUE(thereIs);
+  for (size_t i = 0; i < obs.getScanSize(); i++)
+  {
+    EXPECT_FALSE(obs.getScanRangeValidity(i)) << "at i=" << i;
+  }
+}
+
+TEST(CHokuyoURG, deviceErrorStatusAbortsTurnOn)
+{
+  auto s = std::make_shared<MockStream>();
+  scriptTurnOnSession(*s, 44, 725);
+  // Status "11" is an error reply to the "switch laser on" command:
+  s->replyTo("BM\x0A", scipReply("BM\x0A", "11"));
+
+  CHokuyoURG laser;
+  laser.bindIO(s);
+
+  EXPECT_FALSE(laser.turnOn());
+}
+
+TEST(CHokuyoURG, motorSpeedOutOfRangeAbortsTurnOn)
+{
+  mrpt::config::CConfigFileMemory cfg;
+  const std::string sec = "HOKUYO";
+  cfg.write(sec, "IP_DIR", "192.168.0.10");
+  cfg.write(sec, "PORT_DIR", 10940);
+  // Valid motor speeds are 540..600 rpm:
+  cfg.write(sec, "HOKUYO_motorSpeed_rpm", 300);
+
+  auto s = std::make_shared<MockStream>();
+  scriptTurnOnSession(*s, 44, 725);
+
+  CHokuyoURG laser;
+  laser.loadConfig(cfg, sec);
+  laser.bindIO(s);
+
+  EXPECT_FALSE(laser.turnOn());
+}
+
+TEST(CHokuyoURG, motorSpeedInRangeIsSentToTheDevice)
+{
+  mrpt::config::CConfigFileMemory cfg;
+  const std::string sec = "HOKUYO";
+  cfg.write(sec, "IP_DIR", "192.168.0.10");
+  cfg.write(sec, "PORT_DIR", 10940);
+  cfg.write(sec, "HOKUYO_motorSpeed_rpm", 540);
+
+  auto s = std::make_shared<MockStream>();
+  scriptTurnOnSession(*s, 44, 725);
+  // (600-540)/6 = 10
+  s->replyTo("CR10\x0A", scipReply("CR10\x0A"));
+
+  CHokuyoURG laser;
+  laser.loadConfig(cfg, sec);
+  laser.bindIO(s);
+
+  EXPECT_TRUE(laser.turnOn());
+  EXPECT_NE(s->tx().find("CR10\x0A"), std::string::npos);
+}
+
+TEST(CHokuyoURG, intensityModeAsksForMEScans)
+{
+  auto s = std::make_shared<MockStream>();
+  scriptTurnOnSession(*s, 44, 725);
+
+  CHokuyoURG laser;
+  laser.bindIO(s);
+  EXPECT_TRUE(laser.setIntensityMode(true));
+
+  EXPECT_TRUE(laser.turnOn());
+  // Intensity mode maps to the "ME" command instead of "MD":
+  EXPECT_NE(s->tx().find("ME00440725"), std::string::npos);
+}
+
+TEST(CHokuyoURG, silentDeviceYieldsNoScanAndNoCrash)
+{
+  auto s = std::make_shared<MockStream>();
+  scriptTurnOnSession(*s, FIRST_STEP, LAST_STEP);
+
+  CHokuyoURG laser;
+  laser.bindIO(s);
+  ASSERT_TRUE(laser.turnOn());
+
+  // The device goes quiet:
+  s->setReadsReturnNothing(true);
+
+  bool thereIs = true;
+  bool hwError = false;
+  mrpt::obs::CObservation2DRangeScan obs;
+  laser.doProcessSimple(thereIs, obs, hwError);
+
+  EXPECT_FALSE(thereIs);
+}
+
+TEST(CHokuyoURG, unconfiguredDriverThrows)
+{
+  // Neither bindIO() nor a COM port / IP was given: that is a configuration
+  // error, and is reported as such rather than as a hardware failure.
+  CHokuyoURG laser;
+
+  bool thereIs = true;
+  bool hwError = false;
+  mrpt::obs::CObservation2DRangeScan obs;
+  EXPECT_THROW(laser.doProcessSimple(thereIs, obs, hwError), std::exception);
+}
+
+TEST(CHokuyoURG, loadConfigRejectsAmbiguousConnectionSettings)
+{
+  {
+    // Neither serial port nor IP given:
+    mrpt::config::CConfigFileMemory cfg;
+    cfg.write("HOKUYO", "sensorLabel", "laser1");
+    CHokuyoURG laser;
+    EXPECT_THROW(laser.loadConfig(cfg, "HOKUYO"), std::exception);
+  }
+  {
+    // Both given at once:
+    mrpt::config::CConfigFileMemory cfg;
+    cfg.write("HOKUYO", "COM_port_LIN", "/dev/ttyACM0");
+    cfg.write("HOKUYO", "COM_port_WIN", "COM3");
+    cfg.write("HOKUYO", "IP_DIR", "192.168.0.10");
+    cfg.write("HOKUYO", "PORT_DIR", 10940);
+    CHokuyoURG laser;
+    EXPECT_THROW(laser.loadConfig(cfg, "HOKUYO"), std::exception);
+  }
+  {
+    // Ethernet without a port number:
+    mrpt::config::CConfigFileMemory cfg;
+    cfg.write("HOKUYO", "IP_DIR", "192.168.0.10");
+    cfg.write("HOKUYO", "PORT_DIR", 0);
+    CHokuyoURG laser;
+    EXPECT_THROW(laser.loadConfig(cfg, "HOKUYO"), std::exception);
+  }
+}
+
+TEST(CHokuyoURG, loadConfigReadsSensorSettings)
+{
+  mrpt::config::CConfigFileMemory cfg;
+  const std::string sec = "HOKUYO";
+#ifdef _WIN32
+  cfg.write(sec, "COM_port_WIN", "COM3");
+#else
+  cfg.write(sec, "COM_port_LIN", "/dev/ttyACM0");
+#endif
+  cfg.write(sec, "HOKUYO_motorSpeed_rpm", 600);
+  cfg.write(sec, "pose_x", 0.5);
+  cfg.write(sec, "pose_y", -0.25);
+  cfg.write(sec, "pose_z", 0.1);
+  cfg.write(sec, "pose_yaw", 90.0);
+  cfg.write(sec, "scan_interval", 3);
+  cfg.write(sec, "intensity", true);
+
+  CHokuyoURG laser;
+  laser.loadConfig(cfg, sec);
+
+  EXPECT_EQ(laser.getScanInterval(), 3U);
+#ifdef _WIN32
+  EXPECT_EQ(laser.getSerialPort(), "COM3");
+#else
+  EXPECT_EQ(laser.getSerialPort(), "/dev/ttyACM0");
+#endif
+}

--- a/modules/mrpt_hwdrivers/tests/CHokuyoURG_unittest.cpp
+++ b/modules/mrpt_hwdrivers/tests/CHokuyoURG_unittest.cpp
@@ -16,6 +16,8 @@
 #include <mrpt/config/CConfigFileMemory.h>
 #include <mrpt/hwdrivers/CHokuyoURG.h>
 
+#include <cmath>
+#include <cstdio>
 #include <string>
 
 #include "mock_stream.h"

--- a/modules/mrpt_hwdrivers/tests/CSickLaserSerial_unittest.cpp
+++ b/modules/mrpt_hwdrivers/tests/CSickLaserSerial_unittest.cpp
@@ -1,0 +1,273 @@
+/*                    _
+                     | |    Mobile Robot Programming Toolkit (MRPT)
+ _ __ ___  _ __ _ __ | |_
+| '_ ` _ \| '__| '_ \| __|          https://www.mrpt.org/
+| | | | | | |  | |_) | |_
+|_| |_| |_|_|  | .__/ \__|     https://github.com/MRPT/mrpt/
+               | |
+               |_|
+
+ Copyright (c) 2005-2026, Individual contributors, see AUTHORS file
+ See: https://www.mrpt.org/Authors - All rights reserved.
+ SPDX-License-Identifier: BSD-3-Clause
+*/
+
+#include <gtest/gtest.h>
+#include <mrpt/config/CConfigFileMemory.h>
+#include <mrpt/hwdrivers/CSickLaserSerial.h>
+#include <mrpt/system/crc.h>
+
+#include <string>
+#include <vector>
+
+#include "mock_stream.h"
+
+using namespace mrpt::hwdrivers;
+using mrpt::hwdrivers::testing::MockStream;
+
+namespace
+{
+// Same generator polynomial the driver uses for its frames.
+constexpr uint16_t SICK_CRC16_GEN_POL = 0x8005;
+
+/** Builds a continuous-mode measurement frame (command 0xB0), as the LMS
+ *  sends it:
+ *  | STX | ADDR | L1 | L2 | COM | INF1 | INF2 | DATA | STA | CRC1 | CRC2 |
+ */
+std::string makeScanFrame(
+    const std::vector<int>& ranges, bool mmMode, uint8_t status = 0, bool corruptCRC = false)
+{
+  const int nPoints = static_cast<int>(ranges.size());
+  // INF1/INF2: low 9 bits are the point count, top 2 bits select mm mode.
+  const uint16_t info = static_cast<uint16_t>((nPoints & 0x01FF) | (mmMode ? 0x4000 : 0x0000));
+
+  std::vector<uint8_t> f;
+  f.push_back(0x02);  // STX
+  f.push_back(0x80);  // ADDR
+  f.push_back(0);     // L1 (filled in below)
+  f.push_back(0);     // L2
+  f.push_back(0xB0);  // COM
+  f.push_back(static_cast<uint8_t>(info & 0xFF));
+  f.push_back(static_cast<uint8_t>(info >> 8));
+  for (int r : ranges)
+  {
+    f.push_back(static_cast<uint8_t>(r & 0xFF));
+    f.push_back(static_cast<uint8_t>((r >> 8) & 0xFF));
+  }
+  f.push_back(status);
+
+  // The length field counts everything after the 4-byte header, excluding the
+  // 2 CRC bytes: the driver reads a total frame of (6 + L) bytes.
+  const uint16_t len = static_cast<uint16_t>(f.size() + 2 - 6);
+  f[2] = static_cast<uint8_t>(len & 0xFF);
+  f[3] = static_cast<uint8_t>(len >> 8);
+
+  uint16_t crc = mrpt::system::compute_CRC16(f.data(), f.size(), SICK_CRC16_GEN_POL);
+  if (corruptCRC)
+  {
+    crc = static_cast<uint16_t>(crc + 1);
+  }
+  f.push_back(static_cast<uint8_t>(crc & 0xFF));
+  f.push_back(static_cast<uint8_t>(crc >> 8));
+
+  return {f.begin(), f.end()};
+}
+
+/** A driver already bound to `s` and set to skip the serial-line setup
+ *  handshake, which is what a real port would need but a mock does not. */
+std::shared_ptr<CSickLaserSerial> makeBoundLaser(const std::shared_ptr<MockStream>& s)
+{
+  auto laser = std::make_shared<CSickLaserSerial>();
+  mrpt::config::CConfigFileMemory cfg;
+  // A COM port name is a mandatory config entry even when a stream is bound:
+#ifdef _WIN32
+  cfg.write("SICK", "COM_port_WIN", "COM1");
+#else
+  cfg.write("SICK", "COM_port_LIN", "/dev/null");
+#endif
+  cfg.write("SICK", "skip_laser_config", true);
+  laser->loadConfig(cfg, "SICK");
+  laser->bindIO(s);
+  return laser;
+}
+}  // namespace
+
+TEST(CSickLaserSerial, decodeCentimeterModeScan)
+{
+  auto s = std::make_shared<MockStream>();
+  // 361 points at 250 cm = 2.5 m, the classic LMS200 180 deg / 0.5 deg scan:
+  const std::vector<int> ranges(361, 250);
+  s->pushRx(makeScanFrame(ranges, false));
+
+  auto laser = makeBoundLaser(s);
+
+  bool thereIs = false;
+  bool hwError = false;
+  mrpt::obs::CObservation2DRangeScan obs;
+  laser->doProcessSimple(thereIs, obs, hwError);
+
+  EXPECT_FALSE(hwError);
+  ASSERT_TRUE(thereIs);
+  ASSERT_EQ(obs.getScanSize(), ranges.size());
+  EXPECT_TRUE(obs.rightToLeft);
+  EXPECT_NEAR(obs.aperture, M_PI, 1e-4);
+  // Centimeter mode tops out at 81 m:
+  EXPECT_NEAR(obs.maxRange, 81.0f, 1e-4f);
+  for (size_t i = 0; i < obs.getScanSize(); i++)
+  {
+    EXPECT_NEAR(obs.getScanRange(i), 2.50f, 1e-4f) << "at i=" << i;
+    EXPECT_TRUE(obs.getScanRangeValidity(i)) << "at i=" << i;
+  }
+}
+
+TEST(CSickLaserSerial, decodeMillimeterModeScan)
+{
+  auto s = std::make_shared<MockStream>();
+  // 181 points at 1234 mm:
+  const std::vector<int> ranges(181, 1234);
+  s->pushRx(makeScanFrame(ranges, true));
+
+  auto laser = makeBoundLaser(s);
+
+  bool thereIs = false;
+  bool hwError = false;
+  mrpt::obs::CObservation2DRangeScan obs;
+  laser->doProcessSimple(thereIs, obs, hwError);
+
+  ASSERT_TRUE(thereIs);
+  ASSERT_EQ(obs.getScanSize(), ranges.size());
+  // Millimeter mode tops out at 32.7 m:
+  EXPECT_NEAR(obs.maxRange, 32.7f, 1e-4f);
+  for (size_t i = 0; i < obs.getScanSize(); i++)
+  {
+    EXPECT_NEAR(obs.getScanRange(i), 1.234f, 1e-4f) << "at i=" << i;
+  }
+}
+
+TEST(CSickLaserSerial, outOfRangeReadingsAreMarkedInvalid)
+{
+  auto s = std::make_shared<MockStream>();
+  // 0x1FFF cm = 81.91 m, above the 81 m centimeter-mode maximum:
+  const std::vector<int> ranges(181, 0x1FFF);
+  s->pushRx(makeScanFrame(ranges, false));
+
+  auto laser = makeBoundLaser(s);
+
+  bool thereIs = false;
+  bool hwError = false;
+  mrpt::obs::CObservation2DRangeScan obs;
+  laser->doProcessSimple(thereIs, obs, hwError);
+
+  ASSERT_TRUE(thereIs);
+  for (size_t i = 0; i < obs.getScanSize(); i++)
+  {
+    EXPECT_FALSE(obs.getScanRangeValidity(i)) << "at i=" << i;
+  }
+}
+
+TEST(CSickLaserSerial, badCRCIsRejected)
+{
+  auto s = std::make_shared<MockStream>();
+  const std::vector<int> ranges(181, 500);
+  s->pushRx(makeScanFrame(ranges, false, 0, /*corruptCRC=*/true));
+
+  auto laser = makeBoundLaser(s);
+
+  bool thereIs = false;
+  bool hwError = false;
+  mrpt::obs::CObservation2DRangeScan obs;
+  laser->doProcessSimple(thereIs, obs, hwError);
+
+  EXPECT_FALSE(thereIs);
+}
+
+TEST(CSickLaserSerial, resynchronizesAfterLeadingGarbage)
+{
+  auto s = std::make_shared<MockStream>();
+  const std::vector<int> ranges(181, 300);
+  // Bytes that are not a valid STX/ADDR header must be skipped over:
+  s->pushRx(std::string("\x11\x22\x33\x44", 4) + makeScanFrame(ranges, false));
+
+  auto laser = makeBoundLaser(s);
+
+  bool thereIs = false;
+  bool hwError = false;
+  mrpt::obs::CObservation2DRangeScan obs;
+  laser->doProcessSimple(thereIs, obs, hwError);
+
+  ASSERT_TRUE(thereIs);
+  EXPECT_EQ(obs.getScanSize(), ranges.size());
+  EXPECT_NEAR(obs.getScanRange(0), 3.0f, 1e-4f);
+}
+
+TEST(CSickLaserSerial, silentDeviceYieldsNoScan)
+{
+  auto s = std::make_shared<MockStream>();
+  auto laser = makeBoundLaser(s);
+
+  bool thereIs = true;
+  bool hwError = false;
+  mrpt::obs::CObservation2DRangeScan obs;
+  laser->doProcessSimple(thereIs, obs, hwError);
+
+  EXPECT_FALSE(thereIs);
+}
+
+TEST(CSickLaserSerial, nonMeasurementFramesAreIgnored)
+{
+  auto s = std::make_shared<MockStream>();
+  // A well-formed frame whose command byte is not 0xB0 (measurement):
+  std::string frame = makeScanFrame(std::vector<int>(10, 100), false);
+  frame[4] = static_cast<char>(0xA0);
+  s->pushRx(frame);
+
+  auto laser = makeBoundLaser(s);
+
+  bool thereIs = false;
+  bool hwError = false;
+  mrpt::obs::CObservation2DRangeScan obs;
+  laser->doProcessSimple(thereIs, obs, hwError);
+
+  EXPECT_FALSE(thereIs);
+}
+
+TEST(CSickLaserSerial, unboundDriverWithoutAPortThrows)
+{
+  CSickLaserSerial laser;
+
+  bool thereIs = false;
+  bool hwError = false;
+  mrpt::obs::CObservation2DRangeScan obs;
+  // No bindIO() and no setSerialPort(): reported as a hardware error.
+  laser.doProcessSimple(thereIs, obs, hwError);
+
+  EXPECT_FALSE(thereIs);
+  EXPECT_TRUE(hwError);
+}
+
+TEST(CSickLaserSerial, loadConfigReadsSensorSettings)
+{
+  mrpt::config::CConfigFileMemory cfg;
+  const std::string sec = "SICK";
+#ifdef _WIN32
+  cfg.write(sec, "COM_port_WIN", "COM5");
+#else
+  cfg.write(sec, "COM_port_LIN", "/dev/ttyS0");
+#endif
+  cfg.write(sec, "COM_baudRate", 38400);
+  cfg.write(sec, "mm_mode", true);
+  cfg.write(sec, "FOV", 180);
+  cfg.write(sec, "resolution", 50);
+  cfg.write(sec, "pose_x", 0.1);
+  cfg.write(sec, "pose_y", 0.2);
+  cfg.write(sec, "pose_z", 0.3);
+
+  CSickLaserSerial laser;
+  EXPECT_NO_THROW(laser.loadConfig(cfg, sec));
+
+  // The COM port name is mandatory:
+  mrpt::config::CConfigFileMemory bad;
+  bad.write(sec, "COM_baudRate", 38400);
+  CSickLaserSerial laser2;
+  EXPECT_THROW(laser2.loadConfig(bad, sec), std::exception);
+}

--- a/modules/mrpt_hwdrivers/tests/CSickLaserSerial_unittest.cpp
+++ b/modules/mrpt_hwdrivers/tests/CSickLaserSerial_unittest.cpp
@@ -35,18 +35,22 @@ constexpr uint16_t SICK_CRC16_GEN_POL = 0x8005;
  *  | STX | ADDR | L1 | L2 | COM | INF1 | INF2 | DATA | STA | CRC1 | CRC2 |
  */
 std::string makeScanFrame(
-    const std::vector<int>& ranges, bool mmMode, uint8_t status = 0, bool corruptCRC = false)
+    const std::vector<int>& ranges,
+    bool mmMode,
+    uint8_t status = 0,
+    bool corruptCRC = false,
+    uint8_t commandByte = 0xB0)
 {
   const int nPoints = static_cast<int>(ranges.size());
   // INF1/INF2: low 9 bits are the point count, top 2 bits select mm mode.
   const uint16_t info = static_cast<uint16_t>((nPoints & 0x01FF) | (mmMode ? 0x4000 : 0x0000));
 
   std::vector<uint8_t> f;
-  f.push_back(0x02);  // STX
-  f.push_back(0x80);  // ADDR
-  f.push_back(0);     // L1 (filled in below)
-  f.push_back(0);     // L2
-  f.push_back(0xB0);  // COM
+  f.push_back(0x02);         // STX
+  f.push_back(0x80);         // ADDR
+  f.push_back(0);            // L1 (filled in below)
+  f.push_back(0);            // L2
+  f.push_back(commandByte);  // COM
   f.push_back(static_cast<uint8_t>(info & 0xFF));
   f.push_back(static_cast<uint8_t>(info >> 8));
   for (int r : ranges)
@@ -216,10 +220,13 @@ TEST(CSickLaserSerial, silentDeviceYieldsNoScan)
 TEST(CSickLaserSerial, nonMeasurementFramesAreIgnored)
 {
   auto s = std::make_shared<MockStream>();
-  // A well-formed frame whose command byte is not 0xB0 (measurement):
-  std::string frame = makeScanFrame(std::vector<int>(10, 100), false);
-  frame[4] = static_cast<char>(0xA0);
-  s->pushRx(frame);
+  // A well-formed frame, CRC included, whose command byte is not the 0xB0 of a
+  // measurement reply. The command byte has to be set before the CRC is
+  // computed, or the driver rejects the frame at the CRC check instead and
+  // never reaches the dispatch this test is about.
+  s->pushRx(makeScanFrame(
+      std::vector<int>(10, 100), false, /*status=*/0, /*corruptCRC=*/false,
+      /*commandByte=*/0xA0));
 
   auto laser = makeBoundLaser(s);
 

--- a/modules/mrpt_hwdrivers/tests/CVelodyneScanner_unittest.cpp
+++ b/modules/mrpt_hwdrivers/tests/CVelodyneScanner_unittest.cpp
@@ -22,6 +22,7 @@ using namespace mrpt::hwdrivers;
 using namespace std;
 
 #include <mrpt/hwdrivers/config.h>
+#include <mrpt/obs/config.h>  // MRPT_HAS_TINYXML2
 #if MRPT_HAS_LIBPCAP && MRPT_HAS_TINYXML2
 
 TEST(CVelodyneScanner, sample_vlp16_dataset)

--- a/modules/mrpt_hwdrivers/tests/mock_stream.h
+++ b/modules/mrpt_hwdrivers/tests/mock_stream.h
@@ -1,0 +1,112 @@
+/*                    _
+                     | |    Mobile Robot Programming Toolkit (MRPT)
+ _ __ ___  _ __ _ __ | |_
+| '_ ` _ \| '__| '_ \| __|          https://www.mrpt.org/
+| | | | | | |  | |_) | |_
+|_| |_| |_|_|  | .__/ \__|     https://github.com/MRPT/mrpt/
+               | |
+               |_|
+
+ Copyright (c) 2005-2026, Individual contributors, see AUTHORS file
+ See: https://www.mrpt.org/Authors - All rights reserved.
+ SPDX-License-Identifier: BSD-3-Clause
+*/
+#pragma once
+
+#include <mrpt/core/exceptions.h>
+#include <mrpt/io/CStream.h>
+
+#include <algorithm>
+#include <cstring>
+#include <map>
+#include <string>
+
+namespace mrpt::hwdrivers::testing
+{
+/** A CStream standing in for a serial port or a socket, so that sensor drivers
+ *  can be exercised without any hardware attached.
+ *
+ *  Two ways to feed the driver:
+ *   - pushRx(): queue bytes to be returned by the next Read() calls.
+ *   - replyTo(): register a canned answer that is queued as soon as the driver
+ *     writes that exact command, which is what request/response protocols need.
+ *
+ *  Everything the driver writes is kept in tx() for assertions.
+ */
+class MockStream : public mrpt::io::CStream
+{
+ public:
+  MockStream() = default;
+
+  /** Queue bytes for the driver to read. */
+  void pushRx(const std::string& data) { m_rx += data; }
+
+  /** Queue `reply` as soon as the driver writes exactly `cmd`. */
+  void replyTo(const std::string& cmd, const std::string& reply) { m_replies[cmd] = reply; }
+
+  /** All the bytes written by the driver so far. */
+  const std::string& tx() const { return m_tx; }
+
+  void clearTx() { m_tx.clear(); }
+
+  /** Pending bytes not yet read by the driver. */
+  size_t pendingRx() const { return m_rx.size() - m_rxPos; }
+
+  /** Make the next Read() return 0 bytes, to exercise timeout paths. */
+  void setReadsReturnNothing(bool b) { m_readsReturnNothing = b; }
+
+  /** Make Write() throw, to exercise I/O error paths. */
+  void setWritesThrow(bool b) { m_writesThrow = b; }
+
+  size_t Read(void* Buffer, size_t Count) override
+  {
+    if (m_readsReturnNothing)
+    {
+      return 0;
+    }
+
+    const size_t avail = m_rx.size() - m_rxPos;
+    const size_t n = std::min(Count, avail);
+    if (n > 0)
+    {
+      std::memcpy(Buffer, &m_rx[m_rxPos], n);
+    }
+    m_rxPos += n;
+    return n;
+  }
+
+  size_t Write(const void* Buffer, size_t Count) override
+  {
+    if (m_writesThrow)
+    {
+      THROW_EXCEPTION("MockStream: simulated write error");
+    }
+
+    const std::string chunk(static_cast<const char*>(Buffer), Count);
+    m_tx += chunk;
+
+    if (auto it = m_replies.find(chunk); it != m_replies.end())
+    {
+      m_rx += it->second;
+    }
+
+    return Count;
+  }
+
+  uint64_t Seek(int64_t /*Offset*/, CStream::TSeekOrigin /*Origin*/ = sFromBeginning) override
+  {
+    return 0;
+  }
+  uint64_t getTotalBytesCount() const override { return m_rx.size(); }
+  uint64_t getPosition() const override { return m_rxPos; }
+
+ private:
+  std::string m_rx;
+  std::string m_tx;
+  size_t m_rxPos = 0;
+  bool m_readsReturnNothing = false;
+  bool m_writesThrow = false;
+  std::map<std::string, std::string> m_replies;
+};
+
+}  // namespace mrpt::hwdrivers::testing


### PR DESCRIPTION
Coverage pass on `mrpt_hwdrivers`, the worst-covered non-empty module.

**13.9% -> 29.0% lines, 9.7% -> 20.5% branches** (whole-repo measurement, comparable to the agents.md table). Repo overall 79.8% -> 80.9%. All 82 test binaries pass.

## Approach

`modules/mrpt_hwdrivers/tests/mock_stream.h` is the lever: a `CStream` that records everything a driver writes and replays scripted answers keyed on the command received, which is what request/response sensor protocols need. Any driver reachable through `C2DRangeFinderAbstract::bindIO()` or `CGPSInterface::bindStream()` becomes testable with it.

| file | before | after |
|---|---|---|
| `C2DRangeFinderAbstract.cpp` | 0% | 99% |
| `CGenericSensor.cpp` | 65% | 96% |
| `CHokuyoURG.cpp` | 0% | 62% |
| `CGPSInterface.cpp` | 19% | 47% |
| `CVelodyneScanner.cpp` | 0% | 40% |
| `CSickLaserSerial.cpp` | 0% | 33% |

## The Velodyne pcap support was dead code, not untested code

It took four independent fixes to revive, and had been compiling to nothing on **every** platform, sample `.pcap` datasets and all:

- no `FindPCAP.cmake` existed in the repo, so `find_package(PCAP)` always failed;
- `MRPT_HAS_LIBPCAP` was never emitted into hwdrivers' `config.h`;
- `CVelodyneScanner.cpp` never included that `config.h`, so the guard read an undefined macro;
- the unit test guarded on `MRPT_HAS_TINYXML2` without including `mrpt/obs/config.h`, where that macro lives.

## Seven defects found by the new tests, five of them crashes

**Four destructors abort the process** when a sensor is created by the factory and destroyed before `initialize()` — precisely what `rawlog-grabber` does between `createSensor()` and configuring it, so any config error in between took the process down:

- `~CIbeoLuxETH()` joined a never-started thread (a `std::system_error` escaping a destructor calls `std::terminate()`);
- `~CRoboPeakLidar()` called a `turnOff()` that throws when built without the RPLidar SDK;
- `~CImpinjRFID()` wrote to a null client socket;
- `~CGyroKVHDSP3000()` closed a null serial port.

`CGenericSensor_unittest.cpp` now walks every registered driver to keep that path honest.

Plus:

- `C2DRangeFinderAbstract::getObservation()` could never return anything: `m_lastObservation`, `m_lastObservationIsNew` and `m_hardwareError` were read but written nowhere in the class.
- `CHokuyoURG::parseResponse()` validated the device status code only on replies carrying data, so an error answer to a status-only command (`BM`, `QT`, `CR`, ...) counted as success.
- `CGPSInterface::OnConnectionShutdown()`, called from the destructor, dereferenced a null stream when shutdown commands were configured but nothing was ever opened.
- `CGPSInterface` setup commands were sent only from the serial-open path, so with an externally bound stream they were silently dropped while the matching shutdown commands were still sent.

## One refactor

`CSickLaserSerial` advertised `bindIO()`, but its frame reader, ACK waiter and command sender each `dynamic_cast`ed to `CSerialPort` and asserted on it, so any other bound stream aborted on the first read. Those four functions only ever call `Read()`/`Write()`, so they now go through the bound stream; `open`/`setConfig`/`purgeBuffers` are genuinely serial-specific and were left alone.

## Note for reviewers

Several `MRPT_HAS_*` macros that hwdrivers sources still guard on are **never defined anywhere** in the 3.x build (`MRPT_HAS_OPENCV`, `MRPT_HAS_LIBDC1394_2`, `MRPT_HAS_ROBOPEAK_LIDAR`, `MRPT_HAS_NIDAQMX*`, `MRPT_HAS_PGR_FLYCAPTURE2`, `MRPT_HAS_KINECT_CL_NUI`), so those paths are unconditionally compiled out. I deliberately did **not** enable them here: adding the `MRPT_HAS_LIBDC1394_2` define was tried and `CImageGrabber_dc1394.cpp` no longer compiles against current `mrpt::img` (6 errors), having rotted for as long as the macro was missing. This is documented in agents.md rather than half-fixed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014Mjmvqb883MdKyobSADXvJ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for replaying Velodyne captures from PCAP files when libpcap is available.
  - Expanded SICK laser communication to support generic streams, including non-serial connections.

- **Bug Fixes**
  - Improved hardware-driver stability during initialization, shutdown, and error handling.
  - Fixed GPS setup commands for externally connected streams.
  - Improved validation of Hokuyo URG responses and range-finder observation handling.
  - Prevented crashes when drivers are destroyed before successful initialization.

- **Tests**
  - Added broader automated coverage for GPS, lidar, laser, range-finder, and generic sensor behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->