### PR TITLE
ci(windows): stop Defender from breaking links, widen timeout

### DIFF
--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -6,7 +6,9 @@ jobs:
   build:
     name: ${{ matrix.name }} ${{ matrix.build_type }}
     runs-on: ${{ matrix.os }}
-    timeout-minutes: 120
+    # Cold-cache runs have been landing at 1h41m-1h51m, i.e. within minutes of
+    # the previous 120 min limit.
+    timeout-minutes: 170
 
     env:
       CTEST_OUTPUT_ON_FAILURE: ON
@@ -47,6 +49,25 @@ jobs:
         uses: ilammy/msvc-dev-cmd@v1
         with:
           arch: x64
+
+      # Defender's real-time scanner opens each binary as it is written, and
+      # link.exe/mt.exe then intermittently fail to reopen their own output with
+      # "The process cannot access the file because it is being used by another
+      # process". It hits a different, unrelated target every time, so a failure
+      # says nothing about the commit that triggered it. Excluding the build
+      # tree and the toolchain also takes a sizeable bite out of the build time.
+      # Best-effort: never fail the job if the cmdlets are unavailable.
+      - name: Exclude build tree from Windows Defender
+        shell: powershell
+        continue-on-error: true
+        run: |
+          $ErrorActionPreference = 'SilentlyContinue'
+          Add-MpPreference -ExclusionPath '${{ github.workspace }}'
+          Add-MpPreference -ExclusionPath 'C:\vcpkg'
+          foreach ($p in 'cl.exe','link.exe','mt.exe','rc.exe','ninja.exe','sccache.exe') {
+            Add-MpPreference -ExclusionProcess $p
+          }
+          exit 0
 
       - name: Install vcpkg dependencies
         shell: bash


### PR DESCRIPTION
## The failure

`CI Windows` on `develop` failed right after #1414 merged, at the link step:

```
FAILED: [code=1] bin/test_mrpt_containers.exe
The process cannot access the file because it is being used by another process.
```

The same thing hit #1414's own Windows job hours earlier, on a completely
different target (`slam_range_only_localization_rej_sampling_example.exe`, in
`mrpt_examples_cpp`). Both times the second Windows run over the identical tree
passed.

## Diagnosis

Not a code defect: it is a file-locking race. Defender's real-time scanner opens
each binary as it is written, and `link.exe`/`mt.exe` (via `cmake -E vs_link_exe`)
then intermittently fail to reopen their own output. It lands on a random,
unrelated target each time, so the commit under test is irrelevant.

Frequency on `develop`: **2 of the last 40 runs**. The only other recent failure
(2026-08-31) was a genuine, since-fixed `tinyxml2` link error with an entirely
different signature, so this flake is new — it appeared as the runner moved to
VS 18 / MSVC 14.51.

## Changes

1. **Defender exclusions** for the workspace, `C:\vcpkg` and the toolchain
   processes, before anything is built. Best-effort: `continue-on-error` plus
   `exit 0`, so it can never itself fail the job if the cmdlets are unavailable.
   This is the standard remedy for this error class on hosted Windows runners,
   and it usually shortens the build noticeably too.

2. **`timeout-minutes: 120` → `170`.** Unrelated latent risk found while
   measuring: cold-cache runs land at **1h41m–1h51m**, i.e. within ~9 minutes of
   the old limit. Drop this hunk if you would rather keep the pressure on.

## Caveat

This shifts probabilities; it does not deterministically prove anything. A single
green run here is **not** evidence the flake is gone — at a ~5% rate, most runs
were always going to be green. Worth watching over the next several merges, and
if it recurs the next suspect is vcpkg's `z-applocal` post-link DLL copying,
which runs concurrently across packages.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Increased the maximum time allowed for Windows builds.
  - Improved Windows build reliability by attempting to exclude build directories and tools from antivirus scanning, while continuing when exclusions are unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->