### PR TITLE
fix: resolve gcc warnings flagged by the ROS buildfarm (Humble/Jazzy)

### DIFF
--- a/modules/mrpt_bayes/include/mrpt/bayes/CKalmanFilterCapable.h
+++ b/modules/mrpt_bayes/include/mrpt/bayes/CKalmanFilterCapable.h
@@ -46,7 +46,7 @@ namespace bayes
  * \sa bayes::CKalmanFilterCapable::KF_options
  * \ingroup mrpt_bayes_grp
  */
-enum TKFMethod : int
+enum TKFMethod : std::uint8_t
 {
   kfEKFNaive = 0,
   kfEKFAlaDavison,

--- a/modules/mrpt_bayes/include/mrpt/bayes/CKalmanFilterCapable.h
+++ b/modules/mrpt_bayes/include/mrpt/bayes/CKalmanFilterCapable.h
@@ -46,7 +46,7 @@ namespace bayes
  * \sa bayes::CKalmanFilterCapable::KF_options
  * \ingroup mrpt_bayes_grp
  */
-enum TKFMethod
+enum TKFMethod : int
 {
   kfEKFNaive = 0,
   kfEKFAlaDavison,

--- a/modules/mrpt_bayes/include/mrpt/bayes/CKalmanFilterCapable_impl.h
+++ b/modules/mrpt_bayes/include/mrpt/bayes/CKalmanFilterCapable_impl.h
@@ -31,11 +31,11 @@ namespace kf_detail
 template <typename MAT_R, typename MAT_A, typename MAT_B>
 static void matmul_acc(MAT_R& r, const MAT_A& a, const MAT_B& b)
 {
-  for (int i = 0; i < (int)a.rows(); ++i)
+  for (int i = 0; i < static_cast<int>(a.rows()); ++i)
   {
-    for (int j = 0; j < (int)b.cols(); ++j)
+    for (int j = 0; j < static_cast<int>(b.cols()); ++j)
     {
-      for (int k = 0; k < (int)a.cols(); ++k)
+      for (int k = 0; k < static_cast<int>(a.cols()); ++k)
       {
         r(i, j) += a(i, k) * b(k, j);
       }
@@ -53,11 +53,11 @@ static void matmul(MAT_R& r, const MAT_A& a, const MAT_B& b)
 template <typename MAT_R, typename MAT_A, typename MAT_B>
 static void matmul_ABt_acc(MAT_R& r, const MAT_A& a, const MAT_B& b)
 {
-  for (int i = 0; i < (int)a.rows(); ++i)
+  for (int i = 0; i < static_cast<int>(a.rows()); ++i)
   {
-    for (int j = 0; j < (int)b.rows(); ++j)
+    for (int j = 0; j < static_cast<int>(b.rows()); ++j)
     {
-      for (int k = 0; k < (int)a.cols(); ++k)
+      for (int k = 0; k < static_cast<int>(a.cols()); ++k)
       {
         r(i, j) += a(i, k) * b(j, k);
       }
@@ -75,9 +75,9 @@ static void matmul_ABt(MAT_R& r, const MAT_A& a, const MAT_B& b)
 template <typename MAT>
 static void symmetrize(MAT& m)
 {
-  for (int r = 0; r < (int)m.rows(); ++r)
+  for (int r = 0; r < static_cast<int>(m.rows()); ++r)
   {
-    for (int c = r + 1; c < (int)m.cols(); ++c)
+    for (int c = r + 1; c < static_cast<int>(m.cols()); ++c)
     {
       const auto avg = static_cast<typename MAT::Scalar>(0.5) * (m(r, c) + m(c, r));
       m(r, c) = avg;
@@ -89,9 +89,9 @@ static void symmetrize(MAT& m)
 template <typename MAT>
 static void mat_scale_acc(MAT& dst, const MAT& src, typename MAT::Scalar scale)
 {
-  for (int r = 0; r < (int)dst.rows(); ++r)
+  for (int r = 0; r < static_cast<int>(dst.rows()); ++r)
   {
-    for (int c = 0; c < (int)dst.cols(); ++c)
+    for (int c = 0; c < static_cast<int>(dst.cols()); ++c)
     {
       dst(r, c) += scale * src(r, c);
     }
@@ -101,9 +101,9 @@ static void mat_scale_acc(MAT& dst, const MAT& src, typename MAT::Scalar scale)
 template <typename MAT>
 static void mat_sub_inplace(MAT& dst, const MAT& src)
 {
-  for (int r = 0; r < (int)dst.rows(); ++r)
+  for (int r = 0; r < static_cast<int>(dst.rows()); ++r)
   {
-    for (int c = 0; c < (int)dst.cols(); ++c)
+    for (int c = 0; c < static_cast<int>(dst.cols()); ++c)
     {
       dst(r, c) -= src(r, c);
     }
@@ -114,9 +114,9 @@ template <typename MAT>
 static std::string mat_to_str(const MAT& m)
 {
   std::ostringstream ss;
-  for (int r = 0; r < (int)m.rows(); ++r)
+  for (int r = 0; r < static_cast<int>(m.rows()); ++r)
   {
-    for (int c = 0; c < (int)m.cols(); ++c)
+    for (int c = 0; c < static_cast<int>(m.cols()); ++c)
     {
       ss << m(r, c) << " ";
     }
@@ -129,9 +129,9 @@ template <typename MAT>
 static typename MAT::Scalar mat_diff_sum_abs(const MAT& a, const MAT& b)
 {
   typename MAT::Scalar s = 0;
-  for (int r = 0; r < (int)a.rows(); ++r)
+  for (int r = 0; r < static_cast<int>(a.rows()); ++r)
   {
-    for (int c = 0; c < (int)a.cols(); ++c)
+    for (int c = 0; c < static_cast<int>(a.cols()); ++c)
     {
       auto d = a(r, c) - b(r, c);
       s += d < 0 ? -d : d;
@@ -767,7 +767,7 @@ void CKalmanFilterCapable<VEH_SIZE, OBS_SIZE, FEAT_SIZE, ACT_SIZE, KFTYPE>::runO
               m_timLogger.enter("KF:8.update stage:2.FULLKF:update xkk");
               KFVector Kytilde;
               kf_detail::matmul(Kytilde, m_K, ytilde);
-              for (int q = 0; q < (int)m_xkk.size(); q++)
+              for (int q = 0; q < static_cast<int>(m_xkk.size()); q++)
               {
                 m_xkk[q] += Kytilde[q];
               }
@@ -779,7 +779,7 @@ void CKalmanFilterCapable<VEH_SIZE, OBS_SIZE, FEAT_SIZE, ACT_SIZE, KFTYPE>::runO
 
               // diff = m_xkk - xkk_0
               KFVector diff(m_xkk.size());
-              for (int q = 0; q < (int)m_xkk.size(); q++)
+              for (int q = 0; q < static_cast<int>(m_xkk.size()); q++)
               {
                 diff[q] = m_xkk[q] - xkk_0[q];
               }
@@ -788,7 +788,7 @@ void CKalmanFilterCapable<VEH_SIZE, OBS_SIZE, FEAT_SIZE, ACT_SIZE, KFTYPE>::runO
               kf_detail::matmul(HAx_column, m_dh_dx_full_obs, diff);
               // ytilde2 = ytilde - HAx_column
               KFVector ytilde2(ytilde.size());
-              for (int q = 0; q < (int)ytilde.size(); q++)
+              for (int q = 0; q < static_cast<int>(ytilde.size()); q++)
               {
                 ytilde2[q] = ytilde[q] - HAx_column[q];
               }
@@ -796,7 +796,7 @@ void CKalmanFilterCapable<VEH_SIZE, OBS_SIZE, FEAT_SIZE, ACT_SIZE, KFTYPE>::runO
               m_xkk = xkk_0;
               KFVector Kytilde2;
               kf_detail::matmul(Kytilde2, m_K, ytilde2);
-              for (int q = 0; q < (int)m_xkk.size(); q++)
+              for (int q = 0; q < static_cast<int>(m_xkk.size()); q++)
               {
                 m_xkk[q] += Kytilde2[q];
               }
@@ -902,9 +902,9 @@ void CKalmanFilterCapable<VEH_SIZE, OBS_SIZE, FEAT_SIZE, ACT_SIZE, KFTYPE>::runO
                 if (KF_options.use_joseph_form)
                 {
                   // P' = P - dP - dP^T + K*S_observed*K^T
-                  for (int r = 0; r < (int)m_pkk.rows(); r++)
+                  for (int r = 0; r < static_cast<int>(m_pkk.rows()); r++)
                   {
-                    for (int c = 0; c < (int)m_pkk.cols(); c++)
+                    for (int c = 0; c < static_cast<int>(m_pkk.cols()); c++)
                     {
                       m_pkk(r, c) -= dP(r, c) + dP(c, r);
                     }
@@ -929,9 +929,9 @@ void CKalmanFilterCapable<VEH_SIZE, OBS_SIZE, FEAT_SIZE, ACT_SIZE, KFTYPE>::runO
                   const KFMatrix pkk_dense_result = dense_P_update(m_pkk);
 
                   KFTYPE max_diff = 0;
-                  for (int r = 0; r < (int)pkk_sparse_result.rows(); r++)
+                  for (int r = 0; r < static_cast<int>(pkk_sparse_result.rows()); r++)
                   {
-                    for (int c = 0; c < (int)pkk_sparse_result.cols(); c++)
+                    for (int c = 0; c < static_cast<int>(pkk_sparse_result.cols()); c++)
                     {
                       auto d = pkk_sparse_result(r, c) - pkk_dense_result(r, c);
                       if (d < 0)
@@ -1123,21 +1123,21 @@ void CKalmanFilterCapable<VEH_SIZE, OBS_SIZE, FEAT_SIZE, ACT_SIZE, KFTYPE>::runO
               KFVector Kij_vec;
               kf_detail::matmul(Kij_vec, m_pkk, h_j);
               const KFTYPE inv_Sij = KFTYPE(1) / Sij;
-              for (int q = 0; q < (int)N; q++)
+              for (int q = 0; q < static_cast<int>(N); q++)
               {
                 Kij_vec[q] *= inv_Sij;
               }
 
               // Update state: x' = x + Kij_vec * ytilde(j)
-              for (int q = 0; q < (int)N; q++)
+              for (int q = 0; q < static_cast<int>(N); q++)
               {
                 m_xkk[q] += Kij_vec[q] * ytilde[j];
               }
 
               // Update covariance: P' = P - Sij * Kij * Kij^T (rank-1 downdate)
-              for (int r = 0; r < (int)N; r++)
+              for (int r = 0; r < static_cast<int>(N); r++)
               {
-                for (int c = 0; c < (int)N; c++)
+                for (int c = 0; c < static_cast<int>(N); c++)
                 {
                   m_pkk(r, c) -= Sij * Kij_vec[r] * Kij_vec[c];
                 }
@@ -1288,7 +1288,8 @@ void addNewLandmarks(
       // Append to Pkk:
       // --------------------
       ASSERTDEB_(
-          obj.internal_getPkk().cols() == (int)idx && obj.internal_getPkk().rows() == (int)idx);
+          obj.internal_getPkk().cols() == static_cast<int>(idx) &&
+          obj.internal_getPkk().rows() == static_cast<int>(idx));
 
       obj.internal_getPkk().setSize(idx + FEAT_SIZE, idx + FEAT_SIZE);
 
@@ -1335,9 +1336,9 @@ void addNewLandmarks(
         typename KF::KFMatrix_FxF tmp_ff;
         kf_detail::matmul(tmp_fo, dyn_dhn, R);
         kf_detail::matmul_ABt(tmp_ff, tmp_fo, dyn_dhn);
-        for (int _r = 0; _r < (int)P_yn_yn.rows(); _r++)
+        for (int _r = 0; _r < static_cast<int>(P_yn_yn.rows()); _r++)
         {
-          for (int _c = 0; _c < (int)P_yn_yn.cols(); _c++)
+          for (int _c = 0; _c < static_cast<int>(P_yn_yn.cols()); _c++)
           {
             P_yn_yn(_r, _c) += tmp_ff(_r, _c);
           }
@@ -1345,9 +1346,9 @@ void addNewLandmarks(
       }
       else
       {
-        for (int _r = 0; _r < (int)P_yn_yn.rows(); _r++)
+        for (int _r = 0; _r < static_cast<int>(P_yn_yn.rows()); _r++)
         {
-          for (int _c = 0; _c < (int)P_yn_yn.cols(); _c++)
+          for (int _c = 0; _c < static_cast<int>(P_yn_yn.cols()); _c++)
           {
             P_yn_yn(_r, _c) += dyn_dhn_R_dyn_dhnT(_r, _c);
           }
@@ -1363,12 +1364,12 @@ void addNewLandmarks(
 
 template <size_t VEH_SIZE, size_t OBS_SIZE, size_t ACT_SIZE, typename KFTYPE>
 void addNewLandmarks(
-    CKalmanFilterCapable<VEH_SIZE, OBS_SIZE, 0 /* FEAT_SIZE=0 */, ACT_SIZE, KFTYPE>& obj,
+    CKalmanFilterCapable<VEH_SIZE, OBS_SIZE, 0 /* FEAT_SIZE=0 */, ACT_SIZE, KFTYPE>&,
     const typename CKalmanFilterCapable<VEH_SIZE, OBS_SIZE, 0 /* FEAT_SIZE=0 */, ACT_SIZE, KFTYPE>::
-        vector_KFArray_OBS& Z,
-    const std::vector<int>& data_association,
+        vector_KFArray_OBS&,
+    const std::vector<int>&,
     const typename CKalmanFilterCapable<VEH_SIZE, OBS_SIZE, 0 /* FEAT_SIZE=0 */, ACT_SIZE, KFTYPE>::
-        KFMatrix_OxO& R)
+        KFMatrix_OxO&)
 {
   // Do nothing: this is NOT a SLAM problem.
 }
@@ -1382,7 +1383,7 @@ size_t getNumberOfLandmarksInMap(
 // Specialization for FEAT_SIZE=0
 template <size_t VEH_SIZE, size_t OBS_SIZE, size_t ACT_SIZE, typename KFTYPE>
 size_t getNumberOfLandmarksInMap(
-    const CKalmanFilterCapable<VEH_SIZE, OBS_SIZE, 0 /*FEAT_SIZE*/, ACT_SIZE, KFTYPE>& obj)
+    const CKalmanFilterCapable<VEH_SIZE, OBS_SIZE, 0 /*FEAT_SIZE*/, ACT_SIZE, KFTYPE>&)
 {
   return 0;
 }

--- a/modules/mrpt_bayes/tests/CKalmanFilterCapable_unittest.cpp
+++ b/modules/mrpt_bayes/tests/CKalmanFilterCapable_unittest.cpp
@@ -330,6 +330,11 @@ class Landmark2DKF :
   }
 
  protected:
+  // Overriding the 6-argument overload below hides the base class'
+  // deprecated 4-argument one; bring it back into scope for the test in
+  // Landmark2DKF_LegacyInverseModel that overrides that overload instead.
+  using CKalmanFilterCapable<2, 2, 2, 2, double>::OnInverseObservationModel;
+
   void OnGetAction(KFArray_ACT& out_u) const override
   {
     out_u[0] = actionX;
@@ -645,6 +650,11 @@ namespace
 class Landmark2DKF_LegacyInverseModel : public Landmark2DKF
 {
  protected:
+  // Overriding the deprecated 4-argument overload below hides Landmark2DKF's
+  // 6-argument one; bring it back into scope (unused here, but avoids
+  // -Woverloaded-virtual and keeps the base's overload set intact).
+  using Landmark2DKF::OnInverseObservationModel;
+
   void OnInverseObservationModel(
       const KFArray_OBS& in_z,
       KFArray_FEAT& out_yn,

--- a/modules/mrpt_bayes/tests/bayes_unittest.cpp
+++ b/modules/mrpt_bayes/tests/bayes_unittest.cpp
@@ -447,7 +447,7 @@ TEST(BayesTest, fastDrawSample_staticSampleSize)
     EXPECT_LT(idx, 5u);
   }
   // Calling once more than prepared must throw:
-  EXPECT_THROW(pdf.fastDrawSample(opts), std::exception);
+  EXPECT_THROW((void)pdf.fastDrawSample(opts), std::exception);
 }
 
 TEST(BayesTest, fastDrawSample_adaptiveSampleSize_multinomial)
@@ -500,7 +500,7 @@ TEST(BayesTest, fastDrawSample_adaptiveSampleSize_wrongMethod_Throws)
   CParticleFilter::TParticleFilterOptions drawOpts;
   drawOpts.adaptiveSampleSize = true;
   drawOpts.resamplingMethod = CParticleFilter::TParticleResamplingAlgorithm::Residual;
-  EXPECT_THROW(pdf.fastDrawSample(drawOpts), std::exception);
+  EXPECT_THROW((void)pdf.fastDrawSample(drawOpts), std::exception);
 }
 
 // ---------------------------------------------------------------------------

--- a/modules/mrpt_containers/include/mrpt/containers/CDynamicGrid.h
+++ b/modules/mrpt_containers/include/mrpt/containers/CDynamicGrid.h
@@ -313,14 +313,17 @@ class CDynamicGrid
   /** Transform a coordinate values into cell indexes */
   [[nodiscard]] int x2idx(double x) const { return static_cast<int>((x - m_x_min) / m_resolution); }
   [[nodiscard]] int y2idx(double y) const { return static_cast<int>((y - m_y_min) / m_resolution); }
-  [[nodiscard]] int xy2idx(double x, double y) const { return x2idx(x) + y2idx(y) * m_size_x; }
+  [[nodiscard]] int xy2idx(double x, double y) const
+  {
+    return x2idx(x) + y2idx(y) * static_cast<int>(m_size_x);
+  }
 
   /** Transform a global (linear) cell index value into its corresponding
    * (x,y) cell indexes. */
   void idx2cxcy(int idx, int& cx, int& cy) const
   {
-    cx = idx % m_size_x;
-    cy = idx / m_size_x;
+    cx = idx % static_cast<int>(m_size_x);
+    cy = idx / static_cast<int>(m_size_x);
   }
 
   /** Transform a cell index into a coordinate value of the cell central point
@@ -366,8 +369,14 @@ class CDynamicGrid
     struct aux_saver : public internal::dynamic_grid_txt_saver
     {
       aux_saver(const CDynamicGrid<T>& obj) : m_obj(obj) {}
-      [[nodiscard]] unsigned int getSizeX() const override { return m_obj.getSizeX(); }
-      [[nodiscard]] unsigned int getSizeY() const override { return m_obj.getSizeY(); }
+      [[nodiscard]] unsigned int getSizeX() const override
+      {
+        return static_cast<unsigned int>(m_obj.getSizeX());
+      }
+      [[nodiscard]] unsigned int getSizeY() const override
+      {
+        return static_cast<unsigned int>(m_obj.getSizeY());
+      }
       [[nodiscard]] float getCellAsFloat(unsigned int cx, unsigned int cy) const override
       {
         return m_obj.cell2float(m_obj.m_map[cx + cy * m_obj.getSizeX()]);

--- a/modules/mrpt_core/include/mrpt/core/Clock.h
+++ b/modules/mrpt_core/include/mrpt/core/Clock.h
@@ -121,10 +121,13 @@ class Clock
   static void setSimulatedTime(const time_point& t);
 };
 
-/** Streams a Clock::time_point as the plain number of ticks in its
- *  time_since_epoch(). Found via ADL, this also lets test frameworks (e.g.
- *  gtest) print and compare time_point<Clock> values.
+/** Lets gtest (and anything else following the same convention) print and
+ *  compare Clock::time_point values: gtest looks up `PrintTo` via ADL before
+ *  falling back to `operator<<`, so this alone is enough for
+ *  EXPECT_EQ/ASSERT_EQ on time_point<Clock> to work -- without adding a new
+ *  `operator<<` overload that could clash with unrelated ones brought into
+ *  scope by an unrelated `using namespace`.
  */
-std::ostream& operator<<(std::ostream& os, const Clock::time_point& t);
+void PrintTo(const Clock::time_point& t, std::ostream* os);
 
 }  // namespace mrpt

--- a/modules/mrpt_core/include/mrpt/core/Clock.h
+++ b/modules/mrpt_core/include/mrpt/core/Clock.h
@@ -14,6 +14,7 @@
 #pragma once
 
 #include <chrono>
+#include <iosfwd>
 
 namespace mrpt
 {
@@ -119,4 +120,11 @@ class Clock
    */
   static void setSimulatedTime(const time_point& t);
 };
+
+/** Streams a Clock::time_point as the plain number of ticks in its
+ *  time_since_epoch(). Found via ADL, this also lets test frameworks (e.g.
+ *  gtest) print and compare time_point<Clock> values.
+ */
+std::ostream& operator<<(std::ostream& os, const Clock::time_point& t);
+
 }  // namespace mrpt

--- a/modules/mrpt_core/src/Clock.cpp
+++ b/modules/mrpt_core/src/Clock.cpp
@@ -295,7 +295,7 @@ void mrpt::Clock::setSimulatedTime(const time_point& t)
   clk.simulatedTime(static_cast<uint64_t>(t.time_since_epoch().count()));
 }
 
-std::ostream& mrpt::operator<<(std::ostream& os, const mrpt::Clock::time_point& t)
+void mrpt::PrintTo(const mrpt::Clock::time_point& t, std::ostream* os)
 {
-  return os << static_cast<uint64_t>(t.time_since_epoch().count());
+  *os << static_cast<uint64_t>(t.time_since_epoch().count());
 }

--- a/modules/mrpt_core/src/Clock.cpp
+++ b/modules/mrpt_core/src/Clock.cpp
@@ -294,3 +294,8 @@ void mrpt::Clock::setSimulatedTime(const time_point& t)
   auto& clk = mrpt::internal::ClockState::Instance();
   clk.simulatedTime(static_cast<uint64_t>(t.time_since_epoch().count()));
 }
+
+std::ostream& mrpt::operator<<(std::ostream& os, const mrpt::Clock::time_point& t)
+{
+  return os << static_cast<uint64_t>(t.time_since_epoch().count());
+}

--- a/modules/mrpt_graphs/include/mrpt/graphs/CDirectedTree.h
+++ b/modules/mrpt_graphs/include/mrpt/graphs/CDirectedTree.h
@@ -121,6 +121,13 @@ class CDirectedTree
   {
     using tree_t = CDirectedTree<TYPE_EDGES>;
 
+    Visitor() = default;
+    virtual ~Visitor() = default;
+    Visitor(const Visitor&) = default;
+    Visitor& operator=(const Visitor&) = default;
+    Visitor(Visitor&&) = default;
+    Visitor& operator=(Visitor&&) = default;
+
     /** Virtual method to be implemented by the user and which will be
      * called during the visit to a graph with visitDepthFirst or
      * visitBreadthFirst

--- a/modules/mrpt_graphs/include/mrpt/graphs/CNetworkOfPoses_impl.h
+++ b/modules/mrpt_graphs/include/mrpt/graphs/CNetworkOfPoses_impl.h
@@ -250,7 +250,7 @@ struct graph_ops
     istringstream s;
     while (filParser.getNextLine(s))
     {
-      const unsigned int lineNum = filParser.getCurrentLineNumber();
+      const unsigned int lineNum = static_cast<unsigned int>(filParser.getCurrentLineNumber());
       const string lin = s.str();
 
       string key;
@@ -277,7 +277,7 @@ struct graph_ops
     // Read & process lines each at once until EOF:
     while (filParser.getNextLine(s))
     {
-      const unsigned int lineNum = filParser.getCurrentLineNumber();
+      const unsigned int lineNum = static_cast<unsigned int>(filParser.getCurrentLineNumber());
       const string lin = s.str();
 
       // Recognized strings:
@@ -816,13 +816,13 @@ struct graph_ops
   // These two are for simulating maha2 distances for non-PDF types: fallback
   // to squared-norm:
   template <class VEC>
-  static double auxMaha2Dist(VEC& err, const mrpt::poses::CPose2D& p)
+  static double auxMaha2Dist(VEC& err, const mrpt::poses::CPose2D& /*p*/)
   {
     math::wrapToPiInPlace(err[2]);
     return square(err[0]) + square(err[1]) + square(err[2]);
   }
   template <class VEC>
-  static double auxMaha2Dist(VEC& err, const mrpt::poses::CPose3D& p)
+  static double auxMaha2Dist(VEC& err, const mrpt::poses::CPose3D& /*p*/)
   {
     math::wrapToPiInPlace(err[3]);
     math::wrapToPiInPlace(err[4]);
@@ -907,7 +907,8 @@ struct graph_ops
       //
       mrpt::math::CVectorFixedDouble<constraint_t::type_value::static_size> err;
       for (size_t i = 0; i < constraint_t::type_value::static_size; i++)
-        err[i] = from_plus_delta.getPoseMean()[i] - to_mean[i];
+        err[i] = from_plus_delta.getPoseMean()[static_cast<unsigned int>(i)] -
+                 to_mean[static_cast<unsigned int>(i)];
 
       // (auxMaha2Dist will also take into account the 2PI wrapping)
       return auxMaha2Dist(err, from_plus_delta);

--- a/modules/mrpt_graphs/include/mrpt/graphs/TNodeAnnotations.h
+++ b/modules/mrpt_graphs/include/mrpt/graphs/TNodeAnnotations.h
@@ -45,7 +45,7 @@ struct TNodeAnnotations
   }
 
   /// Used inside the operator==() of derived types:
-  virtual bool equal(const TNodeAnnotations& other) const { return true; }
+  virtual bool equal(const TNodeAnnotations& /*other*/) const { return true; }
 
   /**\brief Create and return a copy of the TNodeAnnotations object at hand.
    *
@@ -57,7 +57,7 @@ struct TNodeAnnotations
    *
    * \return True if setting the annotations part is successful.
    */
-  bool setAnnots(const self_t& other) { return true; }
+  bool setAnnots(const self_t& /*other*/) { return true; }
   /**\brief Indicates if this is a dummy TNodeAnnotations struct or if it does
    * contain meaningful data
    */

--- a/modules/mrpt_graphs/include/mrpt/graphs/dijkstra.h
+++ b/modules/mrpt_graphs/include/mrpt/graphs/dijkstra.h
@@ -278,7 +278,7 @@ class CDijkstra
         break;
       }
 
-      if (min_d > maximum_distance)
+      if (min_d > static_cast<double>(maximum_distance))
       {
         // We are out of the topological region of interest, skip the
         // rest of the graph:
@@ -327,7 +327,7 @@ class CDijkstra
 
         const auto dist_ui = (min_d + edge_ui_weight);
 
-        if (dist_ui > maximum_distance)  // out of radius of interest:
+        if (dist_ui > static_cast<double>(maximum_distance))  // out of radius of interest:
           continue;
 
         if (dist_ui < m_distances[i].dist)

--- a/modules/mrpt_graphslam/include/mrpt/graphslam/interfaces/CNodeRegistrationDecider_impl.h
+++ b/modules/mrpt_graphslam/include/mrpt/graphslam/interfaces/CNodeRegistrationDecider_impl.h
@@ -142,7 +142,7 @@ void CNodeRegistrationDecider<GRAPH_T>::resetPDF(constraint_t* c)
 }  // end of resetPDF
 
 template <class GRAPH_T>
-void CNodeRegistrationDecider<GRAPH_T>::addNodeAnnotsToPose(global_pose_t* pose) const
+void CNodeRegistrationDecider<GRAPH_T>::addNodeAnnotsToPose(global_pose_t* /*pose*/) const
 {
 }
 

--- a/modules/mrpt_graphslam/include/mrpt/graphslam/interfaces/CRegistrationDeciderOrOptimizer_impl.h
+++ b/modules/mrpt_graphslam/include/mrpt/graphslam/interfaces/CRegistrationDeciderOrOptimizer_impl.h
@@ -80,13 +80,13 @@ void CRegistrationDeciderOrOptimizer<GRAPH_T>::updateVisuals()
 
 template <class GRAPH_T>
 void CRegistrationDeciderOrOptimizer<GRAPH_T>::notifyOfWindowEvents(
-    const std::map<std::string, bool>& events_occurred)
+    const std::map<std::string, bool>& /*events_occurred*/)
 {
   ASSERTDEB_(m_initialized_visuals);
 }
 
 template <class GRAPH_T>
-void CRegistrationDeciderOrOptimizer<GRAPH_T>::loadParams(const std::string& source_fname)
+void CRegistrationDeciderOrOptimizer<GRAPH_T>::loadParams(const std::string& /*source_fname*/)
 {
   MRPT_LOG_DEBUG_STREAM("Loading corresponding parameters");
 }
@@ -98,7 +98,8 @@ void CRegistrationDeciderOrOptimizer<GRAPH_T>::printParams() const
 }
 
 template <class GRAPH_T>
-void CRegistrationDeciderOrOptimizer<GRAPH_T>::getDescriptiveReport(std::string* report_str) const
+void CRegistrationDeciderOrOptimizer<GRAPH_T>::getDescriptiveReport(
+    std::string* /*report_str*/) const
 {
   MRPT_LOG_DEBUG_STREAM("Generating corresponding report");
   // TODO - give the compact form here!

--- a/modules/mrpt_graphslam/include/mrpt/graphslam/misc/TUncertaintyPath_impl.h
+++ b/modules/mrpt_graphslam/include/mrpt/graphslam/misc/TUncertaintyPath_impl.h
@@ -75,7 +75,8 @@ bool TUncertaintyPath<GRAPH_T>::isEmpty() const
 
 template <class GRAPH_T>
 void TUncertaintyPath<GRAPH_T>::assertIsBetweenNodeIDs(
-    const mrpt::graphs::TNodeID& from, const mrpt::graphs::TNodeID& to) const
+    [[maybe_unused]] const mrpt::graphs::TNodeID& from,
+    [[maybe_unused]] const mrpt::graphs::TNodeID& to) const
 {
   ASSERTDEBMSG_(
       this->getSource() == from,
@@ -155,7 +156,7 @@ void TUncertaintyPath<GRAPH_T>::addToPath(
 
 template <class GRAPH_T>
 void TUncertaintyPath<GRAPH_T>::loadFromConfigFile(
-    const mrpt::config::CConfigFileBase& source, const std::string& section)
+    const mrpt::config::CConfigFileBase& /*source*/, const std::string& /*section*/)
 {
 }
 

--- a/modules/mrpt_hwdrivers/src/CVelodyneScanner.cpp
+++ b/modules/mrpt_hwdrivers/src/CVelodyneScanner.cpp
@@ -624,9 +624,10 @@ bool CVelodyneScanner::receivePackets(
     mrpt::system::timestampToParts(mrpt::Clock::now(), parts, true);
     string sFilePostfix = "_";
     sFilePostfix += mrpt::format(
-        "%04u-%02u-%02u_%02uh%02um%02us", (unsigned int)parts.year, (unsigned int)parts.month,
-        (unsigned int)parts.day, (unsigned int)parts.hour, (unsigned int)parts.minute,
-        (unsigned int)parts.second);
+        "%04u-%02u-%02u_%02uh%02um%02us", static_cast<unsigned int>(parts.year),
+        static_cast<unsigned int>(parts.month), static_cast<unsigned int>(parts.day),
+        static_cast<unsigned int>(parts.hour), static_cast<unsigned int>(parts.minute),
+        static_cast<unsigned int>(parts.second));
     const string sFileName = m_pcap_output_file +
                              mrpt::system::fileNameStripInvalidChars(sFilePostfix) +
                              string(".pcap");
@@ -666,7 +667,7 @@ bool CVelodyneScanner::receivePackets(
       memcpy(
           &(packetBuffer[0]) + 42, reinterpret_cast<uint8_t*>(&out_data_pkt),
           CObservationVelodyneScan::PACKET_SIZE);
-      pcap_dump((u_char*)this->m_pcap_dumper, &header, &(packetBuffer[0]));
+      pcap_dump(static_cast<u_char*>(this->m_pcap_dumper), &header, &(packetBuffer[0]));
     }
     // Pos pkt:
     if (pos_pkt_timestamp != INVALID_TIMESTAMP)
@@ -679,7 +680,7 @@ bool CVelodyneScanner::receivePackets(
       memcpy(
           &(packetBuffer[0]) + 42, reinterpret_cast<uint8_t*>(&out_pos_pkt),
           CObservationVelodyneScan::POS_PACKET_SIZE);
-      pcap_dump((u_char*)this->m_pcap_dumper, &header, &(packetBuffer[0]));
+      pcap_dump(static_cast<u_char*>(this->m_pcap_dumper), &header, &(packetBuffer[0]));
     }
   }
 #endif

--- a/modules/mrpt_img/tests/CImage_SSEx_unittest.cpp
+++ b/modules/mrpt_img/tests/CImage_SSEx_unittest.cpp
@@ -53,7 +53,8 @@ std::vector<uint8_t> makeGray(int w, int h)
   {
     for (int x = 0; x < w; x++)
     {
-      v[static_cast<size_t>(y) * w + x] = static_cast<uint8_t>((x + y * 7) % 256);
+      v[static_cast<size_t>(y) * static_cast<size_t>(w) + static_cast<size_t>(x)] =
+          static_cast<uint8_t>((x + y * 7) % 256);
     }
   }
   return v;
@@ -66,7 +67,8 @@ std::vector<uint8_t> makeColor(int w, int h)
   {
     for (int x = 0; x < w; x++)
     {
-      const size_t off = (static_cast<size_t>(y) * w + x) * 3;
+      const size_t off =
+          (static_cast<size_t>(y) * static_cast<size_t>(w) + static_cast<size_t>(x)) * 3;
       v[off + 0] = static_cast<uint8_t>((x * 3 + y) % 256);
       v[off + 1] = static_cast<uint8_t>((x * 5 + y * 2) % 256);
       v[off + 2] = static_cast<uint8_t>((x * 7 + y * 3) % 256);
@@ -83,7 +85,7 @@ TEST(CImage_SSEx, ScaleHalf1c8u_MultipleOf16)
   const int w = 32;
   const int h = 4;
   const auto in = makeGray(w, h);
-  std::vector<uint8_t> out(static_cast<size_t>(w / 2) * (h / 2), 0);
+  std::vector<uint8_t> out(static_cast<size_t>(w / 2) * static_cast<size_t>(h / 2), 0);
 
   image_SSE2_scale_half_1c8u(in.data(), out.data(), w, h, w, w / 2);
 
@@ -92,7 +94,8 @@ TEST(CImage_SSEx, ScaleHalf1c8u_MultipleOf16)
     for (int ox = 0; ox < w / 2; ox++)
     {
       EXPECT_EQ(
-          out[static_cast<size_t>(oy) * (w / 2) + ox], in[static_cast<size_t>(2 * oy) * w + 2 * ox])
+          out[static_cast<size_t>(oy) * static_cast<size_t>(w / 2) + static_cast<size_t>(ox)],
+          in[static_cast<size_t>(2 * oy) * static_cast<size_t>(w) + static_cast<size_t>(2 * ox)])
           << "at (" << ox << "," << oy << ")";
     }
   }
@@ -104,7 +107,7 @@ TEST(CImage_SSEx, ScaleHalf1c8u_WithRemainder)
   const int w = 20;
   const int h = 2;
   const auto in = makeGray(w, h);
-  std::vector<uint8_t> out(static_cast<size_t>(w / 2) * (h / 2), 0);
+  std::vector<uint8_t> out(static_cast<size_t>(w / 2) * static_cast<size_t>(h / 2), 0);
 
   image_SSE2_scale_half_1c8u(in.data(), out.data(), w, h, w, w / 2);
 
@@ -119,8 +122,8 @@ TEST(CImage_SSEx, ScaleHalfSmooth1c8u_UniformBlock)
 {
   const int w = 32;
   const int h = 4;
-  std::vector<uint8_t> in(static_cast<size_t>(w) * h, 100);
-  std::vector<uint8_t> out(static_cast<size_t>(w / 2) * (h / 2), 0);
+  std::vector<uint8_t> in(static_cast<size_t>(w) * static_cast<size_t>(h), 100);
+  std::vector<uint8_t> out(static_cast<size_t>(w / 2) * static_cast<size_t>(h / 2), 0);
 
   image_SSE2_scale_half_smooth_1c8u(in.data(), out.data(), w, h, w, w / 2);
 
@@ -135,7 +138,7 @@ TEST(CImage_SSEx, ScaleHalfSmooth1c8u_WithRemainderStaysInRange)
   const int w = 20;
   const int h = 2;
   const auto in = makeGray(w, h);
-  std::vector<uint8_t> out(static_cast<size_t>(w / 2) * (h / 2), 0);
+  std::vector<uint8_t> out(static_cast<size_t>(w / 2) * static_cast<size_t>(h / 2), 0);
 
   image_SSE2_scale_half_smooth_1c8u(in.data(), out.data(), w, h, w, w / 2);
 
@@ -144,10 +147,10 @@ TEST(CImage_SSEx, ScaleHalfSmooth1c8u_WithRemainderStaysInRange)
   // source block.
   for (int ox = 0; ox < w / 2; ox++)
   {
-    const int a = in[2 * ox];
-    const int b = in[2 * ox + 1];
-    const int c = in[w + 2 * ox];
-    const int d = in[w + 2 * ox + 1];
+    const int a = in[static_cast<size_t>(2 * ox)];
+    const int b = in[static_cast<size_t>(2 * ox + 1)];
+    const int c = in[static_cast<size_t>(w + 2 * ox)];
+    const int d = in[static_cast<size_t>(w + 2 * ox + 1)];
     const int lo = std::min({a, b, c, d});
     const int hi = std::max({a, b, c, d});
     EXPECT_GE(out[static_cast<size_t>(ox)], lo);
@@ -171,11 +174,14 @@ TEST(CImage_SSEx, ScaleHalf3c8u_MultipleOf16)
   {
     for (int ox = 0; ox < w / 2; ox++)
     {
-      const size_t outOff = (static_cast<size_t>(oy) * (w / 2) + ox) * 3;
-      const size_t inOff = (static_cast<size_t>(2 * oy) * w + 2 * ox) * 3;
+      const size_t outOff =
+          (static_cast<size_t>(oy) * static_cast<size_t>(w / 2) + static_cast<size_t>(ox)) * 3;
+      const size_t inOff =
+          (static_cast<size_t>(2 * oy) * static_cast<size_t>(w) + static_cast<size_t>(2 * ox)) * 3;
       for (int c = 0; c < 3; c++)
       {
-        EXPECT_EQ(out[outOff + c], in[inOff + c]) << "at (" << ox << "," << oy << ") c=" << c;
+        EXPECT_EQ(out[outOff + static_cast<size_t>(c)], in[inOff + static_cast<size_t>(c)])
+            << "at (" << ox << "," << oy << ") c=" << c;
       }
     }
   }
@@ -197,7 +203,8 @@ TEST(CImage_SSEx, ScaleHalf3c8u_WithRemainder)
     const size_t inOff = static_cast<size_t>(2 * ox) * 3;
     for (int c = 0; c < 3; c++)
     {
-      EXPECT_EQ(out[outOff + c], in[inOff + c]) << "at ox=" << ox << " c=" << c;
+      EXPECT_EQ(out[outOff + static_cast<size_t>(c)], in[inOff + static_cast<size_t>(c)])
+          << "at ox=" << ox << " c=" << c;
     }
   }
 }
@@ -232,7 +239,7 @@ void checkUniformGray(
     const char* label)
 {
   const auto in = makeUniformRgb(w, h, r, g, b);
-  std::vector<uint8_t> out(static_cast<size_t>(w) * h, 0);
+  std::vector<uint8_t> out(static_cast<size_t>(w) * static_cast<size_t>(h), 0);
   fn(in.data(), out.data(), w, h, static_cast<size_t>(w) * 3, static_cast<size_t>(w));
 
   for (auto v : out)

--- a/modules/mrpt_maps/include/mrpt/maps/COccupancyGridMap2D.h
+++ b/modules/mrpt_maps/include/mrpt/maps/COccupancyGridMap2D.h
@@ -834,7 +834,7 @@ class COccupancyGridMap2D :
 
   /** Methods for TLaserSimulUncertaintyParams in
    * laserScanSimulatorWithUncertainty() */
-  enum TLaserSimulUncertaintyMethod
+  enum TLaserSimulUncertaintyMethod : int
   {
     /** Performs an unscented transform */
     sumUnscented = 0,

--- a/modules/mrpt_maps/tests/CPointsMap_insertObs_unittest.cpp
+++ b/modules/mrpt_maps/tests/CPointsMap_insertObs_unittest.cpp
@@ -41,7 +41,12 @@ CSimplePointsMap makeGrid(int n = 5, float step = 1.0f)
 {
   CSimplePointsMap m;
   for (int i = 0; i < n; i++)
-    for (int j = 0; j < n; j++) m.insertPoint(i * step, j * step, 0.0f);
+  {
+    for (int j = 0; j < n; j++)
+    {
+      m.insertPoint(static_cast<float>(i) * step, static_cast<float>(j) * step, 0.0f);
+    }
+  }
   return m;
 }
 
@@ -219,7 +224,7 @@ TEST(CPointsMapInsertObs, insertPlanarMapRejectsNonHorizontalScans)
 
   CSimplePointsMap map;
   map.insertionOptions.isPlanarMap = true;
-  map.insertionOptions.horizontalTolerance = mrpt::DEG2RAD(1.0);
+  map.insertionOptions.horizontalTolerance = static_cast<float>(mrpt::DEG2RAD(1.0));
   EXPECT_FALSE(map.insertObservation(*scan));
   EXPECT_EQ(map.size(), 0U);
 
@@ -283,7 +288,10 @@ TEST(CPointsMapInsertObs, insertWithFuseWithExisting)
 TEST(CPointsMapInsertObs, getAllPointsWithDecimation)
 {
   CSimplePointsMap map;
-  for (int i = 0; i < 20; i++) map.insertPoint(i, 2 * i, 3 * i);
+  for (int i = 0; i < 20; i++)
+  {
+    map.insertPoint(static_cast<float>(i), static_cast<float>(2 * i), static_cast<float>(3 * i));
+  }
 
   std::vector<float> xs, ys;
   map.getAllPoints(xs, ys);
@@ -315,6 +323,11 @@ TEST(CPointsMapInsertObs, setAllPoints)
   const std::vector<float> Y{4.0f, 5.0f, 6.0f};
   const std::vector<float> Z{7.0f, 8.0f, 9.0f};
 
+#if defined(__clang__) || defined(__GNUC__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+#endif
+  // Exercise the deprecated setAllPoints() overloads for coverage:
   map.setAllPoints(X, Y, Z);
   ASSERT_EQ(map.size(), 3U);
   mrpt::math::TPoint3D p;
@@ -330,6 +343,9 @@ TEST(CPointsMapInsertObs, setAllPoints)
   const std::vector<float> shorter{1.0f};
   EXPECT_THROW(map.setAllPoints(X, shorter), std::exception);
   EXPECT_THROW(map.setAllPoints(X, Y, shorter), std::exception);
+#if defined(__clang__) || defined(__GNUC__)
+#pragma GCC diagnostic pop
+#endif
 }
 
 TEST(CPointsMapInsertObs, save2DToTextStream)
@@ -397,7 +413,10 @@ TEST(CPointsMapInsertObs, nnSearchOverloads)
 TEST(CPointsMapInsertObs, getVisualizationIntoColorFromZ)
 {
   CSimplePointsMap map;
-  for (int i = 0; i < 10; i++) map.insertPoint(i, 0, i * 0.1f);
+  for (int i = 0; i < 10; i++)
+  {
+    map.insertPoint(static_cast<float>(i), 0, static_cast<float>(i) * 0.1f);
+  }
 
   // Flat color:
   {

--- a/modules/mrpt_maps/tests/maps_coverage2_unittest.cpp
+++ b/modules/mrpt_maps/tests/maps_coverage2_unittest.cpp
@@ -179,7 +179,11 @@ TEST(CObservationPointCloudDescription, getDescriptionAsText)
   obs->sensorLabel = "lidar";
   obs->sensorPose = mrpt::poses::CPose3D(1, 2, 3, 0, 0, 0);
   obs->pointcloud = CSimplePointsMap::Create();
-  for (int i = 0; i < 10; i++) obs->pointcloud->insertPoint(i * 1.0f, i * 2.0f, i * 0.5f);
+  for (int i = 0; i < 10; i++)
+  {
+    const auto fi = static_cast<float>(i);
+    obs->pointcloud->insertPoint(fi * 1.0f, fi * 2.0f, fi * 0.5f);
+  }
 
   std::ostringstream ss;
   obs->getDescriptionAsText(ss);

--- a/modules/mrpt_math/include/mrpt/math/CHistogram.h
+++ b/modules/mrpt_math/include/mrpt/math/CHistogram.h
@@ -72,10 +72,10 @@ class CHistogram
   template <typename MAT_VECTOR_LIKE, typename = typename MAT_VECTOR_LIKE::Scalar>
   void add(const MAT_VECTOR_LIKE& x)
   {
-    const size_t N = x.size();
+    const auto N = static_cast<size_t>(x.size());
     for (size_t i = 0; i < N; i++)
     {
-      this->add(static_cast<double>(x[i]));
+      this->add(static_cast<double>(x[static_cast<decltype(x.size())>(i)]));
     }
   }
 

--- a/modules/mrpt_math/include/mrpt/math/CMatrixDynamic.h
+++ b/modules/mrpt_math/include/mrpt/math/CMatrixDynamic.h
@@ -321,6 +321,10 @@ class CMatrixDynamic : public MatrixBase<T, CMatrixDynamic<T>>
   {
     MRPT_START
     setSize(static_cast<size_type>(m.rows()), static_cast<size_type>(m.cols()));
+#pragma GCC diagnostic push
+#if defined(__GNUC__) && !defined(__clang__)
+#pragma GCC diagnostic ignored "-Wstringop-overread"
+#endif
     for (Index r = 0; r < rows(); r++)
     {
       for (Index c = 0; c < cols(); c++)
@@ -328,6 +332,7 @@ class CMatrixDynamic : public MatrixBase<T, CMatrixDynamic<T>>
         (*this)(r, c) = static_cast<T>(m(r, c));
       }
     }
+#pragma GCC diagnostic pop
     MRPT_END
   }
 

--- a/modules/mrpt_math/include/mrpt/math/CSparseMatrixTemplate.h
+++ b/modules/mrpt_math/include/mrpt/math/CSparseMatrixTemplate.h
@@ -190,8 +190,10 @@ class CSparseMatrixTemplate
   template <class MATRIX_LIKE>
   void insertMatrix(size_t row, size_t column, const MATRIX_LIKE& mat)
   {
-    for (size_t nr = 0; nr < mat.rows(); nr++)
-      for (size_t nc = 0; nc < mat.cols(); nc++) operator()(row + nr, column + nc) = mat(nr, nc);
+    for (size_t nr = 0; nr < static_cast<size_t>(mat.rows()); nr++)
+      for (size_t nc = 0; nc < static_cast<size_t>(mat.cols()); nc++)
+        operator()(row + nr, column + nc) =
+            mat(static_cast<decltype(mat.rows())>(nr), static_cast<decltype(mat.cols())>(nc));
   }
 
   // Public interface only supports const iterators. This way, no user of this

--- a/modules/mrpt_math/include/mrpt/math/KDTreeCapable.h
+++ b/modules/mrpt_math/include/mrpt/math/KDTreeCapable.h
@@ -303,7 +303,9 @@ class KDTreeCapable
       float& outDistSqr2) const
   {
     float dmy1, dmy2, dmy3, dmy4;
-    kdTreeTwoClosestPoint2D(p0.x, p0.y, dmy1, dmy2, dmy3, dmy4, outDistSqr1, outDistSqr2);
+    kdTreeTwoClosestPoint2D(
+        static_cast<num_t>(p0.x), static_cast<num_t>(p0.y), dmy1, dmy2, dmy3, dmy4, outDistSqr1,
+        outDistSqr2);
     pOut1.x = static_cast<double>(dmy1);
     pOut1.y = static_cast<double>(dmy2);
     pOut2.x = static_cast<double>(dmy3);
@@ -779,7 +781,7 @@ class KDTreeCapable
     if (m_kdtree3d_data.m_num_points != 0)
     {
       const num_t xyz[3] = {x0, y0, z0};
-      m_kdtree3d_data.index->radiusSearch(&xyz[0], maxRadiusSqr, out_indices_dist, {});
+      (void)m_kdtree3d_data.index->radiusSearch(&xyz[0], maxRadiusSqr, out_indices_dist, {});
     }
     return out_indices_dist.size();
     MRPT_END
@@ -813,7 +815,7 @@ class KDTreeCapable
     if (m_kdtree2d_data.m_num_points != 0)
     {
       const num_t xyz[2] = {x0, y0};
-      m_kdtree2d_data.index->radiusSearch(&xyz[0], maxRadiusSqr, out_indices_dist, {});
+      (void)m_kdtree2d_data.index->radiusSearch(&xyz[0], maxRadiusSqr, out_indices_dist, {});
     }
     return out_indices_dist.size();
     MRPT_END

--- a/modules/mrpt_math/include/mrpt/math/MatrixVectorBase.h
+++ b/modules/mrpt_math/include/mrpt/math/MatrixVectorBase.h
@@ -30,7 +30,7 @@ void internalAssertEigenDefined();
 
 /*! Selection of the number format in MatrixVectorBase::saveToTextFile()
  * \ingroup mrpt_math_grp */
-enum TMatrixTextFileFormat
+enum TMatrixTextFileFormat : int
 {
   /** engineering format '%e' */
   MATRIX_FORMAT_ENG = 0,

--- a/modules/mrpt_math/include/mrpt/math/TPoint2D.h
+++ b/modules/mrpt_math/include/mrpt/math/TPoint2D.h
@@ -107,9 +107,9 @@ struct MRPT_EMPTY_BASES TPoint2D_ : public TPoint2D_data<T>, public TPoseOrPoint
   [[nodiscard]] static TPoint2D_<T> FromVector(const Vector& v)
   {
     TPoint2D_<T> o;
-    for (int i = 0; i < 2; i++)
+    for (size_t i = 0; i < 2; i++)
     {
-      o[i] = static_cast<T>(v.at(i));
+      o[i] = static_cast<T>(v.at(static_cast<decltype(v.size())>(i)));
     }
     return o;
   }

--- a/modules/mrpt_math/include/mrpt/math/TTwist2D.h
+++ b/modules/mrpt_math/include/mrpt/math/TTwist2D.h
@@ -46,7 +46,10 @@ struct TTwist2D :
   static TTwist2D FromVector(const Vector& v)
   {
     TTwist2D o;
-    for (int i = 0; i < 3; i++) o[i] = v[i];
+    for (size_t i = 0; i < 3; i++)
+    {
+      o[i] = v[static_cast<decltype(v.size())>(i)];
+    }
     return o;
   }
 

--- a/modules/mrpt_math/include/mrpt/math/distributions.h
+++ b/modules/mrpt_math/include/mrpt/math/distributions.h
@@ -119,7 +119,7 @@ double KLD_Gaussians(
   const MATRIXLIKE2 cov1_inv = cov1.inverse_LLt();
   const VECTORLIKE1 mu_difs = mu0 - mu1;
   return 0.5 * (log(cov1.det() / cov0.det()) + (cov1_inv * cov0).trace() +
-                multiply_HtCH_scalar(mu_difs, cov1_inv) - N);
+                multiply_HtCH_scalar(mu_difs, cov1_inv) - static_cast<double>(N));
   MRPT_END
 }
 
@@ -226,7 +226,7 @@ void confidenceIntervals(
   out_mean = mean(data);
   const auto x_min = data.minCoeff();
   const auto x_max = data.maxCoeff();
-  const auto binWidth = (x_max - x_min) / histogramNumBins;
+  const auto binWidth = (x_max - x_min) / static_cast<double>(histogramNumBins);
 
   const std::vector<double> hitsNormalized =
       mrpt::math::histogram(data, x_min, x_max, histogramNumBins);
@@ -240,8 +240,8 @@ void confidenceIntervals(
   ASSERT_(it_high != Hc.end());
   const size_t idx_low = std::distance(Hc.begin(), it_low);
   const size_t idx_high = std::distance(Hc.begin(), it_high);
-  out_lower_conf_interval = x_min + idx_low * binWidth;
-  out_upper_conf_interval = x_min + idx_high * binWidth;
+  out_lower_conf_interval = x_min + static_cast<double>(idx_low) * binWidth;
+  out_upper_conf_interval = x_min + static_cast<double>(idx_high) * binWidth;
 
   MRPT_END
 }
@@ -265,7 +265,7 @@ void confidenceIntervalsFromHistogram(
 
   const auto x_min = *histogramCoords.begin();
   const auto x_max = *histogramCoords.rbegin();
-  const auto binWidth = (x_max - x_min) / histogramCoords.size();
+  const auto binWidth = (x_max - x_min) / static_cast<double>(histogramCoords.size());
 
   std::vector<double> Hc;
   cumsum(histogramNormalizedHits, Hc);  // CDF
@@ -277,8 +277,8 @@ void confidenceIntervalsFromHistogram(
   ASSERT_(it_high != Hc.end());
   const size_t idx_low = static_cast<size_t>(std::distance(Hc.begin(), it_low));
   const size_t idx_high = static_cast<size_t>(std::distance(Hc.begin(), it_high));
-  out_lower_conf_interval = x_min + idx_low * binWidth;
-  out_upper_conf_interval = x_min + idx_high * binWidth;
+  out_lower_conf_interval = x_min + static_cast<double>(idx_low) * binWidth;
+  out_upper_conf_interval = x_min + static_cast<double>(idx_high) * binWidth;
 
   MRPT_END
 }

--- a/modules/mrpt_math/include/mrpt/math/interp_fit.hpp
+++ b/modules/mrpt_math/include/mrpt/math/interp_fit.hpp
@@ -26,7 +26,7 @@ T interpolate(const T& x, const VECTOR& ys, const T& x0, const T& x1)
   const size_t i = int((x - x0) / Ax);
   if (i >= N - 1) return ys[N - 1];
   const T Ay = ys[i + 1] - ys[i];
-  return ys[i] + (x - (x0 + i * Ax)) * Ay / Ax;
+  return ys[i] + (x - (x0 + static_cast<T>(i) * Ax)) * Ay / Ax;
   MRPT_END
 }
 

--- a/modules/mrpt_math/include/mrpt/math/model_search_impl.h
+++ b/modules/mrpt_math/include/mrpt/math/model_search_impl.h
@@ -88,7 +88,7 @@ bool ModelSearch::ransacSingleModel(
     {
       // Update the estimation of maxIter to pick dataset with no outliers
       // at propability p
-      double f = ninliers / static_cast<double>(nSamples);
+      double f = static_cast<double>(ninliers) / static_cast<double>(nSamples);
       double p = 1 - std::pow(f, static_cast<double>(p_kernelSize));
       const double eps = std::numeric_limits<double>::epsilon();
       p = std::max(eps, p);      // Avoid division by -Inf
@@ -147,14 +147,14 @@ bool ModelSearch::geneticSingleModel(
       // copy the best elders
       for (; i < elderCnt; i++)
       {
-        population.push_back(sortedPopulation[i]);
+        population.push_back(sortedPopulation[static_cast<size_t>(i)]);
       }
 
       // mate elders to make siblings
       int se = static_cast<int>(speciesAlive);  // dead species cannot mate
       for (; i < elderCnt + siblingCnt; i++)
       {
-        Species* sibling = sortedPopulation[--se];
+        Species* sibling = sortedPopulation[static_cast<size_t>(--se)];
         population.push_back(sibling);
 
         // pick two parents, from the species not yet refactored
@@ -166,8 +166,8 @@ bool ModelSearch::geneticSingleModel(
         int p2 = (p1 > se / 2) ? (r2 % p1) : p1 + 1 + (r2 % (se - p1 - 1));
         ASSERT_(p1 != p2 && p1 < se && p2 < se);
         ASSERT_(se >= elderCnt);
-        Species* a = sortedPopulation[p1];
-        Species* b = sortedPopulation[p2];
+        Species* a = sortedPopulation[static_cast<size_t>(p1)];
+        Species* b = sortedPopulation[static_cast<size_t>(p2)];
 
         // merge the sample candidates
         std::set<size_t> sampleSet;
@@ -182,7 +182,7 @@ bool ModelSearch::geneticSingleModel(
       // generate some new random species
       for (; i < static_cast<int>(p_populationSize); i++)
       {
-        Species* s = sortedPopulation[i];
+        Species* s = sortedPopulation[static_cast<size_t>(i)];
         population.push_back(s);
         pickRandomIndex(sampleCount, p_kernelSize, s->sample);
       }
@@ -208,9 +208,9 @@ bool ModelSearch::geneticSingleModel(
         }
         ASSERT_(s.inliers.size() > 0);
 
-        s.fitness /= s.inliers.size();
+        s.fitness /= static_cast<typename TModelFit::Real>(s.inliers.size());
         // scale by the number of outliers
-        s.fitness *= (sampleCount - s.inliers.size());
+        s.fitness *= static_cast<typename TModelFit::Real>(sampleCount - s.inliers.size());
         speciesAlive++;
       }
       else

--- a/modules/mrpt_math/include/mrpt/math/ransac.h
+++ b/modules/mrpt_math/include/mrpt/math/ransac.h
@@ -34,7 +34,7 @@ namespace mrpt::math
 template <typename T>
 size_t ransacDatasetSize(const CMatrixDynamic<T>& dataset)
 {
-  return dataset.cols();
+  return static_cast<size_t>(dataset.cols());
 }
 
 /** A generic RANSAC implementation. By default, the input "dataset" and output

--- a/modules/mrpt_math/tests/CHistogram_unittest.cpp
+++ b/modules/mrpt_math/tests/CHistogram_unittest.cpp
@@ -51,8 +51,8 @@ TEST(CHistogram, addAndCount)
   h.add(100);
   EXPECT_EQ(h.getBinCount(9), 1U);
 
-  EXPECT_THROW(h.getBinCount(10), std::exception);
-  EXPECT_THROW(h.getBinRatio(10), std::exception);
+  EXPECT_THROW((void)h.getBinCount(10), std::exception);
+  EXPECT_THROW((void)h.getBinRatio(10), std::exception);
 
   h.clear();
   EXPECT_EQ(h.getBinCount(0), 0U);
@@ -106,6 +106,6 @@ TEST(CHistogram, createWithFixedWidth)
   h.getHistogram(x, hits);
   EXPECT_EQ(hits.size(), 5U);
 
-  EXPECT_THROW(CHistogram::createWithFixedWidth(10.0, 0.0, 2.0), std::exception);
-  EXPECT_THROW(CHistogram::createWithFixedWidth(0.0, 10.0, 0.0), std::exception);
+  EXPECT_THROW((void)CHistogram::createWithFixedWidth(10.0, 0.0, 2.0), std::exception);
+  EXPECT_THROW((void)CHistogram::createWithFixedWidth(0.0, 10.0, 0.0), std::exception);
 }

--- a/modules/mrpt_math/tests/CPolygon_unittest.cpp
+++ b/modules/mrpt_math/tests/CPolygon_unittest.cpp
@@ -163,6 +163,6 @@ TEST(CPolygon, VertexAccessorsCheckBounds)
   p.add_vertex(1.0, 2.0);
   EXPECT_NEAR(p.get_vertex_x(0), 1.0, 1e-9);
   EXPECT_NEAR(p.get_vertex_y(0), 2.0, 1e-9);
-  EXPECT_THROW(p.get_vertex_x(1), std::exception);
-  EXPECT_THROW(p.get_vertex_y(1), std::exception);
+  EXPECT_THROW((void)p.get_vertex_x(1), std::exception);
+  EXPECT_THROW((void)p.get_vertex_y(1), std::exception);
 }

--- a/modules/mrpt_math/tests/TPoint2D_unittest.cpp
+++ b/modules/mrpt_math/tests/TPoint2D_unittest.cpp
@@ -156,7 +156,7 @@ TYPED_TEST(TPoint2DTests, norms)
   EXPECT_NEAR(double(u.norm()), 1.0, 1e-5);
   EXPECT_NEAR(double(u.x), 0.6, 1e-5);
 
-  EXPECT_THROW(P(0, 0).unitarize(), std::exception);
+  EXPECT_THROW((void)P(0, 0).unitarize(), std::exception);
 }
 
 TYPED_TEST(TPoint2DTests, stringConversion)

--- a/modules/mrpt_nav/tests/holonomic_config_unittest.cpp
+++ b/modules/mrpt_nav/tests/holonomic_config_unittest.cpp
@@ -297,7 +297,7 @@ TEST(CHolonomicFullEval, no_score_matrix_when_disabled)
     m.options.LOG_SCORE_MATRIX = enableLogging;
     const auto no = m.navigate(ni);
     auto* fe = dynamic_cast<CLogFileRecord_FullEval*>(no.logRecord.get());
-    return fe ? fe->dirs_scores.size() : 0U;
+    return fe ? static_cast<unsigned int>(fe->dirs_scores.size()) : 0U;
   };
 
   // The score matrix is only copied into the log record on demand:

--- a/modules/mrpt_nav/tests/nav_interfaces_unittest.cpp
+++ b/modules/mrpt_nav/tests/nav_interfaces_unittest.cpp
@@ -445,7 +445,7 @@ TEST(CReactiveNavigationSystem3D, robot_shape_can_be_redefined)
     poly.add_vertex(0.25, 0.25);
     poly.add_vertex(0.25, -0.25);
     poly.add_vertex(-0.25, -0.25);
-    shape.setHeight(lvl, 0.4 + 0.2 * lvl);
+    shape.setHeight(lvl, 0.4 + 0.2 * static_cast<double>(lvl));
     shape.setRadius(lvl, 0.35);
   }
   EXPECT_NO_THROW(nav.changeRobotShape(shape));

--- a/modules/mrpt_nav/tests/nav_misc_unittest.cpp
+++ b/modules/mrpt_nav/tests/nav_misc_unittest.cpp
@@ -303,7 +303,7 @@ TEST(NavGeomUtils, arc_path_handles_obstacles_on_the_turn_center_axis)
   // Obstacles with x==0 used to make the closed-form solution divide by zero
   // and return NaN. Check a few of them against a brute-force sampling of the
   // arc:
-  for (const auto [r, R, oy] :
+  for (const auto& [r, R, oy] :
        {std::make_tuple(2.0, 0.5, 4.2), std::make_tuple(2.0, 0.5, -0.3),
         std::make_tuple(-3.0, 0.4, -5.8), std::make_tuple(1.0, 0.5, 1.9)})
   {

--- a/modules/mrpt_nav/tests/planners_and_logs_unittest.cpp
+++ b/modules/mrpt_nav/tests/planners_and_logs_unittest.cpp
@@ -119,7 +119,7 @@ TEST(PlannerRRTSE2TPS, obstacles_are_taken_into_account)
   // A wall of obstacles right between start and goal:
   for (double y = -2.0; y <= 2.0; y += 0.05)
   {
-    pi.obstacles_points.insertPoint(1.0, y, .0);
+    pi.obstacles_points.insertPoint(1.0f, static_cast<float>(y), .0f);
   }
 
   PlannerRRT_SE2_TPS::TPlannerResult result;

--- a/modules/mrpt_nav/tests/rnav_variants_unittest.cpp
+++ b/modules/mrpt_nav/tests/rnav_variants_unittest.cpp
@@ -54,7 +54,10 @@ struct HoloSimRobot : public CRobot2NavInterfaceForSimulator_Holo
     obs.clear();
     timestamp = mrpt::Clock::now();
     if (!senseSucceeds) return false;
-    for (const auto& p : obstacles) obs.insertPoint(p.x, p.y, 0.0);
+    for (const auto& p : obstacles)
+    {
+      obs.insertPoint(static_cast<float>(p.x), static_cast<float>(p.y), 0.0f);
+    }
     return true;
   }
 };

--- a/modules/mrpt_obs/include/mrpt/obs/TPixelLabelInfo.h
+++ b/modules/mrpt_obs/include/mrpt/obs/TPixelLabelInfo.h
@@ -64,7 +64,7 @@ struct TPixelLabelInfoBase
     {
       if (it->second == name)
       {
-        return it->first;
+        return static_cast<int>(it->first);
       }
     }
     return -1;

--- a/modules/mrpt_obs/tests/CObservationVelodyneScan_unittest.cpp
+++ b/modules/mrpt_obs/tests/CObservationVelodyneScan_unittest.cpp
@@ -115,36 +115,37 @@ CObservationVelodyneScan::Ptr buildSyntheticVLP16Scan(
 
 TEST(VelodyneCalibration, LoadDefaultVLP16)
 {
-  const auto& cal = loadDefaultCal("VLP16");
+  const auto cal = loadDefaultCal("VLP16");
   EXPECT_FALSE(cal.empty());
   EXPECT_EQ(cal.laser_corrections.size(), 16u);
 }
 
 TEST(VelodyneCalibration, LoadDefaultHDL32)
 {
-  const auto& cal = loadDefaultCal("HDL32");
+  const auto cal = loadDefaultCal("HDL32");
   EXPECT_FALSE(cal.empty());
   EXPECT_EQ(cal.laser_corrections.size(), 32u);
 }
 
 TEST(VelodyneCalibration, LoadDefaultHDL64)
 {
-  const auto& cal = loadDefaultCal("HDL64");
+  const auto cal = loadDefaultCal("HDL64");
   EXPECT_FALSE(cal.empty());
   EXPECT_EQ(cal.laser_corrections.size(), 64u);
 }
 
 TEST(VelodyneCalibration, LoadDefaultUnknownModel)
 {
-  const auto& cal = loadDefaultCal("NOT_A_REAL_MODEL");
+  const auto cal = loadDefaultCal("NOT_A_REAL_MODEL");
   EXPECT_TRUE(cal.empty());
 }
 
 TEST(VelodyneCalibration, LoadDefaultIsCached)
 {
-  const auto& cal1 = loadDefaultCal("VLP16");
-  const auto& cal2 = loadDefaultCal("VLP16");
-  EXPECT_EQ(&cal1, &cal2);
+  // Compare addresses directly (no named references) to check the cache
+  // returns the same instance, without tripping GCC's overly-eager
+  // -Wdangling-reference heuristic on a `const auto&` binding.
+  EXPECT_EQ(&loadDefaultCal("VLP16"), &loadDefaultCal("VLP16"));
 }
 
 TEST(VelodyneCalibration, EmptyAndClear)
@@ -185,7 +186,7 @@ TEST(VelodyneCalibration, RoundtripThroughXMLFile)
 {
   // Re-derive an XML file from the default VLP-16 XML text, then reload it
   // from disk to exercise loadFromXMLFile()'s success path.
-  const auto& original = loadDefaultCal("VLP16");
+  const auto original = loadDefaultCal("VLP16");
   ASSERT_FALSE(original.empty());
 
   // We don't have direct access to the embedded XML string here, so instead

--- a/modules/mrpt_obs/tests/CRawlog_content_unittest.cpp
+++ b/modules/mrpt_obs/tests/CRawlog_content_unittest.cpp
@@ -125,7 +125,15 @@ TEST(CRawlogContent, InsertCommentSetsCommentText)
   EXPECT_EQ(rawlog.getCommentText(), "hello rawlog");
 
   std::string t;
+#if defined(__clang__) || defined(__GNUC__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+#endif
+  // Exercise the deprecated output-argument overload for coverage:
   rawlog.getCommentText(t);
+#if defined(__clang__) || defined(__GNUC__)
+#pragma GCC diagnostic pop
+#endif
   EXPECT_EQ(t, "hello rawlog");
 
   rawlog.setCommentText("new comment");

--- a/modules/mrpt_obs/tests/legacy_serialization_unittest.cpp
+++ b/modules/mrpt_obs/tests/legacy_serialization_unittest.cpp
@@ -147,10 +147,15 @@ TEST(LegacySerialization, CActionRobotMovement2D_v4_v5_v6)
     EXPECT_NEAR(act->velocityLocal.vy, 0.0, 1e-6);
     EXPECT_NEAR(act->velocityLocal.omega, 0.5, 1e-6);
     EXPECT_EQ(act->encoderRightTicks, 4);
-    if (version < 6) EXPECT_EQ(act->timestamp, INVALID_TIMESTAMP);
+    if (version < 6)
+    {
+      EXPECT_EQ(act->timestamp, INVALID_TIMESTAMP);
+    }
     // The additional Thrun std devs default to zero before version 5:
     if (version < 5)
+    {
       EXPECT_NEAR(act->motionModelConfiguration.thrunModel.additional_std_XY, 0.0f, 1e-9f);
+    }
   }
 }
 
@@ -295,11 +300,26 @@ TEST(LegacySerialization, CObservationStereoImages_v0_to_v4)
     EXPECT_TRUE(obs->hasImageRight);
     EXPECT_NEAR(obs->cameraPose.x(), 1.0, 1e-6);
 
-    if (version < 1) EXPECT_EQ(obs->timestamp, INVALID_TIMESTAMP);
-    if (version < 2) EXPECT_NEAR(obs->rightCameraPose.x(), 0.10, 1e-5);
-    if (version >= 2) EXPECT_NEAR(obs->rightCameraPose.x(), 0.2, 1e-5);
-    if (version >= 3) EXPECT_NEAR(obs->leftCamera.focalLengthMeters, 0.004, 1e-9);
-    if (version < 3) EXPECT_NEAR(obs->leftCamera.focalLengthMeters, 0.002, 1e-9);
+    if (version < 1)
+    {
+      EXPECT_EQ(obs->timestamp, INVALID_TIMESTAMP);
+    }
+    if (version < 2)
+    {
+      EXPECT_NEAR(obs->rightCameraPose.x(), 0.10, 1e-5);
+    }
+    if (version >= 2)
+    {
+      EXPECT_NEAR(obs->rightCameraPose.x(), 0.2, 1e-5);
+    }
+    if (version >= 3)
+    {
+      EXPECT_NEAR(obs->leftCamera.focalLengthMeters, 0.004, 1e-9);
+    }
+    if (version < 3)
+    {
+      EXPECT_NEAR(obs->leftCamera.focalLengthMeters, 0.002, 1e-9);
+    }
     EXPECT_EQ(obs->sensorLabel, version >= 4 ? "stereo_old" : "");
   }
 }
@@ -389,7 +409,7 @@ TEST(LegacySerialization, CObservationBeaconRanges_v0_to_v2)
           for (uint32_t i = 0; i < 2; i++)
           {
             a << mrpt::poses::CPoint3D(0.1 * i, 0, 0);
-            a << float(5.0f + i);
+            a << float(5.0f + static_cast<float>(i));
             a << uint32_t(100 + i);
           }
           if (version >= 1) a << mrpt::poses::CPose2D(1, 2, 0);
@@ -401,7 +421,10 @@ TEST(LegacySerialization, CObservationBeaconRanges_v0_to_v2)
     ASSERT_EQ(obs->sensedData.size(), 2U);
     EXPECT_EQ(obs->sensedData[1].beaconID, 101U);
     EXPECT_NEAR(obs->sensedData[1].sensedDistance, 6.0f, 1e-5f);
-    if (version >= 1) EXPECT_NEAR(obs->auxEstimatePose.y(), 2.0, 1e-6);
+    if (version >= 1)
+    {
+      EXPECT_NEAR(obs->auxEstimatePose.y(), 2.0, 1e-6);
+    }
     EXPECT_EQ(obs->sensorLabel, version >= 2 ? "beacons_old" : "");
     EXPECT_EQ(obs->timestamp, INVALID_TIMESTAMP);
   }
@@ -632,7 +655,10 @@ TEST(LegacySerialization, CObservation3DRangeScan_v0_to_v8)
       EXPECT_EQ(obs->cameraParams.nrows, 2U);
     }
     EXPECT_EQ(obs->sensorLabel, "depth");
-    if (version < 5) EXPECT_TRUE(obs->range_is_depth);
+    if (version < 5)
+    {
+      EXPECT_TRUE(obs->range_is_depth);
+    }
   }
 }
 

--- a/modules/mrpt_poses/include/mrpt/poses/CPose3DQuat.h
+++ b/modules/mrpt_poses/include/mrpt/poses/CPose3DQuat.h
@@ -283,7 +283,7 @@ class CPose3DQuat :
   }
 
   /** Read-only [] operator */
-  double operator[](const std::size_t i) const
+  const double& operator[](const std::size_t i) const
   {
     switch (i)
     {

--- a/modules/mrpt_poses/tests/CPose3DPDFGaussian_unittest.cpp
+++ b/modules/mrpt_poses/tests/CPose3DPDFGaussian_unittest.cpp
@@ -516,7 +516,15 @@ TEST(CPose3DPDFGaussian, DrawSamplesBayesianFusionInverseAndOperators)
 
   CMatrixDouble subCov = p.getCovSubmatrix2D();
   CMatrixDouble subCov2;
+#if defined(__clang__) || defined(__GNUC__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+#endif
+  // Exercise the deprecated output-argument overload for coverage:
   p.getCovSubmatrix2D(subCov2);
+#if defined(__clang__) || defined(__GNUC__)
+#pragma GCC diagnostic pop
+#endif
   EXPECT_TRUE(subCov == subCov2);
   EXPECT_EQ(subCov.rows(), 3);
 

--- a/modules/mrpt_poses/tests/CPose3DQuat_unittest.cpp
+++ b/modules/mrpt_poses/tests/CPose3DQuat_unittest.cpp
@@ -847,7 +847,15 @@ TEST(CPose3DQuat, ConstructorsFromMatrixAndHomogeneousMatrixRef)
   EXPECT_NEAR(fromHM.y(), 2.0, 1e-9);
 
   CMatrixDouble44 hm2;
+#if defined(__clang__) || defined(__GNUC__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+#endif
+  // Exercise the deprecated output-argument overload for coverage:
   fromHM.getHomogeneousMatrix(hm2);
+#if defined(__clang__) || defined(__GNUC__)
+#pragma GCC diagnostic pop
+#endif
   EXPECT_TRUE(hm2 == fromHM.getHomogeneousMatrix());
 }
 

--- a/modules/mrpt_poses/tests/CPose3D_unittest.cpp
+++ b/modules/mrpt_poses/tests/CPose3D_unittest.cpp
@@ -954,7 +954,15 @@ TEST(CPose3D, ScalarOpsYPRSphericalAndDistance)
   double yaw2;
   double pitch2;
   double roll2;
+#if defined(__clang__) || defined(__GNUC__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+#endif
+  // Exercise the deprecated output-argument overload for coverage:
   p.getYawPitchRoll(yaw2, pitch2, roll2);
+#if defined(__clang__) || defined(__GNUC__)
+#pragma GCC diagnostic pop
+#endif
   EXPECT_NEAR(yaw2, yaw, 1e-9);
   EXPECT_NEAR(pitch2, pitch, 1e-9);
   EXPECT_NEAR(roll2, roll, 1e-9);
@@ -1081,7 +1089,15 @@ TEST(CPose3D, FromStringAndHomogeneousMatrixRef)
   EXPECT_NEAR(p2.x(), p.x(), 1e-9);
 
   CMatrixDouble44 hm;
+#if defined(__clang__) || defined(__GNUC__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+#endif
+  // Exercise the deprecated output-argument overload for coverage:
   p.getHomogeneousMatrix(hm);
+#if defined(__clang__) || defined(__GNUC__)
+#pragma GCC diagnostic pop
+#endif
   CMatrixDouble44 hm2 = p.getHomogeneousMatrix();
   EXPECT_TRUE(hm == hm2);
 

--- a/modules/mrpt_serialization/include/mrpt/serialization/CSerializable.h
+++ b/modules/mrpt_serialization/include/mrpt/serialization/CSerializable.h
@@ -104,6 +104,10 @@ void OctetVectorToObject(const std::vector<uint8_t>& in_data, CSerializable::Ptr
 /** @} */
 /** This declaration must be inserted in all CSerializable classes definition,
  * within the class declaration. */
+// Note: DEFINE_SCHEMA_SERIALIZABLE() is only ever used together with, and
+// after, DEFINE_SERIALIZABLE() in the same class, which already brings in
+// `using CSerializable::serializeTo/serializeFrom;` (needed so that
+// overriding one overload here does not hide the other from CSerializable).
 #define DEFINE_SCHEMA_SERIALIZABLE()                                             \
  protected:                                                                      \
   /*! @name CSerializable virtual methods for schema based archives*/            \
@@ -139,6 +143,8 @@ void OctetVectorToObject(const std::vector<uint8_t>& in_data, CSerializable::Ptr
  protected:                                                                               \
   /*! @name CSerializable virtual methods */                                              \
   /*! @{ */                                                                               \
+  using mrpt::serialization::CSerializable::serializeTo;                                  \
+  using mrpt::serialization::CSerializable::serializeFrom;                                \
   uint8_t serializeGetVersion() const override;                                           \
   void serializeTo(mrpt::serialization::CArchive& out) const override;                    \
   void serializeFrom(mrpt::serialization::CArchive& in, uint8_t serial_version) override; \

--- a/modules/mrpt_slam/include/mrpt/slam/CICP.h
+++ b/modules/mrpt_slam/include/mrpt/slam/CICP.h
@@ -29,7 +29,7 @@ enum TICPAlgorithm
 
 /** ICP covariance estimation methods, used in mrpt::slam::CICP::options
  * \ingroup mrpt_slam_grp  */
-enum TICPCovarianceMethod
+enum TICPCovarianceMethod : int
 {
   /** Use the covariance of the optimal registration, disregarding uncertainty
    in data association */

--- a/modules/mrpt_slam/tests/CMetricMapBuilderRBPF_unittest.cpp
+++ b/modules/mrpt_slam/tests/CMetricMapBuilderRBPF_unittest.cpp
@@ -427,7 +427,7 @@ mrpt::obs::CSensoryFrame::Ptr simulateBeaconRanges(
   for (const auto& p : beaconPositions())
   {
     mrpt::obs::CObservationBeaconRanges::TMeasurement m;
-    m.beaconID = id++;
+    m.beaconID = static_cast<int32_t>(id++);
     m.sensorLocationOnRobot = mrpt::poses::CPoint3D(0, 0, 0);
     m.sensedDistance = static_cast<float>(mrpt::poses::CPoint3D(p).distanceTo(
         mrpt::poses::CPoint3D(robotPose.x(), robotPose.y(), 0)));

--- a/modules/mrpt_slam/tests/CRejectionSamplingRangeOnlyLocalization_unittest.cpp
+++ b/modules/mrpt_slam/tests/CRejectionSamplingRangeOnlyLocalization_unittest.cpp
@@ -54,7 +54,7 @@ mrpt::obs::CObservationBeaconRanges make_obs(
   for (const auto& [id, range] : idAndRange)
   {
     mrpt::obs::CObservationBeaconRanges::TMeasurement m;
-    m.beaconID = id;
+    m.beaconID = static_cast<int32_t>(id);
     m.sensedDistance = range;
     m.sensorLocationOnRobot = mrpt::poses::CPoint3D(0, 0, 0);
     o.sensedData.push_back(m);

--- a/modules/mrpt_system/include/mrpt/system/datetime.h
+++ b/modules/mrpt_system/include/mrpt/system/datetime.h
@@ -161,10 +161,8 @@ std::string timeLocalToString(mrpt::system::TTimeStamp t, unsigned int secondFra
 std::string intervalFormat(double seconds);
 
 /** Textual representation of a TTimeStamp as the plain number in
- * time_since_epoch().count().
- * \note Defined as mrpt::operator<<(); brought into this namespace so
- * existing qualified calls (`mrpt::system::operator<<`) keep working. */
-using mrpt::operator<<;
+ * time_since_epoch().count() */
+std::ostream& operator<<(std::ostream& o, const TTimeStamp& t);
 
 /** @} */
 

--- a/modules/mrpt_system/include/mrpt/system/datetime.h
+++ b/modules/mrpt_system/include/mrpt/system/datetime.h
@@ -161,8 +161,10 @@ std::string timeLocalToString(mrpt::system::TTimeStamp t, unsigned int secondFra
 std::string intervalFormat(double seconds);
 
 /** Textual representation of a TTimeStamp as the plain number in
- * time_since_epoch().count() */
-std::ostream& operator<<(std::ostream& o, const TTimeStamp& t);
+ * time_since_epoch().count().
+ * \note Defined as mrpt::operator<<(); brought into this namespace so
+ * existing qualified calls (`mrpt::system::operator<<`) keep working. */
+using mrpt::operator<<;
 
 /** @} */
 

--- a/modules/mrpt_system/src/datetime.cpp
+++ b/modules/mrpt_system/src/datetime.cpp
@@ -435,5 +435,9 @@ std::string mrpt::system::intervalFormat(const double seconds)
   return implIntervalFormat(seconds);
 }
 
-// mrpt::system::operator<<(TTimeStamp) is mrpt::operator<<(Clock::time_point);
-// see the `using` declaration in datetime.h.
+std::ostream& mrpt::system::operator<<(std::ostream& o, const TTimeStamp& t)
+{
+  const auto v = static_cast<uint64_t>(t.time_since_epoch().count());
+  o << v;
+  return o;
+}

--- a/modules/mrpt_system/src/datetime.cpp
+++ b/modules/mrpt_system/src/datetime.cpp
@@ -435,9 +435,5 @@ std::string mrpt::system::intervalFormat(const double seconds)
   return implIntervalFormat(seconds);
 }
 
-std::ostream& mrpt::system::operator<<(std::ostream& o, const TTimeStamp& t)
-{
-  const auto v = static_cast<uint64_t>(t.time_since_epoch().count());
-  o << v;
-  return o;
-}
+// mrpt::system::operator<<(TTimeStamp) is mrpt::operator<<(Clock::time_point);
+// see the `using` declaration in datetime.h.

--- a/modules/mrpt_viz/tests/legacy_serialization_unittest.cpp
+++ b/modules/mrpt_viz/tests/legacy_serialization_unittest.cpp
@@ -224,10 +224,10 @@ TEST(VizLegacySerialization, CSetOfLines)
           // Note: a braced list would select CVectorFloat's size ctor.
           auto vec = [](float a0, float a1)
           {
-            mrpt::math::CVectorFloat v(2);
-            v[0] = a0;
-            v[1] = a1;
-            return v;
+            mrpt::math::CVectorFloat result(2);
+            result[0] = a0;
+            result[1] = a1;
+            return result;
           };
           a << vec(0.f, 1.f) << vec(0.f, 1.f) << vec(0.f, 1.f);
           a << vec(10.f, 11.f) << vec(20.f, 21.f) << vec(30.f, 31.f);


### PR DESCRIPTION
## Summary

Fixes every warning category surfaced by the last Humble (Ubuntu Jammy, gcc-11) and Jazzy (Ubuntu Noble, gcc-13) ROS buildfarm `*dev` jobs:

- `-Wold-style-cast`, `-Wconversion`, `-Wsign-conversion`, `-Wfloat-conversion`
- `-Wunused-parameter`, `-Wunused-result`, `-Wdeprecated-declarations`
- `-Wdangling-else`, `-Wdangling-reference`, `-Wnon-virtual-dtor`, `-Woverloaded-virtual`
- `-Wsign-compare`, `-Wstringop-overread`, `-Wshadow`, `-Wreturn-local-addr`, `-Wrange-loop-construct`

across `mrpt_bayes`, `mrpt_containers`, `mrpt_core`, `mrpt_graphs`, `mrpt_graphslam`, `mrpt_hwdrivers`, `mrpt_img`, `mrpt_maps`, `mrpt_math`, `mrpt_nav`, `mrpt_obs`, `mrpt_poses`, `mrpt_serialization`, `mrpt_slam`, `mrpt_system` and `mrpt_viz`.

## Real bugs fixed along the way (not just silenced casts)

- **`CPose3DQuat::operator[](i) const`** returned a temporary `double` by value while its `const_iterator` bound it to a `const double&` — every dereference of a const iterator was dangling (`-Wreturn-local-addr`).
- **`CDirectedTree::Visitor`** and its subclasses had virtual functions but a non-virtual destructor.
- **`CSerializable`**'s schema-archive overloads of `serializeTo`/`serializeFrom` were silently hidden in any class using `DEFINE_SERIALIZABLE` — unreachable without explicit qualification. Added the missing `using` declarations.
- **`mrpt::Clock::time_point`** had no ADL-discoverable `operator<<`, which made gtest's `EXPECT_EQ`/`ASSERT_EQ` fail to *compile* wherever two timestamps were compared, on gcc-11/older libstdc++ — this was the actual Humble build **error**, not just a warning. `mrpt::system::operator<<(TTimeStamp)` already existed but lived in a namespace ADL never reaches from outside `mrpt::system`; it's now `mrpt::operator<<`, with `mrpt::system` bringing it back in via a `using` declaration so existing qualified callers keep working.
- Several `TKFMethod`-shaped unscoped enums (`TKFMethod`, `TLaserSimulUncertaintyMethod`, `TMatrixTextFileFormat`, `TICPCovarianceMethod`) had no fixed underlying type, so a test casting an intentionally-invalid value into them hit "conversion is unspecified" instead of the well-defined reinterpret a fixed underlying type gives.

Everything else is a widening/narrowing cast made explicit, an unused parameter renamed to a comment (or `[[maybe_unused]]` where it's only read inside a debug-only assert macro), `else`-ambiguous one-liners given braces, or a documented false positive (a wrapper around a cached-static-map accessor that gcc's `-Wdangling-reference` still flags) resolved by dropping the unnecessary named reference instead of suppressing the warning.

## Test plan

- [x] Incremental `colcon build --cmake-args -DBUILD_TESTING=ON` of all 16 touched packages under `mrpt_common`'s full warning set (`-Wall -Wextra -Wshadow -Wtype-limits -Wcast-align -Wparentheses -Wunused -Wpedantic -Wconversion -Wsign-conversion -Wdouble-promotion -Woverloaded-virtual -Wold-style-cast -Wnon-virtual-dtor`): zero warnings left, other than a gcc-13/`-O3` `-Wmaybe-uninitialized` false positive on a small fixed-size `CMatrixDynamic` construction that is present in neither buildfarm log and untouched by this change.
- [x] All existing unit tests (2000+ cases across the touched packages) still pass.

https://claude.ai/code/session_01PvVpfLXnmP5wfAzpEjd7vJ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Improvements**
  - Improved type consistency and numeric conversions across Bayesian filtering, mapping, navigation, graph, mathematics, and sensor-processing features.
  - Improved serialization overload compatibility and clock-value output in test frameworks.
  - Clarified enum representations and strengthened graph visitor copy and move behavior.
  - Reduced copying when accessing read-only pose elements.

- **Tests**
  - Expanded warning-free coverage and portability across supported compilers.
  - Updated tests for explicit numeric types, deprecated APIs, and unused return values.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->