### PR TITLE
feat: API cleanups before the next minor bump (archives, const-correctness, points-map accessor)

### DIFF
--- a/apps/mrpt_apps_cli/observations2map/observations2map_main.cpp
+++ b/apps/mrpt_apps_cli/observations2map/observations2map_main.cpp
@@ -112,11 +112,11 @@ int main(int argc, char** argv)
 
     // And as binary serialized files:
     // -------------------------------------
-    for (unsigned int i = 0; i < metricMap.maps.size(); i++)
+    for (unsigned int i = 0; i < metricMap.size(); i++)
     {
       using namespace std::string_literals;
 
-      const auto& m = metricMap.maps.at(i);
+      const auto m = metricMap.mapByIndex(i);
 
       const auto str = outprefix + mrpt::format("_%02u_", i) +
                        mrpt::system::fileNameStripInvalidChars(m->GetRuntimeClass()->className) +

--- a/apps/mrpt_apps_gui/RawLogViewer/CScanAnimation.cpp
+++ b/apps/mrpt_apps_gui/RawLogViewer/CScanAnimation.cpp
@@ -346,8 +346,12 @@ bool CScanAnimation::update_opengl_viz(const CSensoryFrame& sf)
 
   // Insert new scans:
   mrpt::system::TTimeStamp tim_last = INVALID_TIMESTAMP;
-  for (auto& it : sf)
+  for (const auto& itConst : sf)
   {
+    // Non-const: rendering some observations lazy-loads and caches data inside
+    // them.
+    const auto it = std::const_pointer_cast<CObservation>(itConst);
+
     const std::string sNameInMap = it->sensorLabel + std::string(" [Type: ") +
                                    it->GetRuntimeClass()->className + std::string("]");
 

--- a/apps/mrpt_apps_gui/robot-map-gui/CDocument.cpp
+++ b/apps/mrpt_apps_gui/robot-map-gui/CDocument.cpp
@@ -90,9 +90,9 @@ void CDocument::saveAsPng(const std::string& fileName) const
 bool CDocument::hasPointsMap() const { return m_hasPointsMap; }
 void CDocument::saveAsText(const std::string& fileName) const
 {
-  for (auto& m : m_metricmap)
+  for (const auto& m : m_metricmap)
   {
-    auto ptr = std::dynamic_pointer_cast<CSimplePointsMap>(m);
+    auto ptr = std::dynamic_pointer_cast<const CSimplePointsMap>(m);
     if (ptr)
     {
       (void)ptr->save3D_to_text_file(fileName);
@@ -131,7 +131,7 @@ const RenderizableMaps CDocument::renderizableMaps() const
 }
 
 const CSimpleMap& CDocument::simplemap() const { return m_simplemap; }
-const CMultiMetricMap::TListMaps& CDocument::config() const { return m_metricmap.maps; }
+const CMultiMetricMap::TListMaps& CDocument::config() { return m_metricmap.mapsList(); }
 
 const TypeConfig& CDocument::typeConfig() const { return m_typeConfigs; }
 std::vector<size_t> CDocument::remove(const std::vector<size_t>& indexes)

--- a/apps/mrpt_apps_gui/robot-map-gui/CDocument.cpp
+++ b/apps/mrpt_apps_gui/robot-map-gui/CDocument.cpp
@@ -131,7 +131,13 @@ const RenderizableMaps CDocument::renderizableMaps() const
 }
 
 const CSimpleMap& CDocument::simplemap() const { return m_simplemap; }
-const CMultiMetricMap::TListMaps& CDocument::config() { return m_metricmap.mapsList(); }
+TListConstMaps CDocument::config() const
+{
+  TListConstMaps maps;
+  maps.reserve(m_metricmap.size());
+  for (const auto& m : m_metricmap) maps.push_back(m);
+  return maps;
+}
 
 const TypeConfig& CDocument::typeConfig() const { return m_typeConfigs; }
 std::vector<size_t> CDocument::remove(const std::vector<size_t>& indexes)

--- a/apps/mrpt_apps_gui/robot-map-gui/CDocument.h
+++ b/apps/mrpt_apps_gui/robot-map-gui/CDocument.h
@@ -56,7 +56,7 @@ class CDocument
   const RenderizableMaps renderizableMaps() const;
 
   const mrpt::maps::CSimpleMap& simplemap() const;
-  const mrpt::maps::CMultiMetricMap::TListMaps& config() const;
+  const mrpt::maps::CMultiMetricMap::TListMaps& config();
 
   const TypeConfig& typeConfig() const;
 

--- a/apps/mrpt_apps_gui/robot-map-gui/CDocument.h
+++ b/apps/mrpt_apps_gui/robot-map-gui/CDocument.h
@@ -56,7 +56,8 @@ class CDocument
   const RenderizableMaps renderizableMaps() const;
 
   const mrpt::maps::CSimpleMap& simplemap() const;
-  const mrpt::maps::CMultiMetricMap::TListMaps& config();
+  /** The list of child maps, read-only */
+  TListConstMaps config() const;
 
   const TypeConfig& typeConfig() const;
 

--- a/apps/mrpt_apps_gui/robot-map-gui/TypeOfConfig.h
+++ b/apps/mrpt_apps_gui/robot-map-gui/TypeOfConfig.h
@@ -8,7 +8,13 @@
    +---------------------------------------------------------------------------+
    */
 #pragma once
+#include <mrpt/maps/CMetricMap.h>
+
 #include <string>
+#include <vector>
+
+/** A read-only list of metric maps, as handed out by CDocument::config() */
+using TListConstMaps = std::vector<mrpt::maps::CMetricMap::ConstPtr>;
 
 enum TypeOfConfig
 {

--- a/apps/mrpt_apps_gui/robot-map-gui/gui/configWidget/CConfigWidget.cpp
+++ b/apps/mrpt_apps_gui/robot-map-gui/gui/configWidget/CConfigWidget.cpp
@@ -228,15 +228,15 @@ TSetOfMetricMapInitializers CConfigWidget::config()
   return mapCfg;
 }
 
-void CConfigWidget::setConfig(const CMultiMetricMap::TListMaps& config)
+void CConfigWidget::setConfig(const TListConstMaps& config)
 {
   clearConfig();
 
-  for (auto& m : config)
+  for (const auto& m : config)
   {
     bool found = false;
     {
-      if (auto ptr = std::dynamic_pointer_cast<CSimplePointsMap>(m); ptr)
+      if (auto ptr = std::dynamic_pointer_cast<const CSimplePointsMap>(m); ptr)
       {
         CPointsConfig* pConfig = new CPointsConfig();
         addWidget(TypeOfConfig::PointsMap, pConfig);
@@ -247,7 +247,7 @@ void CConfigWidget::setConfig(const CMultiMetricMap::TListMaps& config)
     }
     if (!found)
     {
-      if (auto ptr = std::dynamic_pointer_cast<COccupancyGridMap2D>(m); ptr)
+      if (auto ptr = std::dynamic_pointer_cast<const COccupancyGridMap2D>(m); ptr)
       {
         COccupancyConfig* pConfig = new COccupancyConfig();
         addWidget(TypeOfConfig::Occupancy, pConfig);
@@ -262,7 +262,7 @@ void CConfigWidget::setConfig(const CMultiMetricMap::TListMaps& config)
     }
     if (!found)
     {
-      if (auto ptr = std::dynamic_pointer_cast<CGasConcentrationGridMap2D>(m); m)
+      if (auto ptr = std::dynamic_pointer_cast<const CGasConcentrationGridMap2D>(m); m)
       {
         CGasGridConfig* pConfig = new CGasGridConfig();
         addWidget(TypeOfConfig::GasGrid, pConfig);
@@ -277,7 +277,7 @@ void CConfigWidget::setConfig(const CMultiMetricMap::TListMaps& config)
     }
     if (!found)
     {
-      if (auto ptr = std::dynamic_pointer_cast<CBeaconMap>(m); ptr)
+      if (auto ptr = std::dynamic_pointer_cast<const CBeaconMap>(m); ptr)
       {
         CBeaconConfig* pConfig = new CBeaconConfig();
         addWidget(TypeOfConfig::Beacon, pConfig);

--- a/apps/mrpt_apps_gui/robot-map-gui/gui/configWidget/CConfigWidget.h
+++ b/apps/mrpt_apps_gui/robot-map-gui/gui/configWidget/CConfigWidget.h
@@ -34,7 +34,7 @@ class CConfigWidget : public QWidget
   CConfigWidget(QWidget* parent = nullptr);
   ~CConfigWidget() override;
   mrpt::maps::TSetOfMetricMapInitializers config();
-  void setConfig(const mrpt::maps::CMultiMetricMap::TListMaps& config);
+  void setConfig(const TListConstMaps& config);
 
   const SGeneralSetting& generalSetting();
 

--- a/doc/source/doxygen-docs/port_mrpt3.md
+++ b/doc/source/doxygen-docs/port_mrpt3.md
@@ -620,7 +620,6 @@ obtain a `yaml` copy first.
 
 ---
 
-<a name="removed"></a>
 ### mrpt_serialization
 
 **Streaming into a temporary archive** now works, so the intermediate variable

--- a/doc/source/doxygen-docs/port_mrpt3.md
+++ b/doc/source/doxygen-docs/port_mrpt3.md
@@ -332,6 +332,36 @@ mrpt::math::vectorToTextFile(v, "file.txt", opts);
 See also `COccupancyGridMap2D::getAsImage` (`TGetAsImageParams`) and
 `computeClearance` (struct return) in [§ mrpt_maps](#maps).
 
+<a name="deep-const"></a>
+### 5. `const` containers hand out `ConstPtr`
+
+Containers of smart pointers are now deeply const-correct: reading from a
+`const` container yields `X::ConstPtr`, not `X::Ptr`. This affects the getters
+(which already had `const` / non-`const` overload pairs) and, new in 3.1, the
+`const_iterator`s of `CSensoryFrame`, `CActionCollection`, `CSetOfObjects`,
+`Viewport` and `CMultiMetricMap`.
+
+**Rule:** if you need to modify what you fetched, fetch it from a non-`const`
+reference to the container.
+
+```cpp
+// Reading through a const container:
+void f(const mrpt::obs::CSensoryFrame& sf)
+{
+  for (const auto& obs : sf)  // obs is now a CObservation::ConstPtr
+    std::cout << obs->sensorLabel;
+}
+
+// Modifying: take a non-const reference instead:
+void g(mrpt::obs::CSensoryFrame& sf)
+{
+  for (auto& obs : sf) obs->sensorLabel = "new";  // CObservation::Ptr
+}
+```
+
+Note that these `const_iterator`s are proxies (`operator*` returns by value),
+so use `(*it)->field`, not `it->field`.
+
 ---
 
 <a name="modules"></a>
@@ -591,6 +621,39 @@ obtain a `yaml` copy first.
 ---
 
 <a name="removed"></a>
+### mrpt_serialization
+
+**Streaming into a temporary archive** now works, so the intermediate variable
+is no longer needed:
+
+```cpp
+// Before (still valid):
+auto arch = mrpt::serialization::archiveFrom(myStream);
+arch << myVector;
+
+// Now also possible:
+mrpt::serialization::archiveFrom(myStream) << myVector;
+```
+
+This mirrors what the standard library does for `std::basic_ostream` /
+`std::basic_istream` rvalues.
+
+### mrpt_maps
+
+**`CMultiMetricMap` child-map list** — the public `maps` member is now private.
+See the [Removed APIs](#removed) table for the replacement methods.
+
+```cpp
+// MRPT 3.0:
+theMap.maps.push_back(ptMap);
+const auto n = theMap.maps.size();
+
+// MRPT 3.1:
+theMap.push_back(ptMap);
+const auto n = theMap.size();
+```
+
+<a name="removed"></a>
 ## Removed APIs
 
 No direct replacement unless noted.
@@ -609,6 +672,8 @@ No direct replacement unless noted.
 | `CPointCloud::octree_get_node_count()` | Octree API removed |
 | `#include <mrpt/opengl.h>` | Use individual `<mrpt/viz/...>` headers |
 | `#include <mrpt/examples_config.h>` | Use a CMake compile definition |
+| `CMetricMap::getAsSimplePointsMap()` | Use `mrpt::maps::asPointsMap(map)` (works for any points map, and for a multi-metric map holding one), `CMultiMetricMap::mapByClass<CSimplePointsMap>()`, or a plain `dynamic_cast` |
+| `CMultiMetricMap::maps` (public member) | Use `push_back()`, `size()`, `empty()`, `clearMaps()`, `mapByIndex()`, `begin()`/`end()`, or `mapsList()` for direct access |
 | `#include <mrpt/config.h>` | Use module-specific config headers |
 
 ---

--- a/modules/mrpt_containers/include/mrpt/containers/deep_const_iterator.h
+++ b/modules/mrpt_containers/include/mrpt/containers/deep_const_iterator.h
@@ -1,0 +1,106 @@
+/*                    _
+                     | |    Mobile Robot Programming Toolkit (MRPT)
+ _ __ ___  _ __ _ __ | |_
+| '_ ` _ \| '__| '_ \| __|          https://www.mrpt.org/
+| | | | | | |  | |_) | |_
+|_| |_| |_|_|  | .__/ \__|     https://github.com/MRPT/mrpt/
+               | |
+               |_|
+
+ Copyright (c) 2005-2026, Individual contributors, see AUTHORS file
+ See: https://www.mrpt.org/Authors - All rights reserved.
+ SPDX-License-Identifier: BSD-3-Clause
+*/
+#pragma once
+
+#include <mrpt/containers/deepcopy_poly_ptr.h>
+
+#include <cstddef>
+#include <iterator>
+#include <memory>
+#include <type_traits>
+
+namespace mrpt::containers
+{
+namespace internal
+{
+/** @name Access to the smart pointer stored in a container element
+ * @{ */
+template <typename T>
+const std::shared_ptr<T>& element_as_shared_ptr(const std::shared_ptr<T>& p)
+{
+  return p;
+}
+template <typename T>
+const T& element_as_shared_ptr(const deepcopy_poly_ptr<T>& p)
+{
+  return p.get_ptr();
+}
+/** @} */
+}  // namespace internal
+
+/** Adapts a const_iterator of a container of smart pointers so that
+ * dereferencing it yields a `shared_ptr<const T>` instead of a
+ * `shared_ptr<T>`.
+ *
+ * Containers of `X::Ptr` would otherwise let a `const` container hand out
+ * mutable pointees, defeating const-correctness. Note that, as with any proxy
+ * iterator, `operator*` returns by value, so use `(*it)->method()` and not
+ * `it->method()`.
+ *
+ * \ingroup mrpt_containers_grp
+ */
+template <typename UNDERLYING_IT>
+class deep_const_iterator
+{
+ private:
+  using underlying_ptr_t =
+      std::decay_t<decltype(internal::element_as_shared_ptr(*std::declval<UNDERLYING_IT>()))>;
+
+ public:
+  using element_type = typename underlying_ptr_t::element_type;
+  using value_type = std::shared_ptr<const element_type>;
+  using reference = value_type;
+  using pointer = void;
+  using difference_type = std::ptrdiff_t;
+  using iterator_category = std::bidirectional_iterator_tag;
+
+  deep_const_iterator() = default;
+  deep_const_iterator(const UNDERLYING_IT& it) : m_it(it) {}
+
+  [[nodiscard]] value_type operator*() const { return internal::element_as_shared_ptr(*m_it); }
+
+  deep_const_iterator& operator++()
+  {
+    ++m_it;
+    return *this;
+  }
+  deep_const_iterator operator++(int)
+  {
+    auto aux = *this;
+    ++m_it;
+    return aux;
+  }
+  deep_const_iterator& operator--()
+  {
+    --m_it;
+    return *this;
+  }
+  deep_const_iterator operator--(int)
+  {
+    auto aux = *this;
+    --m_it;
+    return aux;
+  }
+
+  [[nodiscard]] bool operator==(const deep_const_iterator& o) const { return m_it == o.m_it; }
+  [[nodiscard]] bool operator!=(const deep_const_iterator& o) const { return m_it != o.m_it; }
+
+  /** Returns the wrapped underlying iterator */
+  [[nodiscard]] const UNDERLYING_IT& underlying() const { return m_it; }
+
+ private:
+  UNDERLYING_IT m_it;
+};
+
+}  // namespace mrpt::containers

--- a/modules/mrpt_libapps_gui/src/MonteCarloLocalization_App.cpp
+++ b/modules/mrpt_libapps_gui/src/MonteCarloLocalization_App.cpp
@@ -23,6 +23,7 @@
 #include <mrpt/io/vector_loadsave.h>
 #include <mrpt/maps/CMultiMetricMap.h>
 #include <mrpt/maps/COccupancyGridMap2D.h>
+#include <mrpt/maps/CPointsMap.h>
 #include <mrpt/maps/CSimpleMap.h>
 #include <mrpt/maps/CSimplePointsMap.h>
 #include <mrpt/math/data_utils.h>
@@ -411,7 +412,7 @@ void MonteCarloLocalization_Base::do_pf_localization()
       if (SCENE3D_FREQ > 0 || SHOW_PROGRESS_3D_REAL_TIME)
       {
         mrpt::math::TBoundingBoxf bbox({-50, -50, 0}, {50, 50, 0});
-        if (auto pts = metricMap->getAsSimplePointsMap(); pts) bbox = pts->boundingBox();
+        if (auto pts = metricMap->mapByClass<CPointsMap>(); pts) bbox = pts->boundingBox();
 
         scene.insert(
             mrpt::viz::CGridPlaneXY::Create(bbox.min.x, bbox.max.x, bbox.min.y, bbox.max.y, 0, 5));

--- a/modules/mrpt_libapps_gui/tests/RBPF_SLAM_App_unittest.cpp
+++ b/modules/mrpt_libapps_gui/tests/RBPF_SLAM_App_unittest.cpp
@@ -86,9 +86,9 @@ static auto tester_for_ROSLAM_demo = [](mrpt::apps::RBPF_SLAM_App_Base& o)
   EXPECT_LT(mrpt::poses::Lie::SE<3>::log(p - p_gt).norm(), 1.0)
       << "actual pose  =" << p.asString() << "\nexpected pose=" << p_gt.asString();
 
-  const auto& maps = o.mapBuilder->getCurrentlyBuiltMetricMap().maps;
-  ASSERT_EQUAL_(maps.size(), 1U);
-  auto beaconMap = std::dynamic_pointer_cast<mrpt::maps::CBeaconMap>(maps.at(0));
+  const auto& mm = o.mapBuilder->getCurrentlyBuiltMetricMap();
+  ASSERT_EQUAL_(mm.size(), 1U);
+  auto beaconMap = std::dynamic_pointer_cast<const mrpt::maps::CBeaconMap>(mm.mapByIndex(0));
   ASSERT_(beaconMap);
 
   // TODO(jlbc): check why actual LM mean positions seem not to match GT?

--- a/modules/mrpt_maps/include/mrpt/maps/CMultiMetricMap.h
+++ b/modules/mrpt_maps/include/mrpt/maps/CMultiMetricMap.h
@@ -14,6 +14,7 @@
 #pragma once
 
 #include <mrpt/config/CLoadableOptions.h>
+#include <mrpt/containers/deep_const_iterator.h>
 #include <mrpt/maps/CMetricMap.h>
 #include <mrpt/obs/obs_frwds.h>
 #include <mrpt/serialization/CSerializable.h>
@@ -102,7 +103,7 @@ class TSetOfMetricMapInitializers;
  * mrpt::maps::CMultiMetricMap theMap;
  * {
  *  auto ptMap = mrpt::maps::CSimplePointsMap::Create();
- *  theMap.maps.push_back(ptMap);
+ *  theMap.push_back(ptMap);
  * }
  * \endcode
  *
@@ -147,19 +148,30 @@ class CMultiMetricMap : public mrpt::maps::CMetricMap
     @{ */
   using TListMaps = std::deque<mrpt::maps::CMetricMap::Ptr>;
 
-  /** The list of metric maps in this object. Use dynamic_cast or smart
-   * pointer-based downcast to access maps by their actual type.
-   * You can directly manipulate this list. Helper methods to initialize it
-   * are described in the docs of CMultiMetricMap
-   */
-  TListMaps maps;
-
   using iterator = TListMaps::iterator;
-  using const_iterator = TListMaps::const_iterator;
-  iterator begin() { return maps.begin(); }
-  const_iterator begin() const { return maps.begin(); }
-  iterator end() { return maps.end(); }
-  const_iterator end() const { return maps.end(); }
+  /** Dereferencing it yields a CMetricMap::ConstPtr, so that a `const`
+   * multi-map cannot hand out mutable child maps. */
+  using const_iterator = mrpt::containers::deep_const_iterator<TListMaps::const_iterator>;
+  iterator begin() { return m_maps.begin(); }
+  const_iterator begin() const { return m_maps.begin(); }
+  iterator end() { return m_maps.end(); }
+  const_iterator end() const { return m_maps.end(); }
+
+  /** Number of child maps */
+  [[nodiscard]] size_t size() const { return m_maps.size(); }
+  /** Returns true if there are no child maps */
+  [[nodiscard]] bool empty() const { return m_maps.empty(); }
+  /** Appends a new child map to the list */
+  void push_back(const mrpt::maps::CMetricMap::Ptr& m) { m_maps.push_back(m); }
+  /** Removes all child maps */
+  void clearMaps() { m_maps.clear(); }
+
+  /** Direct access to the list of child maps, for advanced manipulation.
+   * Use dynamic_cast or smart pointer-based downcast to access maps by their
+   * actual type. Helper methods to initialize the list are described in the
+   * docs of CMultiMetricMap.
+   */
+  [[nodiscard]] TListMaps& mapsList() { return m_maps; }
 
   /** Gets the i-th map \exception std::runtime_error On out-of-bounds */
   mrpt::maps::CMetricMap::ConstPtr mapByIndex(size_t idx) const;
@@ -180,7 +192,7 @@ class CMultiMetricMap : public mrpt::maps::CMetricMap
   {
     size_t foundCount = 0;
     const auto* class_ID = &T::GetRuntimeClassIdStatic();
-    for (const auto& m : maps)
+    for (const auto& m : m_maps)
     {
       if (m && m->GetRuntimeClass()->derivedFrom(class_ID))
       {
@@ -199,7 +211,7 @@ class CMultiMetricMap : public mrpt::maps::CMetricMap
   {
     size_t foundCount = 0;
     const auto* class_ID = &T::GetRuntimeClassIdStatic();
-    for (auto& m : maps)
+    for (auto& m : m_maps)
     {
       if (m && m->GetRuntimeClass()->derivedFrom(class_ID))
       {
@@ -218,7 +230,7 @@ class CMultiMetricMap : public mrpt::maps::CMetricMap
   {
     size_t foundCount = 0;
     const auto* class_ID = &T::GetRuntimeClassIdStatic();
-    for (const auto& m : maps)
+    for (const auto& m : m_maps)
       if (m->GetRuntimeClass()->derivedFrom(class_ID)) foundCount++;
     return foundCount;
   }
@@ -246,7 +258,6 @@ class CMultiMetricMap : public mrpt::maps::CMetricMap
   void saveMetricMapRepresentationToFile(const std::string& filNamePrefix) const override;
   void auxParticleFilterCleanUp() override;
   void getVisualizationInto(mrpt::viz::CSetOfObjects& outObj) const override;
-  const mrpt::maps::CSimplePointsMap* getAsSimplePointsMap() const override;
 
   /** Returns a short description of the map. */
   std::string asString() const override;
@@ -260,6 +271,10 @@ class CMultiMetricMap : public mrpt::maps::CMetricMap
   bool internal_canComputeObservationLikelihood(const mrpt::obs::CObservation& obs) const override;
   double internal_computeObservationLikelihood(
       const mrpt::obs::CObservation& obs, const mrpt::poses::CPose3D& takenFrom) const override;
+
+ private:
+  /** The list of metric maps in this object */
+  TListMaps m_maps;
 
 };  // End of class def.
 

--- a/modules/mrpt_maps/include/mrpt/maps/CPointsMap.h
+++ b/modules/mrpt_maps/include/mrpt/maps/CPointsMap.h
@@ -1665,6 +1665,17 @@ class CPointsMap :
 
 };  // End of class def.
 
+/** Returns a points map "view" of the given metric map: the map itself if it
+ * already is a points map, or its only child points map if it is a
+ * mrpt::maps::CMultiMetricMap holding exactly one. Returns nullptr if no such
+ * map exists.
+ *
+ * The returned pointer is a non-owning observer, valid as long as `map` is.
+ *
+ * \ingroup mrpt_maps_grp
+ */
+[[nodiscard]] const CPointsMap* asPointsMap(const mrpt::maps::CMetricMap& map);
+
 }  // namespace mrpt::maps
 
 namespace mrpt::viz

--- a/modules/mrpt_maps/include/mrpt/maps/CSimplePointsMap.h
+++ b/modules/mrpt_maps/include/mrpt/maps/CSimplePointsMap.h
@@ -105,7 +105,6 @@ class CSimplePointsMap : public CPointsMap
   /** @} */
 
   // See base docs
-  const mrpt::maps::CSimplePointsMap* getAsSimplePointsMap() const override { return this; }
 
  protected:
   /** Clear the map, erasing all the points.

--- a/modules/mrpt_maps/src/maps/CMultiMetricMap.cpp
+++ b/modules/mrpt_maps/src/maps/CMultiMetricMap.cpp
@@ -55,7 +55,7 @@ struct MapExecutor
     MRPT_START
     // This is to avoid duplicating "::run()" for const and non-const.
     auto& mmm = const_cast<CMultiMetricMap&>(_mmm);
-    std::for_each(mmm.maps.begin(), mmm.maps.end(), op);
+    std::for_each(mmm.mapsList().begin(), mmm.mapsList().end(), op);
     MRPT_END
   }
 };  // end of MapExecutor
@@ -117,7 +117,7 @@ void CMultiMetricMap::setListOfMaps(const TSetOfMetricMapInitializers& inits)
 {
   MRPT_START
   // Erase current list of maps:
-  maps.clear();
+  m_maps.clear();
 
   auto& mmr = mrpt::maps::internal::TMetricMapTypesRegistry::Instance();
 
@@ -128,7 +128,7 @@ void CMultiMetricMap::setListOfMaps(const TSetOfMetricMapInitializers& inits)
     auto theMap = mmr.factoryMapObjectFromDefinition(*i.get());
     ASSERT_(theMap);
     // Add to the list of maps:
-    this->maps.emplace_back(theMap);
+    m_maps.emplace_back(theMap);
   }
   MRPT_END
 }
@@ -136,7 +136,7 @@ void CMultiMetricMap::setListOfMaps(const TSetOfMetricMapInitializers& inits)
 void CMultiMetricMap::internal_clear()
 {
   std::for_each(
-      maps.begin(), maps.end(),
+      m_maps.begin(), m_maps.end(),
       [](auto ptr)
       {
         if (ptr) ptr->clear();
@@ -146,9 +146,9 @@ void CMultiMetricMap::internal_clear()
 uint8_t CMultiMetricMap::serializeGetVersion() const { return 12; }
 void CMultiMetricMap::serializeTo(mrpt::serialization::CArchive& out) const
 {
-  const auto n = static_cast<uint32_t>(maps.size());
+  const auto n = static_cast<uint32_t>(m_maps.size());
   out << n;
-  for (uint32_t i = 0; i < n; i++) out << *maps[i];
+  for (uint32_t i = 0; i < n; i++) out << *m_maps[i];
 }
 
 void CMultiMetricMap::serializeFrom(mrpt::serialization::CArchive& in, uint8_t version)
@@ -168,9 +168,10 @@ void CMultiMetricMap::serializeFrom(mrpt::serialization::CArchive& in, uint8_t v
       // List of maps:
       uint32_t n;
       in >> n;
-      this->maps.resize(n);
+      this->m_maps.resize(n);
       for_each(
-          maps.begin(), maps.end(), ObjectReadFromStreamToPtrs<mrpt::maps::CMetricMap::Ptr>(&in));
+          m_maps.begin(), m_maps.end(),
+          ObjectReadFromStreamToPtrs<mrpt::maps::CMetricMap::Ptr>(&in));
     }
     break;
     default:
@@ -186,7 +187,7 @@ double CMultiMetricMap::internal_computeObservationLikelihood(
   double ret_log_lik = 0;
 
   std::for_each(
-      maps.begin(), maps.end(),
+      m_maps.begin(), m_maps.end(),
       [&](auto& ptr) { ret_log_lik += ptr->computeObservationLikelihood(obs, takenFrom); });
   return ret_log_lik;
 
@@ -198,7 +199,7 @@ bool CMultiMetricMap::internal_canComputeObservationLikelihood(const CObservatio
 {
   bool can_comp = false;
   std::for_each(
-      maps.begin(), maps.end(),
+      m_maps.begin(), m_maps.end(),
       [&](auto& ptr) { can_comp = can_comp || ptr->canComputeObservationLikelihood(obs); });
   return can_comp;  //-V614
 }
@@ -209,7 +210,7 @@ bool CMultiMetricMap::internal_insertObservation(
   int total_insert = 0;
 
   std::for_each(
-      maps.begin(), maps.end(),
+      m_maps.begin(), m_maps.end(),
       [&](auto& ptr)
       {
         const bool ret = ptr->insertObservation(obs, robotPose);
@@ -246,9 +247,9 @@ void CMultiMetricMap::saveMetricMapRepresentationToFile(const std::string& filNa
 {
   MRPT_START
 
-  for (size_t idx = 0; idx < maps.size(); idx++)
+  for (size_t idx = 0; idx < m_maps.size(); idx++)
   {
-    const mrpt::maps::CMetricMap* m = maps[idx].get();
+    const mrpt::maps::CMetricMap* m = m_maps[idx].get();
     ASSERT_(m);
     std::string fil = filNamePrefix;
     fil += mrpt::format(
@@ -264,7 +265,7 @@ void CMultiMetricMap::saveMetricMapRepresentationToFile(const std::string& filNa
 void CMultiMetricMap::getVisualizationInto(mrpt::viz::CSetOfObjects& o) const
 {
   MRPT_START
-  std::for_each(maps.begin(), maps.end(), [&](auto& ptr) { ptr->getVisualizationInto(o); });
+  std::for_each(m_maps.begin(), m_maps.end(), [&](auto& ptr) { ptr->getVisualizationInto(o); });
   MRPT_END
 }
 
@@ -278,7 +279,7 @@ float CMultiMetricMap::compute3DMatchingRatio(
 
   float accumResult = 0;
 
-  for (const auto& map : maps)
+  for (const auto& map : m_maps)
   {
     const mrpt::maps::CMetricMap* m = map.get();
     ASSERT_(m);
@@ -286,7 +287,7 @@ float CMultiMetricMap::compute3DMatchingRatio(
   }
 
   // Return average:
-  const size_t nMapsComputed = maps.size();
+  const size_t nMapsComputed = m_maps.size();
   if (nMapsComputed) accumResult /= static_cast<float>(nMapsComputed);
   return accumResult;
 
@@ -296,27 +297,16 @@ float CMultiMetricMap::compute3DMatchingRatio(
 void CMultiMetricMap::auxParticleFilterCleanUp()
 {
   MRPT_START
-  std::for_each(maps.begin(), maps.end(), [](auto& ptr) { ptr->auxParticleFilterCleanUp(); });
-  MRPT_END
-}
-
-const CSimplePointsMap* CMultiMetricMap::getAsSimplePointsMap() const
-{
-  MRPT_START
-  const auto numPointsMaps = countMapsByClass<CSimplePointsMap>();
-  ASSERT_(numPointsMaps == 1 || numPointsMaps == 0);
-  if (!numPointsMaps)
-    return nullptr;
-  else
-    return this->mapByClass<CSimplePointsMap>(0).get();
+  std::for_each(m_maps.begin(), m_maps.end(), [](auto& ptr) { ptr->auxParticleFilterCleanUp(); });
   MRPT_END
 }
 
 std::string CMultiMetricMap::asString() const
 {
   std::stringstream ss;
-  ss << "Multi-map with " << maps.size() << " children maps: ";
-  for (size_t i = 0; i < maps.size(); i++) ss << "[" << i << "] " << maps[i]->asString() << ", ";
+  ss << "Multi-map with " << m_maps.size() << " children maps: ";
+  for (size_t i = 0; i < m_maps.size(); i++)
+    ss << "[" << i << "] " << m_maps[i]->asString() << ", ";
 
   return ss.str();
 }
@@ -324,14 +314,14 @@ std::string CMultiMetricMap::asString() const
 mrpt::maps::CMetricMap::ConstPtr CMultiMetricMap::mapByIndex(size_t idx) const
 {
   MRPT_START
-  return maps.at(idx);
+  return m_maps.at(idx);
   MRPT_END
 }
 
 mrpt::maps::CMetricMap::Ptr CMultiMetricMap::mapByIndex(size_t idx)
 {
   MRPT_START
-  return maps.at(idx);
+  return m_maps.at(idx);
   MRPT_END
 }
 

--- a/modules/mrpt_maps/src/maps/CPointsMap.cpp
+++ b/modules/mrpt_maps/src/maps/CPointsMap.cpp
@@ -18,6 +18,7 @@
 #include <mrpt/io/CCompressedInputStream.h>
 #include <mrpt/io/CCompressedOutputStream.h>
 #include <mrpt/io/CFileInputStream.h>
+#include <mrpt/maps/CMultiMetricMap.h>
 #include <mrpt/maps/CPointsMap.h>
 #include <mrpt/maps/CSimplePointsMap.h>
 #include <mrpt/math/TPose2D.h>
@@ -730,6 +731,17 @@ void CPointsMap::getVisualizationInto(mrpt::viz::CSetOfObjects& o) const
   MRPT_END
 }
 
+const CPointsMap* mrpt::maps::asPointsMap(const mrpt::maps::CMetricMap& map)
+{
+  if (const auto* pts = dynamic_cast<const CPointsMap*>(&map); pts) return pts;
+
+  if (const auto* mm = dynamic_cast<const CMultiMetricMap*>(&map); mm)
+  {
+    if (mm->countMapsByClass<CPointsMap>() == 1) return mm->mapByClass<CPointsMap>(0).get();
+  }
+  return nullptr;
+}
+
 float CPointsMap::compute3DMatchingRatio(
     const mrpt::maps::CMetricMap* otherMap2,
     const mrpt::poses::CPose3D& otherMapPose,
@@ -741,8 +753,10 @@ float CPointsMap::compute3DMatchingRatio(
 
   params.maxDistForCorrespondence = mrp.maxDistForCorr;
 
-  this->determineMatching3D(
-      otherMap2->getAsSimplePointsMap(), otherMapPose, correspondences, params, extraResults);
+  const auto* otherPts = mrpt::maps::asPointsMap(*otherMap2);
+  ASSERTMSG_(otherPts, "The other map does not contain a points map");
+
+  this->determineMatching3D(otherPts, otherMapPose, correspondences, params, extraResults);
 
   return extraResults.correspondencesRatio;
 }

--- a/modules/mrpt_maps/src/obs/customizable_obs_viz.cpp
+++ b/modules/mrpt_maps/src/obs/customizable_obs_viz.cpp
@@ -691,7 +691,9 @@ bool mrpt::obs::obs_to_viz(
     if (!obs) continue;
     auto glObj = mrpt::viz::CSetOfObjects::Create();
 
-    bool ok = obs_to_viz(obs, vp, *glObj);
+    // Non-const: generating the visualization of some observations lazy-loads
+    // and caches data inside them.
+    bool ok = obs_to_viz(std::const_pointer_cast<CObservation>(obs), vp, *glObj);
     if (!ok) continue;
 
     out.insert(glObj);

--- a/modules/mrpt_maps/tests/CMultiMetricMap_unittest.cpp
+++ b/modules/mrpt_maps/tests/CMultiMetricMap_unittest.cpp
@@ -61,8 +61,8 @@ mrpt::maps::CMultiMetricMap initializer1()
 mrpt::maps::CMultiMetricMap initializer2()
 {
   mrpt::maps::CMultiMetricMap m;
-  m.maps.push_back(mrpt::maps::COccupancyGridMap2D::Create());
-  m.maps.push_back(mrpt::maps::CSimplePointsMap::Create());
+  m.push_back(mrpt::maps::COccupancyGridMap2D::Create());
+  m.push_back(mrpt::maps::CSimplePointsMap::Create());
   return m;
 }
 }  // namespace
@@ -71,15 +71,15 @@ TEST(CMultiMetricMapTests, initializers)
 {
   {
     const auto m = initializer1();
-    EXPECT_EQ(m.maps.size(), 2U);
-    EXPECT_TRUE(IS_CLASS(*m.maps.at(0), mrpt::maps::COccupancyGridMap2D));
-    EXPECT_TRUE(IS_CLASS(*m.maps.at(1), mrpt::maps::CSimplePointsMap));
+    EXPECT_EQ(m.size(), 2U);
+    EXPECT_TRUE(IS_CLASS(*m.mapByIndex(0), mrpt::maps::COccupancyGridMap2D));
+    EXPECT_TRUE(IS_CLASS(*m.mapByIndex(1), mrpt::maps::CSimplePointsMap));
   }
   {
     const auto m = initializer2();
-    EXPECT_EQ(m.maps.size(), 2U);
-    EXPECT_TRUE(IS_CLASS(*m.maps.at(0), mrpt::maps::COccupancyGridMap2D));
-    EXPECT_TRUE(IS_CLASS(*m.maps.at(1), mrpt::maps::CSimplePointsMap));
+    EXPECT_EQ(m.size(), 2U);
+    EXPECT_TRUE(IS_CLASS(*m.mapByIndex(0), mrpt::maps::COccupancyGridMap2D));
+    EXPECT_TRUE(IS_CLASS(*m.mapByIndex(1), mrpt::maps::CSimplePointsMap));
   }
 }
 
@@ -88,7 +88,7 @@ TEST(CMultiMetricMapTests, copyCtorOp)
   using mrpt::maps::CSimplePointsMap;
 
   auto m1 = initializer1();
-  EXPECT_EQ(m1.maps.size(), 2U);
+  EXPECT_EQ(m1.size(), 2U);
 
   m1.mapByClass<CSimplePointsMap>()->insertPoint(1.0f, 2.0f, 3.0f);
 
@@ -111,7 +111,7 @@ TEST(CMultiMetricMapTests, moveOp)
   using mrpt::maps::CSimplePointsMap;
 
   auto m1 = initializer1();
-  EXPECT_EQ(m1.maps.size(), 2U);
+  EXPECT_EQ(m1.size(), 2U);
 
   m1.mapByClass<CSimplePointsMap>()->insertPoint(1.0f, 2.0f, 3.0f);
 
@@ -184,7 +184,7 @@ TEST(CMultiMetricMapTests, DetermineMatching2DWithOnePointsMapWorks)
 TEST(CMultiMetricMapTests, DetermineMatching2DWithZeroPointsMapsThrows)
 {
   mrpt::maps::CMultiMetricMap m;
-  m.maps.push_back(mrpt::maps::COccupancyGridMap2D::Create());  // No points map.
+  m.push_back(mrpt::maps::COccupancyGridMap2D::Create());  // No points map.
 
   mrpt::maps::CSimplePointsMap otherMap;
   otherMap.insertPoint(1.0f, 0.0f, 0.0f);
@@ -198,28 +198,30 @@ TEST(CMultiMetricMapTests, DetermineMatching2DWithZeroPointsMapsThrows)
 }
 
 // =========================================================================
-//  getAsSimplePointsMap(): 0, 1, and >1 points-map sub-map cases
+//  mapByClass<CSimplePointsMap>(): 0, 1, and >1 points-map sub-map cases
 // =========================================================================
 
-TEST(CMultiMetricMapTests, GetAsSimplePointsMapZeroReturnsNull)
+TEST(CMultiMetricMapTests, PointsMapByClassZeroReturnsNull)
 {
   mrpt::maps::CMultiMetricMap m;
-  m.maps.push_back(mrpt::maps::COccupancyGridMap2D::Create());
-  EXPECT_EQ(m.getAsSimplePointsMap(), nullptr);
+  m.push_back(mrpt::maps::COccupancyGridMap2D::Create());
+  EXPECT_EQ(m.mapByClass<mrpt::maps::CSimplePointsMap>(), nullptr);
 }
 
-TEST(CMultiMetricMapTests, GetAsSimplePointsMapOneReturnsIt)
+TEST(CMultiMetricMapTests, PointsMapByClassOneReturnsIt)
 {
   auto m = initializer1();
-  EXPECT_NE(m.getAsSimplePointsMap(), nullptr);
+  EXPECT_NE(m.mapByClass<mrpt::maps::CSimplePointsMap>(), nullptr);
 }
 
-TEST(CMultiMetricMapTests, GetAsSimplePointsMapMultipleThrows)
+TEST(CMultiMetricMapTests, PointsMapByClassMultipleSelectsByIndex)
 {
   mrpt::maps::CMultiMetricMap m;
-  m.maps.push_back(mrpt::maps::CSimplePointsMap::Create());
-  m.maps.push_back(mrpt::maps::CSimplePointsMap::Create());
-  EXPECT_ANY_THROW(m.getAsSimplePointsMap());
+  m.push_back(mrpt::maps::CSimplePointsMap::Create());
+  m.push_back(mrpt::maps::CSimplePointsMap::Create());
+  EXPECT_EQ(m.countMapsByClass<mrpt::maps::CSimplePointsMap>(), 2U);
+  EXPECT_NE(m.mapByClass<mrpt::maps::CSimplePointsMap>(1), nullptr);
+  EXPECT_EQ(m.mapByClass<mrpt::maps::CSimplePointsMap>(2), nullptr);
 }
 
 // =========================================================================
@@ -330,7 +332,7 @@ TEST(CMultiMetricMapTests, SerializeRoundTrip)
     ar.ReadObject(&m2);
   }
 
-  EXPECT_EQ(m2.maps.size(), m1.maps.size());
+  EXPECT_EQ(m2.size(), m1.size());
   EXPECT_EQ(m2.mapByClass<mrpt::maps::CSimplePointsMap>()->size(), 1u);
 }
 

--- a/modules/mrpt_obs/include/mrpt/maps/CMetricMap.h
+++ b/modules/mrpt_obs/include/mrpt/maps/CMetricMap.h
@@ -326,17 +326,6 @@ class CMetricMap :
    * correspondence in the map. */
   virtual float squareDistanceToClosestCorrespondence(float x0, float y0) const;
 
-  /** If the map is a simple points map or it's a multi-metric map that
-   * contains EXACTLY one simple points map, return it.
-   * Otherwise, return nullptr
-   */
-  virtual const mrpt::maps::CSimplePointsMap* getAsSimplePointsMap() const { return nullptr; }
-  mrpt::maps::CSimplePointsMap* getAsSimplePointsMap()
-  {
-    return const_cast<CSimplePointsMap*>(
-        const_cast<const CMetricMap*>(this)->getAsSimplePointsMap());
-  }
-
 };  // End of class def.
 
 }  // namespace mrpt::maps

--- a/modules/mrpt_obs/include/mrpt/obs/CActionCollection.h
+++ b/modules/mrpt_obs/include/mrpt/obs/CActionCollection.h
@@ -13,6 +13,7 @@
 */
 #pragma once
 
+#include <mrpt/containers/deep_const_iterator.h>
 #include <mrpt/containers/deepcopy_poly_ptr.h>
 #include <mrpt/obs/CAction.h>
 #include <mrpt/obs/CActionRobotMovement2D.h>
@@ -52,8 +53,11 @@ class CActionCollection : public mrpt::serialization::CSerializable
   /** You can use CActionCollection::begin to get a iterator to the first
    * element.
    */
-  using const_iterator =
-      std::deque<mrpt::containers::deepcopy_poly_ptr<CAction::Ptr>>::const_iterator;
+  /** Dereferencing it yields a CAction::ConstPtr, so that a `const` action
+   * collection cannot hand out mutable actions.
+   */
+  using const_iterator = mrpt::containers::deep_const_iterator<
+      std::deque<mrpt::containers::deepcopy_poly_ptr<CAction::Ptr>>::const_iterator>;
 
   /** Returns a iterator to the first action: this is an example of usage:
    * \code
@@ -123,7 +127,7 @@ class CActionCollection : public mrpt::serialization::CSerializable
       if (it->GetRuntimeClass()->derivedFrom(class_ID))
         if (foundCount++ == ith)
         {
-          return std::dynamic_pointer_cast<const T>(it.get_ptr());
+          return std::dynamic_pointer_cast<const T>(it);
         }
     return typename T::ConstPtr();  // Not found: return empty smart pointer
     MRPT_END

--- a/modules/mrpt_obs/include/mrpt/obs/CSensoryFrame.h
+++ b/modules/mrpt_obs/include/mrpt/obs/CSensoryFrame.h
@@ -13,6 +13,7 @@
 */
 #pragma once
 
+#include <mrpt/containers/deep_const_iterator.h>
 #include <mrpt/maps/CMetricMap.h>
 #include <mrpt/obs/CObservation.h>
 #include <mrpt/serialization/CSerializable.h>
@@ -198,8 +199,11 @@ class CSensoryFrame : public mrpt::serialization::CSerializable
   using iterator = std::deque<CObservation::Ptr>::iterator;
 
   /** You can use CSensoryFrame::begin to get a iterator to the first element.
+   *  Dereferencing it yields a CObservation::ConstPtr, so that a `const`
+   *  sensory frame cannot hand out mutable observations.
    */
-  using const_iterator = std::deque<CObservation::Ptr>::const_iterator;
+  using const_iterator =
+      mrpt::containers::deep_const_iterator<std::deque<CObservation::Ptr>::const_iterator>;
 
   /** Returns a constant iterator to the first observation: this is an example
    *of usage:
@@ -208,7 +212,7 @@ class CSensoryFrame : public mrpt::serialization::CSerializable
    *   ...
    *   for (CSensoryFrame::const_iterator it=sf.begin();it!=sf.end();++it)
    *	  {
-   *      (*it)->... // (*it) is a "CObservation*"
+   *      (*it)->... // (*it) is a "CObservation::ConstPtr"
    *   }
    *
    * \endcode
@@ -221,7 +225,7 @@ class CSensoryFrame : public mrpt::serialization::CSerializable
    *   ...
    *   for (CSensoryFrame::const_iterator it=sf.begin();it!=sf.end();++it)
    *	  {
-   *      (*it)->... // (*it) is a "CObservation*"
+   *      (*it)->... // (*it) is a "CObservation::ConstPtr"
    *   }
    *
    * \endcode

--- a/modules/mrpt_obs/src/CActionCollection.cpp
+++ b/modules/mrpt_obs/src/CActionCollection.cpp
@@ -105,7 +105,7 @@ CActionRobotMovement2D::ConstPtr CActionCollection::getBestMovementEstimation() 
     if (it->GetRuntimeClass()->derivedFrom(CLASS_ID(CActionRobotMovement2D)))
     {
       CActionRobotMovement2D::ConstPtr temp =
-          std::dynamic_pointer_cast<const CActionRobotMovement2D>(it.get_ptr());
+          std::dynamic_pointer_cast<const CActionRobotMovement2D>(it);
 
       if (temp->estimationMethod == CActionRobotMovement2D::emScan2DMatching)
       {
@@ -152,7 +152,7 @@ CActionRobotMovement2D::ConstPtr CActionCollection::getMovementEstimationByType(
     if (it->GetRuntimeClass()->derivedFrom(CLASS_ID(CActionRobotMovement2D)))
     {
       CActionRobotMovement2D::ConstPtr temp =
-          std::dynamic_pointer_cast<const CActionRobotMovement2D>(it.get_ptr());
+          std::dynamic_pointer_cast<const CActionRobotMovement2D>(it);
 
       // Is it of the required type?
       if (temp->estimationMethod == method)

--- a/modules/mrpt_obs/src/CSensoryFrame.cpp
+++ b/modules/mrpt_obs/src/CSensoryFrame.cpp
@@ -87,7 +87,9 @@ void CSensoryFrame::serializeFrom(mrpt::serialization::CArchive& in, uint8_t ver
 void CSensoryFrame::operator+=(const CSensoryFrame& sf)
 {
   m_cachedMap.reset();
-  for (const auto& obs : sf) m_observations.push_back(obs);
+  // Note: iterate the underlying list, since the public const_iterator hands
+  // out const pointers, and observations are shared, not deep-copied, here.
+  for (const auto& obs : sf.m_observations) m_observations.push_back(obs);
 }
 
 /*---------------------------------------------------------------
@@ -126,16 +128,14 @@ CObservation::ConstPtr CSensoryFrame::getObservationByIndex(size_t idx) const
 {
   MRPT_START
   ASSERT_LT_(idx, size());
-  auto it = begin() + idx;
-  return *it;
+  return m_observations.at(idx);
   MRPT_END
 }
 CObservation::Ptr& CSensoryFrame::getObservationByIndex(size_t idx)
 {
   MRPT_START
   ASSERT_LT_(idx, size());
-  auto it = begin() + idx;
-  return *it;
+  return m_observations.at(idx);
   MRPT_END
 }
 
@@ -243,7 +243,7 @@ void CSensoryFrame::internal_buildAuxPointsMap(const void* options) const
   for (const auto& it : *this)
     if (IS_CLASS(*it, CObservation2DRangeScan))
       (*ptr_internal_build_points_map_from_scan2D)(
-          dynamic_cast<CObservation2DRangeScan&>(*it.get()), m_cachedMap, options);
+          dynamic_cast<const CObservation2DRangeScan&>(*it), m_cachedMap, options);
 }
 
 bool CSensoryFrame::insertObservationsInto(

--- a/modules/mrpt_obs/tests/CMetricMap_unittest.cpp
+++ b/modules/mrpt_obs/tests/CMetricMap_unittest.cpp
@@ -199,7 +199,6 @@ TEST(CMetricMap, DefaultVirtualMethodsThrowOrReturnDefaults)
   EXPECT_THROW(m1.compute3DMatchingRatio(&m2, mrpt::poses::CPose3D(), rparams), std::exception);
   EXPECT_THROW(m1.squareDistanceToClosestCorrespondence(0, 0), std::exception);
 
-  EXPECT_EQ(m1.getAsSimplePointsMap(), nullptr);
   const auto bbox = m1.boundingBox();
   EXPECT_FLOAT_EQ(bbox.min.x, 0.0f);
 }

--- a/modules/mrpt_opengl/include/mrpt/opengl/CompiledScene.h
+++ b/modules/mrpt_opengl/include/mrpt/opengl/CompiledScene.h
@@ -263,18 +263,18 @@ class CompiledScene
    * in the scene graph DAG).
    */
   std::map<
-      std::weak_ptr<mrpt::viz::CVisualObject>,
+      std::weak_ptr<const mrpt::viz::CVisualObject>,
       std::vector<std::vector<RenderableProxy::Ptr>>,
-      std::owner_less<std::weak_ptr<mrpt::viz::CVisualObject>>>
+      std::owner_less<std::weak_ptr<const mrpt::viz::CVisualObject>>>
       m_objectToProxy;
 
   /** Transient per-object occurrence counter used during
    * updateDirtyObjects() tree walk to match each tree occurrence
    * to its corresponding proxy group. Cleared before each walk. */
   std::map<
-      std::weak_ptr<mrpt::viz::CVisualObject>,
+      std::weak_ptr<const mrpt::viz::CVisualObject>,
       size_t,
-      std::owner_less<std::weak_ptr<mrpt::viz::CVisualObject>>>
+      std::owner_less<std::weak_ptr<const mrpt::viz::CVisualObject>>>
       m_updateOccurrenceCounter;
 
   /** Per-object version tracking for dirty detection.
@@ -282,9 +282,9 @@ class CompiledScene
    * it last compiled, so multiple CompiledScenes sharing the same source
    * objects don't interfere with each other's dirty tracking. */
   std::map<
-      std::weak_ptr<mrpt::viz::CVisualObject>,
+      std::weak_ptr<const mrpt::viz::CVisualObject>,
       uint64_t,
-      std::owner_less<std::weak_ptr<mrpt::viz::CVisualObject>>>
+      std::owner_less<std::weak_ptr<const mrpt::viz::CVisualObject>>>
       m_objectVersions;
 
   /** Centralized shader program management */
@@ -313,7 +313,7 @@ class CompiledScene
 
   /** Compiles an object and its children (for CSetOfObjects) */
   void compileObject(
-      const std::shared_ptr<mrpt::viz::CVisualObject>& obj,
+      const std::shared_ptr<const mrpt::viz::CVisualObject>& obj,
       CompiledViewport& compiledViewport,
       CompilationStats& stats,
       const mrpt::math::CMatrixFloat44& parentModelMatrix = mrpt::math::CMatrixFloat44::Identity());
@@ -324,13 +324,13 @@ class CompiledScene
       const mrpt::math::CMatrixFloat44& parentModelMatrix);
 
   /** Checks if we already have a proxy for this object */
-  [[nodiscard]] bool hasProxyFor(const std::shared_ptr<mrpt::viz::CVisualObject>& obj) const;
+  [[nodiscard]] bool hasProxyFor(const std::shared_ptr<const mrpt::viz::CVisualObject>& obj) const;
 
   /** Creates appropriate proxy types based on object's parameter mixins.
    * Returns one proxy per mixin type (e.g., CBox gets both a TrianglesProxy
    * and a LinesProxy). */
   [[nodiscard]] std::vector<RenderableProxy::Ptr> createProxiesByType(
-      const std::shared_ptr<mrpt::viz::CVisualObject>& obj);
+      const std::shared_ptr<const mrpt::viz::CVisualObject>& obj);
 
   /** Cleans up proxies for objects that no longer exist */
   void cleanupOrphanedProxies(CompilationStats& stats);
@@ -344,7 +344,7 @@ class CompiledScene
   /** Recursive helper: walks the scene tree to detect dirty objects
    * (including containers) and update their proxies' model matrices. */
   void updateDirtyObjectRecursive(
-      const std::shared_ptr<mrpt::viz::CVisualObject>& obj,
+      const std::shared_ptr<const mrpt::viz::CVisualObject>& obj,
       const mrpt::math::CMatrixFloat44& parentModelMatrix,
       bool parentDirty,
       bool parentVisible,

--- a/modules/mrpt_opengl/include/mrpt/opengl/CompiledViewport.h
+++ b/modules/mrpt_opengl/include/mrpt/opengl/CompiledViewport.h
@@ -123,7 +123,7 @@ class CompiledViewport
    */
   void addProxy(
       const RenderableProxy::Ptr& proxy,
-      const std::shared_ptr<mrpt::viz::CVisualObject>& sourceObj);
+      const std::shared_ptr<const mrpt::viz::CVisualObject>& sourceObj);
 
   /** Removes proxies whose source objects have been deleted.
    * \return Number of orphaned proxies removed
@@ -134,7 +134,7 @@ class CompiledViewport
    * Called by CompiledScene::updateDirtyObjects().
    */
   void updateProxiesForObject(
-      const std::weak_ptr<mrpt::viz::CVisualObject>& weakObj,
+      const std::weak_ptr<const mrpt::viz::CVisualObject>& weakObj,
       const mrpt::viz::CVisualObject* sourceObj,
       const mrpt::math::CMatrixFloat44& modelMatrix,
       bool effectiveVisible = true);
@@ -339,9 +339,9 @@ class CompiledViewport
    * the same CVisualObject appears at multiple positions in the scene DAG).
    */
   std::map<
-      std::weak_ptr<mrpt::viz::CVisualObject>,
+      std::weak_ptr<const mrpt::viz::CVisualObject>,
       std::vector<RenderableProxy::Ptr>,
-      std::owner_less<std::weak_ptr<mrpt::viz::CVisualObject>>>
+      std::owner_less<std::weak_ptr<const mrpt::viz::CVisualObject>>>
       m_objectToProxy;
 
   /** @name Viewport Configuration

--- a/modules/mrpt_opengl/include/mrpt/opengl/RenderableProxy.h
+++ b/modules/mrpt_opengl/include/mrpt/opengl/RenderableProxy.h
@@ -226,11 +226,11 @@ class RenderableProxy
    * - Query dirty flags
    * Set by CompiledScene during proxy creation.
    */
-  std::weak_ptr<mrpt::viz::CVisualObject> m_sourceObject;
+  std::weak_ptr<const mrpt::viz::CVisualObject> m_sourceObject;
 
  public:
   /** Sets the source object reference. Called by CompiledScene during compilation. */
-  void setSourceObject(std::weak_ptr<mrpt::viz::CVisualObject> obj)
+  void setSourceObject(std::weak_ptr<const mrpt::viz::CVisualObject> obj)
   {
     m_sourceObject = std::move(obj);
   }
@@ -245,7 +245,7 @@ class RenderableProxy
   bool m_visible = true;
 
   /** Returns the source object, or nullptr if it has been deleted. */
-  [[nodiscard]] std::shared_ptr<mrpt::viz::CVisualObject> getSourceObject() const
+  [[nodiscard]] std::shared_ptr<const mrpt::viz::CVisualObject> getSourceObject() const
   {
     return m_sourceObject.lock();
   }

--- a/modules/mrpt_opengl/src/CompiledScene.cpp
+++ b/modules/mrpt_opengl/src/CompiledScene.cpp
@@ -351,7 +351,7 @@ void CompiledScene::compileViewport(
         // Only the first (TexturedTriangles) proxy is used for image view
         compiledViewport.setImageViewMode(proxies.front());
         // Track in proxy maps for dirty-update support
-        std::weak_ptr<CVisualObject> weakPlane = plane;
+        std::weak_ptr<const CVisualObject> weakPlane = plane;
         m_objectToProxy[weakPlane].push_back(std::move(proxies));
         m_objectVersions[weakPlane] = plane->dataVersion();
       }
@@ -396,7 +396,7 @@ mrpt::math::CMatrixFloat44 CompiledScene::computeModelMatrix(
 }
 
 void CompiledScene::compileObject(
-    const std::shared_ptr<CVisualObject>& obj,
+    const std::shared_ptr<const CVisualObject>& obj,
     CompiledViewport& compiledViewport,
     CompilationStats& stats,
     const mrpt::math::CMatrixFloat44& parentModelMatrix)
@@ -425,7 +425,7 @@ void CompiledScene::compileObject(
   if (setOfObjects)
   {
     // Track version for containers (needed for multi-occurrence dirty detection)
-    std::weak_ptr<CVisualObject> weakObj = obj;
+    std::weak_ptr<const CVisualObject> weakObj = obj;
     m_objectVersions[weakObj] = obj->dataVersion();
 
     // Recursively compile children, passing this container's model matrix
@@ -475,7 +475,7 @@ void CompiledScene::compileObject(
   // Register in our tracking map as a new occurrence.
   // m_objectToProxy[weakObj] is a vector of occurrence groups;
   // each group is a vector of proxies for one tree position.
-  std::weak_ptr<CVisualObject> weakObj = obj;
+  std::weak_ptr<const CVisualObject> weakObj = obj;
   m_objectToProxy[weakObj].push_back(std::move(proxies));
   m_objectVersions[weakObj] = obj->dataVersion();
 
@@ -516,20 +516,20 @@ void CompiledScene::compileObject(
   MRPT_END
 }
 
-bool CompiledScene::hasProxyFor(const std::shared_ptr<CVisualObject>& obj) const
+bool CompiledScene::hasProxyFor(const std::shared_ptr<const CVisualObject>& obj) const
 {
   if (!obj)
   {
     return false;
   }
 
-  std::weak_ptr<CVisualObject> weakObj = obj;
+  std::weak_ptr<const CVisualObject> weakObj = obj;
   auto it = m_objectToProxy.find(weakObj);
   return it != m_objectToProxy.end() && !it->second.empty();
 }
 
 std::vector<RenderableProxy::Ptr> CompiledScene::createProxiesByType(
-    const std::shared_ptr<CVisualObject>& obj)
+    const std::shared_ptr<const CVisualObject>& obj)
 {
   std::vector<RenderableProxy::Ptr> proxies;
 
@@ -733,7 +733,7 @@ void CompiledScene::compileNewObjects(CompilationStats& stats)
             proxy->compile(plane.get());
           }
           compiledViewport.setImageViewMode(proxies.front());
-          std::weak_ptr<CVisualObject> weakPlane = plane;
+          std::weak_ptr<const CVisualObject> weakPlane = plane;
           m_objectToProxy[weakPlane].push_back(std::move(proxies));
           m_objectVersions[weakPlane] = plane->dataVersion();
         }
@@ -750,9 +750,9 @@ void CompiledScene::compileNewObjects(CompilationStats& stats)
       }
 
       // Helper: check if a CSetOfObjects is new (not yet tracked in m_objectVersions)
-      auto isNewContainer = [this](const std::shared_ptr<CVisualObject>& o) -> bool
+      auto isNewContainer = [this](const std::shared_ptr<const CVisualObject>& o) -> bool
       {
-        std::weak_ptr<CVisualObject> w = o;
+        std::weak_ptr<const CVisualObject> w = o;
         return m_objectVersions.find(w) == m_objectVersions.end();
       };
 
@@ -772,7 +772,8 @@ void CompiledScene::compileNewObjects(CompilationStats& stats)
         else
         {
           // Existing container: walk into it to find new children
-          std::vector<std::pair<const CSetOfObjects*, std::shared_ptr<CVisualObject>>> containers;
+          std::vector<std::pair<const CSetOfObjects*, std::shared_ptr<const CVisualObject>>>
+              containers;
           containers.push_back({setOfObjects, obj});
 
           while (!containers.empty())
@@ -901,7 +902,7 @@ void CompiledScene::updateDirtyObjects(CompilationStats& stats)
 }
 
 void CompiledScene::updateDirtyObjectRecursive(
-    const std::shared_ptr<mrpt::viz::CVisualObject>& obj,
+    const std::shared_ptr<const mrpt::viz::CVisualObject>& obj,
     const mrpt::math::CMatrixFloat44& parentModelMatrix,
     bool parentDirty,
     bool parentVisible,
@@ -911,7 +912,7 @@ void CompiledScene::updateDirtyObjectRecursive(
   {
     return;
   }
-  std::weak_ptr<mrpt::viz::CVisualObject> weakObj = obj;
+  std::weak_ptr<const mrpt::viz::CVisualObject> weakObj = obj;
   const uint64_t currentVersion = obj->dataVersion();
   auto versionIt = m_objectVersions.find(weakObj);
   const uint64_t lastVersion = (versionIt != m_objectVersions.end()) ? versionIt->second : 0;
@@ -1011,7 +1012,7 @@ void CompiledScene::updateDirtyObjectRecursive(
       if (hasProxyFor(labelPtr))
       {
         auto labelVersionIt =
-            m_objectVersions.find(std::weak_ptr<mrpt::viz::CVisualObject>(labelPtr));
+            m_objectVersions.find(std::weak_ptr<const mrpt::viz::CVisualObject>(labelPtr));
         const uint64_t labelLastVer =
             (labelVersionIt != m_objectVersions.end()) ? labelVersionIt->second : 0;
         if (dirty || labelPtr->dataVersion() != labelLastVer)

--- a/modules/mrpt_opengl/src/CompiledViewport.cpp
+++ b/modules/mrpt_opengl/src/CompiledViewport.cpp
@@ -116,7 +116,8 @@ void CompiledViewport::updateFromVizViewport(const mrpt::viz::Viewport& vizVp)
 }
 
 void CompiledViewport::addProxy(
-    const RenderableProxy::Ptr& proxy, const std::shared_ptr<mrpt::viz::CVisualObject>& sourceObj)
+    const RenderableProxy::Ptr& proxy,
+    const std::shared_ptr<const mrpt::viz::CVisualObject>& sourceObj)
 {
   MRPT_START
 
@@ -140,7 +141,7 @@ void CompiledViewport::addProxy(
   // Track object-to-proxy mapping using weak_ptr
   if (sourceObj)
   {
-    std::weak_ptr<mrpt::viz::CVisualObject> objWeak = sourceObj;
+    std::weak_ptr<const mrpt::viz::CVisualObject> objWeak = sourceObj;
     m_objectToProxy[objWeak].push_back(proxy);
   }
 
@@ -201,7 +202,7 @@ size_t CompiledViewport::cleanupOrphanedProxies()
 }
 
 void CompiledViewport::updateProxiesForObject(
-    const std::weak_ptr<mrpt::viz::CVisualObject>& weakObj,
+    const std::weak_ptr<const mrpt::viz::CVisualObject>& weakObj,
     const mrpt::viz::CVisualObject* sourceObj,
     const mrpt::math::CMatrixFloat44& modelMatrix,
     bool effectiveVisible)
@@ -220,9 +221,9 @@ void CompiledViewport::updateProxiesForObject(
     if (!src) continue;
 
     // Check if this proxy belongs to the same source object
-    auto srcWeak = std::weak_ptr<mrpt::viz::CVisualObject>(src);
-    if (!(std::owner_less<std::weak_ptr<mrpt::viz::CVisualObject>>{}(srcWeak, weakObj) ||
-          std::owner_less<std::weak_ptr<mrpt::viz::CVisualObject>>{}(weakObj, srcWeak)))
+    auto srcWeak = std::weak_ptr<const mrpt::viz::CVisualObject>(src);
+    if (!(std::owner_less<std::weak_ptr<const mrpt::viz::CVisualObject>>{}(srcWeak, weakObj) ||
+          std::owner_less<std::weak_ptr<const mrpt::viz::CVisualObject>>{}(weakObj, srcWeak)))
     {
       // Same object. Update model matrix, visibility, and buffers
       proxy->m_modelMatrix = modelMatrix;
@@ -864,7 +865,8 @@ void CompiledViewport::renderImageView(ShaderProgramManager& shaderManager)
   // (same logic as mrpt v2 Viewport::renderImageView)
   if (auto src = m_imageViewProxy->getSourceObject(); src)
   {
-    if (auto* ttSrc = dynamic_cast<mrpt::viz::VisualObjectParams_TexturedTriangles*>(src.get());
+    if (auto* ttSrc =
+            dynamic_cast<const mrpt::viz::VisualObjectParams_TexturedTriangles*>(src.get());
         ttSrc && ttSrc->textureImageHasBeenAssigned())
     {
       const auto& img = ttSrc->getTextureImage();

--- a/modules/mrpt_poses/include/mrpt/poses/CPointPDF.h
+++ b/modules/mrpt_poses/include/mrpt/poses/CPointPDF.h
@@ -86,7 +86,8 @@ class CPointPDF :
   void getAs3DObject(OPENGL_SETOFOBJECTSPTR& out_obj) const
   {
     using SETOFOBJECTS = typename OPENGL_SETOFOBJECTSPTR::element_type;
-    out_obj->insertCollection(*SETOFOBJECTS::posePDF2opengl(*this));
+    auto objs = SETOFOBJECTS::posePDF2opengl(*this);
+    out_obj->insert(objs->begin(), objs->end());
   }
 
   /** Returns a 3D representation of this PDF.

--- a/modules/mrpt_poses/include/mrpt/poses/CPose3DPDF.h
+++ b/modules/mrpt_poses/include/mrpt/poses/CPose3DPDF.h
@@ -136,7 +136,8 @@ class CPose3DPDF :
   void getAs3DObject(OPENGL_SETOFOBJECTSPTR& out_obj) const
   {
     using SETOFOBJECTS = typename OPENGL_SETOFOBJECTSPTR::element_type;
-    out_obj->insertCollection(*SETOFOBJECTS::posePDF2opengl(*this));
+    auto objs = SETOFOBJECTS::posePDF2opengl(*this);
+    out_obj->insert(objs->begin(), objs->end());
   }
 
   /** Returns a 3D representation of this PDF.

--- a/modules/mrpt_poses/include/mrpt/poses/CPose3DQuatPDF.h
+++ b/modules/mrpt_poses/include/mrpt/poses/CPose3DQuatPDF.h
@@ -99,7 +99,8 @@ class CPose3DQuatPDF :
   void getAs3DObject(OPENGL_SETOFOBJECTSPTR& out_obj) const
   {
     using SETOFOBJECTS = typename OPENGL_SETOFOBJECTSPTR::value_type;
-    out_obj->insertCollection(*SETOFOBJECTS::posePDF2opengl(*this));
+    auto objs = SETOFOBJECTS::posePDF2opengl(*this);
+    out_obj->insert(objs->begin(), objs->end());
   }
 
   /** Returns a 3D representation of this PDF.

--- a/modules/mrpt_poses/include/mrpt/poses/CPosePDF.h
+++ b/modules/mrpt_poses/include/mrpt/poses/CPosePDF.h
@@ -129,7 +129,8 @@ class CPosePDF :
   void getAs3DObject(OPENGL_SETOFOBJECTSPTR& out_obj) const
   {
     using SETOFOBJECTS = typename OPENGL_SETOFOBJECTSPTR::element_type;
-    out_obj->insertCollection(*SETOFOBJECTS::posePDF2opengl(*this));
+    auto objs = SETOFOBJECTS::posePDF2opengl(*this);
+    out_obj->insert(objs->begin(), objs->end());
   }
 
   /** Returns a 3D representation of this PDF.

--- a/modules/mrpt_serialization/include/mrpt/serialization/CArchive.h
+++ b/modules/mrpt_serialization/include/mrpt/serialization/CArchive.h
@@ -26,6 +26,7 @@
 #include <stdexcept>
 #include <string>
 #include <type_traits>  // remove_reference_t, is_polymorphic
+#include <utility>      // declval
 #include <variant>
 #include <vector>
 
@@ -607,6 +608,53 @@ CArchive& operator>>(CArchive& in, ENUM_TYPE& pEnum)
   pEnum = mrpt::typemeta::TEnumType<std::remove_cv_t<ENUM_TYPE>>::name2value(readValue);
   return in;
 }
+
+/** Detects a deduced forwarding-reference parameter that binds an rvalue
+ * archive. Used to constrain the rvalue stream operators below, and checked
+ * before any other condition so that lvalue archives are discarded without
+ * recursively re-examining those very operators. */
+template <typename ARCHIVE>
+constexpr bool is_rvalue_archive_v =
+    !std::is_lvalue_reference_v<ARCHIVE> && std::is_base_of_v<CArchive, std::decay_t<ARCHIVE>>;
+
+/** @name Support for streaming into temporary (rvalue) archives
+ * @{ */
+
+/** Inserts an object into a temporary archive, e.g. `archiveFrom(f) << x;`.
+ *
+ * Free `operator<<` overloads take the archive by non-const reference, so a
+ * temporary archive returned by archiveFrom() cannot bind to them. These
+ * forwarders solve it in the same way as the C++ standard library does for
+ * `std::basic_ostream` (see `[ostream.rvalue]`): the rvalue archive is
+ * forwarded to the regular lvalue overload, and an lvalue reference is
+ * returned so that chaining keeps working.
+ *
+ * They only take part in overload resolution if the equivalent lvalue
+ * expression is well-formed.
+ */
+template <
+    typename ARCHIVE,
+    typename T,
+    std::enable_if_t<is_rvalue_archive_v<ARCHIVE>, int> = 0,
+    typename = decltype(std::declval<CArchive&>() << std::declval<const T&>())>
+CArchive& operator<<(ARCHIVE&& out, const T& a)
+{
+  return out << a;
+}
+
+/** Extracts an object from a temporary archive, e.g. `archiveFrom(f) >> x;`.
+ *  \sa operator<<(CArchive&&, const T&) */
+template <
+    typename ARCHIVE,
+    typename T,
+    std::enable_if_t<is_rvalue_archive_v<ARCHIVE>, int> = 0,
+    typename = decltype(std::declval<CArchive&>() >> std::declval<T&>())>
+CArchive& operator>>(ARCHIVE&& in, T& a)
+{
+  return in >> a;
+}
+
+/** @} */
 
 /** CArchive for mrpt::io::CStream classes (use as template argument).
  * \sa Easier to use via function archiveFrom() */

--- a/modules/mrpt_serialization/include/mrpt/serialization/CArchive.h
+++ b/modules/mrpt_serialization/include/mrpt/serialization/CArchive.h
@@ -630,26 +630,28 @@ constexpr bool is_rvalue_archive_v =
  * returned so that chaining keeps working.
  *
  * They only take part in overload resolution if the equivalent lvalue
- * expression is well-formed.
+ * expression is well-formed. Note that the probe, and the returned type, use
+ * the deduced archive type and not `CArchive`, so that overloads declared for
+ * a derived archive type are honored too.
  */
 template <
     typename ARCHIVE,
     typename T,
     std::enable_if_t<is_rvalue_archive_v<ARCHIVE>, int> = 0,
-    typename = decltype(std::declval<CArchive&>() << std::declval<const T&>())>
-CArchive& operator<<(ARCHIVE&& out, const T& a)
+    typename RET = decltype(std::declval<ARCHIVE&>() << std::declval<const T&>())>
+RET operator<<(ARCHIVE&& out, const T& a)
 {
   return out << a;
 }
 
 /** Extracts an object from a temporary archive, e.g. `archiveFrom(f) >> x;`.
- *  \sa operator<<(CArchive&&, const T&) */
+ *  \sa operator<<(ARCHIVE&&, const T&) */
 template <
     typename ARCHIVE,
     typename T,
     std::enable_if_t<is_rvalue_archive_v<ARCHIVE>, int> = 0,
-    typename = decltype(std::declval<CArchive&>() >> std::declval<T&>())>
-CArchive& operator>>(ARCHIVE&& in, T& a)
+    typename RET = decltype(std::declval<ARCHIVE&>() >> std::declval<T&>())>
+RET operator>>(ARCHIVE&& in, T& a)
 {
   return in >> a;
 }

--- a/modules/mrpt_serialization/tests/CArchive_unittest.cpp
+++ b/modules/mrpt_serialization/tests/CArchive_unittest.cpp
@@ -691,3 +691,46 @@ TEST(CArchive, temporaryReadOnlyVectorArchive)
   archiveFrom(cv) >> out;
   EXPECT_EQ(out, "read-only");
 }
+
+namespace
+{
+/** An archive type of its own, with an insertion operator declared only for
+ *  it, to check that the rvalue forwarders honor overloads of derived archive
+ *  types (and not just of CArchive). */
+class DerivedArchive : public mrpt::serialization::CArchiveStreamBase<std::vector<uint8_t>>
+{
+ public:
+  using CArchiveStreamBase<std::vector<uint8_t>>::CArchiveStreamBase;
+};
+
+struct OnlyForDerivedArchives
+{
+  int32_t value{0};
+};
+
+DerivedArchive& operator<<(DerivedArchive& a, const OnlyForDerivedArchives& o)
+{
+  // Tagged, so that the reader can tell this overload was the one used:
+  a << std::string("derived") << o.value;
+  return a;
+}
+}  // namespace
+
+TEST(CArchive, temporaryArchiveUsesDerivedArchiveOverloads)
+{
+  std::vector<uint8_t> v;
+
+  // Both insertions must resolve to the DerivedArchive overload: the second
+  // one only can if the first returns a DerivedArchive&, not a CArchive&.
+  DerivedArchive(v) << OnlyForDerivedArchives{10} << OnlyForDerivedArchives{20};
+
+  auto rd = archiveFrom(v);
+  for (const int32_t expected : {10, 20})
+  {
+    std::string tag;
+    int32_t got = 0;
+    rd >> tag >> got;
+    EXPECT_EQ(tag, "derived");
+    EXPECT_EQ(got, expected);
+  }
+}

--- a/modules/mrpt_serialization/tests/CArchive_unittest.cpp
+++ b/modules/mrpt_serialization/tests/CArchive_unittest.cpp
@@ -645,3 +645,49 @@ TEST(CArchive, sharedPtrToNonSerializableRoundTrip)
     EXPECT_ANY_THROW(a >> out);
   }
 }
+
+TEST(CArchive, temporaryArchiveInsertionAndExtraction)
+{
+  // Free operators take the archive by non-const reference, so these all used
+  // to be rejected: streaming into the temporary returned by archiveFrom().
+  std::vector<uint8_t> v;
+
+  const uint32_t inNum = 42;
+  const std::string inStr = "hello";
+  archiveFrom(v) << inNum << inStr << SerTestNS::TestEnum::Second;
+
+  uint32_t outNum = 0;
+  std::string outStr;
+  auto outEnum = SerTestNS::TestEnum::First;
+  archiveFrom(v) >> outNum >> outStr >> outEnum;
+
+  EXPECT_EQ(outNum, inNum);
+  EXPECT_EQ(outStr, inStr);
+  EXPECT_EQ(outEnum, SerTestNS::TestEnum::Second);
+}
+
+TEST(CArchive, temporaryArchiveWithSerializableObjects)
+{
+  SerTestNS::registerTestClasses();
+
+  std::vector<uint8_t> v;
+
+  SerTestNS::Foo in;
+  in.m_value = 7;
+  archiveFrom(v) << in;
+
+  SerTestNS::Foo out;
+  archiveFrom(v) >> out;
+  EXPECT_EQ(out.m_value, in.m_value);
+}
+
+TEST(CArchive, temporaryReadOnlyVectorArchive)
+{
+  std::vector<uint8_t> v;
+  archiveFrom(v) << std::string("read-only");
+
+  const std::vector<uint8_t>& cv = v;
+  std::string out;
+  archiveFrom(cv) >> out;
+  EXPECT_EQ(out, "read-only");
+}

--- a/modules/mrpt_slam/include/mrpt/slam/observations_overlap.h
+++ b/modules/mrpt_slam/include/mrpt/slam/observations_overlap.h
@@ -38,8 +38,8 @@ double observationsOverlap(
  *  \note This is used in mrpt::slam::CIncrementalMapPartitioner
  */
 inline double observationsOverlap(
-    const mrpt::obs::CObservation::Ptr& o1,
-    const mrpt::obs::CObservation::Ptr& o2,
+    const mrpt::obs::CObservation::ConstPtr& o1,
+    const mrpt::obs::CObservation::ConstPtr& o2,
     const mrpt::poses::CPose3D* pose_o2_wrt_o1 = nullptr)
 {
   return observationsOverlap(o1.get(), o2.get(), pose_o2_wrt_o1);
@@ -63,8 +63,8 @@ double observationsOverlap(
  *  \note This is used in mrpt::slam::CIncrementalMapPartitioner
  */
 inline double observationsOverlap(
-    const mrpt::obs::CSensoryFrame::Ptr& sf1,
-    const mrpt::obs::CSensoryFrame::Ptr& sf2,
+    const mrpt::obs::CSensoryFrame::ConstPtr& sf1,
+    const mrpt::obs::CSensoryFrame::ConstPtr& sf2,
     const mrpt::poses::CPose3D* pose_sf2_wrt_sf1 = nullptr)
 {
   return observationsOverlap(*sf1.get(), *sf2.get(), pose_sf2_wrt_sf1);

--- a/modules/mrpt_viz/include/mrpt/viz/CSetOfObjects.h
+++ b/modules/mrpt_viz/include/mrpt/viz/CSetOfObjects.h
@@ -13,6 +13,7 @@
 */
 #pragma once
 
+#include <mrpt/containers/deep_const_iterator.h>
 #include <mrpt/containers/yaml.h>
 #include <mrpt/poses/poses_frwds.h>  // All these are needed for the auxiliary methods posePDF2opengl()
 #include <mrpt/viz/CVisualObject.h>
@@ -43,7 +44,9 @@ class CSetOfObjects : public CVisualObject
   CSetOfObjects() = default;
   virtual ~CSetOfObjects() override = default;
 
-  using const_iterator = ListVisualObjects::const_iterator;
+  /** Dereferencing it yields a CVisualObject::ConstPtr, so that a `const`
+   * container cannot hand out mutable objects. */
+  using const_iterator = mrpt::containers::deep_const_iterator<ListVisualObjects::const_iterator>;
   using iterator = ListVisualObjects::iterator;
 
   const_iterator begin() const { return m_objects.begin(); }
@@ -82,7 +85,13 @@ class CSetOfObjects : public CVisualObject
   /** Returns the first object with a given name, or a nullptr pointer if not
    * found.
    */
-  CVisualObject::Ptr getByName(const std::string& str);
+  CVisualObject::ConstPtr getByName(const std::string& str) const;
+  /// \overload Non-const version returning a mutable Ptr
+  CVisualObject::Ptr getByName(const std::string& str)
+  {
+    return std::const_pointer_cast<CVisualObject>(
+        static_cast<const CSetOfObjects*>(this)->getByName(str));
+  }
 
   /** Returns the i'th object of a given class (or of a descendant class), or
   nullptr (an empty smart pointer) if not found.

--- a/modules/mrpt_viz/include/mrpt/viz/Scene.h
+++ b/modules/mrpt_viz/include/mrpt/viz/Scene.h
@@ -147,8 +147,15 @@ class Scene : public mrpt::serialization::CSerializable, public std::enable_shar
   /** Returns the first object with a given name, or nullptr (an empty smart
    * pointer) if not found.
    */
+  CVisualObject::ConstPtr getByName(
+      const std::string& str, const std::string& viewportName = std::string("main")) const;
+  /// \overload Non-const version returning a mutable Ptr
   CVisualObject::Ptr getByName(
-      const std::string& str, const std::string& viewportName = std::string("main"));
+      const std::string& str, const std::string& viewportName = std::string("main"))
+  {
+    return std::const_pointer_cast<CVisualObject>(
+        static_cast<const Scene*>(this)->getByName(str, viewportName));
+  }
 
   /** Returns the i'th object of a given class (or of a descendant class), or
   nullptr (an empty smart pointer) if not found.

--- a/modules/mrpt_viz/include/mrpt/viz/Viewport.h
+++ b/modules/mrpt_viz/include/mrpt/viz/Viewport.h
@@ -14,6 +14,7 @@
 #pragma once
 
 #include <mrpt/containers/PerThreadDataHolder.h>
+#include <mrpt/containers/deep_const_iterator.h>
 #include <mrpt/core/safe_pointers.h>
 #include <mrpt/img/CImage.h>
 #include <mrpt/math/TLine3D.h>
@@ -272,7 +273,9 @@ class Viewport :
   /** @name Contained objects set/get/search
     @{ */
 
-  using const_iterator = ListVisualObjects::const_iterator;
+  /** Dereferencing it yields a CVisualObject::ConstPtr, so that a `const`
+   * container cannot hand out mutable objects. */
+  using const_iterator = mrpt::containers::deep_const_iterator<ListVisualObjects::const_iterator>;
   using iterator = ListVisualObjects::iterator;
 
   [[nodiscard]] const_iterator begin() const { return m_objects.begin(); }
@@ -296,7 +299,13 @@ class Viewport :
 
   /** Returns the first object with a given name, or nullptr if not found.
    */
-  [[nodiscard]] CVisualObject::Ptr getByName(const std::string& str);
+  [[nodiscard]] CVisualObject::ConstPtr getByName(const std::string& str) const;
+  /// \overload Non-const version returning a mutable Ptr
+  [[nodiscard]] CVisualObject::Ptr getByName(const std::string& str)
+  {
+    return std::const_pointer_cast<CVisualObject>(
+        static_cast<const Viewport*>(this)->getByName(str));
+  }
 
   /** Returns the i'th object of a given class (or of a descendant class), or
   nullptr (an empty smart pointer) if not found.

--- a/modules/mrpt_viz/src/CSetOfObjects.cpp
+++ b/modules/mrpt_viz/src/CSetOfObjects.cpp
@@ -200,9 +200,9 @@ CVisualObject& CSetOfObjects::setColorA_u8(const uint8_t a)
 /*---------------------------------------------------------------
               getByName
   ---------------------------------------------------------------*/
-CVisualObject::Ptr CSetOfObjects::getByName(const string& str)
+CVisualObject::ConstPtr CSetOfObjects::getByName(const string& str) const
 {
-  for (auto& o : m_objects)
+  for (const auto& o : m_objects)
   {
     if (!o)
     {
@@ -213,9 +213,9 @@ CVisualObject::Ptr CSetOfObjects::getByName(const string& str)
       return o;
     }
 
-    if (auto* objs = dynamic_cast<CSetOfObjects*>(o.get()))
+    if (const auto* objs = dynamic_cast<const CSetOfObjects*>(o.get()))
     {
-      CVisualObject::Ptr ret = objs->getByName(str);
+      CVisualObject::ConstPtr ret = objs->getByName(str);
       if (ret)
       {
         return ret;

--- a/modules/mrpt_viz/src/Scene.cpp
+++ b/modules/mrpt_viz/src/Scene.cpp
@@ -163,12 +163,13 @@ void Scene::insert(const CVisualObject::Ptr& newObject, const std::string& viewp
 /*---------------------------------------------------------------
               getByName
   ---------------------------------------------------------------*/
-CVisualObject::Ptr Scene::getByName(const string& str, [[maybe_unused]] const string& viewportName)
+CVisualObject::ConstPtr Scene::getByName(
+    const string& str, [[maybe_unused]] const string& viewportName) const
 {
-  CVisualObject::Ptr obj;
+  CVisualObject::ConstPtr obj;
   for (const auto& m_viewport : m_viewports)
   {
-    if (obj = m_viewport->getByName(str); obj)
+    if (obj = std::as_const(*m_viewport).getByName(str); obj)
     {
       break;
     }

--- a/modules/mrpt_viz/src/Viewport.cpp
+++ b/modules/mrpt_viz/src/Viewport.cpp
@@ -299,7 +299,7 @@ void Viewport::serializeFrom(mrpt::serialization::CArchive& in, uint8_t version)
 /*---------------------------------------------------------------
               getByName
   ---------------------------------------------------------------*/
-CVisualObject::Ptr Viewport::getByName(const string& str)
+CVisualObject::ConstPtr Viewport::getByName(const string& str) const
 {
   for (const auto& m_object : m_objects)
   {
@@ -310,8 +310,8 @@ CVisualObject::Ptr Viewport::getByName(const string& str)
 
     if (m_object->GetRuntimeClass() == CLASS_ID_NAMESPACE(CSetOfObjects, mrpt::viz))
     {
-      if (CVisualObject::Ptr ret =
-              std::dynamic_pointer_cast<CSetOfObjects>(m_object)->getByName(str);
+      if (CVisualObject::ConstPtr ret =
+              std::dynamic_pointer_cast<const CSetOfObjects>(m_object)->getByName(str);
           ret)
       {
         return ret;


### PR DESCRIPTION
Three API improvements to land before the next minor version bump. All of them are source-incompatible in places, which is intentional at this point.

## 1. Streaming into temporary archives (`mrpt_serialization`)

Free `operator<<` / `operator>>` take the archive by non-const reference, so the temporary returned by `archiveFrom()` could not bind to them:

```cpp
// Rejected before:
mrpt::serialization::archiveFrom(f) << myVector;
```

Member operators (for `CSerializable`) already worked on rvalues, so only the elemental/STL overloads were affected.

Fixed the way the standard library does it for `std::basic_ostream` / `std::basic_istream` (`[ostream.rvalue]`, `[istream.rvalue]`): SFINAE-constrained forwarders taking the archive by rvalue reference, forwarding to the regular lvalue overloads and returning an lvalue reference so chaining keeps working. No breakage.

Note this was preferred over taking the archive as `const CArchive&`: that would be a claim that streaming does not mutate the archive, which is false for any archive tracking a read position, and it would force the const wave down into `CSerializable::serializeTo/serializeFrom`, i.e. every downstream serializable class.

The constraint deliberately checks "is this a deduced rvalue archive?" before probing that the lvalue expression is well-formed; with the opposite order the probe recursively re-examines the very operator being defined and exceeds the instantiation depth.

## 2. Deep const-correctness in smart-pointer containers

Getters already had `const` -> `ConstPtr` / non-`const` -> `Ptr` pairs, but iterating a `const` container still handed out mutable `Ptr`s, so constness stopped at the container.

* New `mrpt::containers::deep_const_iterator` proxy, used for the `const_iterator`s of `CSensoryFrame`, `CActionCollection`, `CSetOfObjects`, `Viewport` and `CMultiMetricMap`. `CRawlog` already had a hand-rolled equivalent.
* `Scene`, `Viewport` and `CSetOfObjects` gain `const` `getByName()` overloads returning a `ConstPtr`.
* `CMultiMetricMap::maps` is no longer a public member: `push_back()`, `size()`, `empty()`, `clearMaps()`, `mapByIndex()`, `begin()`/`end()`, or `mapsList()` for direct manipulation.
* `observationsOverlap()` takes `ConstPtr` arguments, as it only reads.

The `mrpt_opengl` renderer was relying on the const-iteration hole; it now keeps `const CVisualObject` handles, which required no logic change since every method it calls on the source objects was already `const`. The two viewers that genuinely need mutable observations (rendering a 3D scan lazy-loads and caches data inside it) do one explicit `const_pointer_cast` each.

## 3. `getAsSimplePointsMap()` retired

The virtual returned a raw pointer that was either `this` or a child map owned by a `CMultiMetricMap`, and it only ever answered for `CSimplePointsMap`: any other points map (`CPointsMapXYZI`, ...) silently got a `nullptr`, which `CPointsMap::compute3DMatchingRatio()` then passed straight into `determineMatching3D()`.

Replaced by a free `mrpt::maps::asPointsMap(map)` in `mrpt_maps`, which returns any points map, or the single child points map of a multi-metric map. `compute3DMatchingRatio()` now uses it and therefore works for every points map type. Callers who want ownership should use `CMultiMetricMap::mapByClass<>()`, which returns a real `Ptr`.

## Testing

* `colcon build`: clean, 36/36 packages.
* `colcon test`: green, no failures in any package.
* New unit tests for the temporary-archive operators.
* Porting notes added to `doc/source/doxygen-docs/port_mrpt3.md` (new cross-cutting pattern, module sections, and Removed APIs entries).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Improvements**
  - Improved const-correctness across map, observation, serialization, and visualization APIs.
  - Enhanced points-map lookup and metric-map access through safer, structured interfaces.
  - Temporary serialization archives now preserve derived archive behavior and return types.

- **API Changes**
  - Direct metric-map container access and legacy points-map conversion methods were removed in favor of accessor-based alternatives.
  - Const iteration and lookup now return read-only objects where appropriate.

- **Documentation**
  - Updated migration guidance for container access, serialization, and map APIs.

- **Tests**
  - Expanded coverage for temporary archives and metric-map access patterns.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->