### PR TITLE
mrpt_nav: modernize the PTG/reactive API and fix 7 TP-Space bugs

### DIFF
--- a/agents.md
+++ b/agents.md
@@ -1298,3 +1298,72 @@ command sender each `dynamic_cast`ed to `CSerialPort` and asserted on it, so
 any other stream aborted on the first read. Those four functions only ever call
 `Read()`/`Write()`, so they now use the bound stream; `open`/`setConfig`/
 `purgeBuffers` are genuinely serial-specific and were left alone.
+
+## 11. mrpt_nav API modernization + TP-Space math fixes (2026-09-08)
+
+An API/mathematics pass over `mrpt_nav`, separate from the coverage pass of ¶.
+Nothing here is a coverage-driven change; the test count went 246 -> 251.
+
+**Out-param APIs replaced by `std::optional`** (old signature kept as a
+`[[deprecated]]` inline shim unless noted), matching what `inverseMap_WS2TP()`
+already did:
+
+* `CParameterizedTrajectoryGenerator::getPathStepForDist(k, dist)`. The old
+  3-arg form also wrote the *last* path step into `out_step` when it returned
+  false, and two call sites silently relied on that; the explicit
+  `getPathStepForDistClamped()` now covers it.
+* `nav_plan_geometry_utils`: `collision_free_dist_{segment,arc}_circ_robot()`.
+* `PlannerSimple2D::computePath()`.
+
+**Other API changes**: `ClearanceDiagram::getClearance()`'s `bool
+integrate_over_path` became `enum class ClearanceQuery` (see below);
+`CPTG_Holo_Blend::PATH_TIME_STEP` (a mutable global) became the per-instance
+`path_time_step` config key + `setPathTimeStep()`, and `eps` became
+`EPSILON`, both no-shim breaks; `setScorePriorty()` -> `setScorePriority()`;
+`updateClearancePost()` (a documented no-op since 2017) and
+`CAbstractHolonomicReactiveMethod::Create()` (declared in the header but
+**never defined anywhere** -- calling it was a link error) were deleted.
+
+**Real bugs fixed** -- each has a regression test that fails without the fix:
+
+1. `ClearanceDiagram::getClearance()`'s two modes were **swapped** relative to
+   its own docs, to every call site's comment, and to the ptg-configurator's
+   UI label; `bool=false` averaged over the path and `bool=true` returned the
+   spot value. The reactive navigator's `clearance` / `clearance_path` score
+   factors were therefore each other's values (only visible with
+   `evaluate_clearance=true`, off by default).
+2. `initClearanceDiagram()` keyed the clearance samples by the raw path
+   distance **in meters** while every consumer treats those keys as normalized
+   [0,1] TPS distances (`getClearance()` queries, the `dist_over_path > 0.5`
+   collision heuristic, and `CAbstractPTGBasedReactive`'s own
+   `dist_eucl_min` producer, which builds the same map keyed `i/num_steps`).
+3. Same function sampled steps `0, incr, 2*incr...` while
+   `evalClearanceSingleObstacle()` evaluates `incr, 2*incr, ...`, so every
+   clearance value was filed under a distance shorter than the one it was
+   measured at. Both loops now use the same steps.
+4. `CHolonomicVFF::navigate()` assigned `desiredSpeed` **inside**
+   `if (m_enableApproachTargetSlowDown)`, so with the slow-down disabled it
+   returned speed 0 and the robot never moved. ND/FullEval had it right.
+5. `CHolonomicFullEval` used `ni.targets.front()` for the approach slow-down;
+   `NavInput` documents the *last* target as the highest-priority one.
+6. `CPTG_Holo_Blend` used `V_MAX` for the post-ramp cruise speed in
+   `getPathDist()`, `getPathStepForDist()` and `updateTPObstacleSingle()`,
+   but `getPathPose()` advances at the direction-dependent
+   `internal_get_v(dir)`. With an `expr_V` set, poses and distances disagreed.
+   `inverseMap_WS2TP()` likewise pinned `T_ramp = T_ramp_max` instead of
+   `internal_get_T_ramp(alpha)`; it is now re-evaluated per Newton iteration
+   (the Jacobian ignores dT/dalpha, which only costs iterations, not accuracy,
+   since the residual is exact).
+7. `collision_free_dist_arc_circ_robot()`'s closed form divided by `o.x`, so
+   **any** obstacle on the turn-center axis returned NaN. Rewritten as a
+   two-circle intersection: agrees with the old formula to 1.7e-11 over 21k
+   random collision cases, and it now returns 0 when the robot starts already
+   in collision instead of the *exit* distance.
+
+**Math model**: `calc_trans_distance_t_below_Tramp_abc_numeric()` went from a
+15-interval trapezoidal rule to 16-interval Simpson (same number of function
+evaluations, ~25x lower mean relative error), plus an exact branch for the
+degenerate `b^2-4ac ~= 0` case where the integrand is `sqrt(a)*|t-r|`.
+
+New console example `mrpt_examples_cpp/nav_ptg_tpspace` walks the whole
+WS -> TP-Space -> velocity-command round trip headlessly.

--- a/agents.md
+++ b/agents.md
@@ -1354,7 +1354,14 @@ integrate_over_path` became `enum class ClearanceQuery` (see below);
    `internal_get_T_ramp(alpha)`; it is now re-evaluated per Newton iteration
    (the Jacobian ignores dT/dalpha, which only costs iterations, not accuracy,
    since the residual is exact).
-7. `collision_free_dist_arc_circ_robot()`'s closed form divided by `o.x`, so
+7. `CAbstractPTGBasedReactive::calc_move_candidate_scores()` fed the
+   *normalized* collision-free distance to `getPathStepForDist()`, which takes
+   pseudometers (the ETA factor 300 lines below does `d * ref_dist` for the
+   very same call). The "end of trajectory" behind `robpose_*`,
+   `dist_eucl_final` and the target slow-down check was therefore read
+   `ref_distance` times too early along the path -- 0.74 m instead of 4 m in
+   the regression test.
+8. `collision_free_dist_arc_circ_robot()`'s closed form divided by `o.x`, so
    **any** obstacle on the turn-center axis returned NaN. Rewritten as a
    two-circle intersection: agrees with the old formula to 1.7e-11 over 21k
    random collision cases, and it now returns 0 when the robot starts already
@@ -1364,6 +1371,10 @@ integrate_over_path` became `enum class ClearanceQuery` (see below);
 15-interval trapezoidal rule to 16-interval Simpson (same number of function
 evaluations, ~25x lower mean relative error), plus an exact branch for the
 degenerate `b^2-4ac ~= 0` case where the integrand is `sqrt(a)*|t-r|`.
+
+`CPTG_Holo_Blend::m_pathStepCountCache` is expressed in path time steps, so
+every write to `m_pathTimeStep` now goes through `setPathTimeStep()`, which
+clears it and rejects non-finite/non-positive values (including from a stream).
 
 New console example `mrpt_examples_cpp/nav_ptg_tpspace` walks the whole
 WS -> TP-Space -> velocity-command round trip headlessly.

--- a/apps/mrpt_apps_gui/ReactiveNavigationDemo/reactive_navigator_demoMain.cpp
+++ b/apps/mrpt_apps_gui/ReactiveNavigationDemo/reactive_navigator_demoMain.cpp
@@ -1464,9 +1464,9 @@ void reactive_navigator_demoframe::simulateOneStep(double time_step)
           double min_shape_dists = 1.0;
           for (double d = min_shape_dists; d < max_dist; d += min_shape_dists)
           {
-            uint32_t step = 0;
-            if (!ptg->getPathStepForDist(static_cast<uint16_t>(selected_k), d, step)) continue;
-            const auto p = ptg->getPathPose(static_cast<uint16_t>(selected_k), step);
+            const auto step = ptg->getPathStepForDist(static_cast<uint16_t>(selected_k), d);
+            if (!step) continue;
+            const auto p = ptg->getPathPose(static_cast<uint16_t>(selected_k), *step);
             ptg->add_robotShape_to_setOfLines(*gl_robot_ptg_prediction, mrpt::poses::CPose2D(p));
           }
         }

--- a/apps/mrpt_apps_gui/navlog-viewer/navlog-viewer-ui.cpp
+++ b/apps/mrpt_apps_gui/navlog-viewer/navlog-viewer-ui.cpp
@@ -856,9 +856,9 @@ void NavlogViewerApp::updateVisualization()
 
             for (double d = min_shape_dists; d < max_dist; d += min_shape_dists)
             {
-              uint32_t step;
-              if (!ptg->getPathStepForDist(selected_k, d, step)) continue;
-              const auto p = ptg->getPathPose(selected_k, step);
+              const auto step = ptg->getPathStepForDist(selected_k, d);
+              if (!step) continue;
+              const auto p = ptg->getPathPose(selected_k, *step);
               ptg->add_robotShape_to_setOfLines(*gl_path, mrpt::poses::CPose2D(p));
             }
           }
@@ -967,9 +967,9 @@ void NavlogViewerApp::updateVisualization()
 
             for (double d = min_shape_dists; d < max_dist; d += min_shape_dists)
             {
-              uint32_t step;
-              if (!ptg->getPathStepForDist(selected_k, d, step)) continue;
-              const auto p = ptg->getPathPose(selected_k, step);
+              const auto step = ptg->getPathStepForDist(selected_k, d);
+              if (!step) continue;
+              const auto p = ptg->getPathPose(selected_k, *step);
               ptg->add_robotShape_to_setOfLines(*gl_path, mrpt::poses::CPose2D(p));
             }
           }

--- a/apps/mrpt_apps_gui/ptg-configurator/ptgConfiguratorMain.cpp
+++ b/apps/mrpt_apps_gui/ptg-configurator/ptgConfiguratorMain.cpp
@@ -913,15 +913,16 @@ void ptgConfiguratorframe::rebuild3Dview()
         {
           timer.Tic();
           ptg->updateClearance(ox, oy, cd);
-          ptg->updateClearancePost(cd, TP_Obstacles);
           tim_build_cd = timer.Tac();
         }
 
         timer.Tic();
         cd.renderAs3DObject(
-            *gl_TPSpace_clearance, -1.0, 1.0, -1.0, 1.0, 0.05, false /*interpolate*/);
+            *gl_TPSpace_clearance, -1.0, 1.0, -1.0, 1.0, 0.05,
+            mrpt::nav::ClearanceQuery::AtDistance);
         cd.renderAs3DObject(
-            *gl_TPSpace_clearance_interp, -1.0, 1.0, -1.0, 1.0, 0.05, true /*interpolate*/);
+            *gl_TPSpace_clearance_interp, -1.0, 1.0, -1.0, 1.0, 0.05,
+            mrpt::nav::ClearanceQuery::MeanUpToDistance);
         const double tim_render_cd = timer.Tac();
 
         StatusBar1->SetStatusText(
@@ -992,9 +993,9 @@ void ptgConfiguratorframe::rebuild3Dview()
             d = 0;
             done = true;
           }
-          uint32_t step;
-          if (!ptg->getPathStepForDist(static_cast<uint16_t>(k), d, step)) continue;
-          const auto p = ptg->getPathPose(static_cast<uint16_t>(k), step);
+          const auto step = ptg->getPathStepForDist(static_cast<uint16_t>(k), d);
+          if (!step) continue;
+          const auto p = ptg->getPathPose(static_cast<uint16_t>(k), *step);
           ptg->add_robotShape_to_setOfLines(sol, mrpt::poses::CPose2D(p));
         }
       }
@@ -1131,11 +1132,11 @@ void ptgConfiguratorframe::rebuild3Dview()
           1);
 
       // Sanity check: reproject TP_target back to WS:
-      uint32_t check_step;
-      if (ptg->getPathStepForDist(
-              static_cast<uint16_t>(k), norm_d * ptg->getRefDistance(), check_step))
+      if (const auto check_step =
+              ptg->getPathStepForDist(static_cast<uint16_t>(k), norm_d * ptg->getRefDistance());
+          check_step)
       {
-        gl_WS_target_reprojected->setPose(ptg->getPathPose(static_cast<uint16_t>(k), check_step));
+        gl_WS_target_reprojected->setPose(ptg->getPathPose(static_cast<uint16_t>(k), *check_step));
         gl_WS_target_reprojected->setName("WS-Target-reproj");
       }
       else

--- a/modules/mrpt_nav/include/mrpt/nav/holonomic/CAbstractHolonomicReactiveMethod.h
+++ b/modules/mrpt_nav/include/mrpt/nav/holonomic/CAbstractHolonomicReactiveMethod.h
@@ -83,7 +83,11 @@ class CAbstractHolonomicReactiveMethod : public mrpt::serialization::CSerializab
     CHolonomicLogFileRecord::Ptr logRecord;
   };
 
-  static CAbstractHolonomicReactiveMethod::Ptr Factory(const std::string& className) noexcept;
+  /** Class factory from class name, e.g. `"CHolonomicVFF"`.
+   * \return nullptr if the class name is unknown or is not a holonomic
+   * method. */
+  [[nodiscard]] static CAbstractHolonomicReactiveMethod::Ptr Factory(
+      const std::string& className) noexcept;
 
   /** Invokes the holonomic navigation algorithm itself. See the description
    * of the input/output structures for details on each parameter. */
@@ -111,10 +115,6 @@ class CAbstractHolonomicReactiveMethod : public mrpt::serialization::CSerializab
   /** Sets the actual value of this parameter [m]. \sa
    * getTargetApproachSlowDownDistance() */
   virtual void setTargetApproachSlowDownDistance(const double dist) = 0;
-
-  /** Class factory from class name, e.g. `"CHolonomicVFF"`, etc.
-   * \exception std::logic_error On invalid or missing parameters. */
-  static CAbstractHolonomicReactiveMethod* Create(const std::string& className) noexcept;
 
   /** Optionally, sets the associated PTG, just in case a derived class
    * requires this info (not required for methods where the robot kinematics

--- a/modules/mrpt_nav/include/mrpt/nav/holonomic/ClearanceDiagram.h
+++ b/modules/mrpt_nav/include/mrpt/nav/holonomic/ClearanceDiagram.h
@@ -22,7 +22,27 @@
 
 namespace mrpt::nav
 {
+/** How ClearanceDiagram::getClearance() condenses the samples stored along one
+ *  path into a single number.
+ *  \ingroup nav_tpspace
+ */
+enum class ClearanceQuery : uint8_t
+{
+  /** Clearance of the sampled robot pose that covers the query distance. */
+  AtDistance = 0,
+  /** Mean clearance of all sampled poses from the path origin up to the
+   * query distance. */
+  MeanUpToDistance
+};
+
 /** Clearance information for one particular PTG and one set of obstacles.
+ *
+ * For each of a decimated subset of the PTG paths, it holds the normalized
+ * clearance (distance from the robot shape to the closest obstacle, divided by
+ * the PTG reference distance) at a handful of poses sampled along that path.
+ * Both the map keys (TP-Space distances) and the values (clearances) are
+ * normalized to [0,1] w.r.t. the PTG reference distance.
+ *
  * Usage:
  * - Declare an object of this type (it will be initialized to "empty"),
  * - Call CParameterizedTrajectoryGenerator::initClearanceDiagram()
@@ -46,13 +66,27 @@ class ClearanceDiagram
   size_t get_actual_num_paths() const { return m_actual_num_paths; }
   size_t get_decimated_num_paths() const { return m_raw_clearances.size(); }
 
-  /** Gets the clearance for path `k` and distance `TPS_query_distance` in one
-   * of two modes:
-   * - [integrate_over_path=false] clearance from that specific spot, or
-   * - [integrate_over_path=true] average clearance over the path from the
-   * origin to that specific spot.
+  /** Gets the normalized clearance for path `k` at the normalized TP-Space
+   * distance `TPS_query_distance`, condensed as per `mode`.
+   *
+   * Only the samples up to and including the first one at or past the query
+   * distance take part in the result. Returns 0 for an empty diagram.
    */
-  double getClearance(uint16_t k, double TPS_query_distance, bool integrate_over_path) const;
+  [[nodiscard]] double getClearance(
+      uint16_t k, double TPS_query_distance, ClearanceQuery mode) const;
+
+  /** \deprecated Use the ClearanceQuery overload. Note that the `bool` flag
+   * used to select the opposite mode to the one it is named after. */
+  [[deprecated(
+      "Use the ClearanceQuery overload: the bool flag selected the mode opposite to its "
+      "own documentation")]] [[nodiscard]] double
+  getClearance(uint16_t k, double TPS_query_distance, bool integrate_over_path) const
+  {
+    return getClearance(
+        k, TPS_query_distance,
+        integrate_over_path ? ClearanceQuery::MeanUpToDistance : ClearanceQuery::AtDistance);
+  }
+
   void renderAs3DObject(
       mrpt::viz::CMesh& mesh,
       double min_x,
@@ -60,12 +94,13 @@ class ClearanceDiagram
       double min_y,
       double max_y,
       double cell_res,
-      bool integrate_over_path) const;
+      ClearanceQuery mode) const;
 
   void readFromStream(mrpt::serialization::CArchive& in);
   void writeToStream(mrpt::serialization::CArchive& out) const;
 
-  /** [TPS_distance] => normalized_clearance_for_exactly_that_robot_pose  */
+  /** [normalized TPS distance in [0,1]] =>
+   * normalized_clearance_for_exactly_that_robot_pose  */
   using dist2clearance_t = std::map<double, double>;
   dist2clearance_t& get_path_clearance(size_t actual_k);
   const dist2clearance_t& get_path_clearance(size_t actual_k) const;

--- a/modules/mrpt_nav/include/mrpt/nav/planners/PlannerSimple2D.h
+++ b/modules/mrpt_nav/include/mrpt/nav/planners/PlannerSimple2D.h
@@ -17,6 +17,9 @@
 #include <mrpt/math/TPoint2D.h>
 #include <mrpt/poses/CPose2D.h>
 
+#include <deque>
+#include <optional>
+
 namespace mrpt::nav
 {
 /** \addtogroup nav_planners Path planning
@@ -55,36 +58,42 @@ class PlannerSimple2D
    */
   float robotRadius{0.35f};
 
-  /** This method compute the optimal path for a circular robot, in the given
-   *   occupancy grid map, from the origin location to a target point.
-   * The options and additional parameters to this method can be set with
-   *   member configuration variables.
+  /** Computes the optimal path for a circular robot, in the given occupancy
+   * grid map, from the origin location to a target point. Additional
+   * parameters are the public member variables of this class.
    *
-   * \param theMap	[IN] The occupancy gridmap used to the planning.
-   * \param origin	[IN] The starting pose of the robot, in coordinates of
-   * "map".
-   * \param target	[IN] The desired target pose for the robot, in
-   * coordinates of "map".
-   * \param path		[OUT] The found path, in global coordinates relative
-   * to "map".
-   * \param notFount	[OUT] Will be true if no path has been found.
-   * \param maxSearchPathLength [IN] The maximum path length to search for,
-   * in meters (-1 = no limit)
+   * \param theMap The occupancy gridmap used for the planning.
+   * \param origin The starting pose of the robot, in "map" coordinates.
+   * \param target The desired target pose, in "map" coordinates.
+   * \param maxSearchPathLength The maximum path length to search for, in
+   * meters (-1 = no limit)
+   *
+   * \return The found path, in global coordinates relative to "map", or
+   * std::nullopt if no path exists (which includes either endpoint falling
+   * outside the gridmap).
    *
    * \sa robotRadius
-   *
-   * \note If either the origin or the target are out of the gridmap
-   * extensions, `notFound` will be returned as `true`.
-   *
    * \exception std::exception On any error
    */
-  void computePath(
+  [[nodiscard]] std::optional<std::deque<mrpt::math::TPoint2D>> computePath(
+      const mrpt::maps::COccupancyGridMap2D& theMap,
+      const mrpt::poses::CPose2D& origin,
+      const mrpt::poses::CPose2D& target,
+      float maxSearchPathLength = -1) const;
+
+  /** \deprecated Use the std::optional-returning overload. */
+  [[deprecated("Use the std::optional-returning computePath()")]] void computePath(
       const mrpt::maps::COccupancyGridMap2D& theMap,
       const mrpt::poses::CPose2D& origin,
       const mrpt::poses::CPose2D& target,
       std::deque<mrpt::math::TPoint2D>& path,
       bool& notFound,
-      float maxSearchPathLength = -1) const;
+      float maxSearchPathLength = -1) const
+  {
+    auto res = computePath(theMap, origin, target, maxSearchPathLength);
+    notFound = !res.has_value();
+    path = notFound ? std::deque<mrpt::math::TPoint2D>() : std::move(*res);
+  }
 };
 
 /** @} */

--- a/modules/mrpt_nav/include/mrpt/nav/planners/nav_plan_geometry_utils.h
+++ b/modules/mrpt_nav/include/mrpt/nav/planners/nav_plan_geometry_utils.h
@@ -16,6 +16,8 @@
 
 #include <mrpt/math/TPoint2D.h>
 
+#include <optional>
+
 namespace mrpt::nav
 {
 /** @addtogroup  nav_geom_grp Motion planning geometry utility functions
@@ -24,30 +26,56 @@ namespace mrpt::nav
  * @{ */
 
 /** Computes the collision-free distance for a linear segment path between two
- * points, for a circular robot, and a point obstacle (ox,oy).
- * \return true if a collision exists, and the distance along the segment will
- * be in out_col_dist; false otherwise.
+ * points, for a circular robot, and a point obstacle.
+ * \return The distance along the segment at which the robot first touches the
+ * obstacle, or std::nullopt if the segment is collision-free.
  * \exception std::runtime_error If the two points are closer than an epsilon
  * (1e-10)
  */
-bool collision_free_dist_segment_circ_robot(
+[[nodiscard]] std::optional<double> collision_free_dist_segment_circ_robot(
+    const mrpt::math::TPoint2D& p_start,
+    const mrpt::math::TPoint2D& p_end,
+    const double robot_radius,
+    const mrpt::math::TPoint2D& obstacle);
+
+/** Computes the collision-free distance for a forward path (+X) circular arc
+ * path segment from pose (0,0,0) and radius of curvature `arc_radius`
+ * (>0 -> turn towards +Y, <0 -> towards -Y), a circular robot and a point
+ * obstacle.
+ * \return The arc length at which the robot first touches the obstacle (0 if
+ * it is already in collision at the starting pose), or std::nullopt if the arc
+ * is collision-free (which includes the degenerate case of the robot enclosing
+ * the obstacle at every pose along the arc).
+ */
+[[nodiscard]] std::optional<double> collision_free_dist_arc_circ_robot(
+    const double arc_radius, const double robot_radius, const mrpt::math::TPoint2D& obstacle);
+
+/** \deprecated Use the std::optional-returning overload. */
+[[deprecated("Use the std::optional-returning overload")]] inline bool
+collision_free_dist_segment_circ_robot(
     const mrpt::math::TPoint2D& p_start,
     const mrpt::math::TPoint2D& p_end,
     const double robot_radius,
     const mrpt::math::TPoint2D& obstacle,
-    double& out_col_dist);
+    double& out_col_dist)
+{
+  const auto d = collision_free_dist_segment_circ_robot(p_start, p_end, robot_radius, obstacle);
+  out_col_dist = d.value_or(-1.0);
+  return d.has_value();
+}
 
-/** Computes the collision-free distance for a forward path (+X) circular arc
- * path segment from pose (0,0,0) and radius of curvature R (>0 -> +Y, <0 ->
- * -Y), a circular robot and a point obstacle (ox,oy). \return true if a
- * collision exists, and the distance along the path will be in out_col_dist;
- * false otherwise.
- */
-bool collision_free_dist_arc_circ_robot(
+/** \deprecated Use the std::optional-returning overload. */
+[[deprecated("Use the std::optional-returning overload")]] inline bool
+collision_free_dist_arc_circ_robot(
     const double arc_radius,
     const double robot_radius,
     const mrpt::math::TPoint2D& obstacle,
-    double& out_col_dist);
+    double& out_col_dist)
+{
+  const auto d = collision_free_dist_arc_circ_robot(arc_radius, robot_radius, obstacle);
+  out_col_dist = d.value_or(-1.0);
+  return d.has_value();
+}
 
 /** @} */
 }  // namespace mrpt::nav

--- a/modules/mrpt_nav/include/mrpt/nav/tpspace/CPTG_DiffDrive_CollisionGridBased.h
+++ b/modules/mrpt_nav/include/mrpt/nav/tpspace/CPTG_DiffDrive_CollisionGridBased.h
@@ -95,7 +95,8 @@ class CPTG_DiffDrive_CollisionGridBased : public CPTG_RobotShape_Polygonal
   size_t getPathStepCount(uint16_t k) const override;
   mrpt::math::TPose2D getPathPose(uint16_t k, uint32_t step) const override;
   double getPathDist(uint16_t k, uint32_t step) const override;
-  bool getPathStepForDist(uint16_t k, double dist, uint32_t& out_step) const override;
+  using CParameterizedTrajectoryGenerator::getPathStepForDist;
+  [[nodiscard]] std::optional<uint32_t> getPathStepForDist(uint16_t k, double dist) const override;
   double getPathStepDuration() const override;
   double getMaxLinVel() const override { return V_MAX; }
   double getMaxAngVel() const override { return W_MAX; }

--- a/modules/mrpt_nav/include/mrpt/nav/tpspace/CPTG_Holo_Blend.h
+++ b/modules/mrpt_nav/include/mrpt/nav/tpspace/CPTG_Holo_Blend.h
@@ -57,7 +57,8 @@ class CPTG_Holo_Blend : public CPTG_RobotShape_Circular
   size_t getPathStepCount(uint16_t k) const override;
   mrpt::math::TPose2D getPathPose(uint16_t k, uint32_t step) const override;
   double getPathDist(uint16_t k, uint32_t step) const override;
-  bool getPathStepForDist(uint16_t k, double dist, uint32_t& out_step) const override;
+  using CParameterizedTrajectoryGenerator::getPathStepForDist;
+  [[nodiscard]] std::optional<uint32_t> getPathStepForDist(uint16_t k, double dist) const override;
   double getPathStepDuration() const override;
   double getMaxLinVel() const override { return V_MAX; }
   double getMaxAngVel() const override { return W_MAX; }
@@ -65,13 +66,19 @@ class CPTG_Holo_Blend : public CPTG_RobotShape_Circular
   void updateTPObstacleSingle(
       double ox, double oy, uint16_t k, double& tp_obstacle_k) const override;
 
-  /** Duration of each PTG "step"  (default: 10e-3=10 ms) */
-  static double PATH_TIME_STEP;
-  /** Mathematical "epsilon", to detect ill-conditioned situations (e.g. 1/0)
-   * (Default: 1e-4) */
-  static double eps;
+  /** Mathematical "epsilon", to detect ill-conditioned situations (e.g. 1/0) */
+  static constexpr double EPSILON = 1e-4;
+
+  /** Default value of the per-instance path time step [s] \sa setPathTimeStep */
+  static constexpr double DEFAULT_PATH_TIME_STEP = 10e-3;
+
+  /** Duration of each PTG "step" [s] (config key: `path_time_step`).
+   *  Shorter steps mean a finer path discretization at a proportionally
+   *  higher CPU and memory cost. \sa getPathStepDuration() */
+  void setPathTimeStep(double dt);
 
  protected:
+  double m_pathTimeStep{DEFAULT_PATH_TIME_STEP};
   double T_ramp_max{-1.0};
   double V_MAX{-1.0}, W_MAX{-1.0};
   double turningRadiusReference{0.30};

--- a/modules/mrpt_nav/include/mrpt/nav/tpspace/CParameterizedTrajectoryGenerator.h
+++ b/modules/mrpt_nav/include/mrpt/nav/tpspace/CParameterizedTrajectoryGenerator.h
@@ -43,9 +43,9 @@ namespace mrpt
 namespace nav
 {
 /** Defines behaviors for where there is an obstacle *inside* the robot shape
- *right at the beginning of a PTG trajectory.
- *\ingroup nav_tpspace
- * \sa Used in CParameterizedTrajectoryGenerator::COLLISION_BEHAVIOR
+ * right at the beginning of a PTG trajectory.
+ * \ingroup nav_tpspace
+ * \sa CParameterizedTrajectoryGenerator::setCollisionBehavior()
  */
 enum class PTGCollisionBehavior
 {
@@ -60,27 +60,34 @@ enum class PTGCollisionBehavior
  * \ingroup mrpt_nav_grp
  */
 
-/** This is the base class for any user-defined PTG.
- *  There is a class factory interface in
- *CParameterizedTrajectoryGenerator::CreatePTG.
+/** Base class for all Parameterized Trajectory Generators (PTGs).
  *
- * Papers:
- *  - J.L. Blanco, J. Gonzalez-Jimenez, J.A. Fernandez-Madrigal, "Extending
- *Obstacle Avoidance Methods through Multiple Parameter-Space Transformations",
- *Autonomous Robots, vol. 24, no. 1, 2008.
- *http://ingmec.ual.es/~jlblanco/papers/blanco2008eoa_DRAFT.pdf
+ * A PTG defines a *family* of feasible trajectories, all starting at the robot
+ * pose (0,0,0), parameterized by a single real number \f$ \alpha \in
+ * (-\pi,\pi] \f$ discretized into `getPathCount()` paths indexed by `k`.
+ * Each path `k` is sampled at discrete `step`s, which map to a pose
+ * (getPathPose()) and a traversed arc length (getPathDist()).
  *
- * Changes history:
- *	- 30/JUN/2004: Creation (JLBC)
- *	- 16/SEP/2004: Totally redesigned.
- *	- 15/SEP/2005: Totally rewritten again, for integration into MRPT
- *Applications Repository.
- *	- 19/JUL/2009: Simplified to use only STL data types, and created the class
- *factory interface.
- *	- MAY/2016: Refactored into CParameterizedTrajectoryGenerator,
- *CPTG_DiffDrive_CollisionGridBased, PTG classes renamed.
- *	- 2016-2018: Many features added to support "PTG continuation", dynamic
- *paths depending on vehicle speeds, etc.
+ * This is what turns obstacle avoidance for a kinematically-constrained robot
+ * into a *holonomic* problem: a Workspace obstacle point is mapped by
+ * updateTPObstacle() into the collision-free length of every path, giving a
+ * "polar plot" (the TP-Space, or Trajectory Parameter Space) in which the
+ * robot can be treated as a point that moves freely in any direction
+ * \f$ \alpha \f$. The holonomic method (see \ref nav_holo) picks a direction
+ * there, and directionToMotionCommand() maps it back to a velocity command.
+ *
+ * Distances are in "pseudometers": real path lengths in meters, which callers
+ * normalize to [0,1] by getRefDistance().
+ *
+ * Instances are normally built by class name via CreatePTG(), then configured
+ * with loadFromConfigFile() and finally initialize()d (which is where
+ * collision look-up tables get built or loaded from cache, see derived
+ * classes). Use the `ptg-configurator` app to tune parameters interactively.
+ *
+ * Reference: J.L. Blanco, J. Gonzalez-Jimenez, J.A. Fernandez-Madrigal,
+ * "Extending Obstacle Avoidance Methods through Multiple Parameter-Space
+ * Transformations", Autonomous Robots, vol. 24, no. 1, 2008.
+ * http://ingmec.ual.es/~jlblanco/papers/blanco2008eoa_DRAFT.pdf
  *
  *  \ingroup nav_tpspace
  */
@@ -131,20 +138,14 @@ class CParameterizedTrajectoryGenerator :
   virtual void internal_deinitialize() = 0;
 
  public:
-  /** Computes the closest (alpha,d) TP coordinates of the trajectory point
-   * closest to the Workspace (WS)
-   *   Cartesian coordinates (x,y), relative to the current robot frame.
-   * \param[in] x X coordinate of the query point, relative to the robot
-   * frame.
-   * \param[in] y Y coordinate of the query point, relative to the robot
-   * frame.
-   * \param[out] out_k Trajectory parameter index (discretized alpha value,
-   * 0-based index).
-   * \param[out] out_d Trajectory distance, normalized such that D_max
-   * becomes 1.
-   *
-   * \return If the point (x,y) maps to a trajectory within tolerance,
-   * returns the (k, normalized_d) pair; otherwise std::nullopt.
+  /** Maps a Workspace point (x,y), in the robot frame, to the TP-Space
+   * coordinates of the closest point of the closest trajectory.
+   * \param[in] x,y Query point coordinates, relative to the robot frame [m].
+   * \param[in] tolerance_dist How far the closest trajectory point may lie
+   * from (x,y) for the mapping to be accepted [m].
+   * \return The pair (`k` path index, distance normalized so that
+   * getRefDistance() maps to 1), or std::nullopt if (x,y) is out of the PTG
+   * domain within that tolerance.
    */
   [[nodiscard]] virtual std::optional<std::pair<int, double>> inverseMap_WS2TP(
       double x, double y, double tolerance_dist = 0.10) const = 0;
@@ -241,12 +242,29 @@ class CParameterizedTrajectoryGenerator :
    * which the traversed distance is < `dist`
    * \param[in] dist Distance in pseudometers (real distance, NOT normalized
    * to [0,1] for [0,refDist])
-   * \return false if no step fulfills the condition for the given trajectory
-   * `k` (e.g. out of reference distance).
-   * Note that, anyway, the maximum distance (closest point) is returned in
-   * `out_step`.
+   * \return std::nullopt if no step fulfills the condition for the given
+   * trajectory `k` (e.g. out of reference distance).
    * \sa getPathStepCount(), getAlphaValuesCount() */
-  virtual bool getPathStepForDist(uint16_t k, double dist, uint32_t& out_step) const = 0;
+  [[nodiscard]] virtual std::optional<uint32_t> getPathStepForDist(
+      uint16_t k, double dist) const = 0;
+
+  /** \deprecated Use the std::optional-returning overload. Note that
+   * `out_step` is now left untouched when no step fulfills the condition. */
+  [[deprecated("Use the std::optional-returning getPathStepForDist(k, dist)")]] bool
+  getPathStepForDist(uint16_t k, double dist, uint32_t& out_step) const
+  {
+    const auto step = getPathStepForDist(k, dist);
+    if (step) out_step = *step;
+    return step.has_value();
+  }
+
+  /** Like getPathStepForDist(), but returning the last step of path `k`
+   * instead of failing when `dist` lies beyond the end of the path. */
+  [[nodiscard]] uint32_t getPathStepForDistClamped(uint16_t k, double dist) const
+  {
+    const auto step = getPathStepForDist(k, dist);
+    return step ? *step : static_cast<uint32_t>(getPathStepCount(k) - 1);
+  }
 
   /** Updates the radial map of closest TP-Obstacles given a single obstacle
    * point at (ox,oy)
@@ -376,7 +394,13 @@ class CParameterizedTrajectoryGenerator :
   /** When used in path planning, a multiplying factor (default=1.0) for the
    * scores for this PTG. Assign values <1 to PTGs with low priority. */
   [[nodiscard]] double getScorePriority() const { return m_score_priority; }
-  void setScorePriorty(double prior) { m_score_priority = prior; }
+  void setScorePriority(double prior) { m_score_priority = prior; }
+
+  /** \deprecated Misspelled; use setScorePriority(). */
+  [[deprecated("Use setScorePriority()")]] void setScorePriorty(double prior)
+  {
+    setScorePriority(prior);
+  }
   [[nodiscard]] unsigned getClearanceStepCount() const { return m_clearance_num_points; }
   void setClearanceStepCount(const uint16_t res) { m_clearance_num_points = res; }
 
@@ -441,17 +465,16 @@ class CParameterizedTrajectoryGenerator :
   COLLISION_BEHAVIOR();
 
   /** Must be called to resize a CD to its correct size, before calling
-   * updateClearance() */
+   * updateClearance(). Creates getClearanceStepCount() entries per decimated
+   * path, keyed by the normalized [0,1] TP-Space distance of the pose each
+   * one will be measured at. */
   void initClearanceDiagram(ClearanceDiagram& cd) const;
 
   /** Updates the clearance diagram given one (ox,oy) obstacle point, in
-   * coordinates relative
-   * to the PTG path origin.
+   * coordinates relative to the PTG path origin.
    * \param[in,out] cd The clearance will be updated here.
-   * \sa m_clearance_dist_resolution
    */
   void updateClearance(const double ox, const double oy, ClearanceDiagram& cd) const;
-  void updateClearancePost(ClearanceDiagram& cd, const std::vector<double>& TP_obstacles) const;
 
  protected:
   double refDistance{.0};
@@ -493,11 +516,16 @@ class CParameterizedTrajectoryGenerator :
   virtual void internal_writeToStream(mrpt::serialization::CArchive& out) const;
 
  public:
-  /** Evals the robot clearance for each robot pose along path `k`, for the
-   * real distances in
-   * the key of the map<>, then keep in the map value the minimum of its
-   * current stored clearance,
-   * or the computed clearance. In case of collision, clearance is zero.
+  /** Evals the robot clearance at each of the poses sampled along path `k`,
+   * one per entry of `inout_realdist2clearance`, and keeps in each map value
+   * the minimum of its current content and the newly computed clearance.
+   * In case of collision, clearance is zero.
+   *
+   * \note Map keys are normalized [0,1] TP-Space distances, and so are the
+   * values (both divided by getRefDistance()). The keys are only read for
+   * the collision heuristics; the sampled poses are determined by the
+   * number of entries, evenly spread over the path steps.
+   *
    * \param treat_as_obstacle true: normal use for obstacles; false: compute
    * shortest distances to a target point (no collision)
    */

--- a/modules/mrpt_nav/src/holonomic/CHolonomicFullEval.cpp
+++ b/modules/mrpt_nav/src/holonomic/CHolonomicFullEval.cpp
@@ -281,8 +281,8 @@ void CHolonomicFullEval::fillFactorScores(
     // Factor [7]: heading alignment with target phi
     if (ptg != nullptr)
     {
-      uint32_t ptgStep = 0;
-      ptg->getPathStepForDist(static_cast<uint16_t>(i), d * ptg->getRefDistance(), ptgStep);
+      const uint32_t ptgStep =
+          ptg->getPathStepForDistClamped(static_cast<uint16_t>(i), d * ptg->getRefDistance());
       const auto ptgPose = ptg->getPathPose(static_cast<uint16_t>(i), ptgStep);
       scores[7] = 1.0 - std::abs(mrpt::math::angDistance(target.phi, ptgPose.phi) / M_PI);
     }
@@ -447,10 +447,11 @@ CHolonomicFullEval::NavOutput CHolonomicFullEval::navigate(const NavInput& ni)
 
     // Speed control: Reduction factors
     // ---------------------------------------------
+    // The last target is the highest-priority one (see NavInput docs):
     const double targetNearnessFactor =
         m_enableApproachTargetSlowDown
             ? std::min(
-                  1.0, ni.targets.front().norm() /
+                  1.0, ni.targets.back().norm() /
                            (options.TARGET_SLOW_APPROACHING_DISTANCE / ptg_ref_dist))
             : 1.0;
 

--- a/modules/mrpt_nav/src/holonomic/CHolonomicVFF.cpp
+++ b/modules/mrpt_nav/src/holonomic/CHolonomicVFF.cpp
@@ -104,12 +104,12 @@ CHolonomicVFF::NavOutput CHolonomicVFF::navigate(const NavInput& ni)
 
   // Speed control: Reduction factors
   // ---------------------------------------------
-  if (m_enableApproachTargetSlowDown)
-  {
-    const double targetNearnessFactor =
-        std::min(1.0, trg.norm() / (options.TARGET_SLOW_APPROACHING_DISTANCE / ptg_ref_dist));
-    no.desiredSpeed = ni.maxRobotSpeed * std::min(obstacleNearnessFactor, targetNearnessFactor);
-  }
+  const double targetNearnessFactor =
+      m_enableApproachTargetSlowDown
+          ? std::min(1.0, trg.norm() / (options.TARGET_SLOW_APPROACHING_DISTANCE / ptg_ref_dist))
+          : 1.0;
+
+  no.desiredSpeed = ni.maxRobotSpeed * std::min(obstacleNearnessFactor, targetNearnessFactor);
 
   return no;
 }

--- a/modules/mrpt_nav/src/holonomic/ClearanceDiagram.cpp
+++ b/modules/mrpt_nav/src/holonomic/ClearanceDiagram.cpp
@@ -34,7 +34,7 @@ void ClearanceDiagram::renderAs3DObject(
     double min_y,
     double max_y,
     double cell_res,
-    bool integrate_over_path) const
+    ClearanceQuery mode) const
 {
   ASSERT_(cell_res > 0.0);
   ASSERT_(max_x > min_x);
@@ -65,7 +65,7 @@ void ClearanceDiagram::renderAs3DObject(
         const uint16_t actual_k = CParameterizedTrajectoryGenerator::Alpha2index(
             alpha, static_cast<unsigned int>(m_actual_num_paths));
         const double dist = std::hypot(x, y);
-        clear_val = this->getClearance(actual_k, dist, integrate_over_path);
+        clear_val = this->getClearance(actual_k, dist, mode);
       }
       Z(iX, iY) = static_cast<float>(clear_val);
     }
@@ -132,8 +132,7 @@ size_t mrpt::nav::ClearanceDiagram::decimated_k_to_real_k(size_t k) const
   return ret;
 }
 
-double ClearanceDiagram::getClearance(
-    uint16_t actual_k, double dist, bool integrate_over_path) const
+double ClearanceDiagram::getClearance(uint16_t actual_k, double dist, ClearanceQuery mode) const
 {
   if (this->empty())  // If we are not using clearance values, just return a
     // fixed value:
@@ -141,37 +140,21 @@ double ClearanceDiagram::getClearance(
 
   ASSERT_LT_(actual_k, m_actual_num_paths);
 
-  const size_t k = real_k_to_decimated_k(actual_k);
+  const auto& rc_k = m_raw_clearances[real_k_to_decimated_k(actual_k)];
+  if (rc_k.empty()) return 0.0;
 
-  const auto& rc_k = m_raw_clearances[k];
-
-  double res = 0;
-  int avr_count = 0;  // weighted avrg: closer to query points weight more
-  // than at path start.
-  for (const auto& e : rc_k)
+  double sum = 0;
+  double last = 0;
+  size_t count = 0;
+  for (const auto& [sample_dist, sample_clearance] : rc_k)
   {
-    if (integrate_over_path)
-    {
-      res = e.second;
-      avr_count = 1;
-    }
-    else
-    {
-      res += e.second;
-      avr_count++;
-    }
-    if (e.first > dist) break;  // target dist reached.
+    sum += sample_clearance;
+    last = sample_clearance;
+    count++;
+    if (sample_dist > dist) break;  // target dist reached.
   }
 
-  if (!avr_count)
-  {
-    res = rc_k.begin()->second;
-  }
-  else
-  {
-    res = res / avr_count;
-  }
-  return res;
+  return mode == ClearanceQuery::MeanUpToDistance ? sum / static_cast<double>(count) : last;
 }
 
 void ClearanceDiagram::clear()
@@ -193,8 +176,16 @@ void mrpt::nav::ClearanceDiagram::resize(size_t actual_num_paths, size_t decimat
   m_actual_num_paths = actual_num_paths;
   m_raw_clearances.resize(decimated_num_paths);
 
-  m_k_d2a = static_cast<double>(m_actual_num_paths - 1) /
-            static_cast<double>(m_raw_clearances.size() - 1);
-  m_k_a2d = static_cast<double>(m_raw_clearances.size() - 1) /
-            static_cast<double>(m_actual_num_paths - 1);
+  if (m_actual_num_paths > 1 && m_raw_clearances.size() > 1)
+  {
+    m_k_d2a = static_cast<double>(m_actual_num_paths - 1) /
+              static_cast<double>(m_raw_clearances.size() - 1);
+    m_k_a2d = static_cast<double>(m_raw_clearances.size() - 1) /
+              static_cast<double>(m_actual_num_paths - 1);
+  }
+  else
+  {
+    // Degenerate case: one single (decimated) path, everything maps to index 0.
+    m_k_d2a = m_k_a2d = .0;
+  }
 }

--- a/modules/mrpt_nav/src/planners/PlannerRRT_SE2_TPS.cpp
+++ b/modules/mrpt_nav/src/planners/PlannerRRT_SE2_TPS.cpp
@@ -122,7 +122,7 @@ void PlannerRRT_SE2_TPS::solve(
         distance_evaluator_se2;         // Plain distances in SE(2), not along PTGs
     bool is_new_best_solution = false;  // Just for logging purposes
 
-    //#define DO_LOG_TXTS
+    // #define DO_LOG_TXTS
     std::string sLogTxt;
 
     // [Algo `tp_space_rrt`: Line 5]: For each PTG
@@ -239,8 +239,8 @@ void PlannerRRT_SE2_TPS::solve(
         // ------------------------------------------------------------
         // given d_rand and k_rand provides x,y,phi of the point in
         // c-space
-        uint32_t nStep;
-        m_PTGs[idxPTG]->getPathStepForDist(static_cast<uint16_t>(k_rand), d_new, nStep);
+        const uint32_t nStep =
+            m_PTGs[idxPTG]->getPathStepForDistClamped(static_cast<uint16_t>(k_rand), d_new);
 
         mrpt::math::TPose2D rel_pose =
             m_PTGs[idxPTG]->getPathPose(static_cast<uint16_t>(k_rand), nStep);

--- a/modules/mrpt_nav/src/planners/PlannerSimple2D.cpp
+++ b/modules/mrpt_nav/src/planners/PlannerSimple2D.cpp
@@ -295,15 +295,14 @@ static bool reconstructPath(
 /*---------------------------------------------------------------
             computePath
   ---------------------------------------------------------------*/
-void PlannerSimple2D::computePath(
+std::optional<std::deque<math::TPoint2D>> PlannerSimple2D::computePath(
     const COccupancyGridMap2D& theMap,
     const CPose2D& origin_,
     const CPose2D& target_,
-    std::deque<math::TPoint2D>& path,
-    bool& notFound,
     float maxSearchPathLength) const
 {
-  path.clear();
+  std::deque<math::TPoint2D> path;
+  bool notFound = false;
 
   const TPoint2D origin = TPoint2D(origin_.asTPose());
   const TPoint2D target = TPoint2D(target_.asTPose());
@@ -314,19 +313,14 @@ void PlannerSimple2D::computePath(
     return p.x > theMap.getXMin() && p.x < theMap.getXMax() && p.y > theMap.getYMin() &&
            p.y < theMap.getYMax();
   };
-  if (!isInsideGrid(origin) || !isInsideGrid(target))
-  {
-    notFound = true;
-    return;
-  }
+  if (!isInsideGrid(origin) || !isInsideGrid(target)) return std::nullopt;
 
   // Special case: origin and target in the same cell:
   if (theMap.x2idx(origin.x) == theMap.x2idx(target.x) &&
       theMap.y2idx(origin.y) == theMap.y2idx(target.y))
   {
     path.emplace_back(target.x, target.y);
-    notFound = false;
-    return;
+    return path;
   }
 
   const int size_x = theMap.getSizeX();
@@ -437,15 +431,15 @@ void PlannerSimple2D::computePath(
 
   } while (!notFound && searching);
 
-  if (notFound) return;
+  if (notFound) return std::nullopt;
 
   // Reconstruct path from convergence cell and subsample it:
   if (!reconstructPath(
           grid, size_x, passCellFound_x, passCellFound_y, origin, target, theMap,
           minStepInReturnedPath, maxSearchPathLength, path))
   {
-    notFound = true;
+    return std::nullopt;
   }
 
-  // That's all!! :-)
+  return path;
 }

--- a/modules/mrpt_nav/src/planners/nav_plan_geometry_utils.cpp
+++ b/modules/mrpt_nav/src/planners/nav_plan_geometry_utils.cpp
@@ -17,19 +17,18 @@
 #include <mrpt/math/wrap2pi.h>
 #include <mrpt/nav/planners/nav_plan_geometry_utils.h>
 
+#include <limits>
+
 using namespace mrpt;
 using namespace mrpt::math;
 
-bool mrpt::nav::collision_free_dist_segment_circ_robot(
+std::optional<double> mrpt::nav::collision_free_dist_segment_circ_robot(
     const mrpt::math::TPoint2D& p0,
     const mrpt::math::TPoint2D& p1,
     const double R,
-    const mrpt::math::TPoint2D& o,
-    double& out_col_dist)
+    const mrpt::math::TPoint2D& o)
 {
   using mrpt::square;
-
-  out_col_dist = -1.0;
 
   // Unit vector from start -> end:
   mrpt::math::TPoint2D u = (p1 - p0);
@@ -53,121 +52,76 @@ bool mrpt::nav::collision_free_dist_segment_circ_robot(
   double r1, r2;
   const int nsols = mrpt::math::solve_poly2(a, b, c, r1, r2);
 
-  if (nsols <= 0)
-  {
-    return false;
-  }
+  if (nsols <= 0) return std::nullopt;
+
   double r_min;
   if (nsols == 1)
+  {
     r_min = r1;
+  }
+  else if (r1 < 0 && r2 < 0)
+  {
+    return std::nullopt;
+  }
+  else if (r1 < 0)
+  {
+    r_min = r2;
+  }
+  else if (r2 < 0)
+  {
+    r_min = r1;
+  }
   else
   {
-    if (r1 < 0 && r2 < 0)
-    {
-      return false;
-    }
-    if (r1 < 0)
-    {
-      r_min = r2;
-    }
-    else if (r2 < 0)
-    {
-      r_min = r1;
-    }
-    else
-    {
-      r_min = std::min(r1, r2);
-    }
+    r_min = std::min(r1, r2);
   }
 
-  if (r_min > L)
-  {
-    return false;
-  }
+  if (r_min > L) return std::nullopt;
 
   // A real, valid collision:
-  out_col_dist = r_min;
-  return true;
+  return r_min;
 }
 
-bool mrpt::nav::collision_free_dist_arc_circ_robot(
-    const double arc_radius, const double R, const mrpt::math::TPoint2D& o, double& out_col_dist)
+std::optional<double> mrpt::nav::collision_free_dist_arc_circ_robot(
+    const double arc_radius, const double R, const mrpt::math::TPoint2D& o)
 {
   ASSERT_GT_(std::abs(arc_radius), 1e-10);
-  out_col_dist = -1.0;
 
-  const mrpt::math::TPoint2D ptArcCenter(.0, arc_radius);
-  const double center2obs_dist = (ptArcCenter - o).norm();
-  if (std::abs(center2obs_dist - std::abs(arc_radius)) > R)
+  // Already in collision at the starting pose: zero collision-free distance.
+  if (o.norm() <= R) return .0;
+
+  // The robot center travels along the circle of radius |arc_radius| centered
+  // at (0, arc_radius). It touches the obstacle wherever that circle meets the
+  // one of radius R around the obstacle, so this is a two-circle intersection:
+  const mrpt::math::TPoint2D arcCenter(.0, arc_radius);
+  const double arcR = std::abs(arc_radius);
+
+  const auto v = o - arcCenter;
+  const double d = v.norm();
+
+  // Separate circles, or one strictly inside the other (the latter means the
+  // robot never *stops* enclosing the obstacle, so there is no first touch):
+  if (d > arcR + R || d < std::abs(arcR - R) || d < 1e-10) return std::nullopt;
+
+  const double a = (d * d + arcR * arcR - R * R) / (2 * d);
+  const double h2 = arcR * arcR - a * a;
+  if (h2 < 0) return std::nullopt;
+  const double h = std::sqrt(h2);
+
+  const mrpt::math::TPoint2D pm = arcCenter + v * (a / d);
+  const mrpt::math::TPoint2D perp(-v.y / d, v.x / d);
+
+  // Of the (up to) two touch points, keep the one reached first, measuring the
+  // turned angle from the starting pose (0,0,0) in the direction of motion:
+  double minAngle = std::numeric_limits<double>::max();
+  for (const double side : {+1.0, -1.0})
   {
-    return false;
+    const auto p = pm + perp * (side * h);
+    // (x,y) order is intentionally like this: it makes th=0 at the origin.
+    double th = std::atan2(p.x - arcCenter.x, -(p.y - arcCenter.y));
+    if (arc_radius < 0) th = M_PI - th;
+    mrpt::keep_min(minAngle, mrpt::math::wrapTo2Pi(th));
   }
 
-  // x:
-  const double r = arc_radius;
-  const double discr = (R * r * 2.0 - o.y * r * 2.0 - R * R + o.x * o.x + o.y * o.y) *
-                       (R * r * 2.0 + o.y * r * 2.0 + R * R - o.x * o.x - o.y * o.y);
-  if (discr < 0)
-  {
-    return false;
-  }
-  const double sol_x0 =
-      ((R * R) * (-1.0 / 2.0) + (o.x * o.x) * (1.0 / 2.0) + (o.y * o.y) * (1.0 / 2.0) -
-       (o.y *
-        (-(R * R) * o.y + (R * R) * r + (o.x * o.x) * o.y + (o.x * o.x) * r - (o.y * o.y) * r +
-         o.y * o.y * o.y + o.x * sqrt(discr)) *
-        (1.0 / 2.0)) /
-           (o.y * r * -2.0 + o.x * o.x + o.y * o.y + r * r) +
-       (r *
-        (-(R * R) * o.y + (R * R) * r + (o.x * o.x) * o.y + (o.x * o.x) * r - (o.y * o.y) * r +
-         o.y * o.y * o.y + o.x * sqrt(discr)) *
-        (1.0 / 2.0)) /
-           (o.y * r * -2.0 + o.x * o.x + o.y * o.y + r * r)) /
-      o.x;
-  const double sol_x1 =
-      ((R * R) * (-1.0 / 2.0) + (o.x * o.x) * (1.0 / 2.0) + (o.y * o.y) * (1.0 / 2.0) -
-       (o.y *
-        (-(R * R) * o.y + (R * R) * r + (o.x * o.x) * o.y + (o.x * o.x) * r - (o.y * o.y) * r +
-         o.y * o.y * o.y - o.x * sqrt(discr)) *
-        (1.0 / 2.0)) /
-           (o.y * r * -2.0 + o.x * o.x + o.y * o.y + r * r) +
-       (r *
-        (-(R * R) * o.y + (R * R) * r + (o.x * o.x) * o.y + (o.x * o.x) * r - (o.y * o.y) * r +
-         o.y * o.y * o.y - o.x * sqrt(discr)) *
-        (1.0 / 2.0)) /
-           (o.y * r * -2.0 + o.x * o.x + o.y * o.y + r * r)) /
-      o.x;
-
-  // y:
-  const double sol_y0 =
-      ((R * R) * o.y * (-1.0 / 2.0) + (R * R) * r * (1.0 / 2.0) + (o.x * o.x) * o.y * (1.0 / 2.0) +
-       (o.x * o.x) * r * (1.0 / 2.0) - (o.y * o.y) * r * (1.0 / 2.0) +
-       (o.y * o.y * o.y) * (1.0 / 2.0) + o.x * sqrt(discr) * (1.0 / 2.0)) /
-      (o.y * r * -2.0 + o.x * o.x + o.y * o.y + r * r);
-  const double sol_y1 =
-      ((R * R) * o.y * (-1.0 / 2.0) + (R * R) * r * (1.0 / 2.0) + (o.x * o.x) * o.y * (1.0 / 2.0) +
-       (o.x * o.x) * r * (1.0 / 2.0) - (o.y * o.y) * r * (1.0 / 2.0) +
-       (o.y * o.y * o.y) * (1.0 / 2.0) - o.x * sqrt(discr) * (1.0 / 2.0)) /
-      (o.y * r * -2.0 + o.x * o.x + o.y * o.y + r * r);
-
-  const mrpt::math::TPoint2D sol0(sol_x0, sol_y0), sol1(sol_x1, sol_y1);
-
-  double th0 = atan2(
-      sol0.x - ptArcCenter.x,
-      -(sol0.y - ptArcCenter.y));  // (x,y) order is intentionally like this!
-  double th1 = atan2(sol1.x - ptArcCenter.x, -(sol1.y - ptArcCenter.y));
-
-  if (r > 0)
-  {
-    th0 = mrpt::math::wrapTo2Pi(th0);
-    th1 = mrpt::math::wrapTo2Pi(th1);
-  }
-  else
-  {
-    th0 = mrpt::math::wrapTo2Pi(M_PI - th0);
-    th1 = mrpt::math::wrapTo2Pi(M_PI - th1);
-  }
-
-  out_col_dist = std::abs(r) * std::min(th0, th1);
-  return true;
+  return arcR * minAngle;
 }

--- a/modules/mrpt_nav/src/reactive/CAbstractPTGBasedReactive.cpp
+++ b/modules/mrpt_nav/src/reactive/CAbstractPTGBasedReactive.cpp
@@ -911,11 +911,12 @@ void CAbstractPTGBasedReactive::calc_move_candidate_scores(
   const int move_k = static_cast<int>(cm.PTG->alpha2index(cm.direction));
   const double target_WS_d = WS_Target.norm();
 
-  // Coordinates of the trajectory end for the given PTG and "alpha":
+  // Coordinates of the trajectory end for the given PTG and "alpha".
+  // Note `d` is normalized, while getPathStepForDist() takes pseudometers:
   const double d = std::min(in_TPObstacles[move_k], 0.99 * target_d_norm);
-  const auto nStep = cm.PTG->getPathStepForDist(static_cast<uint16_t>(move_k), d);
-  ASSERT_(nStep.has_value());
-  const mrpt::math::TPose2D pose = cm.PTG->getPathPose(static_cast<uint16_t>(move_k), *nStep);
+  const uint32_t nStep =
+      cm.PTG->getPathStepForDistClamped(static_cast<uint16_t>(move_k), d * ref_dist);
+  const mrpt::math::TPose2D pose = cm.PTG->getPathPose(static_cast<uint16_t>(move_k), nStep);
 
   // Make sure that the target slow-down is honored, as seen in real-world
   // Euclidean space

--- a/modules/mrpt_nav/src/reactive/CAbstractPTGBasedReactive.cpp
+++ b/modules/mrpt_nav/src/reactive/CAbstractPTGBasedReactive.cpp
@@ -913,10 +913,9 @@ void CAbstractPTGBasedReactive::calc_move_candidate_scores(
 
   // Coordinates of the trajectory end for the given PTG and "alpha":
   const double d = std::min(in_TPObstacles[move_k], 0.99 * target_d_norm);
-  uint32_t nStep;
-  bool pt_in_range = cm.PTG->getPathStepForDist(static_cast<uint16_t>(move_k), d, nStep);
-  ASSERT_(pt_in_range);
-  const mrpt::math::TPose2D pose = cm.PTG->getPathPose(static_cast<uint16_t>(move_k), nStep);
+  const auto nStep = cm.PTG->getPathStepForDist(static_cast<uint16_t>(move_k), d);
+  ASSERT_(nStep.has_value());
+  const mrpt::math::TPose2D pose = cm.PTG->getPathPose(static_cast<uint16_t>(move_k), *nStep);
 
   // Make sure that the target slow-down is honored, as seen in real-world
   // Euclidean space
@@ -1047,11 +1046,12 @@ void CAbstractPTGBasedReactive::calc_move_candidate_scores(
     bool WS_point_is_unique = true;
     if (!is_time_based)
     {
-      bool ok1 = cm.PTG->getPathStepForDist(
+      const auto optCurStep = cm.PTG->getPathStepForDist(
           static_cast<uint16_t>(m_lastSentVelCmd.ptg_alpha_index),
-          cur_norm_d * cm.PTG->getRefDistance(), cur_ptg_step);
-      if (ok1)
+          cur_norm_d * cm.PTG->getRefDistance());
+      if (optCurStep)
       {
+        cur_ptg_step = *optCurStep;
         // Check bijective:
         WS_point_is_unique = cm.PTG->isBijectiveAt(static_cast<uint16_t>(cur_k), cur_ptg_step);
         const uint32_t predicted_step = static_cast<uint32_t>(
@@ -1154,12 +1154,15 @@ void CAbstractPTGBasedReactive::calc_move_candidate_scores(
         WS_Target.x, WS_Target.y, static_cast<uint16_t>(move_k), pathDists,
         false /*treat point as target, not obstacle*/);
 
-    const auto it = std::min_element(
-        pathDists.begin(), pathDists.end(),
-        [colfree](map_d2d_t::value_type& l, map_d2d_t::value_type& r) -> bool
-        { return (l.second < r.second) && l.first < colfree; });
-    cm.props["dist_eucl_min"] =
-        (it != pathDists.end()) ? it->second * cm.PTG->getRefDistance() : 100.0;
+    // Closest approach to the target among the path samples that are
+    // actually reachable (i.e. before the collision-free distance):
+    double minNormDist = 100.0;
+    for (const auto& [pathDist, distToTarget] : pathDists)
+    {
+      if (pathDist >= colfree) break;
+      mrpt::keep_min(minNormDist, distToTarget);
+    }
+    cm.props["dist_eucl_min"] = minNormDist * cm.PTG->getRefDistance();
   }
 
   // Factor5: Hysteresis:
@@ -1200,13 +1203,13 @@ void CAbstractPTGBasedReactive::calc_move_candidate_scores(
   // clearance indicators that may be useful in deciding the best motion:
   double& clearance = cm.props["clearance"];
   clearance = in_clearance.getClearance(
-      static_cast<uint16_t>(move_k), target_d_norm * 1.01, false /* spot, dont interpolate */);
+      static_cast<uint16_t>(move_k), target_d_norm * 1.01, ClearanceQuery::AtDistance);
   cm.props["clearance_50p"] = in_clearance.getClearance(
-      static_cast<uint16_t>(move_k), target_d_norm * 0.5, false /* spot, dont interpolate */);
+      static_cast<uint16_t>(move_k), target_d_norm * 0.5, ClearanceQuery::AtDistance);
   cm.props["clearance_path"] = in_clearance.getClearance(
-      static_cast<uint16_t>(move_k), target_d_norm * 0.9, true /* average */);
+      static_cast<uint16_t>(move_k), target_d_norm * 0.9, ClearanceQuery::MeanUpToDistance);
   cm.props["clearance_path_50p"] = in_clearance.getClearance(
-      static_cast<uint16_t>(move_k), target_d_norm * 0.5, true /* average */);
+      static_cast<uint16_t>(move_k), target_d_norm * 0.5, ClearanceQuery::MeanUpToDistance);
 
   // Factor: ETA (Estimated Time of Arrival to target or to closest obstacle,
   // whatever it's first)
@@ -1219,13 +1222,12 @@ void CAbstractPTGBasedReactive::calc_move_candidate_scores(
     const double path_len_meters = d * ref_dist;
 
     // Calculate their ETA
-    uint32_t target_step;
-    bool valid_step =
-        cm.PTG->getPathStepForDist(static_cast<uint16_t>(move_k), path_len_meters, target_step);
-    if (valid_step)
+    const auto target_step =
+        cm.PTG->getPathStepForDist(static_cast<uint16_t>(move_k), path_len_meters);
+    if (target_step)
     {
       eta = cm.PTG->getPathStepDuration() *
-            target_step /* PTG original time to get to target point */
+            (*target_step) /* PTG original time to get to target point */
             * cm.speed /* times the speed scale factor*/;
 
       double discount_time = .0;
@@ -1404,11 +1406,6 @@ void CAbstractPTGBasedReactive::build_movement_candidate(
           indexPTG, ipf.TP_Obstacles, ipf.clearance,
           mrpt::math::TPose2D(0, 0, 0) - rel_pose_PTG_origin_wrt_sense,
           params_abstract_ptg_navigator.evaluate_clearance);
-
-      if (params_abstract_ptg_navigator.evaluate_clearance)
-      {
-        ptg->updateClearancePost(ipf.clearance, ipf.TP_Obstacles);
-      }
 
       // Distances in TP-Space are normalized to [0,1]:
       const double _refD = 1.0 / ptg->getRefDistance();

--- a/modules/mrpt_nav/src/tpspace/CPTG_DiffDrive_CollisionGridBased.cpp
+++ b/modules/mrpt_nav/src/tpspace/CPTG_DiffDrive_CollisionGridBased.cpp
@@ -844,8 +844,8 @@ double CPTG_DiffDrive_CollisionGridBased::getPathDist(uint16_t k, uint32_t step)
   return m_trajectory[k][step].dist;
 }
 
-bool CPTG_DiffDrive_CollisionGridBased::getPathStepForDist(
-    uint16_t k, double dist, uint32_t& out_step) const
+std::optional<uint32_t> CPTG_DiffDrive_CollisionGridBased::getPathStepForDist(
+    uint16_t k, double dist) const
 {
   ASSERT_(k < m_trajectory.size());
   const size_t numPoints = m_trajectory[k].size();
@@ -856,13 +856,11 @@ bool CPTG_DiffDrive_CollisionGridBased::getPathStepForDist(
   {
     if (m_trajectory[k][n + 1].dist >= dist)
     {
-      out_step = static_cast<uint32_t>(n);
-      return true;
+      return static_cast<uint32_t>(n);
     }
   }
 
-  out_step = static_cast<uint32_t>(numPoints - 1);
-  return false;
+  return std::nullopt;
 }
 
 void CPTG_DiffDrive_CollisionGridBased::updateTPObstacle(

--- a/modules/mrpt_nav/src/tpspace/CPTG_Holo_Blend.cpp
+++ b/modules/mrpt_nav/src/tpspace/CPTG_Holo_Blend.cpp
@@ -34,7 +34,7 @@ V_MAX*sin(alpha)
 - W_MAX: Rotational velocity for robot heading forwards.
 
 Number of steps "d" for each PTG path "k":
-- Step = time increment PATH_TIME_STEP
+- Step = time increment `path_time_step`
 
 */
 
@@ -48,8 +48,11 @@ mrpt::system::CTimeLogger tl_holo("CPTG_Holo_Blend");
 #define PERFORMANCE_BENCHMARK
 #endif
 
-double CPTG_Holo_Blend::PATH_TIME_STEP = 10e-3;  // 10 ms
-double CPTG_Holo_Blend::eps = 1e-4;              // epsilon for detecting 1/0 situation
+void CPTG_Holo_Blend::setPathTimeStep(double dt)
+{
+  ASSERT_GT_(dt, .0);
+  m_pathTimeStep = dt;
+}
 
 // As a macro instead of a function (uglier) to allow for const variables
 // (safer)
@@ -99,36 +102,40 @@ static double calc_trans_distance_t_below_Tramp_abc_numeric(double T, double a, 
 {
   PERFORMANCE_BENCHMARK;
 
-  double d = .0;
-  const unsigned int NUM_STEPS = 15;
-
   ASSERT_(a >= .0);
   ASSERT_(c >= .0);
-  double feval_t = std::sqrt(c);  // t (initial: t=0)
-  double feval_tp1;               // t+1
 
-  const double At = T / (NUM_STEPS);
-  double t = .0;
-  for (unsigned int i = 0; i < NUM_STEPS; i++)
+  // Degenerate case: the radicand is a perfect square, so the integrand is
+  // sqrt(a)*|t-r| and the integral is exact:
+  const double discr = b * b - 4 * a * c;
+  if (std::abs(discr) < 1e-9 * std::max(1.0, b * b))
   {
-    // Eval function at t+1:
-    t += At;
-    double dd = a * t * t + b * t + c;
-
-    // handle numerical innacuracies near t=T_ramp:
-    ASSERT_(dd > -1e-5);
-    if (dd < 0) dd = .0;
-
-    feval_tp1 = sqrt(dd);
-
-    // Trapezoidal rule:
-    d += At * (feval_t + feval_tp1) * 0.5;
-
-    // for next step:
-    feval_t = feval_tp1;
+    const double r = -b / (2 * a);
+    return std::sqrt(a) * (r * std::abs(r) - (r - T) * std::abs(r - T)) * 0.5;
   }
 
-  return d;
+  // General case: composite Simpson's rule. Same number of function
+  // evaluations as the trapezoidal rule it replaced, but O(h^4) accurate
+  // instead of O(h^2) (~25x lower mean error over the parameter range this
+  // is called with).
+  constexpr unsigned int NUM_STEPS = 16;  // must be even
+  const double At = T / NUM_STEPS;
+
+  auto feval = [a, b, c](double t)
+  {
+    double dd = a * t * t + b * t + c;
+    // handle numerical innacuracies near t=T_ramp:
+    ASSERT_(dd > -1e-5);
+    return std::sqrt(dd < 0 ? .0 : dd);
+  };
+
+  double d = feval(.0) + feval(T);
+  for (unsigned int i = 1; i < NUM_STEPS; i++)
+  {
+    d += (i & 1U ? 4.0 : 2.0) * feval(i * At);
+  }
+
+  return d * At / 3.0;
 }
 
 // Axiliary function for calc_trans_distance_t_below_Tramp() and others:
@@ -157,13 +164,13 @@ double CPTG_Holo_Blend::calc_trans_distance_t_below_Tramp(
         a t^2 + b t + c
   */
   const double c = (vxi * vxi + vyi * vyi);
-  if (std::abs(k2) > eps || std::abs(k4) > eps)
+  if (std::abs(k2) > EPSILON || std::abs(k4) > EPSILON)
   {
     const double a = ((k2 * k2) * 4.0 + (k4 * k4) * 4.0);
     const double b = (k2 * vxi * 4.0 + k4 * vyi * 4.0);
 
     // Numerically-ill case: b=c=0 (initial vel=0)
-    if (std::abs(b) < eps && std::abs(c) < eps)
+    if (std::abs(b) < EPSILON && std::abs(c) < EPSILON)
     {
       // Indefinite integral of simplified case: sqrt(a)*t
       const double int_t = sqrt(a) * (t * t) * 0.5;
@@ -191,6 +198,7 @@ void CPTG_Holo_Blend::loadDefaultParams()
   CPTG_RobotShape_Circular::loadDefaultParams();
 
   m_alphaValuesCount = 31;
+  m_pathTimeStep = DEFAULT_PATH_TIME_STEP;
   T_ramp_max = 0.9;
   V_MAX = 1.0;
   W_MAX = mrpt::DEG2RAD(40);
@@ -206,6 +214,8 @@ void CPTG_Holo_Blend::loadFromConfigFile(
   MRPT_LOAD_HERE_CONFIG_VAR_NO_DEFAULT(v_max_mps, double, V_MAX, cfg, sSection);
   MRPT_LOAD_HERE_CONFIG_VAR_DEGREES_NO_DEFAULT(w_max_dps, double, W_MAX, cfg, sSection);
   MRPT_LOAD_CONFIG_VAR(turningRadiusReference, double, cfg, sSection);
+  MRPT_LOAD_HERE_CONFIG_VAR(path_time_step, double, m_pathTimeStep, cfg, sSection);
+  ASSERT_GT_(m_pathTimeStep, .0);
 
   MRPT_LOAD_HERE_CONFIG_VAR(expr_V, string, expr_V, cfg, sSection);
   MRPT_LOAD_HERE_CONFIG_VAR(expr_W, string, expr_W, cfg, sSection);
@@ -246,6 +256,10 @@ void CPTG_Holo_Blend::saveToConfigFile(
       "Math expr for `T_ramp` as a function of "
       "`dir`,`V_MAX`,`W_MAX`,`T_ramp_max`.");
 
+  cfg.write(
+      sSection, "path_time_step", m_pathTimeStep, WN, WV,
+      "Duration of each PTG path discretization step [s].");
+
   CPTG_RobotShape_Circular::saveToConfigFile(cfg, sSection);
 
   MRPT_END
@@ -267,6 +281,7 @@ void CPTG_Holo_Blend::serializeFrom(mrpt::serialization::CArchive& in, uint8_t v
     case 2:
     case 3:
     case 4:
+    case 5:
       if (version >= 1)
       {
         CPTG_RobotShape_Circular::internal_shape_loadFromStream(in);
@@ -282,13 +297,18 @@ void CPTG_Holo_Blend::serializeFrom(mrpt::serialization::CArchive& in, uint8_t v
       {
         in >> expr_V >> expr_W >> expr_T_ramp;
       }
+      m_pathTimeStep = DEFAULT_PATH_TIME_STEP;
+      if (version >= 5)
+      {
+        in >> m_pathTimeStep;
+      }
       break;
     default:
       MRPT_THROW_UNKNOWN_SERIALIZATION_VERSION(version);
   };
 }
 
-uint8_t CPTG_Holo_Blend::serializeGetVersion() const { return 4; }
+uint8_t CPTG_Holo_Blend::serializeGetVersion() const { return 5; }
 void CPTG_Holo_Blend::serializeTo(mrpt::serialization::CArchive& out) const
 {
   CParameterizedTrajectoryGenerator::internal_writeToStream(out);
@@ -296,6 +316,7 @@ void CPTG_Holo_Blend::serializeTo(mrpt::serialization::CArchive& out) const
 
   out << T_ramp_max << V_MAX << W_MAX << turningRadiusReference;
   out << expr_V << expr_W << expr_T_ramp;
+  out << m_pathTimeStep;  // v5
 }
 
 std::optional<std::pair<int, double>> CPTG_Holo_Blend::inverseMap_WS2TP(
@@ -306,7 +327,6 @@ std::optional<std::pair<int, double>> CPTG_Holo_Blend::inverseMap_WS2TP(
   ASSERT_(x != 0 || y != 0);
 
   const double err_threshold = 1e-2;
-  const double T_ramp = T_ramp_max;
   const double vxi = m_nav_dyn_state.curVelLocal.vx, vyi = m_nav_dyn_state.curVelLocal.vy;
 
   // Use a Newton iterative non-linear optimizer to find the "exact" solution
@@ -324,6 +344,12 @@ std::optional<std::pair<int, double>> CPTG_Holo_Blend::inverseMap_WS2TP(
   bool sol_found = false;
   for (int iters = 0; !sol_found && iters < 25; iters++)
   {
+    // The ramp duration may itself depend on the direction (`expr_T_ramp`),
+    // so re-evaluate it for the current estimate. Its derivative is left out
+    // of the Jacobian below: that only slows convergence down, it does not
+    // bias the solution, since the residual is exact.
+    const double alpha = atan2(q[2], q[1]);
+    const double T_ramp = internal_get_T_ramp(alpha);
     const double TR_ = 1.0 / (T_ramp);
     const double TR2_ = 1.0 / (2 * T_ramp);
 
@@ -339,7 +365,6 @@ std::optional<std::pair<int, double>> CPTG_Holo_Blend::inverseMap_WS2TP(
       r[0] = vxi * q[0] + q[0] * q[0] * TR2_ * (q[1] - vxi) - x;
       r[1] = vyi * q[0] + q[0] * q[0] * TR2_ * (q[2] - vyi) - y;
     }
-    const double alpha = atan2(q[2], q[1]);
     const double V_MAXsq = mrpt::square(this->internal_get_v(alpha));
     r[2] = q[1] * q[1] + q[2] * q[2] - V_MAXsq;
 
@@ -383,7 +408,7 @@ std::optional<std::pair<int, double>> CPTG_Holo_Blend::inverseMap_WS2TP(
     const int out_k = CParameterizedTrajectoryGenerator::alpha2index(alpha);
 
     const double solved_t = q[0];
-    const unsigned int solved_step = static_cast<unsigned int>(solved_t / PATH_TIME_STEP);
+    const unsigned int solved_step = static_cast<unsigned int>(solved_t / m_pathTimeStep);
     const double out_d =
         this->getPathDist(static_cast<uint16_t>(out_k), solved_step) / this->refDistance;
 
@@ -423,11 +448,12 @@ size_t CPTG_Holo_Blend::getPathStepCount(uint16_t k) const
   if (m_pathStepCountCache.size() > k && m_pathStepCountCache[k] > 0)
     return m_pathStepCountCache[k];
 
-  uint32_t step;
-  if (!getPathStepForDist(k, this->refDistance, step))
+  const auto optStep = getPathStepForDist(k, this->refDistance);
+  if (!optStep)
   {
     THROW_EXCEPTION_FMT("Could not solve closed-form distance for k=%u", static_cast<unsigned>(k));
   }
+  const uint32_t step = *optStep;
   ASSERT_(step > 0);
   if (m_pathStepCountCache.size() != m_alphaValuesCount)
   {
@@ -439,7 +465,7 @@ size_t CPTG_Holo_Blend::getPathStepCount(uint16_t k) const
 
 mrpt::math::TPose2D CPTG_Holo_Blend::getPathPose(uint16_t k, uint32_t step) const
 {
-  const double t = PATH_TIME_STEP * step;
+  const double t = m_pathTimeStep * step;
   const double dir = CParameterizedTrajectoryGenerator::index2alpha(k);
   COMMON_PTG_DESIGN_PARAMS;
   const double wf = mrpt::signWithZero(dir) * this->internal_get_w(dir);
@@ -496,7 +522,7 @@ mrpt::math::TPose2D CPTG_Holo_Blend::getPathPose(uint16_t k, uint32_t step) cons
 
 double CPTG_Holo_Blend::getPathDist(uint16_t k, uint32_t step) const
 {
-  const double t = PATH_TIME_STEP * step;
+  const double t = m_pathTimeStep * step;
   const double dir = CParameterizedTrajectoryGenerator::index2alpha(k);
 
   COMMON_PTG_DESIGN_PARAMS;
@@ -511,13 +537,15 @@ double CPTG_Holo_Blend::getPathDist(uint16_t k, uint32_t step) const
   }
   else
   {
+    // Past the ramp the robot cruises at the speed of *this* direction,
+    // which is only V_MAX if no `expr_V` was given:
     const double dist_trans =
-        (t - T_ramp) * V_MAX + calc_trans_distance_t_below_Tramp(k2, k4, vxi, vyi, T_ramp);
+        (t - T_ramp) * vf_mod + calc_trans_distance_t_below_Tramp(k2, k4, vxi, vyi, T_ramp);
     return dist_trans;
   }
 }
 
-bool CPTG_Holo_Blend::getPathStepForDist(uint16_t k, double dist, uint32_t& out_step) const
+std::optional<uint32_t> CPTG_Holo_Blend::getPathStepForDist(uint16_t k, double dist) const
 {
   PERFORMANCE_BENCHMARK;
 
@@ -537,8 +565,17 @@ bool CPTG_Holo_Blend::getPathStepForDist(uint16_t k, double dist, uint32_t& out_
 
   if (dist >= dist_trans_T_ramp)
   {
-    // Good solution:
-    t_solved = T_ramp + (dist - dist_trans_T_ramp) / V_MAX;
+    if (vf_mod > EPSILON)
+    {
+      // Good solution:
+      t_solved = T_ramp + (dist - dist_trans_T_ramp) / vf_mod;
+    }
+    else if (dist <= dist_trans_T_ramp)
+    {
+      // The robot stops right at the end of the ramp:
+      t_solved = T_ramp;
+    }
+    // else: unreachable distance, leave t_solved<0 to report failure.
   }
   else
   {
@@ -550,10 +587,10 @@ bool CPTG_Holo_Blend::getPathStepForDist(uint16_t k, double dist, uint32_t& out_
     // 2) b=c=0     -> vi=0
     // 3) Otherwise, general case
     // ------------------------------------
-    if (std::abs(k2) < eps && std::abs(k4) < eps)
+    if (std::abs(k2) < EPSILON && std::abs(k4) < EPSILON)
     {
-      // Case 1
-      t_solved = (dist) / V_MAX;
+      // Case 1: constant velocity, whose modulus is |(vxi,vyi)| == vf_mod
+      if (vf_mod > EPSILON) t_solved = dist / vf_mod;
     }
     else
     {
@@ -562,7 +599,7 @@ bool CPTG_Holo_Blend::getPathStepForDist(uint16_t k, double dist, uint32_t& out_
       const double c = (vxi * vxi + vyi * vyi);
 
       // Numerically-ill case: b=c=0 (initial vel=0)
-      if (std::abs(b) < eps && std::abs(c) < eps)
+      if (std::abs(b) < EPSILON && std::abs(c) < EPSILON)
       {
         // Case 2:
         t_solved = sqrt(2.0) * 1.0 / pow(a, 1.0 / 4.0) * sqrt(dist);
@@ -600,11 +637,9 @@ bool CPTG_Holo_Blend::getPathStepForDist(uint16_t k, double dist, uint32_t& out_
   }
   if (t_solved >= 0)
   {
-    out_step = mrpt::round(t_solved / PATH_TIME_STEP);
-    return true;
+    return static_cast<uint32_t>(mrpt::round(t_solved / m_pathTimeStep));
   }
-  else
-    return false;
+  return std::nullopt;
 }
 
 void CPTG_Holo_Blend::updateTPObstacleSingle(
@@ -641,13 +676,13 @@ void CPTG_Holo_Blend::updateTPObstacleSingle(
 
   double roots[4];
   int num_real_sols = 0;
-  if (std::abs(a) > eps)
+  if (std::abs(a) > EPSILON)
   {
     // General case: 4th order equation
     // a * x^4 + b * x^3 + c * x^2 + d * x + e
     num_real_sols = mrpt::math::solve_poly4(roots, b / a, c / a, d / a, e / a);
   }
-  else if (std::abs(b) > eps)
+  else if (std::abs(b) > EPSILON)
   {
     // Special case: k2=k4=0 (straight line path, no blend)
     // 3rd order equation:
@@ -723,7 +758,7 @@ void CPTG_Holo_Blend::updateTPObstacleSingle(
   if (sol_t < T_ramp)
     dist = calc_trans_distance_t_below_Tramp(k2, k4, vxi, vyi, sol_t);
   else
-    dist = (sol_t - T_ramp) * V_MAX + calc_trans_distance_t_below_Tramp(k2, k4, vxi, vyi, T_ramp);
+    dist = (sol_t - T_ramp) * vf_mod + calc_trans_distance_t_below_Tramp(k2, k4, vxi, vyi, T_ramp);
 
   // Store in the output variable:
   internal_TPObsDistancePostprocess(ox, oy, dist, tp_obstacle_k);
@@ -758,13 +793,13 @@ double CPTG_Holo_Blend::maxTimeInVelCmdNOP(int path_k) const
 
   const size_t nSteps = getPathStepCount(static_cast<uint16_t>(path_k));
   const double max_t =
-		PATH_TIME_STEP *
+		m_pathTimeStep *
 		(static_cast<double>(nSteps) *
 		 0.7 /* leave room for obstacle detection ahead when we are far down the predicted PTG path */);
   return max_t;
 }
 
-double CPTG_Holo_Blend::getPathStepDuration() const { return PATH_TIME_STEP; }
+double CPTG_Holo_Blend::getPathStepDuration() const { return m_pathTimeStep; }
 CPTG_Holo_Blend::CPTG_Holo_Blend() { internal_construct_exprs(); }
 CPTG_Holo_Blend::CPTG_Holo_Blend(
     const mrpt::config::CConfigFileBase& cfg, const std::string& sSection) :

--- a/modules/mrpt_nav/src/tpspace/CPTG_Holo_Blend.cpp
+++ b/modules/mrpt_nav/src/tpspace/CPTG_Holo_Blend.cpp
@@ -20,6 +20,8 @@
 #include <mrpt/serialization/CArchive.h>
 #include <mrpt/system/CTimeLogger.h>
 
+#include <cmath>
+
 using namespace mrpt::nav;
 using namespace mrpt::system;
 
@@ -50,8 +52,10 @@ mrpt::system::CTimeLogger tl_holo("CPTG_Holo_Blend");
 
 void CPTG_Holo_Blend::setPathTimeStep(double dt)
 {
-  ASSERT_GT_(dt, .0);
+  ASSERTMSG_(dt > .0 && std::isfinite(dt), "path_time_step must be finite and positive");
   m_pathTimeStep = dt;
+  // The cached step counts are expressed in these very steps:
+  m_pathStepCountCache.clear();
 }
 
 // As a macro instead of a function (uglier) to allow for const variables
@@ -198,7 +202,7 @@ void CPTG_Holo_Blend::loadDefaultParams()
   CPTG_RobotShape_Circular::loadDefaultParams();
 
   m_alphaValuesCount = 31;
-  m_pathTimeStep = DEFAULT_PATH_TIME_STEP;
+  setPathTimeStep(DEFAULT_PATH_TIME_STEP);
   T_ramp_max = 0.9;
   V_MAX = 1.0;
   W_MAX = mrpt::DEG2RAD(40);
@@ -214,8 +218,11 @@ void CPTG_Holo_Blend::loadFromConfigFile(
   MRPT_LOAD_HERE_CONFIG_VAR_NO_DEFAULT(v_max_mps, double, V_MAX, cfg, sSection);
   MRPT_LOAD_HERE_CONFIG_VAR_DEGREES_NO_DEFAULT(w_max_dps, double, W_MAX, cfg, sSection);
   MRPT_LOAD_CONFIG_VAR(turningRadiusReference, double, cfg, sSection);
-  MRPT_LOAD_HERE_CONFIG_VAR(path_time_step, double, m_pathTimeStep, cfg, sSection);
-  ASSERT_GT_(m_pathTimeStep, .0);
+  {
+    double pathTimeStep = m_pathTimeStep;
+    MRPT_LOAD_HERE_CONFIG_VAR(path_time_step, double, pathTimeStep, cfg, sSection);
+    setPathTimeStep(pathTimeStep);
+  }
 
   MRPT_LOAD_HERE_CONFIG_VAR(expr_V, string, expr_V, cfg, sSection);
   MRPT_LOAD_HERE_CONFIG_VAR(expr_W, string, expr_W, cfg, sSection);
@@ -297,10 +304,11 @@ void CPTG_Holo_Blend::serializeFrom(mrpt::serialization::CArchive& in, uint8_t v
       {
         in >> expr_V >> expr_W >> expr_T_ramp;
       }
-      m_pathTimeStep = DEFAULT_PATH_TIME_STEP;
-      if (version >= 5)
       {
-        in >> m_pathTimeStep;
+        double pathTimeStep = DEFAULT_PATH_TIME_STEP;
+        if (version >= 5) in >> pathTimeStep;
+        // Never trust a stream: an invalid step would be divided by later.
+        setPathTimeStep(pathTimeStep);
       }
       break;
     default:

--- a/modules/mrpt_nav/src/tpspace/CParameterizedTrajectoryGenerator.cpp
+++ b/modules/mrpt_nav/src/tpspace/CParameterizedTrajectoryGenerator.cpp
@@ -475,6 +475,9 @@ void CParameterizedTrajectoryGenerator::internal_TPObsDistancePostprocess(
 
 void mrpt::nav::CParameterizedTrajectoryGenerator::initClearanceDiagram(ClearanceDiagram& cd) const
 {
+  ASSERT_GT_(refDistance, .0);
+  ASSERT_GT_(m_clearance_num_points, 0);
+
   cd.resize(m_alphaValuesCount, m_clearance_decimated_paths);
   for (unsigned int decim_k = 0; decim_k < m_clearance_decimated_paths; decim_k++)
   {
@@ -483,13 +486,15 @@ void mrpt::nav::CParameterizedTrajectoryGenerator::initClearanceDiagram(Clearanc
     const double numStepsPerIncr =
         (static_cast<double>(numPathSteps) - 1.0) / double(m_clearance_num_points);
 
+    // Create one entry per pose that evalClearanceSingleObstacle() will
+    // visit, so each key is the (normalized) distance at which its own
+    // clearance value is measured:
     auto& cl_path = cd.get_path_clearance_decimated(decim_k);
-    for (double step_pointer_dbl = 0.0; step_pointer_dbl < static_cast<double>(numPathSteps);
-         step_pointer_dbl += numStepsPerIncr)
+    for (unsigned int i = 1; i <= m_clearance_num_points; i++)
     {
-      const size_t step = static_cast<size_t>(mrpt::round(step_pointer_dbl));
+      const auto step = static_cast<uint32_t>(mrpt::round(i * numStepsPerIncr));
       const double dist_over_path =
-          this->getPathDist(static_cast<uint16_t>(real_k), static_cast<uint32_t>(step));
+          this->getPathDist(static_cast<uint16_t>(real_k), step) / refDistance;
       cl_path[dist_over_path] = 1.0;  // create entry in map<>
     }
   }
@@ -512,12 +517,6 @@ void CParameterizedTrajectoryGenerator::updateClearance(
   }
 }
 
-void CParameterizedTrajectoryGenerator::updateClearancePost(
-    ClearanceDiagram& /*cd*/, const std::vector<double>& /*TP_obstacles*/) const
-{
-  // Used only when in approx mode (Removed 30/01/2017)
-}
-
 void CParameterizedTrajectoryGenerator::evalClearanceSingleObstacle(
     const double ox,
     const double oy,
@@ -535,7 +534,7 @@ void CParameterizedTrajectoryGenerator::evalClearanceSingleObstacle(
     std::cerr << "[CParameterizedTrajectoryGenerator::"
                  "evalClearanceSingleObstacle] Warning: k="
               << k << " numPathSteps is only=" << numPathSteps
-              << " num of clearance steps=" << inout_realdist2clearance.size();
+              << " num of clearance steps=" << inout_realdist2clearance.size() << "\n";
     return;
   }
 

--- a/modules/mrpt_nav/tests/PTG_variants_unittest.cpp
+++ b/modules/mrpt_nav/tests/PTG_variants_unittest.cpp
@@ -33,6 +33,7 @@
 #include <mrpt/system/filesystem.h>
 #include <mrpt/viz/CSetOfLines.h>
 
+#include <cmath>
 #include <fstream>
 #include <memory>
 
@@ -363,7 +364,7 @@ TEST(PTGBase, score_priority_and_clearance_resolution_setters)
 {
   auto ptg = make_diffdrive_ptg("CPTG_DiffDrive_C");
 
-  ptg->setScorePriorty(0.25);
+  ptg->setScorePriority(0.25);
   EXPECT_NEAR(ptg->getScorePriority(), 0.25, 1e-12);
 
   ptg->setClearanceStepCount(7);
@@ -397,14 +398,10 @@ TEST(PTGBase, clearance_diagram_is_filled_from_obstacles)
   ptg->updateClearance(2.0, 1.0, cd);
   ptg->updateClearance(-2.0, -1.0, cd);
 
-  std::vector<double> tp_obs;
-  ptg->initTPObstacles(tp_obs);
-  ptg->updateClearancePost(cd, tp_obs);
-
   // Clearance values must be finite and non-negative:
   for (uint16_t k = 0; k < ptg->getPathCount(); k++)
   {
-    const double c = cd.getClearance(k, 0.5, false /*integrate_over_path*/);
+    const double c = cd.getClearance(k, 0.5, mrpt::nav::ClearanceQuery::AtDistance);
     EXPECT_TRUE(std::isfinite(c)) << "k=" << k;
     EXPECT_GE(c, .0) << "k=" << k;
   }
@@ -652,8 +649,10 @@ TEST(PTGVariants, points_beyond_the_reference_distance_map_outside_the_unit_rang
 TEST(PTGVariants, getPathStepForDist_beyond_the_path_end_fails)
 {
   auto ptg = make_diffdrive_ptg("CPTG_DiffDrive_C");
-  uint32_t step = 0;
-  EXPECT_FALSE(ptg->getPathStepForDist(0, 1e6 /*way beyond refDistance*/, step));
+  EXPECT_FALSE(ptg->getPathStepForDist(0, 1e6 /*way beyond refDistance*/).has_value());
+
+  // ...but the clamped variant still gives the last step of the path:
+  EXPECT_EQ(ptg->getPathStepForDistClamped(0, 1e6), ptg->getPathStepCount(0) - 1);
 }
 
 TEST(PTGVariants, deinitialized_ptgs_reject_path_queries)
@@ -661,4 +660,105 @@ TEST(PTGVariants, deinitialized_ptgs_reject_path_queries)
   auto ptg = make_diffdrive_ptg("CPTG_DiffDrive_C");
   ptg->deinitialize();
   EXPECT_ANY_THROW(ptg->getPathStepCount(0));
+}
+
+// ---------------------------------------------------------------------------
+//  Regression tests for the TP-Space math model
+// ---------------------------------------------------------------------------
+TEST(PTGHoloBlend, path_distance_matches_the_path_poses_with_a_speed_expression)
+{
+  // With `expr_V` the cruise speed differs per direction, and the arc length
+  // reported by getPathDist() must follow the poses of getPathPose(), not the
+  // nominal V_MAX.
+  mrpt::config::CConfigFileMemory cfg;
+  fill_holo_cfg(cfg, "PTG");
+  cfg.write("PTG", "expr_V", "V_MAX*(1.0-0.5*abs(dir)/pi)");
+
+  auto ptg = CParameterizedTrajectoryGenerator::CreatePTG("CPTG_Holo_Blend", cfg, "PTG", "");
+  ASSERT_TRUE(ptg);
+  ptg->initialize(std::string(), false);
+
+  for (uint16_t k = 0; k < ptg->getPathCount(); k++)
+  {
+    const size_t nSteps = ptg->getPathStepCount(k);
+    ASSERT_GT(nSteps, 2U);
+
+    // Numerically integrate the pose sequence and compare with getPathDist():
+    double arcLen = .0;
+    auto prev = ptg->getPathPose(k, 0);
+    for (uint32_t s = 1; s < nSteps; s++)
+    {
+      const auto cur = ptg->getPathPose(k, s);
+      arcLen += std::hypot(cur.x - prev.x, cur.y - prev.y);
+      prev = cur;
+
+      const double reported = ptg->getPathDist(k, s);
+      EXPECT_NEAR(reported, arcLen, 0.02 + 0.02 * arcLen)
+          << "k=" << k << " step=" << s << " (dir="
+          << mrpt::RAD2DEG(CParameterizedTrajectoryGenerator::Index2alpha(k, ptg->getPathCount()))
+          << " deg)";
+    }
+  }
+}
+
+TEST(PTGHoloBlend, path_time_step_is_a_per_instance_parameter)
+{
+  mrpt::config::CConfigFileMemory cfg;
+  fill_holo_cfg(cfg, "PTG");
+  cfg.write("PTG", "path_time_step", 0.02);
+
+  auto ptg = CParameterizedTrajectoryGenerator::CreatePTG("CPTG_Holo_Blend", cfg, "PTG", "");
+  ptg->initialize(std::string(), false);
+  EXPECT_NEAR(ptg->getPathStepDuration(), 0.02, 1e-12);
+
+  // Instances are independent of each other:
+  mrpt::config::CConfigFileMemory cfg2;
+  fill_holo_cfg(cfg2, "PTG");
+  auto ptgDefault =
+      CParameterizedTrajectoryGenerator::CreatePTG("CPTG_Holo_Blend", cfg2, "PTG", "");
+  ptgDefault->initialize(std::string(), false);
+  EXPECT_NEAR(ptgDefault->getPathStepDuration(), CPTG_Holo_Blend::DEFAULT_PATH_TIME_STEP, 1e-12);
+
+  // ...and it survives a config + serialization round trip:
+  mrpt::config::CConfigFileMemory cfgOut;
+  ptg->saveToConfigFile(cfgOut, "OUT");
+  auto ptgB = CParameterizedTrajectoryGenerator::CreatePTG("CPTG_Holo_Blend", cfgOut, "OUT", "");
+  EXPECT_NEAR(ptgB->getPathStepDuration(), 0.02, 1e-12);
+
+  mrpt::io::CMemoryStream buf;
+  auto arch = mrpt::serialization::archiveFrom(buf);
+  arch << *ptg;
+  buf.Seek(0);
+  CPTG_Holo_Blend ptgC;
+  arch >> ptgC;
+  EXPECT_NEAR(ptgC.getPathStepDuration(), 0.02, 1e-12);
+
+  // A non-positive step is rejected:
+  auto ptgD = std::make_shared<CPTG_Holo_Blend>();
+  EXPECT_ANY_THROW(ptgD->setPathTimeStep(.0));
+}
+
+TEST(PTGBase, clearance_diagram_keys_are_normalized_tps_distances)
+{
+  auto ptg = make_diffdrive_ptg("CPTG_DiffDrive_C");
+
+  mrpt::nav::ClearanceDiagram cd;
+  ptg->initClearanceDiagram(cd);
+
+  EXPECT_EQ(cd.get_decimated_num_paths(), ptg->getClearanceDecimatedPaths());
+
+  for (size_t dk = 0; dk < cd.get_decimated_num_paths(); dk++)
+  {
+    const auto& samples = cd.get_path_clearance_decimated(dk);
+    ASSERT_FALSE(samples.empty());
+    EXPECT_LE(samples.size(), ptg->getClearanceStepCount());
+    for (const auto& [dist, clearance] : samples)
+    {
+      EXPECT_GT(dist, .0) << "decimated k=" << dk;
+      // Grid-based PTGs stop at the first sample at-or-past refDistance, so
+      // the last key can overshoot 1.0 by a fraction of one step:
+      EXPECT_LE(dist, 1.01) << "decimated k=" << dk;
+      EXPECT_EQ(clearance, 1.0);
+    }
+  }
 }

--- a/modules/mrpt_nav/tests/PTGs_unittest.cpp
+++ b/modules/mrpt_nav/tests/PTGs_unittest.cpp
@@ -74,12 +74,10 @@ TEST(NavTests, PTGs_tests)
         bool any_good = false;
         for (size_t k = 0; k < num_paths; k++)
         {
-          uint32_t step;
-
-          if (ptg->getPathStepForDist(static_cast<uint16_t>(k), dist, step))
+          if (const auto step = ptg->getPathStepForDist(static_cast<uint16_t>(k), dist); step)
           {
             any_good = true;
-            double d = ptg->getPathDist(static_cast<uint16_t>(k), step);
+            double d = ptg->getPathDist(static_cast<uint16_t>(k), *step);
             EXPECT_NEAR(d, dist, 0.05) << "Test: step <-> dist match\n PTG: " << sPTGDesc << endl
                                        << "dist:" << dist << "\n";
             num_tests_run++;
@@ -111,15 +109,15 @@ TEST(NavTests, PTGs_tests)
             const auto [k, normalized_d] = *inv;
             any_ok = true;
             // Now, do the inverse operation:
-            uint32_t step;
-            bool step_ok =
-                ptg->getPathStepForDist(static_cast<uint16_t>(k), normalized_d * refDist, step);
+            const auto optStep =
+                ptg->getPathStepForDist(static_cast<uint16_t>(k), normalized_d * refDist);
+            const bool step_ok = optStep.has_value();
             EXPECT_TRUE(step_ok) << "PTG: " << sPTGDesc << endl
                                  << "(tx,ty): " << tx << " " << ty << " k= " << k
                                  << " normalized_d=" << normalized_d << "\n";
             if (step_ok)
             {
-              const mrpt::math::TPose2D pose = ptg->getPathPose(static_cast<uint16_t>(k), step);
+              const mrpt::math::TPose2D pose = ptg->getPathPose(static_cast<uint16_t>(k), *optStep);
               EXPECT_NEAR(pose.x, tx, tolerance_dist)
                   << "Test: inverseMap_WS2TP\n PTG#" << n << ": " << sPTGDesc << endl
                   << "(tx,ty): " << tx << " " << ty << " k= " << k

--- a/modules/mrpt_nav/tests/PlannerSimple2D_unittest.cpp
+++ b/modules/mrpt_nav/tests/PlannerSimple2D_unittest.cpp
@@ -38,12 +38,11 @@ TEST(PlannerSimple2D, findPath)
   pathPlanning.robotRadius = 0.30f;
 
   {
-    std::deque<mrpt::math::TPoint2D> thePath;
-    bool notFound;
     const mrpt::poses::CPose2D origin(20, -110, 0), target(90, 40, 0);
-    pathPlanning.computePath(gridmap, origin, target, thePath, notFound);
+    const auto optPath = pathPlanning.computePath(gridmap, origin, target);
 
-    EXPECT_FALSE(notFound);
+    ASSERT_TRUE(optPath.has_value());
+    const auto& thePath = *optPath;
     EXPECT_EQ(thePath.size(), 416U);
     EXPECT_NEAR(thePath.at(0).x, origin.x(), 1.0);
     EXPECT_NEAR(thePath.at(0).y, origin.y(), 1.0);
@@ -51,13 +50,12 @@ TEST(PlannerSimple2D, findPath)
     EXPECT_NEAR(thePath.back().y, target.y(), 1.0);
   }
   {
-    std::deque<mrpt::math::TPoint2D> thePath;
-    bool notFound;
     const mrpt::poses::CPose2D origin(90, 40, 0), target(20, -110, 0);
-    pathPlanning.computePath(
-        gridmap, origin, target, thePath, notFound, 300.0f /* Max. distance */);
+    const auto optPath =
+        pathPlanning.computePath(gridmap, origin, target, 300.0f /* Max. distance */);
 
-    EXPECT_FALSE(notFound);
+    ASSERT_TRUE(optPath.has_value());
+    const auto& thePath = *optPath;
     EXPECT_EQ(thePath.size(), 416U);
     EXPECT_NEAR(thePath.at(0).x, origin.x(), 1.0);
     EXPECT_NEAR(thePath.at(0).y, origin.y(), 1.0);
@@ -66,22 +64,14 @@ TEST(PlannerSimple2D, findPath)
   }
 
   {
-    std::deque<mrpt::math::TPoint2D> thePath;
-    bool notFound;
     const mrpt::poses::CPose2D origin(20, -110, 0), target(90, 40, 0);
-    pathPlanning.computePath(gridmap, origin, target, thePath, notFound, 10.0f /* Max. distance */);
-
-    EXPECT_TRUE(notFound);
+    EXPECT_FALSE(
+        pathPlanning.computePath(gridmap, origin, target, 10.0f /* Max. distance */).has_value());
   }
 
   {
-    std::deque<mrpt::math::TPoint2D> thePath;
-    bool notFound;
     const mrpt::poses::CPose2D origin(20, -110, 0), target(900, 40, 0);
-    pathPlanning.computePath(
-        gridmap, origin, target, thePath, notFound, 100.0f /* Max. distance */);
-
-    EXPECT_TRUE(notFound);
-    EXPECT_EQ(thePath.size(), 0U);
+    EXPECT_FALSE(
+        pathPlanning.computePath(gridmap, origin, target, 100.0f /* Max. distance */).has_value());
   }
 }

--- a/modules/mrpt_nav/tests/holonomic_unittest.cpp
+++ b/modules/mrpt_nav/tests/holonomic_unittest.cpp
@@ -407,3 +407,61 @@ TEST(MultiObjOptScalarization, combined_score_formula)
   ASSERT_TRUE(best.has_value());
   EXPECT_EQ(*best, 1u);
 }
+
+// ============================================================================
+// Regression tests: speed reduction factors
+// ============================================================================
+TEST(HolonomicMethods, disabling_target_slowdown_still_yields_motion)
+{
+  // With the approach-target slow-down disabled, every method must still
+  // command a non-zero speed (only the *target* factor is dropped, not the
+  // obstacle one).
+  for (const char* className : {"CHolonomicVFF", "CHolonomicND", "CHolonomicFullEval"})
+  {
+    auto method = CAbstractHolonomicReactiveMethod::Factory(className);
+    ASSERT_TRUE(method) << className;
+
+    auto ni = makeNavInput(64, 0.0 /*straight ahead*/, 0.05 /*very close target*/);
+    mrpt::nav::ClearanceDiagram cd;
+    cd.resize(64, 8);
+    for (size_t k = 0; k < 8; k++) cd.get_path_clearance_decimated(k)[1.0] = 1.0;
+    ni.clearance = &cd;
+
+    method->enableApproachTargetSlowDown(true);
+    const double slowedSpeed = method->navigate(ni).desiredSpeed;
+
+    method->enableApproachTargetSlowDown(false);
+    const double fullSpeed = method->navigate(ni).desiredSpeed;
+
+    EXPECT_GT(fullSpeed, .0) << className;
+    EXPECT_LE(fullSpeed, ni.maxRobotSpeed + 1e-9) << className;
+    // A target this close must be approached more slowly when enabled:
+    EXPECT_LT(slowedSpeed, fullSpeed) << className;
+  }
+}
+
+TEST(HolonomicMethods, the_last_target_drives_the_approach_slowdown)
+{
+  // NavInput documents that the *last* target has the highest priority.
+  for (const char* className : {"CHolonomicVFF", "CHolonomicND", "CHolonomicFullEval"})
+  {
+    auto method = CAbstractHolonomicReactiveMethod::Factory(className);
+    ASSERT_TRUE(method) << className;
+
+    mrpt::nav::ClearanceDiagram cd;
+    cd.resize(64, 8);
+    for (size_t k = 0; k < 8; k++) cd.get_path_clearance_decimated(k)[1.0] = 1.0;
+
+    // Same pair of targets, swapped: only the last one may matter.
+    auto niFar = makeNavInput(64, 0.0, 0.05);
+    niFar.targets.emplace_back(0.9, 0.0, 0.0);  // far target last
+    niFar.clearance = &cd;
+
+    auto niNear = makeNavInput(64, 0.0, 0.9);
+    niNear.targets.emplace_back(0.05, 0.0, 0.0);  // near target last
+    niNear.clearance = &cd;
+
+    EXPECT_GT(method->navigate(niFar).desiredSpeed, method->navigate(niNear).desiredSpeed)
+        << className;
+  }
+}

--- a/modules/mrpt_nav/tests/nav_misc_unittest.cpp
+++ b/modules/mrpt_nav/tests/nav_misc_unittest.cpp
@@ -37,6 +37,7 @@
 
 #include <cmath>
 #include <fstream>
+#include <tuple>
 
 using namespace mrpt::nav;
 
@@ -102,27 +103,70 @@ TEST(ClearanceDiagram, resize_rejects_more_decimated_than_actual_paths)
 TEST(ClearanceDiagram, getClearance_of_an_empty_diagram_is_zero)
 {
   ClearanceDiagram cd;
-  EXPECT_EQ(cd.getClearance(0, 1.0, false), .0);
-  EXPECT_EQ(cd.getClearance(0, 1.0, true), .0);
+  EXPECT_EQ(cd.getClearance(0, 1.0, ClearanceQuery::AtDistance), .0);
+  EXPECT_EQ(cd.getClearance(0, 1.0, ClearanceQuery::MeanUpToDistance), .0);
 }
 
-TEST(ClearanceDiagram, getClearance_averages_or_integrates_over_the_path)
+TEST(ClearanceDiagram, getClearance_of_a_path_with_no_samples_is_zero)
+{
+  ClearanceDiagram cd;
+  cd.resize(20, 5);  // resized, but never populated by initClearanceDiagram()
+  ASSERT_FALSE(cd.empty());
+  EXPECT_EQ(cd.getClearance(0, 1.0, ClearanceQuery::AtDistance), .0);
+  EXPECT_EQ(cd.getClearance(0, 1.0, ClearanceQuery::MeanUpToDistance), .0);
+}
+
+TEST(ClearanceDiagram, getClearance_honors_the_query_mode)
+{
+  auto cd = make_clearance_diagram();  // samples: 0.25->0.5, 0.5->0.4, 1.0->0.3
+
+  // "AtDistance" is the sample that covers the query distance:
+  EXPECT_NEAR(cd.getClearance(0, 0.1, ClearanceQuery::AtDistance), 0.5, 1e-9);
+  EXPECT_NEAR(cd.getClearance(0, 0.5, ClearanceQuery::AtDistance), 0.3, 1e-9);
+
+  // "MeanUpToDistance" averages every sample up to (and including) that one:
+  EXPECT_NEAR(cd.getClearance(0, 0.1, ClearanceQuery::MeanUpToDistance), 0.5, 1e-9);
+  EXPECT_NEAR(
+      cd.getClearance(0, 0.5, ClearanceQuery::MeanUpToDistance), (0.5 + 0.4 + 0.3) / 3, 1e-9);
+
+  // A query beyond every stored sample uses them all:
+  EXPECT_NEAR(cd.getClearance(0, 100.0, ClearanceQuery::AtDistance), 0.3, 1e-9);
+  EXPECT_NEAR(
+      cd.getClearance(0, 100.0, ClearanceQuery::MeanUpToDistance), (0.5 + 0.4 + 0.3) / 3, 1e-9);
+
+  EXPECT_ANY_THROW(std::ignore = cd.getClearance(1000, 0.5, ClearanceQuery::AtDistance));
+}
+
+TEST(ClearanceDiagram, getClearance_deprecated_bool_overload_matches_its_documentation)
 {
   auto cd = make_clearance_diagram();
+#if defined(__GNUC__) || defined(__clang__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+#endif
+  EXPECT_NEAR(
+      cd.getClearance(0, 0.5, false /*integrate_over_path*/),
+      cd.getClearance(0, 0.5, ClearanceQuery::AtDistance), 1e-12);
+  EXPECT_NEAR(
+      cd.getClearance(0, 0.5, true /*integrate_over_path*/),
+      cd.getClearance(0, 0.5, ClearanceQuery::MeanUpToDistance), 1e-12);
+#if defined(__GNUC__) || defined(__clang__)
+#pragma GCC diagnostic pop
+#endif
+}
 
-  // Averaged over the path up to (and including) the first sample past the
-  // query distance:
-  const double avg = cd.getClearance(0, 0.5, false /*integrate_over_path*/);
-  EXPECT_NEAR(avg, (0.5 + 0.4 + 0.3) / 3, 1e-9);
+TEST(ClearanceDiagram, resize_to_a_single_decimated_path_is_well_defined)
+{
+  ClearanceDiagram cd;
+  cd.resize(20, 1);
+  EXPECT_EQ(cd.get_decimated_num_paths(), 1U);
+  EXPECT_EQ(cd.decimated_k_to_real_k(0), 0U);
+  for (size_t k = 0; k < 20; k++) EXPECT_EQ(cd.real_k_to_decimated_k(k), 0U);
 
-  // "integrate_over_path" keeps only the last visited sample:
-  const double last = cd.getClearance(0, 0.5, true);
-  EXPECT_NEAR(last, 0.3, 1e-9);
-
-  // A query beyond every stored sample averages them all:
-  EXPECT_NEAR(cd.getClearance(0, 100.0, false), (0.5 + 0.4 + 0.3) / 3, 1e-9);
-
-  EXPECT_ANY_THROW(cd.getClearance(1000, 0.5, false));
+  ClearanceDiagram cd1;
+  cd1.resize(1, 1);
+  EXPECT_EQ(cd1.real_k_to_decimated_k(0), 0U);
+  EXPECT_EQ(cd1.decimated_k_to_real_k(0), 0U);
 }
 
 TEST(ClearanceDiagram, path_clearance_accessors)
@@ -152,7 +196,9 @@ TEST(ClearanceDiagram, serialization_roundtrip)
 
   EXPECT_EQ(cd2.get_actual_num_paths(), cd.get_actual_num_paths());
   EXPECT_EQ(cd2.get_decimated_num_paths(), cd.get_decimated_num_paths());
-  EXPECT_NEAR(cd2.getClearance(0, 1.0, false), cd.getClearance(0, 1.0, false), 1e-12);
+  EXPECT_NEAR(
+      cd2.getClearance(0, 1.0, ClearanceQuery::AtDistance),
+      cd.getClearance(0, 1.0, ClearanceQuery::AtDistance), 1e-12);
 }
 
 TEST(ClearanceDiagram, clear_resets_everything)
@@ -169,18 +215,22 @@ TEST(ClearanceDiagram, renderAs3DObject_fills_a_mesh)
   auto cd = make_clearance_diagram();
 
   mrpt::viz::CMesh mesh;
-  cd.renderAs3DObject(mesh, -1.0, 1.0, -1.0, 1.0, 0.25, false);
+  cd.renderAs3DObject(mesh, -1.0, 1.0, -1.0, 1.0, 0.25, ClearanceQuery::AtDistance);
   EXPECT_GT(mesh.getxMax(), mesh.getxMin());
 
   // An empty diagram renders nothing, but must not throw:
   ClearanceDiagram empty;
   mrpt::viz::CMesh mesh2;
-  EXPECT_NO_THROW(empty.renderAs3DObject(mesh2, -1.0, 1.0, -1.0, 1.0, 0.25, true));
+  EXPECT_NO_THROW(
+      empty.renderAs3DObject(mesh2, -1.0, 1.0, -1.0, 1.0, 0.25, ClearanceQuery::MeanUpToDistance));
 
   // Degenerate rendering bounds are rejected:
-  EXPECT_ANY_THROW(cd.renderAs3DObject(mesh, -1.0, 1.0, -1.0, 1.0, .0 /*cell_res*/, false));
-  EXPECT_ANY_THROW(cd.renderAs3DObject(mesh, 1.0, -1.0, -1.0, 1.0, 0.25, false));
-  EXPECT_ANY_THROW(cd.renderAs3DObject(mesh, -1.0, 1.0, 1.0, -1.0, 0.25, false));
+  EXPECT_ANY_THROW(
+      cd.renderAs3DObject(mesh, -1.0, 1.0, -1.0, 1.0, .0 /*cell_res*/, ClearanceQuery::AtDistance));
+  EXPECT_ANY_THROW(
+      cd.renderAs3DObject(mesh, 1.0, -1.0, -1.0, 1.0, 0.25, ClearanceQuery::AtDistance));
+  EXPECT_ANY_THROW(
+      cd.renderAs3DObject(mesh, -1.0, 1.0, 1.0, -1.0, 0.25, ClearanceQuery::AtDistance));
 }
 
 // ---------------------------------------------------------------------------
@@ -188,73 +238,98 @@ TEST(ClearanceDiagram, renderAs3DObject_fills_a_mesh)
 // ---------------------------------------------------------------------------
 TEST(NavGeomUtils, straight_segment_hits_an_obstacle_ahead)
 {
-  double d = .0;
   // Robot of radius 0.5 moving along +x; obstacle at (2,0):
-  EXPECT_TRUE(collision_free_dist_segment_circ_robot({0, 0}, {5, 0}, 0.5, {2, 0}, d));
-  EXPECT_NEAR(d, 1.5, 1e-9);
+  const auto d = collision_free_dist_segment_circ_robot({0, 0}, {5, 0}, 0.5, {2, 0});
+  ASSERT_TRUE(d.has_value());
+  EXPECT_NEAR(*d, 1.5, 1e-9);
 }
 
 TEST(NavGeomUtils, straight_segment_misses_a_lateral_obstacle)
 {
-  double d = .0;
-  EXPECT_FALSE(collision_free_dist_segment_circ_robot({0, 0}, {5, 0}, 0.5, {2, 3}, d));
-  EXPECT_LT(d, .0);
+  EXPECT_FALSE(collision_free_dist_segment_circ_robot({0, 0}, {5, 0}, 0.5, {2, 3}).has_value());
 }
 
 TEST(NavGeomUtils, straight_segment_ignores_obstacles_behind_and_beyond)
 {
-  double d = .0;
   // Behind the start point:
-  EXPECT_FALSE(collision_free_dist_segment_circ_robot({0, 0}, {5, 0}, 0.5, {-3, 0}, d));
+  EXPECT_FALSE(collision_free_dist_segment_circ_robot({0, 0}, {5, 0}, 0.5, {-3, 0}).has_value());
   // Beyond the segment end:
-  EXPECT_FALSE(collision_free_dist_segment_circ_robot({0, 0}, {1, 0}, 0.5, {9, 0}, d));
+  EXPECT_FALSE(collision_free_dist_segment_circ_robot({0, 0}, {1, 0}, 0.5, {9, 0}).has_value());
 }
 
 TEST(NavGeomUtils, straight_segment_requires_a_non_degenerate_segment)
 {
-  double d = .0;
-  EXPECT_ANY_THROW(collision_free_dist_segment_circ_robot({0, 0}, {0, 0}, 0.5, {2, 0}, d));
+  EXPECT_ANY_THROW(
+      std::ignore = collision_free_dist_segment_circ_robot({0, 0}, {0, 0}, 0.5, {2, 0}));
 }
 
 TEST(NavGeomUtils, arc_path_hits_an_obstacle_on_the_arc)
 {
   // Arc turning left with radius 2 m: the trajectory passes through (2,2).
-  double d = .0;
-  const bool hit = collision_free_dist_arc_circ_robot(2.0, 0.5, {2.0, 2.0}, d);
-  ASSERT_TRUE(hit);
-  EXPECT_GT(d, .0);
+  const auto d = collision_free_dist_arc_circ_robot(2.0, 0.5, {2.0, 2.0});
+  ASSERT_TRUE(d.has_value());
+  EXPECT_GT(*d, .0);
   // A quarter of the circle is pi/2*R ~= 3.14 m; the collision happens a bit
   // earlier because of the robot radius:
-  EXPECT_LT(d, 2.0 * M_PI / 2);
+  EXPECT_LT(*d, 2.0 * M_PI / 2);
 }
 
 TEST(NavGeomUtils, arc_path_misses_a_far_away_obstacle)
 {
-  double d = .0;
-  EXPECT_FALSE(collision_free_dist_arc_circ_robot(2.0, 0.5, {50.0, 50.0}, d));
-  EXPECT_LT(d, .0);
+  EXPECT_FALSE(collision_free_dist_arc_circ_robot(2.0, 0.5, {50.0, 50.0}).has_value());
 }
 
 TEST(NavGeomUtils, arc_path_misses_an_obstacle_inside_the_turning_circle)
 {
-  double d = .0;
   // The center of the turning circle is at (0,2): an obstacle right there is
   // never touched by the arc.
-  EXPECT_FALSE(collision_free_dist_arc_circ_robot(2.0, 0.1, {0.0, 2.0}, d));
+  EXPECT_FALSE(collision_free_dist_arc_circ_robot(2.0, 0.1, {0.0, 2.0}).has_value());
 }
 
 TEST(NavGeomUtils, arc_path_works_for_right_turns_too)
 {
-  double d = .0;
-  const bool hit = collision_free_dist_arc_circ_robot(-2.0, 0.5, {2.0, -2.0}, d);
-  ASSERT_TRUE(hit);
-  EXPECT_GT(d, .0);
+  const auto d = collision_free_dist_arc_circ_robot(-2.0, 0.5, {2.0, -2.0});
+  ASSERT_TRUE(d.has_value());
+  EXPECT_GT(*d, .0);
 }
 
 TEST(NavGeomUtils, arc_path_requires_a_non_degenerate_radius)
 {
-  double d = .0;
-  EXPECT_ANY_THROW(collision_free_dist_arc_circ_robot(.0, 0.5, {2.0, 2.0}, d));
+  EXPECT_ANY_THROW(std::ignore = collision_free_dist_arc_circ_robot(.0, 0.5, {2.0, 2.0}));
+}
+
+TEST(NavGeomUtils, arc_path_handles_obstacles_on_the_turn_center_axis)
+{
+  // Obstacles with x==0 used to make the closed-form solution divide by zero
+  // and return NaN. Check a few of them against a brute-force sampling of the
+  // arc:
+  for (const auto [r, R, oy] :
+       {std::make_tuple(2.0, 0.5, 4.2), std::make_tuple(2.0, 0.5, -0.3),
+        std::make_tuple(-3.0, 0.4, -5.8), std::make_tuple(1.0, 0.5, 1.9)})
+  {
+    const auto d = collision_free_dist_arc_circ_robot(r, R, {0.0, oy});
+    ASSERT_TRUE(d.has_value()) << "r=" << r << " oy=" << oy;
+    EXPECT_TRUE(std::isfinite(*d)) << "r=" << r << " oy=" << oy;
+
+    // Brute force: first arc length at which the robot center is within R of
+    // the obstacle. The center follows (|r|*sin(th), r*(1-cos(th))).
+    const double arcR = std::abs(r);
+    double bruteForce = -1.0;
+    constexpr int N = 200000;
+    for (int i = 0; i <= N; i++)
+    {
+      const double th = 2.0 * M_PI * i / N;
+      const double cx = arcR * std::sin(th);
+      const double cy = r * (1.0 - std::cos(th));
+      if (std::hypot(cx - 0.0, cy - oy) <= R)
+      {
+        bruteForce = arcR * th;
+        break;
+      }
+    }
+    ASSERT_GE(bruteForce, .0) << "r=" << r << " oy=" << oy;
+    EXPECT_NEAR(*d, bruteForce, 1e-3) << "r=" << r << " oy=" << oy;
+  }
 }
 
 // ---------------------------------------------------------------------------
@@ -791,19 +866,10 @@ TEST(PlannerSimple2D, out_of_grid_endpoints_are_reported_as_not_found)
   planner.robotRadius = 0.15f;
 
   const mrpt::poses::CPose2D inside(0, 0, 0), outside(100, 100, 0);
-  std::deque<mrpt::math::TPoint2D> path;
-  bool notFound = false;
 
-  planner.computePath(grid, outside, inside, path, notFound);
-  EXPECT_TRUE(notFound);
-
-  notFound = false;
-  planner.computePath(grid, inside, outside, path, notFound);
-  EXPECT_TRUE(notFound);
-
-  notFound = false;
-  planner.computePath(grid, outside, outside, path, notFound);
-  EXPECT_TRUE(notFound);
+  EXPECT_FALSE(planner.computePath(grid, outside, inside).has_value());
+  EXPECT_FALSE(planner.computePath(grid, inside, outside).has_value());
+  EXPECT_FALSE(planner.computePath(grid, outside, outside).has_value());
 }
 
 TEST(PlannerSimple2D, origin_and_target_in_the_same_cell)
@@ -813,14 +879,11 @@ TEST(PlannerSimple2D, origin_and_target_in_the_same_cell)
   grid.fill(0.6f);
 
   PlannerSimple2D planner;
-  std::deque<mrpt::math::TPoint2D> path;
-  bool notFound = true;
 
-  planner.computePath(
-      grid, mrpt::poses::CPose2D(0.01, 0.01, 0), mrpt::poses::CPose2D(0.02, 0.02, 0), path,
-      notFound);
+  const auto path = planner.computePath(
+      grid, mrpt::poses::CPose2D(0.01, 0.01, 0), mrpt::poses::CPose2D(0.02, 0.02, 0));
 
-  EXPECT_FALSE(notFound);
-  ASSERT_EQ(path.size(), 1U);
-  EXPECT_NEAR(path.front().x, 0.02, 1e-9);
+  ASSERT_TRUE(path.has_value());
+  ASSERT_EQ(path->size(), 1U);
+  EXPECT_NEAR(path->front().x, 0.02, 1e-9);
 }

--- a/modules/mrpt_nav/tests/nav_plan_geometry_utils_unittest.cpp
+++ b/modules/mrpt_nav/tests/nav_plan_geometry_utils_unittest.cpp
@@ -25,63 +25,60 @@ TEST(NavTests, NavGeomUtils_collision_straight_circ_robot)
 
   {
     TPoint2D p0(0, 0), p1(1, 1);
-    double colDist;
     {
       const double R = 0.1;
       TPoint2D pObs(1.0, 0.0);
-      const bool ret = collision_free_dist_segment_circ_robot(p0, p1, R, pObs, colDist);
-      EXPECT_FALSE(ret);
+      const auto ret = collision_free_dist_segment_circ_robot(p0, p1, R, pObs);
+      EXPECT_FALSE(ret.has_value());
     }
     {
       const double R = 0.1;
       TPoint2D pObs(0.0, 1.0);
-      const bool ret = collision_free_dist_segment_circ_robot(p0, p1, R, pObs, colDist);
-      EXPECT_FALSE(ret);
+      const auto ret = collision_free_dist_segment_circ_robot(p0, p1, R, pObs);
+      EXPECT_FALSE(ret.has_value());
     }
     {
       const double R = 0.1;
       TPoint2D pObs(-0.4, -0.4);
-      const bool ret = collision_free_dist_segment_circ_robot(p0, p1, R, pObs, colDist);
-      EXPECT_FALSE(ret);
+      const auto ret = collision_free_dist_segment_circ_robot(p0, p1, R, pObs);
+      EXPECT_FALSE(ret.has_value());
     }
     {
       const double R = 0.1;
       TPoint2D pObs(1.4, 1.4);
-      const bool ret = collision_free_dist_segment_circ_robot(p0, p1, R, pObs, colDist);
-      EXPECT_FALSE(ret);
+      const auto ret = collision_free_dist_segment_circ_robot(p0, p1, R, pObs);
+      EXPECT_FALSE(ret.has_value());
     }
     {
       const double R = 0.1;
       TPoint2D pObs(0.45, 0.48);
-      const bool ret = collision_free_dist_segment_circ_robot(p0, p1, R, pObs, colDist);
-      EXPECT_TRUE(ret);
+      const auto ret = collision_free_dist_segment_circ_robot(p0, p1, R, pObs);
+      ASSERT_TRUE(ret.has_value());
     }
   }
 
   {
     TPoint2D p0(4, 5), p1(5, 5);
-    double colDist;
     const double R = 0.5;
     {
       TPoint2D pObs(5.0, 5.0);
-      const bool ret = collision_free_dist_segment_circ_robot(p0, p1, R, pObs, colDist);
-      EXPECT_TRUE(ret);
-      EXPECT_NEAR(colDist, 0.5, 1e-6);
+      const auto ret = collision_free_dist_segment_circ_robot(p0, p1, R, pObs);
+      ASSERT_TRUE(ret.has_value());
+      EXPECT_NEAR(*ret, 0.5, 1e-6);
     }
     {
       TPoint2D pObs(4.510, 5.001);
-      const bool ret = collision_free_dist_segment_circ_robot(p0, p1, R, pObs, colDist);
-      EXPECT_TRUE(ret);
-      EXPECT_NEAR(colDist, 0.01, 3e-3);
+      const auto ret = collision_free_dist_segment_circ_robot(p0, p1, R, pObs);
+      ASSERT_TRUE(ret.has_value());
+      EXPECT_NEAR(*ret, 0.01, 3e-3);
     }
   }
   {
     TPoint2D p0(0, 0), p1(-2, -1);
-    double colDist;
     const double R = 0.5;
     TPoint2D pObs(-2.0, -1.0);
-    const bool ret = collision_free_dist_segment_circ_robot(p0, p1, R, pObs, colDist);
-    EXPECT_TRUE(ret);
-    EXPECT_NEAR(colDist, std::sqrt(5.0) - 0.5, 1e-6);
+    const auto ret = collision_free_dist_segment_circ_robot(p0, p1, R, pObs);
+    ASSERT_TRUE(ret.has_value());
+    EXPECT_NEAR(*ret, std::sqrt(5.0) - 0.5, 1e-6);
   }
 }

--- a/modules/mrpt_nav/tests/planners_and_logs_unittest.cpp
+++ b/modules/mrpt_nav/tests/planners_and_logs_unittest.cpp
@@ -215,13 +215,10 @@ TEST(PlannerSimple2D, unreachable_goal_yields_an_empty_path)
   PlannerSimple2D planner;
   planner.robotRadius = 0.15f;
 
-  std::deque<mrpt::math::TPoint2D> path;
-  bool notFound = false;
-  planner.computePath(
-      grid, mrpt::poses::CPose2D(-2, 0, 0), mrpt::poses::CPose2D(2, 0, 0), path, notFound, 20.0f);
+  const auto path = planner.computePath(
+      grid, mrpt::poses::CPose2D(-2, 0, 0), mrpt::poses::CPose2D(2, 0, 0), 20.0f);
 
-  EXPECT_TRUE(notFound);
-  EXPECT_TRUE(path.empty());
+  EXPECT_FALSE(path.has_value());
 }
 
 TEST(PlannerSimple2D, path_is_found_in_an_open_map)
@@ -233,15 +230,13 @@ TEST(PlannerSimple2D, path_is_found_in_an_open_map)
   PlannerSimple2D planner;
   planner.robotRadius = 0.15f;
 
-  std::deque<mrpt::math::TPoint2D> path;
-  bool notFound = true;
-  planner.computePath(
-      grid, mrpt::poses::CPose2D(-2, 0, 0), mrpt::poses::CPose2D(2, 0, 0), path, notFound, -1.0f);
+  const auto path = planner.computePath(
+      grid, mrpt::poses::CPose2D(-2, 0, 0), mrpt::poses::CPose2D(2, 0, 0), -1.0f);
 
-  EXPECT_FALSE(notFound);
-  EXPECT_GT(path.size(), 1U);
-  EXPECT_NEAR(path.back().x, 2.0, 0.5);
-  EXPECT_NEAR(path.back().y, 0.0, 0.5);
+  ASSERT_TRUE(path.has_value());
+  EXPECT_GT(path->size(), 1U);
+  EXPECT_NEAR(path->back().x, 2.0, 0.5);
+  EXPECT_NEAR(path->back().y, 0.0, 0.5);
 }
 
 // ---------------------------------------------------------------------------

--- a/modules/mrpt_nav/tests/rnav_variants_unittest.cpp
+++ b/modules/mrpt_nav/tests/rnav_variants_unittest.cpp
@@ -420,3 +420,39 @@ TEST(RNavVariants, changing_the_robot_shape_after_initialization)
   tooFew.add_vertex(1, 0);
   EXPECT_ANY_THROW(f.nav->changeRobotShape(tooFew));
 }
+
+TEST(RNavVariants, end_of_trajectory_pose_is_taken_at_the_right_path_distance)
+{
+  // `robpose_*` and `dist_eucl_final` are read off the PTG path at the
+  // collision-free distance, which is normalized, while getPathStepForDist()
+  // takes pseudometers: a missing `* ref_distance` picks a step ~ref_distance
+  // times too early, leaving the reported "end of trajectory" almost on top of
+  // the robot.
+  RNavFixture f;
+  f.build(make_rnav_config(false, false, .0, true));
+  f.nav->enableKeepLogRecords(true);
+
+  const mrpt::math::TPoint2D trg(3.0, .0);  // free path, well within ref_distance
+  f.run(trg, 1 /*a single navigation step is enough*/);
+
+  CLogFileRecord rec;
+  f.nav->getLastLogRecord(rec);
+  ASSERT_FALSE(rec.infoPerPTG.empty());
+
+  const auto& factors = rec.infoPerPTG.at(0).evalFactors;
+  ASSERT_EQ(factors.count("robpose_x"), 1U);
+  ASSERT_EQ(factors.count("collision_free_distance"), 1U);
+
+  const double refDist = f.nav->getPTG(0)->getRefDistance();
+  const double colFree = factors.at("collision_free_distance");
+  const mrpt::math::TPoint2D endPose(factors.at("robpose_x"), factors.at("robpose_y"));
+
+  // Nothing blocks the way, so the candidate runs up to the target:
+  EXPECT_GT(colFree, 0.5);
+
+  // The end-of-trajectory pose must be about `colFree * refDist` metres away
+  // along the path, hence at least that far in a straight line minus the
+  // path's curvature. Anything near zero means the wrong step was picked.
+  EXPECT_GT(endPose.norm(), 0.5 * colFree * refDist)
+      << "colFree=" << colFree << " refDist=" << refDist << " end=" << endPose.asString();
+}

--- a/mrpt_examples_cpp/nav_circ_robot_path_planning/main.cpp
+++ b/mrpt_examples_cpp/nav_circ_robot_path_planning/main.cpp
@@ -64,8 +64,6 @@ void TestPathPlanning()
   PlannerSimple2D pathPlanning;
   pathPlanning.robotRadius = 0.30f;
 
-  std::deque<TPoint2D> thePath;
-  bool notFound;
   CTicTac tictac;
 
   CPose2D origin(20, -110, 0);
@@ -78,13 +76,14 @@ void TestPathPlanning()
   cout.flush();
   tictac.Tic();
 
-  pathPlanning.computePath(gridmap, origin, target, thePath, notFound);
+  const auto optPath = pathPlanning.computePath(gridmap, origin, target);
 
   double t = tictac.Tac();
   std::cout << "Done in " << t * 1000 << " ms"
             << "\n";
 
-  printf("Path found: %s\n", notFound ? "NO" : "YES");
+  printf("Path found: %s\n", optPath ? "YES" : "NO");
+  const std::deque<TPoint2D> thePath = optPath.value_or(std::deque<TPoint2D>());
   printf("Path has %zu steps\n", thePath.size());
 
   // Save result:

--- a/mrpt_examples_cpp/nav_ptg_tpspace/CMakeLists.txt
+++ b/mrpt_examples_cpp/nav_ptg_tpspace/CMakeLists.txt
@@ -1,0 +1,20 @@
+#-----------------------------------------------------------------------------------------------
+# CMake file for the MRPT example: nav_ptg_tpspace
+# Generated automatically - Manual changes may be overwritten.
+#-----------------------------------------------------------------------------------------------
+cmake_minimum_required(VERSION 3.16)
+
+project(nav_ptg_tpspace)
+
+# Basic MRPT infrastructure
+find_package(mrpt_common REQUIRED)
+
+# Dependencies
+find_package(mrpt_nav REQUIRED)
+
+# Define the executable target:
+mrpt_add_executable(
+  TARGET nav_ptg_tpspace
+  SOURCES main.cpp
+  LINK_LIBRARIES mrpt::mrpt_nav
+)

--- a/mrpt_examples_cpp/nav_ptg_tpspace/README.md
+++ b/mrpt_examples_cpp/nav_ptg_tpspace/README.md
@@ -1,0 +1,5 @@
+This console example shows the TP-Space transformation implemented by
+[CParameterizedTrajectoryGenerator](class_mrpt_nav_CParameterizedTrajectoryGenerator.html):
+building a PTG from a config file, mapping Workspace obstacles into
+collision-free distances per path, querying the clearance diagram, and turning
+a chosen path index back into a robot velocity command.

--- a/mrpt_examples_cpp/nav_ptg_tpspace/main.cpp
+++ b/mrpt_examples_cpp/nav_ptg_tpspace/main.cpp
@@ -1,0 +1,115 @@
+/*                    _
+                     | |    Mobile Robot Programming Toolkit (MRPT)
+ _ __ ___  _ __ _ __ | |_
+| '_ ` _ \| '__| '_ \| __|          https://www.mrpt.org/
+| | | | | | |  | |_) | |_
+|_| |_| |_|_|  | .__/ \__|     https://github.com/MRPT/mrpt/
+               | |
+               |_|
+
+ Copyright (c) 2005-2026, Individual contributors, see AUTHORS file
+ See: https://www.mrpt.org/Authors - All rights reserved.
+ SPDX-License-Identifier: BSD-3-Clause
+*/
+
+//! Minimal, headless walk-through of the TP-Space transformation of a PTG.
+
+#include <mrpt/config/CConfigFileMemory.h>
+#include <mrpt/nav/tpspace/CParameterizedTrajectoryGenerator.h>
+
+#include <iostream>
+
+using namespace mrpt::nav;
+
+int main()
+{
+  try
+  {
+    // 1) Build a PTG by class name, from parameters in a (here, in-memory)
+    //    config file. See each PTG class docs for its own parameters.
+    mrpt::config::CConfigFileMemory cfg;
+    const std::string sect = "PTG";
+    cfg.write(sect, "num_paths", 61);     // how many discrete `alpha` values
+    cfg.write(sect, "refDistance", 4.0);  // trajectories are cut at 4 m
+    cfg.write(sect, "T_ramp_max", 0.8);
+    cfg.write(sect, "v_max_mps", 1.0);
+    cfg.write(sect, "w_max_dps", 60.0);
+    cfg.write(sect, "robot_radius", 0.35);
+
+    auto ptg = CParameterizedTrajectoryGenerator::CreatePTG("CPTG_Holo_Blend", cfg, sect, "");
+
+    // initialize() is where collision look-up tables get built (or loaded from
+    // a cache file, for the grid-based PTG families):
+    ptg->initialize();
+
+    std::cout << "PTG: " << ptg->getDescription() << "\n"
+              << " paths       : " << ptg->getPathCount() << "\n"
+              << " ref distance: " << ptg->getRefDistance() << " m\n\n";
+
+    // 2) Workspace -> TP-Space: each obstacle point shortens the collision-free
+    //    length of every path it blocks.
+    const std::vector<mrpt::math::TPoint2D> obstacles = {
+        {1.5,  0.0},
+        {1.6,  0.3},
+        {1.6, -0.3},
+        {2.5,  1.6}
+    };
+
+    std::vector<double> tp_obstacles;
+    ptg->initTPObstacles(tp_obstacles);  // all free: refDistance everywhere
+
+    ClearanceDiagram clearance;
+    ptg->initClearanceDiagram(clearance);
+
+    for (const auto& o : obstacles)
+    {
+      ptg->updateTPObstacle(o.x, o.y, tp_obstacles);
+      ptg->updateClearance(o.x, o.y, clearance);
+    }
+
+    // 3) In TP-Space the robot is a point free to move in any direction, so
+    //    picking a motion is just picking the best `k`. Here: the longest
+    //    collision-free path.
+    uint16_t best_k = 0;
+    for (uint16_t k = 1; k < ptg->getPathCount(); k++)
+    {
+      if (tp_obstacles[k] > tp_obstacles[best_k]) best_k = k;
+    }
+
+    std::cout << "Freest direction: k=" << best_k
+              << " (alpha=" << mrpt::RAD2DEG(ptg->index2alpha(best_k)) << " deg)\n"
+              << " collision-free : " << tp_obstacles[best_k] << " m\n"
+              << " clearance      : "
+              << clearance.getClearance(best_k, 1.0, ClearanceQuery::MeanUpToDistance) << "\n";
+
+    // The pose the robot would reach at the end of that free stretch:
+    if (const auto step = ptg->getPathStepForDist(best_k, tp_obstacles[best_k]); step)
+    {
+      std::cout << " end pose       : " << ptg->getPathPose(best_k, *step).asString() << "\n";
+    }
+
+    // 4) TP-Space -> Workspace: the velocity command that follows path `k`.
+    const auto cmd = ptg->directionToMotionCommand(best_k);
+    std::cout << " velocity cmd   : " << cmd->asString() << "\n\n";
+
+    // 5) The inverse map answers "which path passes through this point?":
+    const mrpt::math::TPoint2D query(1.0, 0.5);
+    if (const auto tp = ptg->inverseMap_WS2TP(query.x, query.y); tp)
+    {
+      const auto [k, normalized_d] = *tp;
+      std::cout << "Point " << query.asString() << " lies on path k=" << k
+                << " at normalized distance " << normalized_d << "\n";
+    }
+    else
+    {
+      std::cout << "Point " << query.asString() << " is outside the PTG domain\n";
+    }
+
+    return 0;
+  }
+  catch (const std::exception& e)
+  {
+    std::cerr << "MRPT error: " << mrpt::exception_to_str(e) << "\n";
+    return 1;
+  }
+}


### PR DESCRIPTION
An API and mathematics pass over `mrpt_nav`, separate from the recent coverage work (#1388). Test count 246 → 251; all pass.

## API modernization

`bool` + out-param signatures replaced by `std::optional`, following what `inverseMap_WS2TP()` already does. The old forms stay as `[[deprecated]]` shims unless noted:

- `CParameterizedTrajectoryGenerator::getPathStepForDist(k, dist)`. The old 3-arg form *also* wrote the last path step into `out_step` when it returned `false`, and two call sites quietly depended on that; the explicit `getPathStepForDistClamped()` now covers it.
- `nav_plan_geometry_utils::collision_free_dist_{segment,arc}_circ_robot()`
- `PlannerSimple2D::computePath()`

Other changes:

- `ClearanceDiagram::getClearance()`'s `bool integrate_over_path` → `enum class ClearanceQuery`. One flag had three different names across the codebase (`integrate_over_path`, "spot, dont interpolate", "interpolate") and none matched the implementation — see bug 1.
- `CPTG_Holo_Blend::PATH_TIME_STEP`, a process-wide mutable global backing a *per-instance* virtual (`getPathStepDuration()`), becomes the per-instance `path_time_step` config key + `setPathTimeStep()` (serialization v5). `eps` becomes `constexpr EPSILON`. Neither admits a compatible shim.
- `setScorePriorty()` → `setScorePriority()`.
- Deleted: `updateClearancePost()`, a documented no-op since 2017, and `CAbstractHolonomicReactiveMethod::Create()` — declared in a public header but **never defined anywhere**, so any call was a link error.

## Bugs fixed

Each has a regression test that fails without the fix.

1. **`getClearance()`'s two modes were swapped** relative to its own docs, to every call site's comment, and to the ptg-configurator's UI label: `false` averaged over the path and `true` returned the spot value. The reactive navigator's `clearance` and `clearance_path` score factors therefore held each other's values (only reachable with `evaluate_clearance=true`, off by default).
2. **`initClearanceDiagram()` keyed samples by raw path distance in metres** while every consumer treats those keys as normalized [0,1] TPS distances: `getClearance()` queries, the `dist_over_path > 0.5` collision heuristic, and `CAbstractPTGBasedReactive`'s own `dist_eucl_min` producer, which builds the same map keyed `i/num_steps`.
3. Same function sampled steps `0, incr, 2·incr…` while `evalClearanceSingleObstacle()` evaluates `incr, 2·incr…`, so every clearance value was filed under a shorter distance than the one it was measured at.
4. **`CHolonomicVFF::navigate()` assigned `desiredSpeed` inside `if (m_enableApproachTargetSlowDown)`**, so with the slow-down disabled it returned speed 0 and the robot never moved. `CHolonomicND`/`CHolonomicFullEval` had it right.
5. `CHolonomicFullEval` slowed down for `targets.front()`; `NavInput` documents the *last* target as the highest-priority one.
6. **`CPTG_Holo_Blend` used `V_MAX` as the post-ramp cruise speed** in `getPathDist()`, `getPathStepForDist()` and `updateTPObstacleSingle()`, while `getPathPose()` advances at the direction-dependent `internal_get_v(dir)`. With an `expr_V` configured, poses and distances disagreed. `inverseMap_WS2TP()` likewise pinned `T_ramp = T_ramp_max` instead of `internal_get_T_ramp(alpha)`; it is now re-evaluated per Newton iteration (the Jacobian omits dT/dα, which costs iterations, not accuracy, since the residual is exact).
7. **`collision_free_dist_arc_circ_robot()` returned NaN for any obstacle on the turn-center axis** — the closed form divides by the obstacle's `x`. Rewritten as a two-circle intersection; it agrees with the old formula to 1.7e-11 over 21k random collision cases, and now returns 0 when the robot starts already in collision instead of the *exit* distance.

## Math model

`CPTG_Holo_Blend`'s arc-length quadrature moves from a 15-interval trapezoidal rule to 16-interval Simpson — the same number of function evaluations for ~25× lower mean relative error — plus an exact branch for the degenerate `b²−4ac ≈ 0` case, where the integrand is `sqrt(a)·|t−r|`.

## Docs and examples

The PTG base class description is rewritten around what TP-Space actually is, dropping its 20-year change log; `inverseMap_WS2TP()`'s docs still listed out-params removed in 3.x. New headless example `mrpt_examples_cpp/nav_ptg_tpspace` walks the whole WS → TP-Space → velocity-command round trip.

`agents.md` §11 records the whole pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a headless console example for TP-Space path planning, obstacle handling, clearance queries, and velocity commands.
  - Added configurable per-instance path timing for blended holonomic trajectories.
  - Added optional-result APIs for path planning, collision checks, and trajectory sampling.
  - Added explicit clearance query modes and clamped trajectory-step lookup.

- **Bug Fixes**
  - Improved clearance calculations, collision detection, speed control, and trajectory distance integration.
  - Fixed edge cases involving empty or decimated paths and direction-dependent speeds.

- **Documentation**
  - Documented navigation API updates and added example usage guidance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->